### PR TITLE
Remove HealPIX earth2grid optional dependency

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,17 +22,13 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: v1-${{ env.CURRENT_WEEK }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('docs/requirements.txt') }}-${{ hashFiles('requirements-healpix.txt') }}-${{ hashFiles('constraints.txt') }}
+          key: v1-${{ env.CURRENT_WEEK }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('docs/requirements.txt') }}-${{ hashFiles('constraints.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install uv
-          # can't use --system here because it doesn't work with --no-build-isolation and a healpix dependency
-          uv venv --python 3.11
-          uv pip install -c constraints.txt -e .[docs]
-          uv pip install --no-build-isolation -c constraints.txt -e .[docs,healpix]
+          uv pip install --system -c constraints.txt -e .[docs]
       - name: Build docs
         run: |
-          source .venv/bin/activate
           cd docs && make doctest html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,19 +22,15 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: v1-${{ env.CURRENT_WEEK }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('requirements-healpix.txt') }}-${{ hashFiles('constraints.txt') }}
+          key: v1-${{ env.CURRENT_WEEK }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('constraints.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install uv
-          # can't use --system here because it doesn't work with --no-build-isolation and a healpix dependency
-          uv venv --python 3.11
-          uv pip install -c constraints.txt -e .[dev]
-          uv pip install --no-build-isolation -c constraints.txt -e .[dev,healpix]
+          uv pip install --system -c constraints.txt -e .[dev]
       - name: Run pytest with code coverage
         run: |
-          source .venv/bin/activate
           make test_cov
-  cpu-very-fast-no-healpix:
+  cpu-very-fast:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = { file = "requirements.txt" }
 optional-dependencies.dev = { file = "requirements-dev.txt" }
 optional-dependencies.docs = { file = "docs/requirements.txt" }
 optional-dependencies.deploy = { file = "requirements-deploy.txt" }
-optional-dependencies.healpix = { file = "requirements-healpix.txt" }
 
 [tool.setuptools.packages]
 find = {}
@@ -40,7 +39,6 @@ cache-keys = [
     { file = "requirements.txt" },
     { file = "requirements-dev.txt" },
     { file = "docs/requirements.txt" },
-    { file = "requirements-healpix.txt" },
 ]
 
 [tool.ruff.lint]

--- a/requirements-healpix.txt
+++ b/requirements-healpix.txt
@@ -1,1 +1,0 @@
-earth2grid @ git+https://github.com/NVlabs/earth2grid.git@d2d077d573f42335687c8a61a811ceb215081206


### PR DESCRIPTION
The `earth2grid` optional dependency (of the `healpix` package extra of `fme`) is not supported for publishing to PyPI because it is a direct reference to a repo instead of a published package. This removes `earth2grid` and the `healpix` extra, allowing installation of `fme` from PyPI. This means that the HealPIX functionality will not be available, unless the user decides to install the extra dependency on their own.

I tested that I was able to publish to PyPI (https://pypi.org/project/fme/#history) and then install and import the package successfully. 
