### PR TITLE
Change default preemptible option in job runner

### DIFF
--- a/job_runner/lib.sh
+++ b/job_runner/lib.sh
@@ -160,7 +160,7 @@ git_commit_and_push() {
 run_gantry_training_job() {
     local REPO_ROOT=$(git rev-parse --show-toplevel)
     local DESCRIPTION="${1:-Training job}"
-    local PREEMPTIBLE="${PREEMPTIBLE:---minRuntime 0}"
+    local PREEMPTIBLE="${PREEMPTIBLE:---min-runtime 0}"
 
     # Build override string
     local OVERRIDE=""

--- a/job_runner/lib.sh
+++ b/job_runner/lib.sh
@@ -160,7 +160,7 @@ git_commit_and_push() {
 run_gantry_training_job() {
     local REPO_ROOT=$(git rev-parse --show-toplevel)
     local DESCRIPTION="${1:-Training job}"
-    local PREEMPTIBLE="${PREEMPTIBLE:---preemptible}"
+    local PREEMPTIBLE="${PREEMPTIBLE:---minRuntime 0}"
 
     # Build override string
     local OVERRIDE=""


### PR DESCRIPTION
Getting this warning in the latest gantry:
```sh
DeprecationWarning: The option 'preemptible' is deprecated. Use --min-runtime and/or --no-auto-resume instead.
```

I think `--min-runtime 0` keeps the job preemptible.