### PR TITLE
Update README to link to zenodo repo with checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You may verify installation by running `pytest fme/`.
 
 ### 2. Download data and checkpoint
 
-The checkpoint and a 1-year subsample of the validation data is available at
+The checkpoint and a 1-year subsample of the validation data are available at
 [this Zenodo repository](https://zenodo.org/doi/10.5281/zenodo.10791086).
 Download these to your local system.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is rapidly changing research software. We make no guarantees of maintaining
 
 ### 1. Clone this repository and install dependencies
 
-Assuming [conda](https://docs.conda.io/en/latest/) is available, run
+Clone this repository. Then assuming [conda](https://docs.conda.io/en/latest/)
+is available, run
 ```
 make create_environment
 ```
@@ -18,7 +19,11 @@ You may verify installation by running `pytest fme/`.
 
 ### 2. Download data and checkpoint
 
-These are available via a public
+The checkpoint and a 1-year subsample of the validation data is available at
+[this Zenodo repository](https://zenodo.org/doi/10.5281/zenodo.10791086).
+Download these to your local system.
+
+Alternatively, if interested in the complete dataset, this is available via a public
 [requester pays](https://cloud.google.com/storage/docs/requester-pays)
 Google Cloud Storage bucket. The checkpoint can be downloaded with:
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is rapidly changing research software. We make no guarantees of maintaining
 
 ## Quickstart
 
-### 1. Clone this repository and install dependencies
+### 1. Install
 
 Clone this repository. Then assuming [conda](https://docs.conda.io/en/latest/)
 is available, run
@@ -25,18 +25,17 @@ Download these to your local system.
 
 Alternatively, if interested in the complete dataset, this is available via a public
 [requester pays](https://cloud.google.com/storage/docs/requester-pays)
-Google Cloud Storage bucket. The checkpoint can be downloaded with:
-```
-gsutil -u YOUR_GCP_PROJECT cp gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/checkpoints/ace_ckpt.tar .
-```
-Download the 10-year validation data (approx. 190GB; can also download a portion only,
-but it is required to download enough data to span the desired prediction period):
+Google Cloud Storage bucket. For example, the 10-year validation data (approx. 190GB)
+can be downloaded with:
 ```
 gsutil -m -u YOUR_GCP_PROJECT cp -r gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/data/repeating-climSST-1deg-netCDFs/validation .
 ```
+It is possible to download a portion of the dataset  only, but it is necessary to have
+enough data to span the desired prediction period. The checkpoint is also available on GCS at `gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/checkpoints/ace_ckpt.tar`.
 
-### 3. Update the paths in the [example config](examples/config-inference.yaml).
-Then in the `fme` conda environment, run inference with:
+### 3. Update configuration and run
+Update the paths in the [example config](examples/config-inference.yaml). Then in the
+`fme` conda environment, run inference with:
 ```
 python -m fme.fcn_training.inference.inference examples/config-inference.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You may verify installation by running `pytest fme/`.
 
 The checkpoint and a 1-year subsample of the validation data are available at
 [this Zenodo repository](https://zenodo.org/doi/10.5281/zenodo.10791086).
-Download these to your local system.
+Download these to your local filesystem.
 
 Alternatively, if interested in the complete dataset, this is available via a public
 [requester pays](https://cloud.google.com/storage/docs/requester-pays)
@@ -30,8 +30,9 @@ can be downloaded with:
 ```
 gsutil -m -u YOUR_GCP_PROJECT cp -r gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/data/repeating-climSST-1deg-netCDFs/validation .
 ```
-It is possible to download a portion of the dataset  only, but it is necessary to have
-enough data to span the desired prediction period. The checkpoint is also available on GCS at `gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/checkpoints/ace_ckpt.tar`.
+It is possible to download a portion of the dataset only, but it is necessary to have
+enough data to span the desired prediction period. The checkpoint is also available on GCS at
+`gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/checkpoints/ace_ckpt.tar`.
 
 ### 3. Update configuration and run
 Update the paths in the [example config](examples/config-inference.yaml). Then in the

--- a/examples/config-inference.yaml
+++ b/examples/config-inference.yaml
@@ -11,7 +11,7 @@ logging:
   entity: your_wandb_entity
 validation_data:
   batch_size: 1
-  data_path: /path/to/validation/ic_0011
+  data_path: /path/to/data/directory
   data_type: xarray
   num_data_workers: 4
   n_samples: 1

--- a/examples/config-inference.yaml
+++ b/examples/config-inference.yaml
@@ -11,7 +11,7 @@ logging:
   entity: your_wandb_entity
 validation_data:
   batch_size: 1
-  data_path: /path/to/data/directory
+  data_path: /path/to/data/directory  # time-ordered netCDFs ending in .nc
   data_type: xarray
   num_data_workers: 4
   n_samples: 1


### PR DESCRIPTION
Add a link to a zenodo data repository which contains model checkpoint and a 1-year subsample of the validation data.