### PR TITLE
Fix bug causing step sampler to be ignored

### DIFF
--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -30,6 +30,7 @@ from fme.ace.stepper.derived_forcings import DerivedForcingsConfig, ForcingDeriv
 from fme.ace.stepper.insolation.config import InsolationConfig, NameConfig, ValueConfig
 from fme.ace.stepper.single_module import (
     AtmosphereCorrectorConfig,
+    EpochNotProvidedError,
     Stepper,
     StepperConfig,
     StepperOverrideConfig,
@@ -39,6 +40,7 @@ from fme.ace.stepper.single_module import (
     load_stepper_config,
 )
 from fme.ace.stepper.time_length_probabilities import (
+    TimeLength,
     TimeLengthMilestone,
     TimeLengthProbabilities,
     TimeLengthProbability,
@@ -175,6 +177,41 @@ def test_stepper_no_train_step_specified():
     stepper = config.get_stepper(dataset_info)
     stepper._init_for_epoch(0)
     assert stepper._train_n_forward_steps_sampler is None
+
+
+def test_stepper_step_int():
+    normalization_config = NetworkAndLossNormalizationConfig(
+        network=NormalizationConfig(
+            means=get_scalar_data(["a", "b"], 0.0),
+            stds=get_scalar_data(["a", "b"], 2.0),
+        ),
+        loss=NormalizationConfig(
+            means=get_scalar_data(["a", "b"], 0.0),
+            stds=get_scalar_data(["a", "b"], 3.0),
+        ),
+    )
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": torch.nn.Identity()}
+                    ),
+                    in_names=["a", "b"],
+                    out_names=["a", "b"],
+                    normalization=normalization_config,
+                )
+            ),
+        ),
+        train_n_forward_steps=2,
+        loss=StepLossConfig(type="MSE"),
+    )
+    dataset_info = get_dataset_info()
+    stepper = config.get_stepper(dataset_info)
+    assert stepper._train_n_forward_steps_schedule is not None
+    stepper._init_for_epoch(0)
+    assert stepper._train_n_forward_steps_sampler is not None
 
 
 def test_stepper_step_probabilities():
@@ -701,6 +738,58 @@ def _setup_and_train_on_batch(
     dataset_info = get_dataset_info()
     stepper = config.get_stepper(dataset_info)
     return stepper.train_on_batch(data, optimization=optimization)
+
+
+@pytest.mark.parametrize("has_epoch", [True, False])
+@pytest.mark.parametrize("uses_scheduling", [True, False])
+def test_train_on_batch_requires_epoch(has_epoch: bool, uses_scheduling: bool):
+    in_names, out_names = ["a"], ["a"]
+    data = BatchData.new_for_testing(
+        names=["a"], n_samples=2, n_timesteps=3, epoch=0 if has_epoch else None
+    ).to_device()
+    module = ReturnZerosModule(len(in_names), len(out_names))
+
+    optimization_config = OptimizationConfig()
+    optimization = optimization_config.build(modules=[module], max_epochs=2)
+
+    if uses_scheduling:
+        train_n_forward_steps: TimeLengthSchedule | TimeLength = TimeLengthSchedule(
+            start_value=2,
+            milestones=[
+                TimeLengthMilestone(epoch=1, value=3),
+            ],
+        )
+    else:
+        train_n_forward_steps = 2
+
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(type="prebuilt", config={"module": module}),
+                    in_names=in_names,
+                    out_names=out_names,
+                    normalization=NetworkAndLossNormalizationConfig(
+                        network=NormalizationConfig(
+                            means=get_scalar_data(set(in_names + out_names), 0.0),
+                            stds=get_scalar_data(set(in_names + out_names), 1.0),
+                        ),
+                    ),
+                )
+            ),
+        ),
+        train_n_forward_steps=train_n_forward_steps,
+        loss=StepLossConfig(type="MSE"),
+    )
+
+    dataset_info = get_dataset_info()
+    stepper = config.get_stepper(dataset_info)
+    if uses_scheduling and not has_epoch:
+        with pytest.raises(EpochNotProvidedError):
+            stepper.train_on_batch(data, optimization=optimization)
+    else:
+        stepper.train_on_batch(data, optimization=optimization)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A bug in our code was causing `train_n_forward_steps` on the StepperConfig to be ignored. This PR fixes that bug.

Changes:
- Fixed a bug causing StepperConfig.train_n_forward_steps to be ignored

- [x] Tests added

