### PR TITLE
Call optimizer autocast in stepper predict generator

### DIFF
--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1175,6 +1175,7 @@ class Stepper(
 
             def checkpoint(module):
                 return optimizer.checkpoint(module, step=step)
+
             with optimizer.autocast():
                 state = self.step(
                     StepArgs(


### PR DESCRIPTION
Our stepper currently has a bug where the optimizer autocast configuration is ignored. This only affects runs with automatic mixed precision enabled, which is disabled by default and we don't use in our runs presently.

Changes:
- Call optimizer autocast when training with ace Stepper

- [ ] Tests added

