### PR TITLE
Fix: downscaling sampler dtype on MPS

### DIFF
--- a/fme/downscaling/samplers.py
+++ b/fme/downscaling/samplers.py
@@ -104,8 +104,10 @@ def stochastic_sampler(
             f"{img_lr.shape[0]} vs {latents.shape[0]}."
         )
 
+    compute_dtype = torch.float32 if latents.device.type == "mps" else torch.float64
+
     # Time step discretization.
-    step_indices = torch.arange(num_steps, dtype=torch.float64, device=latents.device)
+    step_indices = torch.arange(num_steps, dtype=compute_dtype, device=latents.device)
     t_steps = (
         sigma_max ** (1 / rho)
         + step_indices
@@ -119,7 +121,7 @@ def stochastic_sampler(
     x_lr = img_lr
 
     # Main sampling loop.
-    x_next = latents.to(torch.float64) * t_steps[0]
+    x_next = latents.to(compute_dtype) * t_steps[0]
     latent_steps = [x_next.to(latents.dtype)]
     for i, (t_cur, t_next) in enumerate(zip(t_steps[:-1], t_steps[1:])):  # 0, ..., N-1
         x_cur = x_next
@@ -141,7 +143,7 @@ def stochastic_sampler(
             x_hat_batch,
             x_lr,
             t_hat,
-        ).to(torch.float64)
+        ).to(compute_dtype)
 
         d_cur = (x_hat - denoised) / t_hat
         x_next = x_hat + (t_next - t_hat) * d_cur
@@ -155,7 +157,7 @@ def stochastic_sampler(
                 x_next_batch,
                 x_lr,
                 t_next,
-            ).to(torch.float64)
+            ).to(compute_dtype)
             d_prime = (x_next - denoised) / t_next
             x_next = x_hat + (t_next - t_hat) * (0.5 * d_cur + 0.5 * d_prime)
         latent_steps.append(x_next.to(latents.dtype))


### PR DESCRIPTION
The updated vendorized sampler code ([Vendorize Apache 2.0 Nvidia Downscaling Code](https://github.com/ai2cm/ace/pull/748/changes#top)) casts to float64, which is not allowed when running on MPS and thus breaks a lot of tests when running locally on macs. This PR updates the cast to use float32 on MPS.