### PR TITLE
Ensure `IceCorrectorConfig` is added to `CorrectorSelector` registry

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -68,8 +68,8 @@ from fme.ace.stepper.time_length_probabilities import (
 from fme.ace.train.train_config import WeatherEvaluationConfig
 from fme.core.cli import ResumeResultsConfig
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
-from fme.core.corrector.ocean import OceanCorrectorConfig
 from fme.core.corrector.ice import IceCorrectorConfig
+from fme.core.corrector.ocean import OceanCorrectorConfig
 from fme.core.dataset.concat import ConcatDatasetConfig
 from fme.core.dataset.merged import MergeDatasetConfig, MergeNoConcatDatasetConfig
 from fme.core.dataset.time import RepeatedInterval, TimeSlice

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -69,6 +69,7 @@ from fme.ace.train.train_config import WeatherEvaluationConfig
 from fme.core.cli import ResumeResultsConfig
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.corrector.ocean import OceanCorrectorConfig
+from fme.core.corrector.ice import IceCorrectorConfig
 from fme.core.dataset.concat import ConcatDatasetConfig
 from fme.core.dataset.merged import MergeDatasetConfig, MergeNoConcatDatasetConfig
 from fme.core.dataset.time import RepeatedInterval, TimeSlice


### PR DESCRIPTION
Needed to register ice corrector after recent changes to CorrectorConfigABC

Changes:
- added `from fme.core.corrector.ice import IceCorrectorConfig` to `fme.ace.__init__.py`