### PR TITLE
Add processing configuration for 4-degree X-SHiELD dataset

### DIFF
--- a/scripts/data_process/Makefile
+++ b/scripts/data_process/Makefile
@@ -308,7 +308,7 @@ shield_amip_c96_idealized_0p1_heating_ensemble_dataset:
 
 .PHONY: xshield_amip_dataset_and_stats
 xshield_amip_dataset_and_stats:
-	./compute_dataset.sh --config configs/X-SHiELD-AMIP-1deg-$(LAYERS)-11yr.yaml
+	./compute_dataset.sh --dataset --stats --time-coarsen --config configs/X-SHiELD-AMIP-$(RESOLUTION)-$(LAYERS)-11yr.yaml
 
 .PHONY: xshield_amip_plus_4K_dataset_and_stats
 xshield_amip_plus_4K_dataset_and_stats:

--- a/scripts/data_process/configs/X-SHiELD-AMIP-4deg-8layer-11yr.yaml
+++ b/scripts/data_process/configs/X-SHiELD-AMIP-4deg-8layer-11yr.yaml
@@ -1,0 +1,196 @@
+runs:
+  2025-09-11-X-SHiELD-AMIP-4deg-8layer-11yr: gs://vcm-ml-raw-flexible-retention/2025-07-25-X-SHiELD-AMIP-FME/regridded-zarrs/gaussian_grid_45_by_90/control
+data_output_directory: gs://vcm-ml-intermediate
+stats:
+  output_directory: gs://vcm-ml-intermediate/2025-09-11-X-SHiELD-AMIP-4deg-8layer-11yr-stats
+  beaker_dataset: 2025-09-11-X-SHiELD-AMIP-4deg-8layer-11yr-stats
+  start_date: "2014-01-01T06:00:00"  # Ignore first year as spin-up.
+  end_date: "2024-01-01T00:00:00"  # Span exactly 10 years (note datetime string indexing is inclusive).
+  data_type: FV3GFS
+dataset_computation:
+  sharding:
+    time_dim: 3600
+  n_split: 10
+  reference_vertical_coordinate_file: gs://vcm-ml-raw-flexible-retention/2024-03-10-C96-SHiELD-FME-reference/vertical-coordinate-file/fv_core.res.nc
+  vertical_coarsening_indices:
+    - [0, 11]
+    - [11, 21]
+    - [21, 30]
+    - [30, 39]
+    - [39, 49]
+    - [49, 58]
+    - [58, 67]
+    - [67, 79]
+  renaming:
+    specific_humidity_at_two_meters: Q2m
+    air_temperature_at_two_meters: TMP2m
+    eastward_wind_at_ten_meters: UGRD10m
+    northward_wind_at_ten_meters: VGRD10m
+  variable_sources:
+    fluxes_2d.zarr:
+      - PRATEsfc
+      - LHTFLsfc
+      - SHTFLsfc
+      - DLWRFsfc
+      - DSWRFsfc
+      - DSWRFtoa
+      - ULWRFsfc
+      - ULWRFtoa
+      - USWRFsfc
+      - USWRFtoa
+      - GRAUPELsfc
+      - ICEsfc
+      - SNOWsfc
+    column_integrated_dynamical_fields.zarr:
+      - precipitable_water_path
+      - PRESsfc
+    air_temperature.zarr:
+      - air_temperature
+    eastward_wind.zarr:
+      - eastward_wind
+    northward_wind.zarr:
+      - northward_wind
+    specific_humidity.zarr:
+      - specific_humidity
+    cloud_water_mixing_ratio.zarr:
+      - cloud_water_mixing_ratio
+    cloud_ice_mixing_ratio.zarr:
+      - cloud_ice_mixing_ratio
+    rain_mixing_ratio.zarr:
+      - rain_mixing_ratio
+    snow_mixing_ratio.zarr:
+      - snow_mixing_ratio
+    graupel_mixing_ratio.zarr:
+      - graupel_mixing_ratio
+    pressure_thickness_of_atmospheric_layer.zarr:
+      - pressure_thickness_of_atmospheric_layer
+    instantaneous_physics_fields.zarr:
+      - air_temperature_at_two_meters
+      - eastward_wind_at_ten_meters
+      - northward_wind_at_ten_meters
+      - surface_temperature
+      - soil_moisture_0
+      - soil_moisture_1
+      - soil_moisture_2
+      - soil_moisture_3
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - snow_cover_fraction
+      - specific_humidity_at_two_meters
+    pressure_interpolated_fields.zarr:
+      - RH200
+      - RH500
+      - RH850
+      - TMP200
+      - TMP500
+      - TMP850
+      - UGRD200
+      - UGRD500
+      - UGRD850
+      - UGRD1000
+      - VGRD200
+      - VGRD500
+      - VGRD850
+      - VGRD1000
+      - h50
+      - h500
+      - h850
+      - h1000
+    static.zarr:
+      - HGTsfc
+    scalar.zarr:
+      - global_mean_co2
+  standard_names:
+    total_frozen_precip_rate: None
+time_coarsen:
+  factor: 4
+  data_output_directory: gs://vcm-ml-intermediate/2025-09-11-X-SHiELD-AMIP-4deg-daily-8layer-11yr-fme-dataset
+  stats_output_directory: gs://vcm-ml-intermediate/2025-09-11-X-SHiELD-AMIP-4deg-daily-8layer-11yr-fme-dataset-stats
+  snapshot_names:
+    - PRESsfc
+    - Q2m
+    - RH200
+    - RH500
+    - RH850
+    - TMP200
+    - TMP2m
+    - TMP500
+    - TMP850
+    - UGRD1000
+    - UGRD10m
+    - UGRD200
+    - UGRD500
+    - UGRD850
+    - VGRD1000
+    - VGRD10m
+    - VGRD200
+    - VGRD500
+    - VGRD850
+    - air_temperature_0
+    - air_temperature_1
+    - air_temperature_2
+    - air_temperature_3
+    - air_temperature_4
+    - air_temperature_5
+    - air_temperature_6
+    - air_temperature_7
+    - eastward_wind_0
+    - eastward_wind_1
+    - eastward_wind_2
+    - eastward_wind_3
+    - eastward_wind_4
+    - eastward_wind_5
+    - eastward_wind_6
+    - eastward_wind_7
+    - h1000
+    - h50
+    - h500
+    - h850
+    - land_fraction
+    - northward_wind_0
+    - northward_wind_1
+    - northward_wind_2
+    - northward_wind_3
+    - northward_wind_4
+    - northward_wind_5
+    - northward_wind_6
+    - northward_wind_7
+    - ocean_fraction
+    - sea_ice_fraction
+    - snow_cover_fraction
+    - soil_moisture_0
+    - soil_moisture_1
+    - soil_moisture_2
+    - soil_moisture_3
+    - specific_total_water_0
+    - specific_total_water_1
+    - specific_total_water_2
+    - specific_total_water_3
+    - specific_total_water_4
+    - specific_total_water_5
+    - specific_total_water_6
+    - specific_total_water_7
+    - surface_temperature
+    - total_water_path
+  window_names:
+    - DLWRFsfc
+    - DSWRFsfc
+    - DSWRFtoa
+    - LHTFLsfc
+    - PRATEsfc
+    - SHTFLsfc
+    - ULWRFsfc
+    - ULWRFtoa
+    - USWRFsfc
+    - USWRFtoa
+    - global_mean_co2
+    - tendency_of_total_water_path
+    - tendency_of_total_water_path_due_to_advection
+    - total_frozen_precipitation_rate
+  constant_prefixes:
+    - ak_
+    - bk_
+    - HGTsfc
+    - grid_xt
+    - grid_yt


### PR DESCRIPTION
This PR adds a processing configuration for the 4-degree version of the 11-year AMIP X-SHiELD dataset. We compute a 6-hourly resolution dataset and then subsequently compute a daily dataset. The time-coarsening configuration is based on that for the C96 SHiELD AMIP dataset, though we have made `global_mean_co2` a `window_name` rather than a `snapshot_name` for consistency with other datasets.

Running argo workflow: `compute-fme-dataset-ensemble-2nmbw`

Changes
- Adds a processing configuration for the 4-degree version of the 11-year AMIP X-SHiELD dataset at both 6-hourly and daily temporal resolution.
