### PR TITLE
Remove `netcdf4` as a dependency

### DIFF
--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -78,7 +78,7 @@ def _save_netcdf(
         data_vars[f"ak_{i}"] = float(i)
         data_vars[f"bk_{i}"] = float(i + 1)
     ds = xr.Dataset(data_vars=data_vars, coords=coords)
-    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4_CLASSIC")
+    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4")
     return ds
 
 

--- a/fme/ace/data_loading/test_metadata.py
+++ b/fme/ace/data_loading/test_metadata.py
@@ -60,7 +60,7 @@ def _save_netcdf(
         data_vars[f"bk_{i}"] = float(i + 1)
 
     ds = xr.Dataset(data_vars=data_vars, coords=coords)
-    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4_CLASSIC")
+    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4")
 
 
 @pytest.mark.parametrize("n_ensemble_members", [1, 2])

--- a/fme/ace/inference/data_writer/monthly.py
+++ b/fme/ace/inference/data_writer/monthly.py
@@ -7,7 +7,7 @@ import cftime
 import numpy as np
 import torch
 import xarray as xr
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 
 from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
 from fme.ace.inference.data_writer.utils import (
@@ -269,7 +269,7 @@ class MonthlyDataWriter:
         month_min = np.min(months)
         month_range = np.max(months) - month_min + 1
 
-        old_size = self.dataset.variables[LEAD_TIME_DIM].size
+        old_size = self.dataset.variables[LEAD_TIME_DIM].shape[0]
         new_size = month_min + month_range
 
         self._extend_lead_time(old_size, new_size)
@@ -303,7 +303,7 @@ class MonthlyDataWriter:
 
             # Add the data to the variable totals
             # Have to extract the data and write it back as `.at` does not play nicely
-            # with netCDF4
+            # with h5netcdf
             # We pull just the month subset we need for speed reasons
             self._extend_variable(variable_name, old_size, new_size, initial_value=0.0)
             month_data = self.dataset.variables[variable_name][
@@ -320,7 +320,7 @@ class MonthlyDataWriter:
             ] = month_data
         # counts must be added after data, as we use the base counts when updating means
         for i_sample in range(n_samples_data):
-            self.dataset.variables[COUNTS][i_sample] += np.bincount(
+            self.dataset.variables[COUNTS][i_sample : i_sample + 1] += np.bincount(
                 months[i_sample], minlength=self.dataset.variables[COUNTS].shape[1]
             )
 

--- a/fme/ace/inference/data_writer/raw.py
+++ b/fme/ace/inference/data_writer/raw.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 import torch
 import xarray as xr
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 
 from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
 from fme.ace.inference.data_writer.utils import (
@@ -224,9 +224,6 @@ class RawDataWriter:
 
         if current_lead_time_size > 0:
             init_times_numeric: np.ndarray = self.dataset.variables[INIT_TIME][:]
-            init_times_numeric = (
-                init_times_numeric.filled()
-            )  # convert masked array to ndarray
             init_times: np.ndarray = cftime.num2date(
                 init_times_numeric,
                 units=self.dataset.variables[INIT_TIME].units,

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import torch
 import xarray as xr
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 from xarray.coding.times import CFDatetimeCoder
 
 from fme.ace.data_loading.batch_data import PairedData

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -66,7 +66,7 @@ class InitialConditionConfig:
     """
 
     path: str
-    engine: Literal["netcdf4", "h5netcdf", "zarr"] = "netcdf4"
+    engine: Literal["h5netcdf", "zarr"] = "h5netcdf"
     start_indices: StartIndices | None = None
 
     def get_dataset(self) -> xr.Dataset:
@@ -408,5 +408,5 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
             with GlobalTimer():
                 run_inference_from_config(config_copy)
         config_copy.initial_condition = InitialConditionConfig(
-            path=restart_path, engine="netcdf4"
+            path=restart_path, engine="h5netcdf"
         )

--- a/fme/ace/testing/fv3gfs_data.py
+++ b/fme/ace/testing/fv3gfs_data.py
@@ -92,7 +92,7 @@ def save_nd_netcdf(
         for name in variable_names:
             for i in range(dim_sizes.n_time):
                 ds[name].isel(time=i).values[:] = time_varying_values[i]
-    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4_CLASSIC")
+    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4")
     if return_ds:
         return ds
     return None
@@ -103,7 +103,7 @@ def save_scalar_netcdf(
     variable_names: list[str],
 ):
     ds = get_scalar_dataset(variable_names)
-    ds.to_netcdf(filename, format="NETCDF4_CLASSIC")
+    ds.to_netcdf(filename, format="NETCDF4")
 
 
 @dataclasses.dataclass
@@ -219,7 +219,7 @@ class MonthlyReferenceData:
             months_list.append(xr.DataArray(months, dims=["time"]))
         ds = xr.concat(member_datasets, dim="sample")
         ds.coords["valid_time"] = xr.concat(months_list, dim="sample")
-        ds.to_netcdf(self.data_filename, format="NETCDF4_CLASSIC")
+        ds.to_netcdf(self.data_filename, format="NETCDF4")
         self.start_time = cftime.DatetimeProlepticGregorian(2000, 1, 1)
 
     @property

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -192,7 +192,7 @@ def _get_data(
         filenames.append(filename)
 
     initial_condition_names = ()
-    start_indices = _get_cumulative_timesteps(_get_raw_times(filenames, "netcdf4"))
+    start_indices = _get_cumulative_timesteps(_get_raw_times(filenames, "h5netcdf"))
     if write_extra_vars:
         variable_names = VariableNames(
             time_dependent_names=(*var_names, "varying_scalar_var"),
@@ -289,7 +289,7 @@ def mock_monthly_zarr_ensemble_dim(
     )
 
 
-def load_files_without_dask(files, engine="netcdf4") -> xr.Dataset:
+def load_files_without_dask(files, engine="h5netcdf") -> xr.Dataset:
     """Load a sequence of files without dask, concatenating along the time dimension.
 
     We load the data from the files into memory to ensure Datasets are properly closed,
@@ -407,7 +407,7 @@ def xarray_dataset_constructor(
 @pytest.mark.parametrize(
     "mock_data_fixture, engine, file_pattern, labels",
     [
-        ("mock_monthly_netcdfs", "netcdf4", "*.nc", set()),
+        ("mock_monthly_netcdfs", "h5netcdf", "*.nc", set()),
         ("mock_monthly_zarr", "zarr", "*.zarr", {"foo_label"}),
     ],
 )
@@ -777,7 +777,7 @@ def test_dataset_config_dtype_raises():
 @pytest.mark.parametrize(
     "mock_data_fixture, engine, file_pattern",
     [
-        ("mock_monthly_netcdfs_with_nans", "netcdf4", "*.nc"),
+        ("mock_monthly_netcdfs_with_nans", "h5netcdf", "*.nc"),
         ("mock_monthly_zarr_with_nans", "zarr", "*.zarr"),
     ],
 )
@@ -1049,7 +1049,7 @@ def test_invalid_config_field_raises_error(kwargs):
 @pytest.mark.parametrize(
     "mock_data_fixture, engine, file_pattern",
     [
-        ("mock_monthly_netcdfs_ensemble_dim", "netcdf4", "*.nc"),
+        ("mock_monthly_netcdfs_ensemble_dim", "h5netcdf", "*.nc"),
         ("mock_monthly_zarr_ensemble_dim", "zarr", "*.zarr"),
     ],
 )
@@ -1074,7 +1074,7 @@ def test_dataset_with_nonspacetime_dim(
 @pytest.mark.parametrize(
     "mock_data_fixture, engine, file_pattern",
     [
-        ("mock_monthly_netcdfs_ensemble_dim", "netcdf4", "*.nc"),
+        ("mock_monthly_netcdfs_ensemble_dim", "h5netcdf", "*.nc"),
         ("mock_monthly_zarr_ensemble_dim", "zarr", "*.zarr"),
     ],
 )
@@ -1098,7 +1098,7 @@ def test_dataset_raise_error_on_dim_mismatch(
 @pytest.mark.parametrize(
     "mock_data_fixture, engine, file_pattern",
     [
-        ("mock_monthly_netcdfs_ensemble_dim", "netcdf4", "*.nc"),
+        ("mock_monthly_netcdfs_ensemble_dim", "h5netcdf", "*.nc"),
         ("mock_monthly_zarr_ensemble_dim", "zarr", "*.zarr"),
     ],
 )
@@ -1191,7 +1191,7 @@ def test_parallel__get_raw_times(tmpdir):
         ds.isel(time=time_slice).to_netcdf(path)
         paths.append(path)
 
-    result = np.concatenate(_get_raw_times(paths, engine="netcdf4"))
+    result = np.concatenate(_get_raw_times(paths, engine="h5netcdf"))
     np.testing.assert_equal(result, times)
 
 

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -448,7 +448,7 @@ class XarrayDataConfig(DatasetConfigABC):
     data_path: str
     file_pattern: str = "*.nc"
     n_repeats: int = 1
-    engine: Literal["netcdf4", "h5netcdf", "zarr"] = "netcdf4"
+    engine: Literal["h5netcdf", "zarr"] = "h5netcdf"
     spatial_dimensions: Literal["healpix", "latlon"] = "latlon"
     subset: Slice | TimeSlice | RepeatedInterval = dataclasses.field(
         default_factory=Slice

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -113,7 +113,7 @@ def _save_netcdf(
                     data_vars[name] = data_vars[name].where(mask == 1, float("nan"))
             data_vars[f"idepth_{i}"] = float(i)
     ds = xr.Dataset(data_vars=data_vars, coords=coords)
-    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4_CLASSIC")
+    ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4")
     return ds
 
 
@@ -451,14 +451,14 @@ def test_zarr_engine_used_true():
     config = CoupledDataLoaderConfig(
         dataset=[
             CoupledDatasetConfig(
-                ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+                ocean=XarrayDataConfig(data_path="ocean", engine="h5netcdf"),
                 atmosphere=XarrayDataConfig(
                     data_path="atmos", file_pattern="data.zarr", engine="zarr"
                 ),
             ),
             CoupledDatasetConfig(
-                ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
-                atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
+                ocean=XarrayDataConfig(data_path="ocean", engine="h5netcdf"),
+                atmosphere=XarrayDataConfig(data_path="atmos", engine="h5netcdf"),
             ),
         ],
         batch_size=1,
@@ -470,8 +470,8 @@ def test_zarr_engine_used_false():
     config = CoupledDataLoaderConfig(
         dataset=[
             CoupledDatasetConfig(
-                ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
-                atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
+                ocean=XarrayDataConfig(data_path="ocean", engine="h5netcdf"),
+                atmosphere=XarrayDataConfig(data_path="atmos", engine="h5netcdf"),
             )
         ],
         batch_size=1,
@@ -482,7 +482,7 @@ def test_zarr_engine_used_false():
 def test_zarr_engine_used_true_inference():
     config = InferenceDataLoaderConfig(
         dataset=CoupledDatasetWithOptionalOceanConfig(
-            ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+            ocean=XarrayDataConfig(data_path="ocean", engine="h5netcdf"),
             atmosphere=XarrayDataConfig(
                 data_path="atmos", file_pattern="data.zarr", engine="zarr"
             ),
@@ -495,8 +495,8 @@ def test_zarr_engine_used_true_inference():
 def test_zarr_engine_used_false_inference():
     config = InferenceDataLoaderConfig(
         dataset=CoupledDatasetWithOptionalOceanConfig(
-            ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
-            atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
+            ocean=XarrayDataConfig(data_path="ocean", engine="h5netcdf"),
+            atmosphere=XarrayDataConfig(data_path="atmos", engine="h5netcdf"),
         ),
         start_indices=ExplicitIndices([0]),
     )

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -52,7 +52,7 @@ class ComponentInitialConditionConfig:
     """
 
     path: str
-    engine: Literal["netcdf4", "h5netcdf", "zarr"] = "netcdf4"
+    engine: Literal["h5netcdf", "zarr"] = "h5netcdf"
 
     def get_dataset(self, start_indices: StartIndices | None = None) -> xr.Dataset:
         ic_config = InitialConditionConfig(

--- a/fme/downscaling/inference/test_output.py
+++ b/fme/downscaling/inference/test_output.py
@@ -21,7 +21,7 @@ from fme.downscaling.test_utils import data_paths_helper
 def test_single_xarray_config_accepts_single_config():
     """Test that _single_xarray_config accepts a single XarrayDataConfig."""
     xarray_config = XarrayDataConfig(
-        data_path="/path/to/data", file_pattern="*.nc", engine="netcdf4"
+        data_path="/path/to/data", file_pattern="*.nc", engine="h5netcdf"
     )
     result = DownscalingOutputConfig._single_xarray_config([xarray_config])
     assert result == [xarray_config]
@@ -30,10 +30,10 @@ def test_single_xarray_config_accepts_single_config():
 def test_single_xarray_config_rejects_multiple_configs():
     """Test that _single_xarray_config rejects multiple configs."""
     config1 = XarrayDataConfig(
-        data_path="/path1", file_pattern="*.nc", engine="netcdf4"
+        data_path="/path1", file_pattern="*.nc", engine="h5netcdf"
     )
     config2 = XarrayDataConfig(
-        data_path="/path2", file_pattern="*.nc", engine="netcdf4"
+        data_path="/path2", file_pattern="*.nc", engine="h5netcdf"
     )
 
     with pytest.raises(NotImplementedError, match="single XarrayDataConfig"):
@@ -84,7 +84,7 @@ def loader_config(tmp_path):
             XarrayDataConfig(
                 data_path=str(test_data_path.coarse),
                 file_pattern="*.nc",
-                engine="netcdf4",
+                engine="h5netcdf",
             )
         ],
         batch_size=2,

--- a/fme/downscaling/test_utils.py
+++ b/fme/downscaling/test_utils.py
@@ -49,7 +49,7 @@ def create_test_data_on_disk(
     ds = xr.Dataset(data_vars=data_vars, coords=coords)
     unlimited_dims = ["time"] if "time" in ds.dims else None
 
-    ds.to_netcdf(filename, unlimited_dims=unlimited_dims, format="NETCDF4_CLASSIC")
+    ds.to_netcdf(filename, unlimited_dims=unlimited_dims, format="NETCDF4")
     return filename
 
 

--- a/requirements-healpix.txt
+++ b/requirements-healpix.txt
@@ -1,1 +1,1 @@
-earth2grid @ git+https://github.com/NVlabs/earth2grid.git@d2d077d573f42335687c8a61a811ceb215081206
+earth2grid @ git+https://github.com/NVlabs/earth2grid.git@11dcf1b0787a7eb6a8497a3a5a5e1fdcc31232d3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cartopy>=0.22.0
+cftime
 dacite
 gcsfs
 h5netcdf
@@ -6,7 +7,6 @@ h5py
 imageio>=2.28.1
 matplotlib
 moviepy
-netcdf4
 numpy
 omegaconf>=2.1.0
 pandas


### PR DESCRIPTION
Without resorting to a more sophisticated package manager like `conda` or building packages from source, it is difficult to simultaneously install `netcdf4` and `h5py` (and by extension, `h5netcdf`) in a robust way.  For example, `pip`-installed binaries may not have been built with the same underlying `hdf5` library (https://github.com/h5py/h5py/issues/2453, https://github.com/Unidata/netcdf4-python/issues/1343, https://github.com/pydata/xarray/pull/10888#issuecomment-3543158028), leading to errors like those we see [here](https://github.com/ai2cm/ace/actions/runs/20718136741/job/59474373898).

With `h5netcdf` we can do all that we wanted with `netcdf4`, and more (e.g. write to bytes).  This PR demonstrates what changes are needed to drop `netcdf4` as a dependency.

Changes:
- Removes `netcdf4` as a dependency both for ACE and downscaling.
- Adds `cftime` as an explicit requirement, which previously would be installed as a requirement of `netcdf4`.
- Bumps up to latest version of `earth2grid` in `requirements-healpix.txt` (the current pinned version lists `netcdf4` as a required dependency).

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
