### PR TITLE
Include `"deptho"` in CM4 coupled ocean datasets

### DIFF
--- a/scripts/data_process/configs/CM4-1pctCO2-140yr-coupled.yaml
+++ b/scripts/data_process/configs/CM4-1pctCO2-140yr-coupled.yaml
@@ -50,7 +50,7 @@ input_datasets:
     zarr_path: /climate-default/2025-10-16-cm4-1pctCO2-140yr-ocean-no-smoothing.zarr
     time_chunk_size: 25
     extra_fields:
-      names_and_prefixes: ["idepth_", "mask_"]
+      names_and_prefixes: ["idepth_", "mask_", "deptho"]
   stats:
     atmosphere_dir: /climate-default/2025-06-18-CM4-1pctCO2-atmosphere-land-1deg-8layer-140yr-stats/combined
     ocean_dir: /climate-default/2025-10-16-cm4-1pctCO2-140yr-ocean-no-smoothing-stats

--- a/scripts/data_process/configs/CM4-piControl-200yr-coupled.yaml
+++ b/scripts/data_process/configs/CM4-piControl-200yr-coupled.yaml
@@ -46,7 +46,7 @@ input_datasets:
     zarr_path: /climate-default/2025-10-15-cm4-piControl-200yr-ocean-no-smoothing.zarr
     time_chunk_size: 25
     extra_fields:
-      names_and_prefixes: ["idepth_", "mask_"]
+      names_and_prefixes: ["idepth_", "mask_", "deptho"]
   stats:
     atmosphere_dir: /climate-default/2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr-stats/combined
     ocean_dir: /climate-default/2025-10-15-cm4-piControl-200yr-ocean-no-smoothing-stats


### PR DESCRIPTION
Adds `"deptho"` as an extra coupled ocean variable in the CM4 1pctCO2 and piControl datasets.