### PR TITLE
Avoid having two copies of weights on GPU when loading checkpoints

### DIFF
--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -507,3 +507,10 @@ class FCN3Step(StepABC):
             state: The state to load.
         """
         self.module.load_state_dict(state["module"])
+
+    def to(self, device: str) -> "FCN3Step":
+        """Move the step's tensors and modules to the specified device."""
+        self.module = self.module.to(device)
+        self._normalizer = self._normalizer.to(device)
+        self._corrector.to(device)
+        return self

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -343,8 +343,8 @@ class TrainOutput(TrainOutputABC):
     target_data: EnsembleTensorDict
     time: xr.DataArray
     normalize: Callable[[TensorDict], TensorDict]
-    derive_func: Callable[[TensorMapping, TensorMapping], TensorDict] = (
-        lambda x, _: dict(x)
+    derive_func: Callable[[TensorMapping, TensorMapping], TensorDict] = lambda x, _: (
+        dict(x)
     )
 
     def __post_init__(self):
@@ -1350,6 +1350,16 @@ class Stepper:
         stepper.load_state(state)
         return stepper
 
+    def to(self, device: str) -> "Stepper":
+        """Move the stepper's tensors and modules to the specified device."""
+        self._step_obj.to(device)
+        self._dataset_info = self._dataset_info.to(device)
+        if hasattr(self._input_process_func, "to"):
+            self._input_process_func.to(device)
+        if hasattr(self._output_process_func, "to"):
+            self._output_process_func.to(device)
+        return self
+
     def set_eval(self) -> None:
         for module in self.modules:
             module.eval()
@@ -1795,10 +1805,10 @@ def load_stepper(
     if override_config is None:
         override_config = StepperOverrideConfig()
 
-    checkpoint = torch.load(
-        checkpoint_path, map_location=get_device(), weights_only=False
-    )
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     stepper = Stepper.from_state(checkpoint["stepper"])
+    del checkpoint
+    stepper.to(get_device())
 
     if override_config.ocean != "keep":
         logging.info(

--- a/fme/core/atmosphere_data.py
+++ b/fme/core/atmosphere_data.py
@@ -58,6 +58,9 @@ class HasAtmosphereVerticalIntegral(Protocol):
     def get_bk(self) -> torch.Tensor:
         pass
 
+    def to(self, device: str) -> "HasAtmosphereVerticalIntegral":
+        pass
+
 
 class AtmosphereData:
     """Container for atmospheric data for accessing variables and providing

--- a/fme/core/coordinates.py
+++ b/fme/core/coordinates.py
@@ -108,6 +108,9 @@ PostProcessFnType = Callable[[TensorMapping], TensorDict]
 
 
 class NullPostProcessFn:
+    def to(self, device: str) -> "NullPostProcessFn":
+        return self
+
     def __call__(self, data: TensorMapping) -> TensorDict:
         return dict(data)
 

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -162,6 +162,11 @@ class AtmosphereCorrector(CorrectorABC):
         else:
             self._dry_air_precision = torch.float64
 
+    def to(self, device: str) -> "AtmosphereCorrector":
+        if self._vertical_coordinate is not None:
+            self._vertical_coordinate = self._vertical_coordinate.to(device)
+        return self
+
     def __call__(
         self,
         input_data: TensorMapping,

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -212,6 +212,9 @@ class IceCorrector(CorrectorABC):
         self._gridded_operations = gridded_operations
         self._timestep = timestep
 
+    def to(self, device: str) -> "IceCorrector":
+        return self
+
     def __call__(
         self,
         input_data: TensorMapping,

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -165,6 +165,11 @@ class OceanCorrector(CorrectorABC):
         self._vertical_coordinate = vertical_coordinate
         self._timestep = timestep
 
+    def to(self, device: str) -> "OceanCorrector":
+        if self._vertical_coordinate is not None:
+            self._vertical_coordinate = self._vertical_coordinate.to(device)
+        return self
+
     def __call__(
         self,
         input_data: TensorMapping,

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -39,3 +39,6 @@ class CorrectorABC(abc.ABC):
         gen_data: TensorMapping,
         forcing_data: TensorMapping,
     ) -> TensorDict: ...
+
+    @abc.abstractmethod
+    def to(self, device: str) -> "CorrectorABC": ...

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -33,6 +33,9 @@ class _MockDepth:
         thickness = idepth.diff(dim=-1)
         return torch.nansum(_MASK * integrand * thickness, dim=-1)
 
+    def to(self, device: str) -> "_MockDepth":
+        return self
+
 
 _VERTICAL_COORD = _MockDepth()
 

--- a/fme/core/dataset_info.py
+++ b/fme/core/dataset_info.py
@@ -240,6 +240,28 @@ class DatasetInfo:
             all_labels=self._all_labels,
         )
 
+    def to(self, device: str) -> "DatasetInfo":
+        """Move tensor-holding components to the specified device."""
+        horizontal_coordinates = self._horizontal_coordinates
+        if horizontal_coordinates is not None:
+            horizontal_coordinates = horizontal_coordinates.to(device)
+        vertical_coordinate = self._vertical_coordinate
+        if vertical_coordinate is not None:
+            vertical_coordinate = vertical_coordinate.to(device)
+        mask_provider = self._mask_provider
+        if mask_provider is not None:
+            mask_provider = mask_provider.to(device)
+        return DatasetInfo(
+            horizontal_coordinates=horizontal_coordinates,
+            vertical_coordinate=vertical_coordinate,
+            mask_provider=mask_provider,
+            timestep=self._timestep,
+            variable_metadata=self._variable_metadata,
+            gridded_operations=self._gridded_operations,
+            img_shape=self._img_shape,
+            all_labels=self._all_labels,
+        )
+
     def get_state(self) -> dict[str, Any]:
         if self._gridded_operations is not None:
             gridded_operations = self._gridded_operations.get_state()

--- a/fme/core/masking.py
+++ b/fme/core/masking.py
@@ -131,6 +131,10 @@ class StaticMasking:
         exclude = self._exclude_regex and re.match(self._exclude_regex, name)
         return not exclude
 
+    def to(self, device: str) -> "StaticMasking":
+        self._mask = self._mask.to(device)
+        return self
+
     def __call__(self, data: TensorMapping) -> TensorDict:
         """
         Apply masking to the data for standard names recognized by a stacker.
@@ -166,5 +170,8 @@ class StaticMasking:
 
 
 class NullMasking:
+    def to(self, device: str) -> "NullMasking":
+        return self
+
     def __call__(self, data: TensorMapping) -> TensorDict:
         return dict(data)

--- a/fme/core/normalizer.py
+++ b/fme/core/normalizer.py
@@ -175,6 +175,15 @@ class StandardNormalizer:
             fill_nans_on_denormalize=state.get("fill_nans_on_denormalize", False),
         )
 
+    def to(self, device: str) -> "StandardNormalizer":
+        """Move the normalizer's tensors to the specified device."""
+        return StandardNormalizer(
+            means={k: v.to(device) for k, v in self.means.items()},
+            stds={k: v.to(device) for k, v in self.stds.items()},
+            fill_nans_on_normalize=self._fill_nans_on_normalize,
+            fill_nans_on_denormalize=self._fill_nans_on_denormalize,
+        )
+
     def get_normalization_config(self) -> NormalizationConfig:
         return NormalizationConfig(
             means={k: float(v.cpu().numpy().item()) for k, v in self.means.items()},

--- a/fme/core/ocean_data.py
+++ b/fme/core/ocean_data.py
@@ -37,6 +37,8 @@ class HasOceanDepthIntegral(Protocol):
         integrand: torch.Tensor,
     ) -> torch.Tensor: ...
 
+    def to(self, device: str) -> "HasOceanDepthIntegral": ...
+
 
 class HasCellAreaInMetersSquared(Protocol):
     """Protocol for objects that can provide cell areas in square meters."""

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -323,3 +323,8 @@ class MultiCallStep(StepABC):
             state: The ML model state of the multi-call step.
         """
         self._wrapped_step.load_state(state["wrapped_step"])
+
+    def to(self, device: str) -> "MultiCallStep":
+        """Move the step's tensors and modules to the specified device."""
+        self._wrapped_step.to(device)
+        return self

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -420,3 +420,11 @@ class SeparateRadiationStep(StepABC):
         """
         self.module.load_state(state["module"])
         self.radiation_module.load_state(state["radiation_module"])
+
+    def to(self, device: str) -> "SeparateRadiationStep":
+        """Move the step's tensors and modules to the specified device."""
+        self.module = self.module.to(device)
+        self.radiation_module = self.radiation_module.to(device)
+        self._normalizer = self._normalizer.to(device)
+        self._corrector.to(device)
+        return self

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -402,6 +402,14 @@ class SingleModuleStep(StepABC):
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
 
+    def to(self, device: str) -> "SingleModuleStep":
+        """Move the step's tensors and modules to the specified device."""
+        self.module = self.module.to(device)
+        self.secondary_decoder = self.secondary_decoder.to(device)
+        self._normalizer = self._normalizer.to(device)
+        self._corrector.to(device)
+        return self
+
 
 def step_with_adjustments(
     input: TensorMapping,

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -353,3 +353,8 @@ class StepABC(abc.ABC):
         Load the state of the step object.
         """
         pass
+
+    @abc.abstractmethod
+    def to(self: SelfType, device: str) -> SelfType:
+        """Move the step's tensors and modules to the specified device."""
+        pass

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -70,6 +70,9 @@ class MockStep(StepABC):
     def load_state(self, state):
         pass
 
+    def to(self, device: str) -> "MockStep":
+        return self
+
 
 @StepSelector.register("mock")
 @dataclasses.dataclass


### PR DESCRIPTION
I noticed when calling the `load_stepper` function that the GPU memory used was 2x the size of the checkpoint being used. This PR implements some changes to avoid this.

Changes:
- symbol (e.g. `fme.core.my_function`) or script and concise description of changes or added feature
- Can group multiple related symbols on a single bullet

Don't have a great testbed, but compared running `load_stepper` on the ACE2-ERA5 checkpoint in a colab notebook with 2026.1.1 fme release and this branch.

v2026.1.1:
<img width="122" height="110" alt="Screenshot 2026-04-09 at 9 44 53 AM" src="https://github.com/user-attachments/assets/c41d10a2-8bff-4299-b7f3-03b0a77f1498" />

This branch:
<img width="114" height="113" alt="Screenshot 2026-04-09 at 9 22 34 AM" src="https://github.com/user-attachments/assets/65bd3ddf-7bf9-42c7-99c7-3f7ba9b5bdef" />
