### PR TITLE
Skip gradient magnitude percent diff for model-parallelism

### DIFF
--- a/fme/ace/aggregator/one_step/reduced.py
+++ b/fme/ace/aggregator/one_step/reduced.py
@@ -79,6 +79,7 @@ class MeanAggregator:
             try:
                 Distributed.get_instance().require_no_spatial_parallelism(
                     "gradient magnitude percent diff metric"
+                    " not supported for spatial parallelism."
                 )
                 self._variable_metrics["weighted_grad_mag_percent_diff"] = (
                     AreaWeightedReducedMetric(


### PR DESCRIPTION
Simply skip gradient magnitude diff metric until it is implemented. This is an alternative to #975 (as we review it more carefully, including determining how best to impl this specific metric)