### PR TITLE
Make test_xarray_loader parallelism-aware

### DIFF
--- a/fme/ace/data_loading/gridded_data.py
+++ b/fme/ace/data_loading/gridded_data.py
@@ -182,7 +182,6 @@ class InferenceGriddedData(InferenceDataABC[PrognosticState, BatchData]):
             )
         else:
             self._initial_condition = initial_condition.to_device()
-        self._initial_time: xr.DataArray | None = None
 
     @property
     def loader(self) -> DataLoader[BatchData]:
@@ -243,13 +242,7 @@ class InferenceGriddedData(InferenceDataABC[PrognosticState, BatchData]):
 
     @property
     def initial_time(self) -> xr.DataArray:
-        if self._initial_time is None:
-            for batch in self.loader:
-                self._initial_time = batch.time.isel(time=0)
-                break
-            else:
-                raise ValueError("No data found in loader")
-        return self._initial_time
+        return self.initial_condition.as_batch_data().time.isel(time=0)
 
 
 class PSType:

--- a/fme/ace/inference/data_writer/file_writer.py
+++ b/fme/ace/inference/data_writer/file_writer.py
@@ -5,7 +5,9 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import TypeAlias, TypeGuard, Union
 
+import cftime
 import numpy as np
+import numpy.typing as npt
 import torch
 import xarray as xr
 
