### PR TITLE
Implement zonal_mean and gradient_magnitude_percent_diff for distributed

### DIFF
--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -349,10 +349,61 @@ class ModelTorchDistributed(DistributedBackend):
             local_weight_sum
         )
 
-    def zonal_mean(self, data: torch.Tensor) -> torch.Tensor:
-        raise NotImplementedError(
-            "zonal_mean is not yet supported under spatial parallelism."
+    def _gather_along_dim(
+        self,
+        tensor: torch.Tensor,
+        dim: int,
+        group: torch.distributed.ProcessGroup,
+        group_size: int,
+    ) -> torch.Tensor:
+        """All-gather tensor slices along ``dim`` within ``group``."""
+        if group_size == 1:
+            return tensor
+
+        # Communicate local sizes to handle uneven splits.
+        local_size = torch.tensor(
+            [tensor.shape[dim]], device=tensor.device, dtype=torch.long
         )
+        all_sizes = [torch.empty_like(local_size) for _ in range(group_size)]
+        torch.distributed.all_gather(all_sizes, local_size, group=group)
+        sizes = [s.item() for s in all_sizes]
+
+        max_size = max(sizes)
+
+        # Pad to the largest slice so all_gather receives uniform shapes.
+        if tensor.shape[dim] < max_size:
+            pad_shape = list(tensor.shape)
+            pad_shape[dim] = max_size - tensor.shape[dim]
+            tensor = torch.cat([tensor, tensor.new_zeros(pad_shape)], dim=dim)
+
+        chunks = [torch.empty_like(tensor) for _ in range(group_size)]
+        torch.distributed.all_gather(chunks, tensor, group=group)
+
+        # Trim each chunk back to its true size and concatenate.
+        trimmed = []
+        for chunk, size in zip(chunks, sizes):
+            idx = [slice(None)] * chunk.dim()
+            idx[dim] = slice(0, size)
+            trimmed.append(chunk[tuple(idx)])
+
+        return torch.cat(trimmed, dim=dim)
+
+    def _gather_spatial(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reconstruct the full spatial tensor by gathering across h and w."""
+        tensor = self._gather_along_dim(tensor, -1, self._w_group, self._w_size)
+        tensor = self._gather_along_dim(tensor, -2, self._h_group, self._h_size)
+        return tensor
+
+    def zonal_mean(self, data: torch.Tensor) -> torch.Tensor:
+        if self._w_size == 1:
+            return data.nanmean(dim=-1)
+
+        # Distributed nanmean over the longitude (w) dimension.
+        local_sum = data.nansum(dim=-1)
+        local_count = (~torch.isnan(data)).to(data.dtype).sum(dim=-1)
+        torch.distributed.all_reduce(local_sum, group=self._w_group)
+        torch.distributed.all_reduce(local_count, group=self._w_group)
+        return local_sum / local_count
 
     def gradient_magnitude_percent_diff(
         self,
@@ -361,9 +412,15 @@ class ModelTorchDistributed(DistributedBackend):
         weights: torch.Tensor,
         dim: tuple[int, ...],
     ) -> torch.Tensor:
-        raise NotImplementedError(
-            "gradient_magnitude_percent_diff is not yet supported "
-            "under spatial parallelism."
+        from fme.core import metrics
+
+        # Gradient computation needs neighboring spatial values, so gather the
+        # full spatial domain before computing the metric.
+        truth_full = self._gather_spatial(truth)
+        predicted_full = self._gather_spatial(predicted)
+        weights_full = self._gather_spatial(weights)
+        return metrics.gradient_magnitude_percent_diff(
+            truth_full, predicted_full, weights=weights_full, dim=dim
         )
 
     def get_sht(self, nlat, nlon, lmax=None, mmax=None, grid="legendre-gauss"):

--- a/fme/core/distributed/parallel_tests/test_backend.py
+++ b/fme/core/distributed/parallel_tests/test_backend.py
@@ -12,7 +12,7 @@ analytically, so the outcome is deterministic regardless of rank count.
 import pytest
 import torch
 
-from fme.core import get_device
+from fme.core import get_device, metrics
 from fme.core.distributed import Distributed
 
 
@@ -271,3 +271,83 @@ def test_gloo_all_to_all_patch():
         # Restore whatever state was in place before.
         torch_dist.all_to_all = saved_current
         gloo_patch._original_all_to_all = saved_original
+
+
+@pytest.mark.parallel
+def test_zonal_mean():
+    """Zonal mean of a known tensor matches non-distributed nanmean over lon."""
+    dist = Distributed.get_instance()
+    device = get_device()
+    global_shape = (2, 3, 8, 16)
+
+    # Use a fixed seed so every rank builds the same global tensor.
+    gen = torch.Generator(device="cpu").manual_seed(42)
+    global_data = torch.randn(*global_shape, generator=gen).to(device)
+
+    slices = dist.get_local_slices(global_shape)
+    local_data = global_data[slices]
+
+    result = dist.zonal_mean(local_data)
+
+    # Expected: full zonal mean restricted to local h-slice.
+    expected_full = global_data.nanmean(dim=-1)
+    expected = expected_full[slices[:-1]]  # drop w-slice (averaged away)
+
+    torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.parallel
+def test_zonal_mean_with_nans():
+    """Zonal mean correctly ignores NaNs across distributed lon slices."""
+    dist = Distributed.get_instance()
+    device = get_device()
+    global_shape = (2, 8, 16)
+
+    gen = torch.Generator(device="cpu").manual_seed(99)
+    global_data = torch.randn(*global_shape, generator=gen).to(device)
+    # Sprinkle NaNs at fixed positions.
+    global_data[0, 3, 5] = float("nan")
+    global_data[1, 0, 14] = float("nan")
+    global_data[0, 7, 0] = float("nan")
+
+    slices = dist.get_local_slices(global_shape)
+    local_data = global_data[slices]
+
+    result = dist.zonal_mean(local_data)
+
+    expected_full = global_data.nanmean(dim=-1)
+    expected = expected_full[slices[:-1]]
+
+    torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.parallel
+def test_gradient_magnitude_percent_diff():
+    """Distributed gradient_magnitude_percent_diff matches single-rank result."""
+    dist = Distributed.get_instance()
+    device = get_device()
+    global_shape = (2, 3, 8, 16)
+
+    gen = torch.Generator(device="cpu").manual_seed(123)
+    # Use 1 + rand to keep truth positive and avoid division-by-zero.
+    truth = (1.0 + torch.rand(*global_shape, generator=gen)).to(device)
+    predicted = (truth.cpu() + 0.1 * torch.randn(*global_shape, generator=gen)).to(
+        device
+    )
+    weights = torch.rand(8, 16, generator=gen).to(device)
+
+    slices = dist.get_local_slices(global_shape)
+    local_truth = truth[slices]
+    local_predicted = predicted[slices]
+    # weights only have spatial dims
+    local_weights = weights[slices[-2:]]
+
+    result = dist.gradient_magnitude_percent_diff(
+        local_truth, local_predicted, local_weights, dim=(-2, -1)
+    )
+
+    expected = metrics.gradient_magnitude_percent_diff(
+        truth, predicted, weights=weights, dim=(-2, -1)
+    )
+
+    torch.testing.assert_close(result, expected)


### PR DESCRIPTION
Implement support for `zonal_mean` and `gradient_magnitude_percent_diff` metrics under spatial parallelism. Previously these methods raised `NotImplementedError`.

Changes:
- `fme.core.distributed.model_torch_distributed.Distributed.zonal_mean`: Compute distributed nanmean over longitude dimension by reducing local sums and counts across the width process group
- `fme.core.distributed.model_torch_distributed.Distributed.gradient_magnitude_percent_diff`: Gather full spatial domain across all ranks before computing gradient-based metric
- `fme.core.distributed.model_torch_distributed.Distributed._gather_along_dim`: New helper to all-gather tensor slices along a specified dimension with proper handling of uneven splits
- `fme.core.distributed.model_torch_distributed.Distributed._gather_spatial`: New helper to reconstruct full spatial tensor by gathering across height and width dimensions
- `fme/core/distributed/parallel_tests/test_backend.py`: Added three new parallel tests (`test_zonal_mean`, `test_zonal_mean_with_nans`, `test_gradient_magnitude_percent_diff`) to verify distributed implementations match single-rank results

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

https://claude.ai/code/session_014JrHhq8vg2gXHTEEDMX9Mz