### PR TITLE
Use `obstore` in data processing workflows

### DIFF
--- a/scripts/data_process/Makefile
+++ b/scripts/data_process/Makefile
@@ -28,7 +28,7 @@ NAME_CLIMSST_4DEG = fv3gfs-ensemble-4deg
 NAME_AMIP_1DEG = fv3gfs-AMIP-ensemble
 NAME_AMIP_4DEG = fv3gfs-AMIP-ensemble-4deg
 ATMOSPHERE_PROCESSING_IMAGE = us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing
-ATMOSPHERE_PROCESSING_IMAGE_VERSION = v2025.12.0  # Use vYYYY.MM.MICRO (MICRO is zero-indexed)
+ATMOSPHERE_PROCESSING_IMAGE_VERSION = v2026.03.0  # Use vYYYY.MM.MICRO (MICRO is zero-indexed)
 HEALPIX_PROCESSING_IMAGE = dlwp-ace-datapipe
 HEALPIX_PROCESSING_IMAGE_VERSION = v2025.09.0  # Use vYYYY.MM.MICRO (MICRO is zero-indexed)
 

--- a/scripts/data_process/compute_dataset.py
+++ b/scripts/data_process/compute_dataset.py
@@ -20,6 +20,7 @@ import fsspec
 import numpy as np
 import xarray as xr
 import yaml
+from zarr.storage import ObjectStore
 
 try:
     from xtorch_harmonics import roundtrip_filter
@@ -27,6 +28,14 @@ except ModuleNotFoundError:
 
     def roundtrip_filter(*args, **kwargs):
         raise ModuleNotFoundError("xtorch_harmonics")