@@ -270,7 +272,7 @@ class FileWriterConfig:
     def build_paired(
         self,
         experiment_dir: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps: int,
         timestep: datetime.timedelta,
         variable_metadata: Mapping[str, VariableMetadata],
@@ -284,7 +286,7 @@ class FileWriterConfig:
             prediction_label = f"{self.label}_{prediction_suffix}"
             reference_writer = dataclasses.replace(self, label=reference_label).build(
                 experiment_dir=experiment_dir,
-                n_initial_conditions=n_initial_conditions,
+                initial_condition_times=initial_condition_times,
                 n_timesteps=n_timesteps,
                 timestep=timestep,
                 variable_metadata=variable_metadata,
@@ -296,7 +298,7 @@ class FileWriterConfig:
             reference_writer = None
         prediction_writer = dataclasses.replace(self, label=prediction_label).build(
             experiment_dir=experiment_dir,
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             timestep=timestep,
             variable_metadata=variable_metadata,
@@ -310,7 +312,7 @@ class FileWriterConfig:
     def build(
         self,
         experiment_dir: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps: int,
         timestep: datetime.timedelta,
         variable_metadata: Mapping[str, VariableMetadata],
@@ -322,7 +324,8 @@ class FileWriterConfig:
 
         Args:
             experiment_dir: The directory where experiment outputs are saved.
-            n_initial_conditions: The number of initial conditions or ensemble members.
+            initial_condition_times: 1D array of initial condition times
+                (start time for each inference run).
             n_timesteps: Total number of inference forward steps.
             timestep: The time delta between each timestep.
             variable_metadata: Metadata for each variable.
@@ -334,6 +337,8 @@ class FileWriterConfig:
             spatial_dims = DIM_INFO_HEALPIX
         else:
             spatial_dims = DIM_INFO_LATLON
+
+        n_initial_conditions = len(initial_condition_times)
 
         if (self.lat_extent and LAT_NAME not in coords) or (
             self.lon_extent and LON_NAME not in coords
@@ -372,8 +377,10 @@ class FileWriterConfig:
         if isinstance(self.format, ZarrWriterConfig):
             if isinstance(self.time_coarsen, TimeCoarsenConfig):
                 n_timesteps_write = n_timesteps // self.time_coarsen.coarsen_factor
+                timestep_write = self.time_coarsen.coarsen_factor * timestep
             else:
                 n_timesteps_write = n_timesteps
+                timestep_write = timestep
 
             zarr_writer_cls: type[SeparateICZarrWriterAdapter | ZarrWriterAdapter]
 
@@ -387,8 +394,9 @@ class FileWriterConfig:
                 path=os.path.join(experiment_dir, f"{self.label}.zarr"),
                 dims=dims,
                 data_coords=ensure_numpy_coords(subselect_coords_),
+                timestep=timestep_write,
                 n_timesteps=n_timesteps_write,
-                n_initial_conditions=n_initial_conditions,
+                initial_condition_times=initial_condition_times,
                 data_vars=self.names,
                 variable_metadata=variable_metadata,
                 dataset_metadata=dataset_metadata,
@@ -415,7 +423,7 @@ class FileWriterConfig:
                 raw_writer = RawDataWriter(
                     path=experiment_dir,
                     label=self.label,
-                    n_initial_conditions=n_initial_conditions,
+                    initial_condition_times=initial_condition_times,
                     save_names=self.names,
                     variable_metadata=variable_metadata,
                     coords=subselect_coords_,

--- a/fme/ace/inference/data_writer/main.py
+++ b/fme/ace/inference/data_writer/main.py
@@ -5,7 +5,9 @@ import warnings
 from collections.abc import Mapping, Sequence
 from typing import TypeAlias
 
+import cftime
 import numpy as np
+import numpy.typing as npt
 import torch
 import xarray as xr
 
@@ -76,7 +78,7 @@ class DataWriterConfig:
     def build_paired(
         self,
         experiment_dir: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps: int,
         timestep: datetime.timedelta,
         variable_metadata: Mapping[str, VariableMetadata],
@@ -85,7 +87,7 @@ class DataWriterConfig:
     ) -> "PairedDataWriter":
         return PairedDataWriter(
             path=experiment_dir,
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             timestep=timestep,
             variable_metadata=variable_metadata,
@@ -101,7 +103,7 @@ class DataWriterConfig:
     def build(
         self,
         experiment_dir: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps: int,
         timestep: datetime.timedelta,
         variable_metadata: Mapping[str, VariableMetadata],
@@ -110,7 +112,7 @@ class DataWriterConfig:
     ) -> "DataWriter":
         return DataWriter(
             path=experiment_dir,
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             variable_metadata=variable_metadata,
             coords=coords,
@@ -128,7 +130,7 @@ class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
     def __init__(
         self,
         path: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps: int,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
@@ -143,7 +145,8 @@ class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
         """
         Args:
             path: Path to write netCDF file(s).
-            n_initial_conditions: Number of ICs/ensemble members to write to the file.
+            initial_condition_times: 1D array of initial condition times
+                (start time for each inference run).
             n_timesteps: Number of timesteps to write to the file.
             variable_metadata: Metadata for each variable to be written to the file.
             coords: Coordinate data to be written to the file.
@@ -170,12 +173,14 @@ class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
                 return time_coarsen.build_paired(data_writer)
             return data_writer
 
+        n_samples = len(initial_condition_times)
+
         if enable_prediction_netcdfs:
             self._writers.append(
                 _time_coarsen_builder(
                     PairedRawDataWriter(
                         path=path,
-                        n_initial_conditions=n_initial_conditions,
+                        initial_condition_times=initial_condition_times,
                         save_names=save_names,
                         variable_metadata=variable_metadata,
                         coords=coords,
@@ -187,7 +192,7 @@ class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
             self._writers.append(
                 PairedMonthlyDataWriter(
                     path=path,
-                    n_samples=n_initial_conditions,
+                    n_samples=n_samples,
                     n_timesteps=n_timesteps,
                     timestep=timestep,
                     save_names=save_names,
@@ -201,7 +206,7 @@ class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
                 self._writers.append(
                     writer_config.build_paired(
                         experiment_dir=path,
-                        n_initial_conditions=n_initial_conditions,
+                        initial_condition_times=initial_condition_times,
                         n_timesteps=n_timesteps,
                         timestep=timestep,
                         variable_metadata=variable_metadata,
@@ -311,7 +316,7 @@ class DataWriter(WriterABC[PrognosticState, PairedData]):
     def __init__(
         self,
         path: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps: int,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
@@ -326,8 +331,8 @@ class DataWriter(WriterABC[PrognosticState, PairedData]):
         """
         Args:
             path: Directory within which to write netCDF file(s).
-            n_initial_conditions: Number of initial conditions / timeseries
-                to write to the file.
+            initial_condition_times: 1D array of initial condition times
+                (start time for each inference run).
             n_timesteps: Number of timesteps to write to the file.
             variable_metadata: Metadata for each variable to be written to the file.
             coords: Coordinate data to be written to the file.
@@ -352,13 +357,15 @@ class DataWriter(WriterABC[PrognosticState, PairedData]):
                 return time_coarsen.build(data_writer)
             return data_writer
 
+        n_initial_conditions = len(initial_condition_times)
+
         if enable_prediction_netcdfs:
             self._writers.append(
                 _time_coarsen_builder(
                     RawDataWriter(
                         path=path,
                         label="autoregressive_predictions",
-                        n_initial_conditions=n_initial_conditions,
+                        initial_condition_times=initial_condition_times,
                         save_names=save_names,
                         variable_metadata=variable_metadata,
                         coords=coords,
@@ -385,7 +392,7 @@ class DataWriter(WriterABC[PrognosticState, PairedData]):
                 self._writers.append(
                     writer_config.build(
                         experiment_dir=path,
-                        n_initial_conditions=n_initial_conditions,
+                        initial_condition_times=initial_condition_times,
                         n_timesteps=n_timesteps,
                         timestep=timestep,
                         variable_metadata=variable_metadata,

--- a/fme/ace/inference/data_writer/raw.py
+++ b/fme/ace/inference/data_writer/raw.py
@@ -20,12 +20,11 @@ from fme.ace.inference.data_writer.utils import (
 )
 from fme.core.cloud import is_local
 from fme.core.dataset.data_typing import VariableMetadata
+from fme.core.writer import DATETIME_ENCODING_UNITS, TIMEDELTA_ENCODING_UNITS
 
 LEAD_TIME_DIM = "time"
-LEAD_TIME_UNITS = "microseconds"
 IC_DIM = "sample"
 INIT_TIME = "init_time"
-INIT_TIME_UNITS = "microseconds since 1970-01-01 00:00:00"
 VALID_TIME = "valid_time"
 
 
@@ -45,7 +44,7 @@ class PairedRawDataWriter:
     def __init__(
         self,
         path: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         save_names: Sequence[str] | None,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
@@ -54,7 +53,7 @@ class PairedRawDataWriter:
         self._target_writer = RawDataWriter(
             path=path,
             label="autoregressive_target",
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             save_names=save_names,
             variable_metadata=variable_metadata,
             coords=coords,
@@ -63,7 +62,7 @@ class PairedRawDataWriter:
         self._prediction_writer = RawDataWriter(
             path=path,
             label="autoregressive_predictions",
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             save_names=save_names,
             variable_metadata=variable_metadata,
             coords=coords,
@@ -103,7 +102,7 @@ class RawDataWriter:
         self,
         path: str,
         label: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         save_names: Sequence[str] | None,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
@@ -113,8 +112,8 @@ class RawDataWriter:
         Args:
             path: Directory within which to write the file.
             label: Name of the file to write.
-            n_initial_conditions: Number of initial conditions / timeseries
-                to write to the file.
+            initial_condition_times: 1D array of initial condition times
+                (start time for each inference run).
             save_names: Names of variables to save in the output file.
                 If None, all provided variables will be saved.
             variable_metadata: Metadata for each variable to be written to the file.
@@ -128,18 +127,28 @@ class RawDataWriter:
                 "non-local filesystem."
             )
         filename = str(Path(path) / f"{label}.nc")
+        calendar = _infer_calendar(initial_condition_times)
+        n_initial_conditions = len(initial_condition_times)
         self._save_names = save_names
+        self.initial_condition_times = initial_condition_times
         self.variable_metadata = variable_metadata
         self.coords = coords
         self.dataset = Dataset(filename, "w", format="NETCDF4")
         self.dataset.createDimension(LEAD_TIME_DIM, None)  # unlimited dimension
         self.dataset.createVariable(LEAD_TIME_DIM, "i8", (LEAD_TIME_DIM,))
-        self.dataset.variables[LEAD_TIME_DIM].units = LEAD_TIME_UNITS
+        self.dataset.variables[LEAD_TIME_DIM].units = TIMEDELTA_ENCODING_UNITS
         self.dataset.createDimension(IC_DIM, n_initial_conditions)
         self.dataset.createVariable(INIT_TIME, "i8", (IC_DIM,))
-        self.dataset.variables[INIT_TIME].units = INIT_TIME_UNITS
+        self.dataset.variables[INIT_TIME].units = DATETIME_ENCODING_UNITS
+        self.dataset.variables[INIT_TIME].calendar = calendar
+        self.dataset.variables[INIT_TIME][:] = cftime.date2num(
+            self.initial_condition_times,
+            units=self.dataset.variables[INIT_TIME].units,
+            calendar=self.dataset.variables[INIT_TIME].calendar,
+        )
         self.dataset.createVariable(VALID_TIME, "i8", (IC_DIM, LEAD_TIME_DIM))
-        self.dataset.variables[VALID_TIME].units = INIT_TIME_UNITS
+        self.dataset.variables[VALID_TIME].units = DATETIME_ENCODING_UNITS
+        self.dataset.variables[VALID_TIME].calendar = calendar
         self._dataset_dims_created = False
         dataset_metadata = copy.copy(dataset_metadata)
         dataset_metadata.title = f"ACE {label.replace('_', ' ')} data file"
@@ -223,32 +232,8 @@ class RawDataWriter:
                 :,
             ] = data_numpy
 
-        # handle time dimensions
-        if not hasattr(self.dataset.variables[INIT_TIME], "calendar"):
-            self.dataset.variables[INIT_TIME].calendar = batch_time.dt.calendar
-        if not hasattr(self.dataset.variables[VALID_TIME], "calendar"):
-            self.dataset.variables[VALID_TIME].calendar = batch_time.dt.calendar
-
-        if current_lead_time_size > 0:
-            init_times_numeric: np.ndarray = self.dataset.variables[INIT_TIME][:]
-            init_times_numeric = (
-                init_times_numeric.filled()
-            )  # convert masked array to ndarray
-            init_times: np.ndarray = cftime.num2date(
-                init_times_numeric,
-                units=self.dataset.variables[INIT_TIME].units,
-                calendar=self.dataset.variables[INIT_TIME].calendar,
-            )
-        else:
-            init_times = batch_time.isel(time=0).values
-            init_times_numeric = cftime.date2num(
-                init_times,
-                units=self.dataset.variables[INIT_TIME].units,
-                calendar=self.dataset.variables[INIT_TIME].calendar,
-            )
-            self.dataset.variables[INIT_TIME][:] = init_times_numeric
         lead_time_microseconds = get_batch_lead_time_microseconds(
-            init_times,
+            self.initial_condition_times,
             batch_time.values,
         )
         self.dataset.variables[LEAD_TIME_DIM][
@@ -314,3 +299,18 @@ def get_batch_lead_time_microseconds(
     if not np.all(lead_time_microseconds == lead_time_microseconds[0, :]):
         raise ValueError("Lead times are not the same for each sample in the batch.")
     return lead_time_microseconds[0, :]
+
+
+def _infer_calendar(array: npt.NDArray[cftime.datetime]) -> str:
+    """Infer the calendar of an array of cftime.datetime objects.
+
+    Assumes that all the datetime objects in the array have the same calendar,
+    and that the array is not empty.
+
+    Args:
+        array: Array of cftime.datetime objects.
+
+    Returns:
+        Calendar of the array.
+    """
+    return array.ravel()[0].calendar

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -3,6 +3,7 @@ from typing import NamedTuple
 
 import cftime
 import numpy as np
+import numpy.typing as npt
 import pytest
 import torch
 import xarray as xr
@@ -33,6 +34,36 @@ CALENDAR_CFTIME = {
 SECONDS_PER_HOUR = 3600
 MICROSECONDS_PER_SECOND = 1_000_000
 TIMESTEP = datetime.timedelta(hours=6)
+
+
+def get_initial_condition_times(
+    batch_start_time: tuple[int, int, int, int, int, int],
+    calendar: str,
+    n_initial_conditions: int,
+    separation_timedelta: datetime.timedelta = datetime.timedelta(hours=0),
+    model_timestep: datetime.timedelta = TIMESTEP,
+) -> npt.NDArray[cftime.datetime]:
+    """Generate an array of initial condition times.
+
+    Args:
+        batch_start_time: The start time of the first batch as a tuple of
+            year, month, day, hour, minute, second. The calendar is specified by
+            the calendar parameter. The first initial condition time will be the
+            batch_start_time minus the model timestep.
+        calendar: The calendar to use.
+        n_initial_conditions: The number of initial condition times to generate.
+        separation_timedelta: The time between initial condition times.
+        model_timestep: The timestep of the model.
+
+    Returns:
+        An array of initial condition times.
+    """
+    base_datetime = CALENDAR_CFTIME[calendar](*batch_start_time)
+    initial_condition_times = []
+    for i in range(n_initial_conditions):
+        time = base_datetime + separation_timedelta * i - model_timestep
+        initial_condition_times.append(time)
+    return np.array(initial_condition_times)
 
 
 def test_data_writer_config_save_names():
@@ -172,10 +203,14 @@ class TestDataWriter:
         coords,
     ):
         n_initial_conditions = 2
+        start_time = (2020, 1, 1, 0, 0, 0)
+        initial_condition_times = get_initial_condition_times(
+            start_time, calendar, n_initial_conditions
+        )
         n_timesteps = 6
         writer = PairedDataWriter(
             str(tmp_path),
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             timestep=TIMESTEP,
             variable_metadata=sample_metadata,
@@ -185,7 +220,6 @@ class TestDataWriter:
             save_names=None,
             dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
         )
-        start_time = (2020, 1, 1, 0, 0, 0)
         end_time = (2020, 1, 1, 12, 0, 0)
         batch_time = self.get_batch_time(
             start_time=start_time,
@@ -222,7 +256,7 @@ class TestDataWriter:
         # Open the file and check the data
         dataset = Dataset(tmp_path / "autoregressive_predictions.nc", "r")
         assert dataset["time"].units == "microseconds"
-        assert dataset["init_time"].units == "microseconds since 1970-01-01 00:00:00"
+        assert dataset["init_time"].units == "microseconds since 1970-01-01"
         assert dataset["init_time"].calendar == calendar
         assert "source.inference_version" in dataset.ncattrs()
         assert dataset.getncattr("source.inference_version") == "1.0"
@@ -268,23 +302,20 @@ class TestDataWriter:
             expected_lead_times = xr.DataArray(
                 [
                     MICROSECONDS_PER_SECOND * SECONDS_PER_HOUR * i
-                    for i in np.arange(0, 31, 6)
+                    for i in np.arange(6, 37, 6)
                 ],
                 dims="time",
             ).assign_coords(
                 {
                     "time": [
                         MICROSECONDS_PER_SECOND * SECONDS_PER_HOUR * i
-                        for i in np.arange(0, 31, 6)
+                        for i in np.arange(6, 37, 6)
                     ]
                 }
             )
             xr.testing.assert_equal(ds["time"], expected_lead_times)
             expected_init_times = xr.DataArray(
-                [
-                    CALENDAR_CFTIME[calendar](*start_time)
-                    for _ in range(n_initial_conditions)
-                ],
+                initial_condition_times,
                 dims=["sample"],
             )
             expected_init_times = expected_init_times.assign_coords(
@@ -329,9 +360,14 @@ class TestDataWriter:
         save_names,
     ):
         n_samples = 2
+        calendar = "julian"
+        start_time = (2020, 1, 1, 0, 0, 0)
+        initial_condition_times = get_initial_condition_times(
+            start_time, calendar, n_samples
+        )
         writer = PairedDataWriter(
             str(tmp_path),
-            n_initial_conditions=n_samples,
+            initial_condition_times=initial_condition_times,
             n_timesteps=4,  # unused
             timestep=TIMESTEP,
             variable_metadata=sample_metadata,
@@ -397,9 +433,14 @@ class TestDataWriter:
         self, sample_metadata, sample_target_data, sample_prediction_data, tmp_path
     ):
         n_samples = 2
+        calendar = "julian"
+        start_time = (2020, 1, 1, 0, 0, 0)
+        initial_condition_times = get_initial_condition_times(
+            start_time, calendar, n_samples
+        )
         writer = PairedDataWriter(
             str(tmp_path),
-            n_initial_conditions=n_samples,
+            initial_condition_times=initial_condition_times,
             n_timesteps=3,
             timestep=TIMESTEP,
             variable_metadata=sample_metadata,
@@ -409,7 +450,6 @@ class TestDataWriter:
             save_names=None,
             dataset_metadata=DatasetMetadata(),
         )
-        start_time = (2020, 1, 1, 0, 0, 0)
         end_time = (2020, 1, 1, 12, 0, 0)
         batch_time = self.get_batch_time(
             start_time=start_time,
@@ -428,6 +468,10 @@ class TestDataWriter:
 
     def test_prediction_only_append_batch(self, sample_metadata, tmp_path, calendar):
         n_samples = 2
+        start_time = (2020, 1, 1, 0, 0, 0)
+        initial_condition_times = get_initial_condition_times(
+            start_time, calendar, n_samples
+        )
         n_timesteps = 8
         coarsen_factor = 2
         device = get_device()
@@ -455,7 +499,7 @@ class TestDataWriter:
 
         writer = DataWriter(
             str(tmp_path),
-            n_initial_conditions=n_samples,
+            initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             variable_metadata=sample_metadata,
             coords={"lat": np.arange(4), "lon": np.arange(5)},
@@ -467,7 +511,6 @@ class TestDataWriter:
             files=[region_config],
             dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
         )
-        start_time = (2020, 1, 1, 0, 0, 0)
         end_time = (2020, 1, 1, 18, 0, 0)
         batch_time = self.get_batch_time(
             start_time=start_time,
@@ -554,9 +597,13 @@ class TestDataWriter:
         tmp_path,
     ):
         n_samples = 2
+        calendar = "julian"
+        start_time = (2020, 1, 1, 0, 0, 0)
+        initial_condition_times = get_initial_condition_times(
+            start_time, calendar, n_samples, separation_timedelta=TIMESTEP
+        )
         n_timesteps = 8
         coarsen_factor = 2
-        calendar = "julian"
         n_lat, n_lon = 4, 5
 
         device = get_device()
@@ -582,7 +629,7 @@ class TestDataWriter:
         )
         writer = DataWriter(
             str(tmp_path),
-            n_initial_conditions=n_samples,
+            initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             variable_metadata=sample_metadata,
             coords={"lat": np.arange(n_lat), "lon": np.arange(n_lon)},
@@ -594,7 +641,6 @@ class TestDataWriter:
             files=[region_config],
             dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
         )
-        start_time = (2020, 1, 1, 0, 0, 0)
         end_time = (2020, 1, 1, 18, 0, 0)
         batch_time = self.get_batch_time(
             start_time=start_time,

--- a/fme/ace/inference/data_writer/test_file_writer.py
+++ b/fme/ace/inference/data_writer/test_file_writer.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import cftime
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 import xarray as xr
@@ -40,7 +41,7 @@ def test_file_writer_config_build():
         mock_writer.return_value = MagicMock()
         writer = config.build(
             experiment_dir="test_experiment",
-            n_initial_conditions=1,
+            initial_condition_times=np.array([cftime.DatetimeGregorian(2020, 1, 1)]),
             n_timesteps=10,
             variable_metadata={},
             timestep=datetime.timedelta(days=1),
@@ -84,7 +85,7 @@ def test_file_writer_config_build_missing_coords():
     with pytest.raises(ValueError):
         config.build(
             experiment_dir="test_experiment",
-            n_initial_conditions=1,
+            initial_condition_times=np.array([cftime.DatetimeGregorian(2020, 1, 1)]),
             n_timesteps=10,
             timestep=datetime.timedelta(days=1),
             variable_metadata={},
@@ -207,14 +208,15 @@ def test__select_time_file_writer_single_sample(
         names=["temperature"],
         n_samples=n_samples,
         n_timesteps=n_timesteps,
-        t_initial=cftime.datetime(2020, 1, 1),
+        t_initial=cftime.DatetimeGregorian(2020, 1, 1),
         freq=freq,
     )
     second_batch_data = BatchData.new_for_testing(
         names=["temperature"],
         n_samples=n_samples,
         n_timesteps=n_timesteps,
-        t_initial=cftime.datetime(2020, 1, 1) + datetime.timedelta(days=n_timesteps),
+        t_initial=cftime.DatetimeGregorian(2020, 1, 1)
+        + datetime.timedelta(days=n_timesteps),
         freq=freq,
     )
     all_time = xr.concat([batch_data.time, second_batch_data.time], dim="time")
@@ -229,7 +231,7 @@ def test__select_time_file_writer_single_sample(
     )
     file_writer = file_writer_config.build(
         experiment_dir=str(tmpdir),
-        n_initial_conditions=n_samples,
+        initial_condition_times=np.array([cftime.DatetimeGregorian(2019, 12, 31)]),
         n_timesteps=-1,  # unused for netcdf
         timestep=datetime.timedelta(days=1),
         coords={},
@@ -277,6 +279,7 @@ def test__select_time_file_writer_multiple_samples(time_selection, tmpdir):
         n_samples=n_samples,
         n_timesteps=n_timesteps,
         t_initial="2020-01-01T00:00:00",
+        calendar="gregorian",
         freq="1D",
         increment_times=True,
     )
@@ -286,6 +289,9 @@ def test__select_time_file_writer_multiple_samples(time_selection, tmpdir):
         format=NetCDFWriterConfig(name="netcdf"),
         time_selection=time_selection,
     )
+    initial_condition_times = np.array(
+        [cftime.DatetimeGregorian(2020, 1, i) for i in range(1, n_samples + 1)]
+    )
 
     if isinstance(time_selection, TimeSlice) or isinstance(
         time_selection, MonthSelector
@@ -293,7 +299,7 @@ def test__select_time_file_writer_multiple_samples(time_selection, tmpdir):
         with pytest.raises(NotImplementedError):
             file_writer = file_writer_config.build(
                 experiment_dir=str(tmpdir),
-                n_initial_conditions=n_samples,
+                initial_condition_times=initial_condition_times,
                 n_timesteps=-1,  # unused for netcdf
                 timestep=datetime.timedelta(days=1),
                 coords={},
@@ -304,7 +310,7 @@ def test__select_time_file_writer_multiple_samples(time_selection, tmpdir):
 
     file_writer = file_writer_config.build(
         experiment_dir=str(tmpdir),
-        n_initial_conditions=n_samples,
+        initial_condition_times=initial_condition_times,
         n_timesteps=-1,  # unused for netcdf
         timestep=datetime.timedelta(days=1),
         coords={},
@@ -441,9 +447,12 @@ def test_file_writer_with_healpix_data_and_zarr(tmpdir):
     n_timesteps = 6
     shape = (12, 4, 4)
     coords = {"face": np.arange(12), "height": np.arange(4), "width": np.arange(4)}
+    initial_condition_times = np.array(
+        [cftime.DatetimeGregorian(2019, 12, 31)] * n_samples
+    )
     writer = config.build(
         experiment_dir=str(tmpdir),
-        n_initial_conditions=n_samples,
+        initial_condition_times=initial_condition_times,
         n_timesteps=n_timesteps,
         timestep=datetime.timedelta(days=1),
         variable_metadata={},
@@ -524,9 +533,10 @@ def test_file_writer_monthly(tmpdir):
     config = FileWriterConfig(label=label, time_coarsen=MonthlyCoarsenConfig())
     n_timesteps = 24
     n_samples = 1
+    initial_condition_times = np.array([cftime.DatetimeGregorian(2020, 1, 1)])
     writer = config.build(
         experiment_dir=str(tmpdir),
-        n_initial_conditions=n_samples,
+        initial_condition_times=initial_condition_times,
         n_timesteps=n_timesteps,
         timestep=datetime.timedelta(days=5),
         variable_metadata={},
@@ -554,9 +564,10 @@ def test_file_writer_paired_save_reference(tmpdir, save_reference: bool):
         names=["temperature"],
         save_reference=save_reference,
     )
+    initial_condition_times = np.array([cftime.DatetimeGregorian(2020, 1, 1)])
     writer = config.build_paired(
         experiment_dir=str(tmpdir),
-        n_initial_conditions=1,
+        initial_condition_times=initial_condition_times,
         n_timesteps=10,
         timestep=datetime.timedelta(days=1),
         variable_metadata={},
@@ -592,13 +603,105 @@ def test_netcdf_file_writer_with_non_local_experiment_dir(
         time_coarsen=time_coarsen,
         format=format,
     )
+    initial_condition_times = np.array([cftime.DatetimeGregorian(2020, 1, 1)])
     with pytest.raises(ValueError, match="only supports local"):
         config.build(
             experiment_dir=experiment_dir,
-            n_initial_conditions=1,
+            initial_condition_times=initial_condition_times,
             n_timesteps=1,
             timestep=datetime.timedelta(hours=6),
             variable_metadata={},
             coords={},
             dataset_metadata=DatasetMetadata(),
         )
+
+
+@pytest.mark.parametrize(
+    "n_timesteps",
+    [
+        pytest.param(2, id="steps-in-memory-equal-to-coarsen-factor"),
+        pytest.param(4, id="steps-in-memory-greater-than-coarsen-factor"),
+    ],
+)
+@pytest.mark.parametrize(
+    "format",
+    [
+        pytest.param(NetCDFWriterConfig(), id="netCDF"),
+        pytest.param(ZarrWriterConfig(), id="Zarr"),
+    ],
+)
+def test_coarsened_file_writer_time_coordinates(
+    tmpdir, n_timesteps: int, format: NetCDFWriterConfig | ZarrWriterConfig
+):
+    initial_condition_times = np.array([cftime.DatetimeGregorian(2020, 1, 1)])
+    n_initial_conditions = len(initial_condition_times)
+    coarsen_factor = 2
+    timestep = datetime.timedelta(days=1)
+
+    config = FileWriterConfig(
+        label="test",
+        names=["temperature"],
+        time_coarsen=TimeCoarsenConfig(coarsen_factor=coarsen_factor),
+        format=format,
+    )
+    writer = config.build(
+        experiment_dir=str(tmpdir),
+        initial_condition_times=initial_condition_times,
+        n_timesteps=n_timesteps,
+        timestep=timestep,
+        variable_metadata={},
+        coords={"lat": np.linspace(-90, 90, 2), "lon": np.linspace(-180, 180, 2)},
+        dataset_metadata=DatasetMetadata(),
+    )
+    data = {"temperature": torch.ones(n_initial_conditions, n_timesteps, 2, 2)}
+    batch_time = xr.DataArray(
+        xr.date_range(
+            "2020-01-02", periods=n_timesteps, freq=timestep, use_cftime=True
+        ),
+        dims="time",
+    )
+    batch_time = batch_time.expand_dims("sample", axis=0)
+    writer.append_batch(data, batch_time=batch_time)
+    writer.finalize()
+
+    expected_n_timesteps = n_timesteps // coarsen_factor
+    expected_lead_times = pd.timedelta_range(
+        "1 days 12:00:00", periods=expected_n_timesteps, freq=f"{coarsen_factor}D"
+    )
+    expected_time = xr.DataArray(expected_lead_times, dims="time")
+
+    expected_init_time = xr.DataArray(
+        [cftime.DatetimeGregorian(2020, 1, 1)], dims="sample"
+    )
+    if n_timesteps == 2:
+        expected_valid_time_values = [[cftime.DatetimeGregorian(2020, 1, 2, 12, 0, 0)]]
+    elif n_timesteps == 4:
+        expected_valid_time_values = [
+            [
+                cftime.DatetimeGregorian(2020, 1, 2, 12, 0, 0),
+                cftime.DatetimeGregorian(2020, 1, 4, 12, 0, 0),
+            ]
+        ]
+    expected_valid_time = xr.DataArray(
+        expected_valid_time_values, dims=["sample", "time"]
+    )
+    expected_valid_time = expected_valid_time.assign_coords(
+        time=expected_lead_times,
+        init_time=expected_init_time,
+        valid_time=expected_valid_time,
+    )
+
+    coding_kwargs = {
+        "decode_times": xr.coders.CFDatetimeCoder(use_cftime=True),
+        "decode_timedelta": True,
+    }
+    if isinstance(format, NetCDFWriterConfig):
+        ds = xr.open_dataset(tmpdir / "test.nc", **coding_kwargs)
+    elif isinstance(format, ZarrWriterConfig):
+        ds = xr.open_zarr(tmpdir / "test.zarr", **coding_kwargs)
+        # Zarr writer includes an additional "sample" coordinate.
+        expected_valid_time = expected_valid_time.assign_coords(sample=[0.0])
+    assert ds.temperature.dims == ("sample", "time", "lat", "lon")
+    assert ds.temperature.shape == (n_initial_conditions, expected_n_timesteps, 2, 2)
+    xr.testing.assert_equal(ds.time, expected_time)
+    xr.testing.assert_equal(ds.valid_time, expected_valid_time)

--- a/fme/ace/inference/data_writer/test_zarr.py
+++ b/fme/ace/inference/data_writer/test_zarr.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 import xarray as xr
 
+from fme.ace.inference.data_writer.test_data_writer import get_initial_condition_times
 from fme.ace.inference.data_writer.zarr import (
     SeparateICZarrWriterAdapter,
     ZarrWriterAdapter,
@@ -44,11 +45,16 @@ def test__get_ace_time_coords(calendar):
     n_batch_times = 3
     n_timesteps = 6
     n_samples = 2
+    timestep = datetime.timedelta(hours=6)
+    start_time = (2020, 1, 1, 0, 0, 0)
+    initial_condition_times = get_initial_condition_times(
+        start_time, calendar, n_samples, separation_timedelta=timestep
+    )
     batch_time = get_batch_time(
         n_batch_times=n_batch_times, n_initial_conditions=n_samples, calendar=calendar
     )
     lead_times_coord, init_times_coord, valid_times_coord = _get_ace_time_coords(
-        batch_time, n_timesteps=n_timesteps
+        initial_condition_times, batch_time, timestep, n_timesteps=n_timesteps
     )
 
     assert lead_times_coord.dims == ("time",)
@@ -65,15 +71,12 @@ def test__get_ace_time_coords(calendar):
 
     start = CALENDARS[calendar](2020, 1, 1, 0)
     np.testing.assert_array_equal(
-        lead_times_coord.values, np.arange(n_timesteps) * 6 * 3600 * 1e6
+        lead_times_coord.values, np.arange(1, n_timesteps + 1) * 6 * 3600 * 1e6
     )
-    expected_init_times = [
-        start + datetime.timedelta(hours=6) * i for i in range(n_samples)
-    ]
     np.testing.assert_array_equal(
         init_times_coord.values,
         cftime.date2num(
-            expected_init_times,
+            initial_condition_times,
             units="microseconds since 1970-01-01",
             calendar=calendar,
         ),
@@ -96,6 +99,8 @@ def test__get_ace_time_coords(calendar):
 @pytest.mark.parametrize("writer_cls", [ZarrWriterAdapter, SeparateICZarrWriterAdapter])
 def test_zarr_adapter_can_overwrite(tmpdir, writer_cls):
     data = {"foo": torch.zeros((1, 2, 2, 2))}
+    timestep = datetime.timedelta(days=1)
+    initial_condition_times = np.array([cftime.datetime(2019, 12, 31)])
     time = xr.DataArray(
         [[cftime.datetime(2020, 1, 1), cftime.datetime(2020, 1, 2)]],
         dims=("sample", "time"),
@@ -112,8 +117,9 @@ def test_zarr_adapter_can_overwrite(tmpdir, writer_cls):
                 "ak": xr.DataArray([0, 1], dims=["z_interface"]),
             }
         ),
+        timestep=timestep,
         n_timesteps=2,
-        n_initial_conditions=1,
+        initial_condition_times=initial_condition_times,
     )
     adapter = writer_cls(**args)  # type: ignore
     adapter.append_batch(data, time)
@@ -125,6 +131,8 @@ def test_zarr_adapter_single_timestep_data(
     tmpdir,
 ):
     data = {"foo": torch.zeros((1, 1, 2, 2))}
+    timestep = datetime.timedelta(days=1)
+    initial_condition_times = np.array([cftime.datetime(2019, 12, 31)])
     time = xr.DataArray(
         [
             [
@@ -143,8 +151,9 @@ def test_zarr_adapter_single_timestep_data(
                 "ak": xr.DataArray([0, 1], dims=["z_interface"]),
             }
         ),
+        timestep=timestep,
         n_timesteps=1,
-        n_initial_conditions=1,
+        initial_condition_times=initial_condition_times,
     )
     adapter = ZarrWriterAdapter(**args)  # type: ignore
     adapter.append_batch(data, time)

--- a/fme/ace/inference/data_writer/zarr.py
+++ b/fme/ace/inference/data_writer/zarr.py
@@ -1,4 +1,5 @@
 import copy
+import datetime
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -6,17 +7,19 @@ from typing import Literal
 
 import cftime
 import numpy as np
+import numpy.typing as npt
 import torch
 import xarray as xr
 
 from fme.core.dataset.data_typing import VariableMetadata
-from fme.core.dataset.utils import encode_timestep
-from fme.core.dataset.xarray import _get_timestep
-from fme.core.writer import DATETIME_ENCODING_UNITS, ZarrWriter
+from fme.core.writer import (
+    DATETIME_ENCODING_UNITS,
+    TIMEDELTA_ENCODING_DTYPE,
+    TIMEDELTA_ENCODING_UNITS,
+    ZarrWriter,
+)
 
 from .dataset_metadata import DatasetMetadata
-
-LEAD_TIME_UNITS = "microseconds"
 
 
 def _variable_metadata_to_dict(
@@ -30,38 +33,56 @@ def _variable_metadata_to_dict(
     }
 
 
-def _get_ace_time_coords(batch_time: xr.DataArray, n_timesteps: int):
-    if n_timesteps > 1:
-        dt_timedelta = _get_timestep(batch_time.isel(sample=0).values)
-        dt_microseconds = encode_timestep(dt_timedelta)
-        lead_times_microseconds = dt_microseconds * np.arange(n_timesteps)
-        lead_times_coord = xr.DataArray(
-            lead_times_microseconds,
-            dims=["time"],
-            attrs={"units": "microseconds", "dtype": "timedelta64[us]"},
-        )
-    elif n_timesteps == 1:
-        lead_times_coord = xr.DataArray(
-            np.array([0], dtype=np.int64),
-            dims=["time"],
-            attrs={"units": "microseconds", "dtype": "timedelta64[us]"},
-        )
-    init_times_datetime = batch_time.isel(time=0).values
-    init_times_numeric = cftime.date2num(
-        init_times_datetime,
-        units=DATETIME_ENCODING_UNITS,
-        calendar=batch_time.dt.calendar,
+def _get_encoded_lead_times(
+    initial_condition_times: npt.NDArray[cftime.datetime],
+    batch_time: xr.DataArray,
+    timestep: datetime.timedelta,
+    n_timesteps: int,
+) -> npt.NDArray[np.int64]:
+    # Note the first lead time is a special case, because in the context of time
+    # coarsening, it will be equal to half the coarse timestep plus half the
+    # model timestep. Since we only have access to the coarse timestep in this
+    # context we will infer it from the difference between the first batch time
+    # and the initial condition time. All subsequent lead times will be coarse
+    # timestep increments on top of that. This is safe to do, because we do not
+    # support time subselection when using the zarr writer.
+    first_lead_time = (
+        batch_time.isel(sample=0, time=0).item() - initial_condition_times[0]
     )
+    subsequent_lead_times = first_lead_time + timestep * np.arange(1, n_timesteps)
+    lead_times = np.concatenate([[first_lead_time], subsequent_lead_times])
+    return lead_times.astype("timedelta64[us]").astype(np.int64)
 
+
+def _get_ace_time_coords(
+    initial_condition_times: npt.NDArray[cftime.datetime],
+    batch_time: xr.DataArray,
+    timestep: datetime.timedelta,
+    n_timesteps: int,
+) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
+    calendar = batch_time.dt.calendar
+    init_times_numeric = cftime.date2num(
+        initial_condition_times,
+        units=DATETIME_ENCODING_UNITS,
+        calendar=calendar,
+    )
     init_times_coord = xr.DataArray(
         init_times_numeric,
         dims=["sample"],
-        attrs={"units": DATETIME_ENCODING_UNITS, "calendar": batch_time.dt.calendar},
+        attrs={"units": DATETIME_ENCODING_UNITS, "calendar": calendar},
+    )
+    lead_times_microseconds = _get_encoded_lead_times(
+        initial_condition_times, batch_time, timestep, n_timesteps
+    )
+    lead_times_coord = xr.DataArray(
+        lead_times_microseconds,
+        dims=["time"],
+        attrs={"units": TIMEDELTA_ENCODING_UNITS, "dtype": TIMEDELTA_ENCODING_DTYPE},
     )
     valid_times_coord = init_times_coord + lead_times_coord
     valid_times_coord.attrs = {
         "units": DATETIME_ENCODING_UNITS,
-        "calendar": batch_time.dt.calendar,
+        "calendar": calendar,
     }
     return lead_times_coord, init_times_coord, valid_times_coord
 
@@ -97,8 +118,9 @@ class ZarrWriterAdapter:
         path: str,
         dims: tuple,
         data_coords: dict[str, np.ndarray],
+        timestep: datetime.timedelta,
         n_timesteps: int,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         dataset_metadata: DatasetMetadata | None = None,
         data_vars: list[str] | None = None,
@@ -108,8 +130,10 @@ class ZarrWriterAdapter:
         self.path = path
         self.dims = dims
 
+        self.timestep = timestep
         self.n_timesteps = n_timesteps
-        self.n_initial_conditions = n_initial_conditions
+        self.initial_condition_times = initial_condition_times
+        self.n_initial_conditions = len(self.initial_condition_times)
         self._current_timestep = 0
         self.variable_metadata = _variable_metadata_to_dict(variable_metadata)
 
@@ -154,7 +178,7 @@ class ZarrWriterAdapter:
     def _initialize_writer(self, batch_time: xr.DataArray):
         # batch.time is dataarray with dims (sample, time) w/o coords
         lead_times_coord, init_times_coord, valid_times_coord = _get_ace_time_coords(
-            batch_time, self.n_timesteps
+            self.initial_condition_times, batch_time, self.timestep, self.n_timesteps
         )
         self._nondim_coords.update(
             {
@@ -176,7 +200,7 @@ class ZarrWriterAdapter:
             shards={"time": batch_time.sizes["time"]},
             array_attributes=self.variable_metadata,
             group_attributes=self.dataset_metadata,
-            time_units=LEAD_TIME_UNITS,
+            time_units=TIMEDELTA_ENCODING_UNITS,
             time_calendar=None,
             nondim_coords=self._nondim_coords,
             mode="w",  # ACE data writers are expected to overwrite existing data
@@ -230,8 +254,9 @@ class SeparateICZarrWriterAdapter:
         path: str,
         dims: tuple,
         data_coords: dict[str, np.ndarray],
+        timestep: datetime.timedelta,
         n_timesteps: int,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         dataset_metadata: DatasetMetadata | None = None,
         data_vars: list[str] | None = None,
@@ -242,8 +267,10 @@ class SeparateICZarrWriterAdapter:
         self.dims = dims
         # spatial coords are passed at init, time coords are read from first batch
         self.coords = data_coords
+        self.timestep = timestep
         self.n_timesteps = n_timesteps
-        self.n_initial_conditions = n_initial_conditions
+        self.initial_condition_times = initial_condition_times
+        self.n_initial_conditions = len(self.initial_condition_times)
         self._current_timestep = 0
         self.data_vars = data_vars
         self.chunks = chunks
@@ -278,13 +305,20 @@ class SeparateICZarrWriterAdapter:
 
     def _initialize_writers(self, first_batch_time: xr.DataArray):
         self._writers = []
+        lead_time_microseconds = _get_encoded_lead_times(
+            self.initial_condition_times,
+            first_batch_time,
+            self.timestep,
+            self.n_timesteps,
+        )
         for s in range(self.n_initial_conditions):
             _coords = copy.copy(self.coords)
-            start_time = first_batch_time.isel(sample=s).values[0]
-            timestep = first_batch_time.isel(sample=s).values[1] - start_time
-            _coords["time"] = np.array(
-                [start_time + i * timestep for i in range(self.n_timesteps)]
+            init_time_numeric = cftime.date2num(
+                self.initial_condition_times[s],
+                units=DATETIME_ENCODING_UNITS,
+                calendar=first_batch_time.dt.calendar,
             )
+            _coords["time"] = init_time_numeric + lead_time_microseconds
             self._writers.append(
                 ZarrWriter(
                     path=self.path.replace(".zarr", f"_ic{s:04d}.zarr"),

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -3,8 +3,10 @@ import datetime
 import logging
 from collections.abc import Callable, Mapping, Sequence
 
+import cftime
 import dacite
 import numpy as np
+import numpy.typing as npt
 import torch
 
 import fme
@@ -177,13 +179,14 @@ class InferenceEvaluatorConfig:
 
     def get_data_writer(
         self,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         timestep: datetime.timedelta,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
     ) -> PairedDataWriter:
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
-            n_initial_conditions=self.loader.n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             n_timesteps=self.n_forward_steps,
             timestep=timestep,
             variable_metadata=variable_metadata,
@@ -294,6 +297,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
     )
 
     writer = config.get_data_writer(
+        initial_condition_times=data.initial_time.to_numpy(),
         timestep=data.timestep,
         variable_metadata=variable_metadata,
         coords=data.coords,

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -6,8 +6,10 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import Literal
 
+import cftime
 import dacite
 import numpy as np
+import numpy.typing as npt
 import torch
 import xarray as xr
 from xarray.coding.times import CFDatetimeCoder
@@ -248,7 +250,7 @@ class InferenceConfig:
 
     def get_data_writer(
         self,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         timestep: datetime.timedelta,
         coords: Mapping[str, np.ndarray],
         variable_metadata: Mapping[str, VariableMetadata],
@@ -256,7 +258,7 @@ class InferenceConfig:
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
             # each batch contains all samples, for different times
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=initial_condition_times,
             n_timesteps=self.n_forward_steps,
             timestep=timestep,
             variable_metadata=variable_metadata,
@@ -343,7 +345,7 @@ def run_inference_from_config(config: InferenceConfig):
         )
 
         writer = config.get_data_writer(
-            n_initial_conditions=data.n_initial_conditions,
+            initial_condition_times=data.initial_time.to_numpy(),
             timestep=data.timestep,
             coords=data.coords,
             variable_metadata=variable_metadata,

--- a/fme/ace/inference/test_evaluator.py
+++ b/fme/ace/inference/test_evaluator.py
@@ -7,6 +7,7 @@ import tempfile
 from collections.abc import Iterable
 from unittest.mock import patch
 
+import cftime
 import dacite
 import fsspec
 import numpy as np
@@ -377,11 +378,19 @@ def inference_helper(
             assert dim_name in initial_condition_ds.data_vars[example_output_var].dims
             assert dim_name in initial_condition_ds.coords
 
+    decode_times = xr.coders.CFDatetimeCoder(use_cftime=True)
     prediction_ds = xr.open_dataset(
         tmp_path / "autoregressive_predictions.nc",
         decode_timedelta=False,
-        decode_times=False,
+        decode_times=decode_times,
     )
+
+    # Regression test for GitHub issue #886; ensure the init_time is properly
+    # propagated from the initial conditions to the prediction outputs.
+    expected_init_time = cftime.DatetimeProlepticGregorian(2000, 1, 1)
+    result_init_time = prediction_ds["init_time"].squeeze("sample").item()
+    assert result_init_time == expected_init_time
+
     assert len(prediction_ds["time"]) == config.n_forward_steps
     for i in range(config.n_forward_steps - 1):
         np.testing.assert_allclose(

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -134,7 +134,10 @@ def test_inference_segmented_entrypoint():
         initial_condition_path = tmp_path / "init_data" / "ic.nc"
         initial_condition_path.parent.mkdir()
         initial_condition["time"] = xr.DataArray(
-            [cftime.datetime(2000, 1, 1, 6), cftime.datetime(2000, 1, 1, 18)],
+            [
+                cftime.DatetimeProlepticGregorian(2000, 1, 1, 6),
+                cftime.DatetimeProlepticGregorian(2000, 1, 1, 18),
+            ],
             dims=["sample"],
         )
         initial_condition.to_netcdf(initial_condition_path, mode="w")

--- a/fme/core/writer.py
+++ b/fme/core/writer.py
@@ -12,6 +12,8 @@ from fme.core.distributed import Distributed
 
 logger = logging.getLogger(__name__)
 DATETIME_ENCODING_UNITS = "microseconds since 1970-01-01"
+TIMEDELTA_ENCODING_UNITS = "microseconds"
+TIMEDELTA_ENCODING_DTYPE = "timedelta64[us]"
 
 
 def _encode_cftime_times(times, calendar="julian"):

--- a/fme/coupled/data_loading/gridded_data.py
+++ b/fme/coupled/data_loading/gridded_data.py
@@ -2,7 +2,9 @@ import datetime
 import logging
 from collections import namedtuple
 
+import numpy as np
 import torch
+import xarray as xr
 
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.dataset.properties import DatasetProperties
@@ -247,3 +249,16 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
     @property
     def coords(self) -> CoupledCoords:
         return self._properties.coords
+
+    @property
+    def initial_time(self) -> xr.DataArray:
+        atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+        ocean_data = self.initial_condition.as_batch_data().ocean_data
+        atmosphere_initial_time = atmosphere_data.time.isel(time=0)
+        ocean_initial_time = ocean_data.time.isel(time=0)
+        np.testing.assert_array_equal(
+            atmosphere_initial_time,
+            ocean_initial_time,
+            err_msg="Atmosphere and ocean initial times must be the same",
+        )
+        return atmosphere_initial_time

--- a/fme/coupled/inference/data_writer.py
+++ b/fme/coupled/inference/data_writer.py
@@ -3,6 +3,9 @@ import datetime
 import os
 from collections.abc import Mapping
 
+import cftime
+import numpy.typing as npt
+
 from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
 from fme.ace.inference.data_writer.main import DataWriterConfig, PairedDataWriter
 from fme.core.cloud import makedirs
@@ -38,7 +41,7 @@ class CoupledDataWriterConfig:
     def build_paired(
         self,
         experiment_dir: str,
-        n_initial_conditions: int,
+        initial_condition_times: npt.NDArray[cftime.datetime],
         n_timesteps_ocean: int,
         n_timesteps_atmosphere: int,
         ocean_timestep: datetime.timedelta,
@@ -54,7 +57,7 @@ class CoupledDataWriterConfig:
         return CoupledPairedDataWriter(
             ocean_writer=self.ocean.build_paired(
                 experiment_dir=ocean_dir,
-                n_initial_conditions=n_initial_conditions,
+                initial_condition_times=initial_condition_times,
                 n_timesteps=n_timesteps_ocean,
                 timestep=ocean_timestep,
                 variable_metadata=variable_metadata,
@@ -63,7 +66,7 @@ class CoupledDataWriterConfig:
             ),
             atmosphere_writer=self.atmosphere.build_paired(
                 experiment_dir=atmos_dir,
-                n_initial_conditions=n_initial_conditions,
+                initial_condition_times=initial_condition_times,
                 n_timesteps=n_timesteps_atmosphere,
                 timestep=atmosphere_timestep,
                 variable_metadata=variable_metadata,

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -238,7 +238,7 @@ class InferenceEvaluatorConfig:
         }
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
-            n_initial_conditions=self.loader.n_initial_conditions,
+            initial_condition_times=data.initial_time.to_numpy(),
             n_timesteps_ocean=self.n_coupled_steps,
             n_timesteps_atmosphere=self.n_coupled_steps * data.n_inner_steps,
             ocean_timestep=data.ocean_timestep,

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -154,7 +154,6 @@ class InferenceConfig:
 
     def get_data_writer(
         self,
-        n_initial_conditions: int,
         data: InferenceGriddedData,
     ) -> CoupledPairedDataWriter:
         if self.data_writer.ocean.time_coarsen is not None:
@@ -186,7 +185,7 @@ class InferenceConfig:
         }
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
-            n_initial_conditions=n_initial_conditions,
+            initial_condition_times=data.initial_time.to_numpy(),
             n_timesteps_ocean=self.n_coupled_steps,
             n_timesteps_atmosphere=self.n_coupled_steps * data.n_inner_steps,
             ocean_timestep=data.ocean_timestep,
@@ -260,9 +259,7 @@ def run_inference_from_config(config: InferenceConfig):
         output_dir=config.experiment_dir,
     )
 
-    writer = config.get_data_writer(
-        n_initial_conditions=data.n_initial_conditions, data=data
-    )
+    writer = config.get_data_writer(data=data)
     timer.stop()
     logging.info("Starting inference")
     record_logs = get_record_to_wandb(label="inference")


### PR DESCRIPTION
Adds a regression test in test_xarray_loader that ensures the loaded data matches the checkpoint value, regardless of parallel decomposition.

Changes:
- Added `Distributed.scatter_object`
- Fixed type hints on `Distributed.gather_object`
- Fixed issue where comparing tensor dicts in fme.core.testing.regression would not show metrics on how badly the assert_close failed during failure, clobbered by msg arg

- [x] Tests added

Resolves #914

