### PR TITLE
Change default env behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ create_environment:
 	conda create -n $(ENVIRONMENT_NAME) python=3.11 $(CONDA_PACKAGES)
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) python -m pip install uv
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install -c constraints.txt -e .[dev,docs]
-	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install --no-build-isolation -c constraints.txt -e .[dev,docs,healpix]
+	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install --no-build-isolation -c constraints.txt -e .[dev,docs]
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install -r analysis-deps.txt
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ create_environment:
 	conda create -n $(ENVIRONMENT_NAME) python=3.11 $(CONDA_PACKAGES)
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) python -m pip install uv
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install -c constraints.txt -e .[dev,docs]
-	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install --no-build-isolation -c constraints.txt -e .[dev,docs]
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install -r analysis-deps.txt
 
 test:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,6 @@ ENV FORCE_CUDA_EXTENSION=1
 # install python deps
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt
-COPY requirements-healpix.txt /tmp/requirements-healpix.txt
-RUN python3 -m pip install --no-build-isolation -r /tmp/requirements-healpix.txt
 
 FROM base AS production
 

--- a/fme/core/test_coordinates.py
+++ b/fme/core/test_coordinates.py
@@ -8,6 +8,7 @@ from fme.core.coordinates import (
     HEALPixCoordinates,
     HybridSigmaPressureCoordinate,
     LatLonCoordinates,
+    e2ghpx,
 )
 from fme.core.mask_provider import MaskProvider
 
@@ -239,6 +240,7 @@ def test_healpix_ops_raises_value_error_with_mask():
         healpix_coords.get_gridded_operations(mask_provider=mask_provider)
 
 
+@pytest.mark.skipif(e2ghpx is None, reason="earth2grid healpix not available")
 @pytest.mark.parametrize("pad", [True, False])
 def test_healpix_coordinates_xyz(pad: bool, very_fast_only: bool):
     if very_fast_only:


### PR DESCRIPTION
Skip installing healpix since it may not work for all platforms. This is currently not a publicly supported option, so we should not install by default.