### PR TITLE
Wrap ace evaluator in distributed context

### DIFF
--- a/fme/ace/evaluator.py
+++ b/fme/ace/evaluator.py
@@ -1,7 +1,9 @@
 from fme.ace.inference.evaluator import main
 from fme.core.cli import get_parser
+from fme.core.distributed import Distributed
 
 if __name__ == "__main__":
     parser = get_parser()
     args = parser.parse_args()
-    main(args.yaml_config, override_dotlist=args.override)
+    with Distributed.context():
+        main(args.yaml_config, override_dotlist=args.override)


### PR DESCRIPTION
Changes:
- Resolved exception when calling ace evaluator entrypoint due to not having a Distributed.context call

- [ ] Tests added

