### PR TITLE
Increase nccl process group timeout to 60 minutes

### DIFF
--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -32,7 +32,7 @@ class TorchDistributed(DistributedBackend):
                     torch.distributed.init_process_group(
                         backend="nccl",
                         init_method="env://",
-                        timeout=timedelta(minutes=20),
+                        timeout=timedelta(minutes=60),
                     )
                 else:
                     torch.distributed.init_process_group(


### PR DESCRIPTION
A temporary bandaid for inline inference timeouts in coupled training on beaker until we can find and fix the root cause.