### PR TITLE
Add bootstrap initialization option to `ParameterInitializationConfig`

### DIFF
--- a/fme/ace/stepper/parameter_init.py
+++ b/fme/ace/stepper/parameter_init.py
@@ -70,6 +70,21 @@ def _freeze_weight(module: nn.Module, name: str):
         pass
 
 
+def _bootstrap_state_dict(
+    state_dict: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Sample values of each tensor with replacement, preserving shape."""
+    result = {}
+    for name, tensor in state_dict.items():
+        if isinstance(tensor, torch.Tensor) and tensor.numel() > 0:
+            flat = tensor.flatten()
+            indices = torch.randint(0, flat.numel(), (flat.numel(),))
+            result[name] = flat[indices].reshape(tensor.shape)
+        else:
+            result[name] = tensor
+    return result
+
+
 RegularizerFunction = Callable[[], torch.Tensor]
 
 
@@ -111,6 +126,11 @@ class ParameterInitializationConfig:
             By default modules are unfrozen and all parameters are included.
             Must be provided in the same order as provided by the stepper's
             `.modules` attribute.
+        bootstrap: if True, instead of loading the checkpoint weights directly,
+            randomly sample the values of each parameter tensor with replacement.
+            This preserves the per-parameter value distribution while destroying
+            learned structure, useful for generating diverse ensemble
+            initializations.
         alpha: L2 regularization coefficient keeping initialized weights
             close to their intiial values
         beta: L2 regularization coefficient keeping uninitialized weights
@@ -121,12 +141,20 @@ class ParameterInitializationConfig:
 
     weights_path: str | None = None
     parameters: list[ParameterClassification] = dataclasses.field(default_factory=list)
+    bootstrap: bool = False
     alpha: float = 0.0
     beta: float = 0.0
     exclude_parameters: list[str] | None = None
     frozen_parameters: FrozenParameterConfig | None = None
 
     def __post_init__(self):
+        if self.bootstrap and (self.alpha != 0 or self.beta != 0):
+            raise ValueError(
+                "Cannot use bootstrap initialization with L2-SP tuning "
+                "(alpha or beta != 0). Bootstrap destroys the learned weight "
+                "structure, making L2-SP regularization back to those weights "
+                "scientifically invalid."
+            )
         if self.exclude_parameters is not None or self.frozen_parameters is not None:
             if len(self.parameters) > 0:
                 raise ValueError(
@@ -210,6 +238,8 @@ class ParameterInitializer:
             for module, state_dict, classification in zip(
                 modules, self.base_weights, filled_parameters
             ):
+                if self.config.bootstrap:
+                    state_dict = _bootstrap_state_dict(state_dict)
                 overwrite_weights(
                     state_dict,
                     module,

--- a/fme/ace/stepper/test_parameter_init.py
+++ b/fme/ace/stepper/test_parameter_init.py
@@ -425,6 +425,88 @@ def test_parameter_init_with_regularizer(tmpdir):
             )
 
 
+def test_bootstrap_initialization():
+    """
+    Test that bootstrap initialization produces weights with the same
+    distribution but different structure from the original checkpoint.
+    """
+    torch.manual_seed(0)
+    device = get_device()
+    saved_module = ComplexModule(10, 20).to(device)
+    saved_state = saved_module.state_dict()
+
+    config = ParameterInitializationConfig(
+        weights_path="unused",
+        bootstrap=True,
+    )
+    parameter_initializer = config.build(
+        load_weights_and_history=lambda _: (
+            [saved_state],
+            TrainingHistory(),
+        )
+    )
+
+    module = ComplexModule(10, 20).to(device)
+    parameter_initializer.apply_weights([module])
+
+    # Weights should differ from the original (with very high probability)
+    any_different = False
+    for name in saved_state:
+        new_val = module.state_dict()[name]
+        if not torch.allclose(new_val, saved_state[name]):
+            any_different = True
+        # Each bootstrapped tensor should only contain values from the original
+        original_values = set(saved_state[name].flatten().tolist())
+        for val in new_val.flatten().tolist():
+            assert (
+                val in original_values
+            ), f"Bootstrap produced value {val} not in original for {name}"
+    assert any_different, "Bootstrap should produce different weights"
+
+
+@pytest.mark.parametrize(
+    "alpha, beta",
+    [
+        pytest.param(1.0, 0.0, id="alpha_nonzero"),
+        pytest.param(0.0, 1.0, id="beta_nonzero"),
+        pytest.param(1.0, 1.0, id="both_nonzero"),
+    ],
+)
+def test_bootstrap_with_l2sp_raises(alpha, beta):
+    """Bootstrap with L2-SP tuning should raise at config init time."""
+    with pytest.raises(ValueError, match="bootstrap.*L2-SP"):
+        ParameterInitializationConfig(
+            weights_path="unused",
+            bootstrap=True,
+            alpha=alpha,
+            beta=beta,
+        )
+
+
+def test_bootstrap_false_loads_exact_weights():
+    """Test that bootstrap=False (default) loads weights exactly."""
+    torch.manual_seed(0)
+    device = get_device()
+    saved_module = ComplexModule(10, 20).to(device)
+    saved_state = saved_module.state_dict()
+
+    config = ParameterInitializationConfig(
+        weights_path="unused",
+        bootstrap=False,
+    )
+    parameter_initializer = config.build(
+        load_weights_and_history=lambda _: (
+            [saved_state],
+            TrainingHistory(),
+        )
+    )
+    module = ComplexModule(10, 20).to(device)
+    parameter_initializer.apply_weights([module])
+
+    for name in saved_state:
+        assert torch.allclose(module.state_dict()[name], saved_state[name])
+
+
 def test_parameter_init_weights_loaded_once(tmpdir):
     """
     Test that the parameter initialization config only loads the weights once,


### PR DESCRIPTION
Add a `bootstrap` flag (default False) that, when enabled, randomly samples checkpoint weight values with replacement for each parameter tensor before initializing the model. This preserves the per-layer value distribution (scale, mean, variance) of a trained checkpoint while destroying learned spatial and structural correlations, providing a principled way to generate diverse initializations for ensemble training from a single checkpoint.

Bootstrap initialization is disallowed in combination with L2-SP tuning (alpha/beta), since regularizing toward bootstrapped weights is not scientifically meaningful.

Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

Changes:
- symbol (e.g. `fme.core.my_function`) or script and concise description of changes or added feature
- Can group multiple related symbols on a single bullet

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)
