### PR TITLE
Bump version to 2026.1.0

### DIFF
--- a/fme/__init__.py
+++ b/fme/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2025.7.0"
+__version__ = "2026.1.0"
 
 
 from . import ace, coupled


### PR DESCRIPTION
Bump version to 2026.1.0 corresponding to start of public development.