### PR TITLE
Add link to colab notebook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Docs](https://readthedocs.org/projects/ai2-climate-emulator/badge/?version=latest)](https://ai2-climate-emulator.readthedocs.io/en/latest/)
 [![PyPI](https://img.shields.io/pypi/v/fme.svg)](https://pypi.org/project/fme/)
 [![Model checkpoints](https://img.shields.io/badge/%F0%9F%A4%97%20HF-Models-yellow)](https://huggingface.co/collections/allenai/ace)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1M6y9UBnb8pJLgO6PrJydfRogBFkdd2oL?usp=sharing)
 
 <img src="ACE-logo.png" alt="Logo for the ACE Project" style="width: auto; height: 50px;">
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Docs](https://readthedocs.org/projects/ai2-climate-emulator/badge/?version=latest)](https://ai2-climate-emulator.readthedocs.io/en/latest/)
 [![PyPI](https://img.shields.io/pypi/v/fme.svg)](https://pypi.org/project/fme/)
 [![Model checkpoints](https://img.shields.io/badge/%F0%9F%A4%97%20HF-Models-yellow)](https://huggingface.co/collections/allenai/ace)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1M6y9UBnb8pJLgO6PrJydfRogBFkdd2oL?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1M6y9UBnb8pJLgO6PrJydfRogBFkdd2oL)
 
 <img src="ACE-logo.png" alt="Logo for the ACE Project" style="width: auto; height: 50px;">
 


### PR DESCRIPTION
Add a link to a colab with a simple of example running ACE2-ERA5 inference. That notebook uses a pinned version of `fme` which should help reduce impacts of breaking changes.