### PR TITLE
Fix instruction for installing from GitHub

### DIFF
--- a/fme/docs/installation.rst
+++ b/fme/docs/installation.rst
@@ -15,7 +15,7 @@ To install directly from github, you can run:
 
 .. code-block:: shell
 
-    pip install 'git://github.com/ai2cm/ace.git#egg=fme&subdirectory=fme'
+    pip install git+https://github.com/ai2cm/ace#subdirectory=fme
 
 Conda
 -----


### PR DESCRIPTION
The syntax was incorrect for documentation on installing direct from GitHub.