### PR TITLE
Update to v1.1 zenodo id

### DIFF
--- a/fme/docs/inference_config.rst
+++ b/fme/docs/inference_config.rst
@@ -34,7 +34,7 @@ in the dataset configuration.  See :class:`fme.ace.XarrayDataConfig` for an exam
 Example YAML Configuration
 ---------------------------
 
-.. _Zenodo repository: https://zenodo.org/records/13787710
+.. _Zenodo repository: https://zenodo.org/records/14606905
 
 .. literalinclude:: inference-config.yaml
    :language: yaml


### PR DESCRIPTION
The initial condition files in the simple inference example Zenodo repository were full of NaNs.  Re-uploaded the files, confirmed that the actual values were present, and published a new version  v1.1.

https://zenodo.org/records/14606905

Resolves #27 
