### PR TITLE
Extract run_validation_loop and refactor Trainer to use run_validation

### DIFF
--- a/fme/core/generics/test_validation.py
+++ b/fme/core/generics/test_validation.py
@@ -1,0 +1,92 @@
+import unittest.mock
+
+import torch
+
+from fme.core.ema import EMATracker
+from fme.core.generics.test_trainer import TrainData, TrainStepper, ValidationAggregator
+from fme.core.generics.validation import run_validation_loop
+
+
+def test_run_validation_loop_returns_none():
+    stepper = TrainStepper()
+    valid_data = TrainData(n_batches=3, shuffle=False)
+    aggregator = ValidationAggregator(validation_loss=0.5)
+    ema = EMATracker(stepper.modules, decay=0.9999)
+
+    run_validation_loop(
+        stepper=stepper,
+        valid_data=valid_data,
+        aggregator=aggregator,
+        ema=ema,
+        validate_using_ema=False,
+    )
+
+    assert stepper.validation_batches_seen == [0, 1, 2]
+    logs = aggregator.get_logs(label="val")
+    assert "val/mean/loss" in logs
+    assert logs["val/mean/loss"] == 0.5
+
+
+def test_run_validation_loop_with_ema():
+    """When validate_using_ema=True, EMA params are applied during validation."""
+    stepper = TrainStepper()
+    valid_data = TrainData(n_batches=2, shuffle=False)
+    aggregator = ValidationAggregator(validation_loss=0.3)
+
+    # Set a non-zero weight so EMA differs from the initial zero weight
+    stepper.modules[0].weight.data.fill_(1.0)
+    ema = EMATracker(stepper.modules, decay=0.5)
+    # Update EMA with current params, then change model weight
+    ema(stepper.modules)
+    stepper.modules[0].weight.data.fill_(2.0)
+
+    weight_before = stepper.modules[0].weight.data.clone()
+
+    run_validation_loop(
+        stepper=stepper,
+        valid_data=valid_data,
+        aggregator=aggregator,
+        ema=ema,
+        validate_using_ema=True,
+    )
+
+    # After run_validation_loop, the original weights should be restored
+    assert torch.allclose(stepper.modules[0].weight.data, weight_before)
+    logs = aggregator.get_logs(label="val")
+    assert "val/mean/loss" in logs
+
+
+def test_run_validation_loop_without_ema_none():
+    """When ema is None and validate_using_ema=False, validation still works."""
+    stepper = TrainStepper()
+    valid_data = TrainData(n_batches=2, shuffle=False)
+    aggregator = ValidationAggregator(validation_loss=0.7)
+
+    run_validation_loop(
+        stepper=stepper,
+        valid_data=valid_data,
+        aggregator=aggregator,
+        ema=None,
+        validate_using_ema=False,
+    )
+
+    logs = aggregator.get_logs(label="val")
+    assert logs["val/mean/loss"] == 0.7
+
+
+def test_run_validation_loop_does_not_flush_diagnostics():
+    """run_validation_loop should not call flush_diagnostics on the aggregator."""
+    stepper = TrainStepper()
+    valid_data = TrainData(n_batches=2, shuffle=False)
+    aggregator = ValidationAggregator(validation_loss=0.1)
+    aggregator.flush_diagnostics = unittest.mock.MagicMock()  # type: ignore
+
+    run_validation_loop(
+        stepper=stepper,
+        valid_data=valid_data,
+        aggregator=aggregator,
+        ema=None,
+        validate_using_ema=False,
+    )
+
+    aggregator.flush_diagnostics.assert_not_called()

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -70,6 +70,7 @@ from fme.core.generics.data import GriddedDataABC, InferenceDataABC
 from fme.core.generics.inference import run_inference
 from fme.core.generics.metrics_aggregator import MetricsAggregator
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
+from fme.core.generics.validation import run_validation
 from fme.core.optimization import NullOptimization, Optimization
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingJob
@@ -558,23 +559,17 @@ class Trainer:
             f"{self._epochs_trained} epochs"
         )
         self.valid_data.set_epoch(self._epochs_trained)
-        self.stepper.set_eval()
         aggregator = self._aggregator_builder.get_validation_aggregator()
         logging.info("Starting loop over validation data")
