### PR TITLE
Add set_learning_rate to OptimizationABC

### DIFF
--- a/fme/core/generics/optimization.py
+++ b/fme/core/generics/optimization.py
@@ -17,6 +17,13 @@ class OptimizationABC(abc.ABC):
     def learning_rate(self) -> float: ...
 
     @abc.abstractmethod
+    def set_learning_rate(self, lr: float):
+        """
+        Set the learning rate for all parameter groups.
+        """
+        ...
+
+    @abc.abstractmethod
     def set_mode(self, modules: nn.ModuleList):
         """
         Sets the mode of the module to train.

--- a/fme/core/optimization.py
+++ b/fme/core/optimization.py
@@ -191,6 +191,10 @@ class Optimization(OptimizationABC):
             self.gscaler.update()
         self._accumulated_loss = torch.tensor(0.0, device=get_device())
 
+    def set_learning_rate(self, lr: float):
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = lr
+
     def get_state(self):
         """
         Returns state as a serializable data structure.
@@ -292,6 +296,9 @@ class NullOptimization(OptimizationABC):
     @property
     def learning_rate(self) -> float:
         return float("nan")
+
+    def set_learning_rate(self, lr: float):
+        pass
 
     def checkpoint(self, module: nn.Module, step: int) -> nn.Module:
         return module

--- a/fme/core/test_optimization.py
+++ b/fme/core/test_optimization.py
@@ -416,6 +416,150 @@ def test_sequential_scheduler_reload():
         assert torch.allclose(model_first_final_state[k], model_second_final_state[k])
 
 
+def test_set_learning_rate():
+    model = nn.Linear(1, 1).to(fme.get_device())
+    optimization = Optimization(
+        parameters=model.parameters(),
+        optimizer_type="Adam",
+        lr=0.001,
+        max_epochs=10,
+        scheduler=SchedulerConfig(),
+        enable_automatic_mixed_precision=False,
+        kwargs={},
+    )
+    assert optimization.learning_rate == 0.001
+    optimization.set_learning_rate(0.01)
+    assert optimization.learning_rate == 0.01
+
+
+def test_set_learning_rate_null():
+    optimization = NullOptimization()
+    optimization.set_learning_rate(0.01)  # should not raise
+
+
+def test_load_state_into_different_parameters():
+    """
+    Test that optimizer state (including momentum) can be loaded from one
+    Optimization into another built with different parameter objects but
+    the same structure. This is the pattern used by LR tuning trials,
+    where we deepcopy a model and need the fork's optimizer to start
+    with the original's momentum.
+    """
+    torch.manual_seed(0)
+    model = nn.Linear(2, 2).to(fme.get_device())
+    x = torch.randn(10, 2).to(fme.get_device())
+
+    optimization = Optimization(
+        parameters=model.parameters(),
+        optimizer_type="Adam",
+        lr=0.001,
+        max_epochs=10,
+        scheduler=SchedulerConfig(),
+        enable_automatic_mixed_precision=False,
+        kwargs={},
+    )
+
+    # Train a few steps to build up momentum state
+    for _ in range(3):
+        loss = model(x).sum()
+        optimization.accumulate_loss(loss)
+        optimization.step_weights()
+
+    saved_state = optimization.get_state()
+
+    # Create a new model with the same structure but different parameter objects
+    model2 = copy.deepcopy(model)
+    optimization2 = Optimization(
+        parameters=model2.parameters(),
+        optimizer_type="Adam",
+        lr=0.001,
+        max_epochs=10,
+        scheduler=SchedulerConfig(),
+        enable_automatic_mixed_precision=False,
+        kwargs={},
+    )
+    optimization2.load_state(saved_state)
+
+    # Train both for one more step on identical data and verify identical results
+    x2 = x.clone()
+    loss1 = model(x).sum()
+    optimization.accumulate_loss(loss1)
+    optimization.step_weights()
+
+    loss2 = model2(x2).sum()
+    optimization2.accumulate_loss(loss2)
+    optimization2.step_weights()
+
+    for p1, p2 in zip(model.parameters(), model2.parameters()):
+        assert torch.allclose(
+            p1, p2
+        ), "Parameters should match after identical training"
+
+
+def test_load_state_then_set_learning_rate():
+    """
+    Test that set_learning_rate works correctly after loading state,
+    which is the pattern used to create a candidate fork at a different LR.
+    """
+    torch.manual_seed(0)
+    model = nn.Linear(2, 2).to(fme.get_device())
+    x = torch.randn(10, 2).to(fme.get_device())
+
+    optimization = Optimization(
+        parameters=model.parameters(),
+        optimizer_type="Adam",
+        lr=0.001,
+        max_epochs=10,
+        scheduler=SchedulerConfig(),
+        enable_automatic_mixed_precision=False,
+        kwargs={},
+    )
+
+    # Train a few steps
+    for _ in range(3):
+        loss = model(x).sum()
+        optimization.accumulate_loss(loss)
+        optimization.step_weights()
+
+    saved_state = optimization.get_state()
+
+    # Build a new optimization, load state, then override LR
+    model2 = copy.deepcopy(model)
+    optimization2 = Optimization(
+        parameters=model2.parameters(),
+        optimizer_type="Adam",
+        lr=0.001,
+        max_epochs=10,
+        scheduler=SchedulerConfig(),
+        enable_automatic_mixed_precision=False,
+        kwargs={},
+    )
+    optimization2.load_state(saved_state)
+    optimization2.set_learning_rate(0.0005)
+
+    assert optimization2.learning_rate == 0.0005
+
+    # Verify it actually trains at the new LR (different from original)
+    x2 = x.clone()
+
+    loss1 = model(x).sum()
+    optimization.accumulate_loss(loss1)
+    optimization.step_weights()
+
+    loss2 = model2(x2).sum()
+    optimization2.accumulate_loss(loss2)
+    optimization2.step_weights()
+
+    # With different LRs, parameters should diverge
+    params_match = all(
+        torch.allclose(p1, p2)
+        for p1, p2 in zip(model.parameters(), model2.parameters())
+    )
+    assert (
+        not params_match
+    ), "Parameters should differ when trained at different learning rates"
+
+
 def test_scheduler_step_timing():
     """
     Test that schedulers step at the correct timing based on


### PR DESCRIPTION
## Summary
- Add `set_learning_rate(lr)` abstract method to `OptimizationABC` and implement on `Optimization` (updates all param groups) and `NullOptimization` (no-op)

## Test plan
- [x] New tests verify learning rate is updated and optimizer momentum state is preserved
- [x] Existing optimization tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)