### PR TITLE
Gracefully shutdown when loss is NaN

### DIFF
--- a/fme/core/optimization.py
+++ b/fme/core/optimization.py
@@ -10,7 +10,6 @@ import torch
 from torch import nn
 
 from fme.core.device import get_device
-from fme.core.distributed import Distributed
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.scheduler import SchedulerConfig, SequentialSchedulerConfig
 from fme.core.typing_ import TensorDict, TensorMapping
@@ -217,9 +216,6 @@ class Optimization(OptimizationABC):
     def _validate_loss(self, loss: torch.Tensor):
         with torch.no_grad():
             if torch.isnan(loss):
-                dist = Distributed.get_instance()
-                if dist.is_distributed():
-                    dist.shutdown()
                 raise ValueError("Loss is NaN-valued during training.")
 
 


### PR DESCRIPTION
We raise an exception when the loss is NaN, where this check is done locally on each rank (see `_validate_loss` in `fme/core/optimization.py`). However, there is a chance that there is only an NaN loss on a subset of the ranks. When this error is not raised on all the ranks the other ranks call torch.backward, which is a collective all reduce and instead the other GPUs hang until a NCCL timeout error occurs. 

Changes:
- add dist shutdown to `_validate_loss` in `fme/core/optimization.py` if the training is distributed

- [ ] Tests added

Resolves #849

