### PR TITLE
Use spawn start method for multiprocessing with CUDA

### DIFF
--- a/fme/core/distributed/distributed.py
+++ b/fme/core/distributed/distributed.py
@@ -31,13 +31,13 @@ class Distributed:
 
     def __init__(self, force_non_distributed: bool = False):
         if TorchDistributed.is_available() and not force_non_distributed:
-            self._distributed: DistributedBackend = TorchDistributed()
             if get_device().type == "cuda":
                 logger.info(
                     "Setting torch multiprocessing start method to 'spawn' "
                     "for compatibility of CUDA with multiprocessing."
                 )
                 mp.set_start_method("spawn", force=True)
+            self._distributed: DistributedBackend = TorchDistributed()
         else:
             self._distributed = NonDistributed()
         self._seed = 0


### PR DESCRIPTION
This PR sets the torch multiprocessing start method to "spawn" if CUDA is enabled.

- [ ] Tests added

Fixes error encountered in [this run](https://beaker.org/orgs/ai2/workspaces/climate-titan/work/01KESW8EMMZWWCJ5DNAF1GDQBB/logs?jobId=01KESW8F0DHDC3NJKFENMQ5TDR).