-        with torch.no_grad(), self.validation_context(), GlobalTimer():
-            for batch in self.valid_data.loader:
-                stepped = self.stepper.train_on_batch(
-                    batch,
-                    optimization=NullOptimization(),
-                    compute_derived_variables=True,
-                )
-                aggregator.record_batch(
-                    batch=stepped,
-                )
-        logging.info("Starting flush of reduced diagnostics to disk")
-        aggregator.flush_diagnostics(subdir=f"epoch_{self._epochs_trained:04d}")
-        logging.info("Getting validation aggregator logs")
-        return aggregator.get_logs(label="val")
+        return run_validation(
+            train_stepper=self.stepper,
+            validation_data=self.valid_data,
+            aggregator=aggregator,
+            diagnostics_subdir=f"epoch_{self._epochs_trained:04d}",
+            record_logs=lambda logs: None,
+            ema=self._ema,
+            validate_using_ema=self.config.validate_using_ema,
+        )
 
     def inference_one_epoch(
         self,

--- a/fme/core/generics/validation.py
+++ b/fme/core/generics/validation.py
@@ -1,7 +1,11 @@
+import contextlib
 import logging
 from collections.abc import Callable
 from typing import TypeVar
 
+import torch
+
+from fme.core.ema import EMATracker
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.generics.data import GriddedDataABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
@@ -14,6 +18,46 @@ BD = TypeVar("BD")  # batch data
 FD = TypeVar("FD")  # forcing data
 SD = TypeVar("SD")  # stepped data
 TO = TypeVar("TO", bound=TrainOutputABC)  # train output
+
+
+def run_validation_loop(
+    stepper: TrainStepperABC,
+    valid_data: GriddedDataABC,
+    aggregator: AggregatorABC,
+    ema: EMATracker | None = None,
+    validate_using_ema: bool = False,
+    compute_derived_variables: bool = True,
+) -> None:
+    """Run the core validation loop: iterate batches and record to aggregator.
+
+    This is the minimal validation loop used by both `run_validation` and
+    LR tuning trials. It does NOT call `aggregator.get_logs`,
+    `aggregator.flush_diagnostics`, or log to WandB — callers are responsible
+    for those.
+
+    Args:
+        stepper: The train stepper to evaluate.
+        valid_data: The validation dataset.
+        aggregator: The aggregator to record batch results into.
+        ema: The EMA tracker, or None if EMA is not used.
+        validate_using_ema: Whether to use EMA parameters during validation.
+        compute_derived_variables: Whether to compute derived variables.
+    """
+    stepper.set_eval()
+    ema_context: contextlib.AbstractContextManager = (
+        ema.applied_params(stepper.modules)
+        if validate_using_ema and ema is not None
+        else contextlib.nullcontext()
+    )
+    no_opt = NullOptimization()
+    with torch.no_grad(), ema_context:
+        for batch in valid_data.loader:
+            stepped = stepper.train_on_batch(
+                batch,
+                optimization=no_opt,
+                compute_derived_variables=compute_derived_variables,
+            )
+            aggregator.record_batch(batch=stepped)
 
 
 def _get_record_to_wandb() -> Callable[[dict[str, float]], None]:
@@ -35,8 +79,13 @@ def run_validation(
     diagnostics_subdir: str | None = None,
     record_logs: Callable[[dict[str, float]], None] | None = None,
     compute_derived_variables: bool = True,
+    ema: EMATracker | None = None,
+    validate_using_ema: bool = False,
 ) -> dict[str, float]:
     """Run validation loop for a train stepper and validation dataset.
+
+    High-level wrapper around `run_validation_loop` that also flushes
+    diagnostics, collects logs, and optionally records them to WandB.
 
     Args:
         train_stepper: Train-stepper wrapper to compute validation outputs.
@@ -46,6 +95,8 @@ def run_validation(
         diagnostics_subdir: Optional subdirectory for diagnostic output.
         record_logs: Optional function to record logs (defaults to WandB).
         compute_derived_variables: Whether to compute derived variables.
+        ema: The EMA tracker, or None if EMA is not used.
+        validate_using_ema: Whether to use EMA parameters during validation.
 
     Returns:
         Dictionary of validation metrics (keys prefixed by the label).
@@ -57,18 +108,14 @@ def run_validation(
 
     logging.info("Starting validation loop")
 
-    no_opt = NullOptimization()
-    n_batches = len(validation_data.loader)
-
-    for i, batch in enumerate(validation_data.loader):
-        logging.info(f"Validation: processing batch {i + 1} of {n_batches}.")
-        stepped = train_stepper.train_on_batch(
-            batch,
-            optimization=no_opt,
-            compute_derived_variables=compute_derived_variables,
-        )
-        with timer.context("aggregator"):
-            aggregator.record_batch(stepped)
+    run_validation_loop(
+        stepper=train_stepper,
+        valid_data=validation_data,
+        aggregator=aggregator,
+        ema=ema,
+        validate_using_ema=validate_using_ema,
+        compute_derived_variables=compute_derived_variables,
+    )
 
     logging.info("Flushing validation diagnostics")
     with timer.context("flush_diagnostics"):


### PR DESCRIPTION
## Summary
- Extract `run_validation_loop` as a minimal validation loop (eval, no_grad, EMA, iterate, record) without flush/WandB side effects, for reuse by callers that need only the core loop
- Refactor `run_validation` to delegate to `run_validation_loop` instead of having an inline loop
- Switch `Trainer.validate_one_epoch` from an inline validation loop to using `run_validation`
- Add `ema` and `validate_using_ema` parameters to `run_validation` so callers can pass EMA config through

## Test plan
- [x] New unit tests for `run_validation_loop` covering basic operation, EMA application, no-EMA case, and verifying no diagnostic flush
- [x] Existing `test_trainer.py` and `test_evaluator.py` tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)