### PR TITLE
Update version (2025.12.0) for switch to open development release

### DIFF
--- a/fme/__init__.py
+++ b/fme/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2025.7.0"
+__version__ = "2025.12.0"
 
 
 from . import ace, coupled


### PR DESCRIPTION
Bump version to mark release for history breaking change of our switch to open development and test use of actions and GKE hosted GPU runners.
