### PR TITLE
Add link to zenodo archive with checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ See complete documentation [here](https://ai2-climate-emulator.readthedocs.io/en
 
 A quickstart guide may be found [here](https://ai2-climate-emulator.readthedocs.io/en/latest/quickstart.html).
 
+## Model checkpoint
+
+The trained ACE checkpoint and a 1-year subsample of the validation dataset is available in
+[this Zenodo repository](https://doi.org/10.5281/zenodo.10791087).
+
 ## Available datasets
-Two versions of the dataset described in [arxiv:2310.02074](https://arxiv.org/abs/2310.02074)
-are available:
+Two versions of the complete dataset described in [arxiv:2310.02074](https://arxiv.org/abs/2310.02074)
+are available on a requester pays Google Cloud Storage bucket:
 ```
 gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/data/repeating-climSST-1deg-zarrs
 gs://ai2cm-public-requester-pays/2023-11-29-ai2-climate-emulator-v1/data/repeating-climSST-1deg-netCDFs


### PR DESCRIPTION
Make zenodo archive with the ACE checkpoint findable without user having to click through to docs.
