### PR TITLE
Fix shared mutable state in EMATracker.get_state

### DIFF
--- a/fme/core/ema.py
+++ b/fme/core/ema.py
@@ -199,10 +199,10 @@ class EMATracker:
             The state of the EMA tracker.
         """
         return {
-            "decay": self.decay,
-            "num_updates": self.num_updates,
+            "decay": self.decay.clone(),
+            "num_updates": self.num_updates.clone(),
             "faster_decay_at_start": self._faster_decay_at_start,
-            "module_name_to_ema_name": self._module_name_to_ema_name,
+            "module_name_to_ema_name": dict(self._module_name_to_ema_name),
             "ema_params": {
                 name: param.clone().detach() for name, param in self._ema_params.items()
             },


### PR DESCRIPTION
## Summary
- Clone tensors (`decay`, `num_updates`) and copy the `module_name_to_ema_name` dict in `EMATracker.get_state` to prevent callers from inadvertently sharing mutable state with the tracker

## Test plan
- [x] Existing EMA tests pass
- [x] Verified by inspection that `ema_params` was already cloned, `faster_decay_at_start` is immutable

🤖 Generated with [Claude Code](https://claude.com/claude-code)