### PR TITLE
Use exec gantry run in GH action

### DIFF
--- a/.github/workflows/beaker.yaml
+++ b/.github/workflows/beaker.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: ACE evaluator beaker job
         run: |
-          gantry run \
+          exec gantry run \
             --show-logs \
             --name ${{ env.JOB_NAME }} \
             --task-name ${{ env.JOB_NAME }} \


### PR DESCRIPTION
@epwalsh recommended this so that the beaker workload gets cancelled if the GH action job is canceled.