+
+
+try:
+    import obstore  # noqa: F401
+
+    _HAS_OBSTORE = True
+except ImportError:
+    _HAS_OBSTORE = False
 
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -342,13 +351,31 @@ def get_dataset_urls(
     return {k: os.path.join(run_directory, k) for k in config.variable_sources}
 
 
+def get_zarr_store(url: str, read_only: bool = True):
+    """Create a zarr store from a URL using obstore if available.
+
+    Args:
+        url: The URL of the zarr store to create.
+        read_only: Whether to open the store in read-only mode.
+    Returns:
+        A zarr store or the path to a zarr store if obstore is not available.
+    """
+    if url.startswith("gs://") and _HAS_OBSTORE:
+        from obstore.store import from_url
+
+        return ObjectStore(from_url(url), read_only=read_only)
+    else:
+        return url
+
+
 def open_datasets(
     config: DatasetComputationConfig, urls: MutableMapping[str, str]
 ) -> xr.Dataset:
     datasets = []
     for store, names in config.variable_sources.items():
         url = urls[store]
-        ds = xr.open_zarr(url, decode_timedelta=True)[names]
+        store = get_zarr_store(url)
+        ds = xr.open_zarr(store, decode_timedelta=True)[names]
         datasets.append(ds)
     return xr.merge(datasets, compat="equals")
 
@@ -994,6 +1021,7 @@ def main(
     ds = clear_compressors_encoding(ds)
 
     logging.info(f"Output dataset size is {ds.nbytes / 1e9} GB")
+    output_store = get_zarr_store(output_store, read_only=False)
     if debug:
         with xr.set_options(display_max_rows=500):
             logging.info(ds)

--- a/scripts/data_process/compute_dataset_argo_workflow.yaml
+++ b/scripts/data_process/compute_dataset_argo_workflow.yaml
@@ -117,7 +117,7 @@ spec:
           - name: output_directory
           - name: run
       container:
-        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
+        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2026.03.0
         resources:
           limits:
             cpu: "30000m"
@@ -196,7 +196,7 @@ spec:
           - name: config
           - name: run
       container:
-        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
+        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2026.03.0
         resources:
           limits:
             cpu: "30000m"
@@ -241,7 +241,7 @@ spec:
           - name: config
           - name: run
       container:
-        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
+        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2026.03.0
         resources:
           limits:
             cpu: "30000m"
@@ -281,7 +281,7 @@ spec:
           - name: python_script
           - name: config
       container:
-        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
+        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2026.03.0
         resources:
           limits:
             cpu: "8000m"
@@ -319,7 +319,7 @@ spec:
           - name: python_script
           - name: config
       container:
-        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
+        image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2026.03.0
         resources:
           limits:
             cpu: "8000m"

--- a/scripts/data_process/get_stats.py
+++ b/scripts/data_process/get_stats.py
@@ -15,6 +15,14 @@ import dacite
 import fsspec
 import xarray as xr
 import yaml
+from zarr.storage import ObjectStore
+
+try:
+    import obstore  # noqa: F401
+
+    _HAS_OBSTORE = True
+except ImportError:
+    _HAS_OBSTORE = False
 
 # these are auxiliary variables that exist in dataset for convenience, e.g. to do
 # masking or to more easily compute vertical integrals. But they are not inputs
@@ -103,6 +111,23 @@ class Config:
     time_coarsen: TimeCoarsenConfig | None = None
 
 
+def get_zarr_store(url: str, read_only: bool = True):
+    """Create a zarr store from a URL using obstore if available.
+
+    Args:
+        url: The URL of the zarr store to create.
+        read_only: Whether to open the store in read-only mode.
+    Returns:
+        A zarr store or the path to a zarr store if obstore is not available.
+    """
+    if url.startswith("gs://") and _HAS_OBSTORE:
+        from obstore.store import from_url
+
+        return ObjectStore(from_url(url), read_only=read_only)
+    else:
+        return url
+
+
 def get_stats(
     config: StatsConfig,
     input_zarr: str,
@@ -126,14 +151,16 @@ def get_stats(
     xr.set_options(keep_attrs=True, display_max_rows=100)
     logging.info(f"Reading data from {input_zarr}")
 
+    input_store = get_zarr_store(input_zarr)
+
     # Open data with roughly 128 MiB chunks via dask's automatic chunking. This
     # is useful when opening sharded zarr stores with an inner chunk size of 1,
     # which is otherwise inefficient for the type of computation done here.
     if dask is not None:
         with dask.config.set({"array.chunk-size": "128MiB"}):
-            ds = xr.open_zarr(input_zarr, chunks={"time": "auto"})
+            ds = xr.open_zarr(input_store, chunks={"time": "auto"})
     else:
-        ds = xr.open_zarr(input_zarr)
+        ds = xr.open_zarr(input_store)
 
     ds = ds.drop_vars(DROP_VARIABLES, errors="ignore")
     ds = ds.sel(time=slice(config.start_date, config.end_date))

--- a/scripts/data_process/requirements-atmosphere.txt
+++ b/scripts/data_process/requirements-atmosphere.txt
@@ -5,6 +5,7 @@ dacite
 dask[distributed]
 fsspec
 gcsfs
+obstore
 pyyaml
 scipy
 xarray>=2025.1.2

--- a/scripts/data_process/time_coarsen.py
+++ b/scripts/data_process/time_coarsen.py
@@ -12,7 +12,7 @@ import xarray as xr
 import yaml
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from get_stats import StatsConfig
+from get_stats import StatsConfig, get_zarr_store
 
 try:
     import dask  # noqa: F401
@@ -151,7 +151,8 @@ def coarsen(ds: xr.Dataset, config: TimeCoarsenConfig) -> xr.Dataset:
 
 def _write_eager(ds: xr.Dataset, path: str) -> None:
     """Write dataset eagerly using xarray's to_zarr."""
-    ds.to_zarr(path, mode="w", zarr_version=3)
+    output_store = get_zarr_store(path, read_only=False)
+    ds.to_zarr(output_store, mode="w", zarr_version=3)
 
 
 def _write_xpartition(ds: xr.Dataset, path: str, config: TimeCoarsenConfig) -> None:
@@ -170,13 +171,14 @@ def _write_xpartition(ds: xr.Dataset, path: str, config: TimeCoarsenConfig) -> N
     else:
         inner_chunks = config.chunking
 
-    ds.partition.initialize_store(path, inner_chunks=inner_chunks)
+    output_store = get_zarr_store(path, read_only=False)
+    ds.partition.initialize_store(output_store, inner_chunks=inner_chunks)
     for i in range(config.n_split):
         segment_number = f"{i + 1} / {config.n_split}"
         logging.info(f"Writing segment {segment_number}")
         segment_time = time.time()
         ds.partition.write(
-            path,
+            output_store,
             config.n_split,
             ["time"],
             i,
@@ -193,11 +195,12 @@ def process_path_pair(
     if os.path.exists(output_path):
         logging.warning(f"Output path {output_path} already exists. Skipping.")
         return
+    input_store = get_zarr_store(input_path)
     if _HAS_XPARTITION:
         with dask.config.set({"array.chunk-size": "128MiB"}):
-            ds = xr.open_zarr(input_path, chunks={"time": "auto"})
+            ds = xr.open_zarr(input_store, chunks={"time": "auto"})
     else:
-        ds = xr.open_dataset(input_path)
+        ds = xr.open_dataset(input_store)
     ds_coarsened = coarsen(ds, config)
     if not dry_run:
         if _HAS_XPARTITION:


### PR DESCRIPTION
This follows [the approach we have taken in the ERA5 data processing workflow](https://github.com/ai2cm/ace/blob/9e36dd8c527219dffa1123fd9c50022270a60bef/scripts/era5/pipeline/xr-beam-pipeline.py#L269-L274) to use `obstore` when reading/writing from/to zarr in the cloud.  It is expected this should provide a meaningful performance improvement, particularly when reading from stores with small inner chunks, namely the stats and time coarsening parts of our workflow.

Test workflows on the same 10-year dataset:
- Without `obstore`: `compute-fme-dataset-ensemble-fzl9k`
- With `obstore`: `compute-fme-dataset-ensemble-cjp5g`

Timing results:

||Dataset computation|Stats computation|
|-|-|-|
|Without `obstore`| 48m | 34m|
|With `obstore`| 38m | 35m |

Surprisingly we do not see any meaningful change in the stats computation time, though we do see a faster dataset computation step.

Changes:
- Adds a `get_zarr_store` function in `compute_dataset.py` and `get_stats.py` and uses it in `compute_stats.py`, `get_stats.py`, and `time_coarsen.py`.
- Updates the processing image to include `obstore`. The new image is tagged `v2026.03.0` and we have updated the argo workflow to use the image in all steps.
