### PR TITLE
Remove dependency on deprecated pkg_resources

### DIFF
--- a/fme/core/cuhpx/tools.py
+++ b/fme/core/cuhpx/tools.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import os
+from importlib.resources import files
 
 import numpy as np
-import pkg_resources
 import torch
 
 DATAPATH = None
@@ -27,7 +27,7 @@ def get_datapath():
     if DATAPATH is None:
         # Using pkg_resources to ensure the path is correctly resolved
         # for installed packages
-        DATAPATH = pkg_resources.resource_filename("fme", "core/cuhpx/data")
+        DATAPATH = str(files("fme").joinpath("core/cuhpx/data"))
     return DATAPATH
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ omegaconf>=2.1.0
 pandas
 plotly
 s3fs
-setuptools
 tensorly
 tensorly-torch
 torch-harmonics==0.8.0  # pinned since we use private API


### PR DESCRIPTION
Our tests are currently failing due to a use of the deprecated `pkg_resources` from `setuptools`. This PR updates our code to use importlib instead.

```
>>> import pkg_resources
<stdin>:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```