### PR TITLE
Pass static inputs to event gridded data build

### DIFF
--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -239,7 +239,9 @@ class EvaluatorConfig:
         evaluator_model: DiffusionModel | PatchPredictor
 
         dataset = event_config.get_paired_gridded_data(
-            base_data_config=self.data, requirements=self.model.data_requirements
+            base_data_config=self.data,
+            requirements=self.model.data_requirements,
+            static_inputs_from_checkpoint=model.static_inputs,
         )
 
         if (dataset.coarse_shape[0] > model.coarse_shape[0]) or (


### PR DESCRIPTION
Fixes a bug where the static inputs from the model were not passed to the data builder in the  event evaluator.