### PR TITLE
Fix version format

### DIFF
--- a/fme/__init__.py
+++ b/fme/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2025.07.0"
+__version__ = "2025.7.0"
 
 
 from . import ace


### PR DESCRIPTION
We didn't use leading zeros in with CalVer in previous releases, so stick with that.