### PR TITLE
Remove deprecated n_forward_steps from TrainConfig

### DIFF
--- a/configs/baselines/amip-c96-shield/train-ace2.yaml
+++ b/configs/baselines/amip-c96-shield/train-ace2.yaml
@@ -4,7 +4,6 @@ experiment_dir: /results
 save_checkpoint: true
 validate_using_ema: true
 max_epochs: 120
-n_forward_steps: 2
 ema:
   decay: 0.999
 inference:
@@ -74,6 +73,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/baselines/amip-c96-shield/train-baseline.yaml
+++ b/configs/baselines/amip-c96-shield/train-baseline.yaml
@@ -4,7 +4,6 @@ experiment_dir: /results
 save_checkpoint: true
 validate_using_ema: true
 max_epochs: 120
-n_forward_steps: 2
 ema:
   decay: 0.999
 inference:
@@ -65,6 +64,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/baselines/climsst/train-baseline-4deg.yaml
+++ b/configs/baselines/climsst/train-baseline-4deg.yaml
@@ -3,7 +3,6 @@ experiment_dir: /results
 save_checkpoint: true
 validate_using_ema: true
 max_epochs: 120
-n_forward_steps: 2
 ema:
   decay: 0.999
 inference:
@@ -76,6 +75,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/baselines/climsst/train-baseline.yaml
+++ b/configs/baselines/climsst/train-baseline.yaml
@@ -2,7 +2,6 @@ experiment_dir: /results
 save_checkpoint: true
 validate_using_ema: true
 max_epochs: 120
-n_forward_steps: 2
 ema:
   decay: 0.999
 inference:
@@ -75,6 +74,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/baselines/cm4-piControl/uncoupled-atmos/train-config.yaml
+++ b/configs/baselines/cm4-piControl/uncoupled-atmos/train-config.yaml
@@ -4,7 +4,6 @@ validate_using_ema: true
 ema:
   decay: 0.999
 max_epochs: 50
-n_forward_steps: 2
 inference:
   n_forward_steps: 29200
   forward_steps_in_memory: 40
@@ -78,6 +77,7 @@ optimization:
   kwargs:
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/baselines/cm4-piControl/uncoupled-ocean/train-config.yaml
+++ b/configs/baselines/cm4-piControl/uncoupled-ocean/train-config.yaml
@@ -4,7 +4,6 @@ validate_using_ema: true
 ema:
   decay: 0.999
 max_epochs: 150
-n_forward_steps: 4
 inference:
   n_forward_steps: 1440
   forward_steps_in_memory: 40
@@ -90,6 +89,7 @@ optimization:
   kwargs:
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 4
   loss:
     type: MSE
 stepper:

--- a/configs/baselines/era5/ace-train-config.yaml
+++ b/configs/baselines/era5/ace-train-config.yaml
@@ -3,7 +3,6 @@ experiment_dir: /results
 save_checkpoint: true
 validate_using_ema: true
 max_epochs: 120
-n_forward_steps: 2
 ema:
   decay: 0.999
 inference:
@@ -66,6 +65,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/baselines/shield-som/ace-train-config.yaml
+++ b/configs/baselines/shield-som/ace-train-config.yaml
@@ -4,7 +4,6 @@ validate_using_ema: true
 ema:
   decay: 0.999
 max_epochs: 50
-n_forward_steps: 2
 inference:
   n_forward_steps: 10220
   forward_steps_in_memory: 40
@@ -77,6 +76,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/configs/examples/perlmutter-conda/config-train.yaml
+++ b/configs/examples/perlmutter-conda/config-train.yaml
@@ -5,7 +5,6 @@ validate_using_ema: true
 ema:
   decay: 0.999
 max_epochs: 30
-n_forward_steps: 2
 inference:
   n_forward_steps: 5110
   forward_steps_in_memory: 40
@@ -58,6 +57,7 @@ optimization:
     fused: true
     weight_decay: 0.01
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: MSE
     weights:

--- a/docs/train-config.yaml
+++ b/docs/train-config.yaml
@@ -2,7 +2,6 @@ experiment_dir: train_output
 save_checkpoint: true
 validate_using_ema: true
 max_epochs: 80
-n_forward_steps: 1
 inference:
   n_forward_steps: 7300  # 5 years
   forward_steps_in_memory: 50
@@ -50,6 +49,7 @@ optimization:
   optimizer_type: AdamW
   # can also set kwargs: fused: true for performance if using GPU
 stepper_training:
+  n_forward_steps: 1
   loss:
     type: MSE
 stepper:

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -113,7 +113,7 @@ class ValidationConfig:
             settings, and forward step scheduling. Set this to match the training
             configuration if you want ``val/mean/loss`` to be directly comparable.
             The number of forward steps is derived from
-            ``stepper_training.train_n_forward_steps`` (defaults to 1 if unset).
+            ``stepper_training.n_forward_steps`` (defaults to 1 if unset).
 
     """
 
@@ -131,9 +131,9 @@ class ValidationConfig:
                 "stepper_training.parameter_init is not used for validation within "
                 "inference evaluator jobs."
             )
-        if isinstance(self.stepper_training.train_n_forward_steps, TimeLengthSchedule):
+        if isinstance(self.stepper_training.n_forward_steps, TimeLengthSchedule):
             raise ValueError(
-                "stepper_training.train_n_forward_steps may not be a "
+                "stepper_training.n_forward_steps may not be a "
                 "TimeLengthSchedule for validation within inference evaluator jobs. "
                 "Use TimeLengthProbabilities or an int instead."
             )
@@ -141,13 +141,13 @@ class ValidationConfig:
     def get_n_forward_steps(self) -> int:
         """Resolve the effective number of forward steps for validation.
 
-        Derives the value from ``stepper_training.train_n_forward_steps``.
+        Derives the value from ``stepper_training.n_forward_steps``.
         Defaults to 1 for standard single-step validation if unset.
         """
-        train_n = self.stepper_training.train_n_forward_steps
+        train_n = self.stepper_training.n_forward_steps
         if train_n is None:
             logging.info(
-                "stepper_training.train_n_forward_steps was not configured for "
+                "stepper_training.n_forward_steps was not configured for "
                 "validation within the inference evaluator job, defaulting to "
                 "n_forward_steps=1."
             )

--- a/fme/ace/inference/test_evaluator.py
+++ b/fme/ace/inference/test_evaluator.py
@@ -1335,13 +1335,13 @@ def test_evaluator_with_non_local_experiment_dir(
     [
         pytest.param(dict(), id="default"),
         pytest.param(
-            dict(stepper_training=TrainStepperConfig(train_n_forward_steps=1)),
+            dict(stepper_training=TrainStepperConfig(n_forward_steps=1)),
             id="stepper_training_int",
         ),
         pytest.param(
             dict(
                 stepper_training=TrainStepperConfig(
-                    train_n_forward_steps=TimeLengthProbabilities(
+                    n_forward_steps=TimeLengthProbabilities(
                         outcomes=[TimeLengthProbability(steps=1, probability=1.0)]
                     )
                 )

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1370,15 +1370,18 @@ class TrainStepperConfig:
         n_ensemble: The number of ensemble members evaluated for each training
             batch member. Default is 2 if the loss type is EnsembleLoss, otherwise
             the default is 1. Must be 2 for EnsembleLoss to be valid.
-        train_n_forward_steps: The number of timesteps to train on and (optionally)
-            associated sampling probabilities.
+        train_n_forward_steps: The number of timesteps to train on and associated
+            sampling probabilities. By default, the stepper will train on the full
+            number of timesteps present in the training dataset samples. Values must
+            be less than or equal to the number of timesteps present
+            in the training dataset samples.
         parameter_init: The parameter initialization configuration for fine-tuning.
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
     optimize_last_step_only: bool = False
     n_ensemble: int = -1  # sentinel value to avoid None typing of attribute
-    train_n_forward_steps: TimeLength | TimeLengthSchedule = 1
+    train_n_forward_steps: TimeLength | TimeLengthSchedule | None = None
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=lambda: ParameterInitializationConfig()
     )
@@ -1391,7 +1394,9 @@ class TrainStepperConfig:
                 self.n_ensemble = 1
 
     @property
-    def train_n_forward_steps_schedule(self) -> TimeLengthSchedule:
+    def train_n_forward_steps_schedule(self) -> TimeLengthSchedule | None:
+        if self.train_n_forward_steps is None:
+            return None
         if isinstance(self.train_n_forward_steps, TimeLengthSchedule):
             return self.train_n_forward_steps
         return TimeLengthSchedule.from_constant(self.train_n_forward_steps)

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1370,18 +1370,15 @@ class TrainStepperConfig:
         n_ensemble: The number of ensemble members evaluated for each training
             batch member. Default is 2 if the loss type is EnsembleLoss, otherwise
             the default is 1. Must be 2 for EnsembleLoss to be valid.
-        train_n_forward_steps: The number of timesteps to train on and associated
-            sampling probabilities. By default, the stepper will train on the full
-            number of timesteps present in the training dataset samples. Values must
-            be less than or equal to the number of timesteps present
-            in the training dataset samples.
+        train_n_forward_steps: The number of timesteps to train on and (optionally)
+            associated sampling probabilities.
         parameter_init: The parameter initialization configuration for fine-tuning.
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
     optimize_last_step_only: bool = False
     n_ensemble: int = -1  # sentinel value to avoid None typing of attribute
-    train_n_forward_steps: TimeLength | TimeLengthSchedule | None = None
+    train_n_forward_steps: TimeLength | TimeLengthSchedule = 1
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=lambda: ParameterInitializationConfig()
     )
@@ -1394,9 +1391,7 @@ class TrainStepperConfig:
                 self.n_ensemble = 1
 
     @property
-    def train_n_forward_steps_schedule(self) -> TimeLengthSchedule | None:
-        if self.train_n_forward_steps is None:
-            return None
+    def train_n_forward_steps_schedule(self) -> TimeLengthSchedule:
         if isinstance(self.train_n_forward_steps, TimeLengthSchedule):
             return self.train_n_forward_steps
         return TimeLengthSchedule.from_constant(self.train_n_forward_steps)

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -343,8 +343,8 @@ class TrainOutput(TrainOutputABC):
     target_data: EnsembleTensorDict
     time: xr.DataArray
     normalize: Callable[[TensorDict], TensorDict]
-    derive_func: Callable[[TensorMapping, TensorMapping], TensorDict] = (
-        lambda x, _: dict(x)
+    derive_func: Callable[[TensorMapping, TensorMapping], TensorDict] = lambda x, _: (
+        dict(x)
     )
 
     def __post_init__(self):
@@ -1370,7 +1370,7 @@ class TrainStepperConfig:
         n_ensemble: The number of ensemble members evaluated for each training
             batch member. Default is 2 if the loss type is EnsembleLoss, otherwise
             the default is 1. Must be 2 for EnsembleLoss to be valid.
-        train_n_forward_steps: The number of timesteps to train on and associated
+        n_forward_steps: The number of timesteps to train on and associated
             sampling probabilities. By default, the stepper will train on the full
             number of timesteps present in the training dataset samples. Values must
             be less than or equal to the number of timesteps present
@@ -1381,7 +1381,7 @@ class TrainStepperConfig:
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
     optimize_last_step_only: bool = False
     n_ensemble: int = -1  # sentinel value to avoid None typing of attribute
-    train_n_forward_steps: TimeLength | TimeLengthSchedule | None = None
+    n_forward_steps: TimeLength | TimeLengthSchedule | None = None
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=lambda: ParameterInitializationConfig()
     )
@@ -1394,12 +1394,12 @@ class TrainStepperConfig:
                 self.n_ensemble = 1
 
     @property
-    def train_n_forward_steps_schedule(self) -> TimeLengthSchedule | None:
-        if self.train_n_forward_steps is None:
+    def n_forward_steps_schedule(self) -> TimeLengthSchedule | None:
+        if self.n_forward_steps is None:
             return None
-        if isinstance(self.train_n_forward_steps, TimeLengthSchedule):
-            return self.train_n_forward_steps
-        return TimeLengthSchedule.from_constant(self.train_n_forward_steps)
+        if isinstance(self.n_forward_steps, TimeLengthSchedule):
+            return self.n_forward_steps
+        return TimeLengthSchedule.from_constant(self.n_forward_steps)
 
     def _get_parameter_initializer(
         self,
@@ -1487,10 +1487,10 @@ class TrainStepper(
         self._stepper = stepper
         self._config = config
 
-        self._train_n_forward_steps_sampler: TimeLengthProbabilities | None = None
-        self._train_n_forward_steps_schedule: TimeLengthSchedule | None = None
-        if config.train_n_forward_steps_schedule is not None:
-            self._train_n_forward_steps_schedule = config.train_n_forward_steps_schedule
+        self._n_forward_steps_sampler: TimeLengthProbabilities | None = None
+        self._n_forward_steps_schedule: TimeLengthSchedule | None = None
+        if config.n_forward_steps_schedule is not None:
+            self._n_forward_steps_schedule = config.n_forward_steps_schedule
 
         self._epoch: int | None = None  # to keep track of cached values
 
@@ -1595,8 +1595,8 @@ class TrainStepper(
         )
         output_list: list[EnsembleTensorDict] = []
         output_iterator = iter(output_generator)
-        if self._train_n_forward_steps_sampler is not None:
-            stochastic_n_forward_steps = self._train_n_forward_steps_sampler.sample()
+        if self._n_forward_steps_sampler is not None:
+            stochastic_n_forward_steps = self._n_forward_steps_sampler.sample()
             if stochastic_n_forward_steps > n_forward_steps:
                 raise RuntimeError(
                     "The number of forward steps to train on "
@@ -1689,8 +1689,8 @@ class TrainStepper(
     def _init_for_epoch(self, epoch: int | None):
         if (
             epoch is None
-            and self._train_n_forward_steps_schedule is not None
-            and len(self._train_n_forward_steps_schedule.milestones) > 0
+            and self._n_forward_steps_schedule is not None
+            and len(self._n_forward_steps_schedule.milestones) > 0
         ):
             raise EpochNotProvidedError(
                 "current configuration requires epoch to be provided "
@@ -1698,13 +1698,13 @@ class TrainStepper(
             )
         if self._epoch == epoch:
             return
-        if self._train_n_forward_steps_schedule is not None:
+        if self._n_forward_steps_schedule is not None:
             assert epoch is not None  # already checked, but needed for mypy
-            self._train_n_forward_steps_sampler = probabilities_from_time_length(
-                self._train_n_forward_steps_schedule.get_value(epoch)
+            self._n_forward_steps_sampler = probabilities_from_time_length(
+                self._n_forward_steps_schedule.get_value(epoch)
             )
         else:
-            self._train_n_forward_steps_sampler = None
+            self._n_forward_steps_sampler = None
         self._epoch = epoch
 
     def set_eval(self) -> None:

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -152,21 +152,19 @@ def get_scalar_data(names, value):
 def test_stepper_no_train_step_specified():
     stepper = _init_train_stepper(loss=StepLossConfig(type="MSE"))
     stepper._init_for_epoch(0)
-    assert stepper._train_n_forward_steps_sampler is None
+    assert stepper._n_forward_steps_sampler is None
 
 
 def test_stepper_step_int():
-    stepper = _init_train_stepper(
-        train_n_forward_steps=2, loss=StepLossConfig(type="MSE")
-    )
-    assert stepper._train_n_forward_steps_schedule is not None
+    stepper = _init_train_stepper(n_forward_steps=2, loss=StepLossConfig(type="MSE"))
+    assert stepper._n_forward_steps_schedule is not None
     stepper._init_for_epoch(0)
-    assert stepper._train_n_forward_steps_sampler is not None
+    assert stepper._n_forward_steps_sampler is not None
 
 
 def test_stepper_step_probabilities():
     stepper = _init_train_stepper(
-        train_n_forward_steps=TimeLengthProbabilities(
+        n_forward_steps=TimeLengthProbabilities(
             outcomes=[
                 TimeLengthProbability(steps=1, probability=0.5),
                 TimeLengthProbability(steps=2, probability=0.5),
@@ -174,14 +172,14 @@ def test_stepper_step_probabilities():
         ),
         loss=StepLossConfig(type="MSE"),
     )
-    assert stepper._train_n_forward_steps_schedule is not None
+    assert stepper._n_forward_steps_schedule is not None
     stepper._init_for_epoch(0)
-    assert stepper._train_n_forward_steps_sampler is not None
+    assert stepper._n_forward_steps_sampler is not None
 
 
 def test_stepper_step_schedule():
     stepper = _init_train_stepper(
-        train_n_forward_steps=TimeLengthSchedule(
+        n_forward_steps=TimeLengthSchedule(
             start_value=1,
             milestones=[
                 TimeLengthMilestone(
@@ -197,9 +195,9 @@ def test_stepper_step_schedule():
         ),
         loss=StepLossConfig(type="MSE"),
     )
-    assert stepper._train_n_forward_steps_schedule is not None
+    assert stepper._n_forward_steps_schedule is not None
     stepper._init_for_epoch(0)
-    assert stepper._train_n_forward_steps_sampler is not None
+    assert stepper._n_forward_steps_sampler is not None
 
 
 def test_train_on_batch_normalizer_changes_only_norm_data():
@@ -603,14 +601,14 @@ def test_train_on_batch_requires_epoch(has_epoch: bool, uses_scheduling: bool):
     optimization = optimization_config.build(modules=[module], max_epochs=2)
 
     if uses_scheduling:
-        train_n_forward_steps: TimeLengthSchedule | TimeLength = TimeLengthSchedule(
+        n_forward_steps: TimeLengthSchedule | TimeLength = TimeLengthSchedule(
             start_value=2,
             milestones=[
                 TimeLengthMilestone(epoch=1, value=3),
             ],
         )
     else:
-        train_n_forward_steps = 2
+        n_forward_steps = 2
 
     config = StepperConfig(
         step=StepSelector(
@@ -633,7 +631,7 @@ def test_train_on_batch_requires_epoch(has_epoch: bool, uses_scheduling: bool):
 
     stepper = _get_train_stepper(
         config,
-        train_n_forward_steps=train_n_forward_steps,
+        n_forward_steps=n_forward_steps,
         loss=StepLossConfig(type="MSE"),
     )
     if uses_scheduling and not has_epoch:

--- a/fme/ace/test_ocean_train.py
+++ b/fme/ace/test_ocean_train.py
@@ -215,7 +215,6 @@ experiment_dir: {results_dir}
 save_checkpoint: true
 save_per_epoch_diagnostics: {save_per_epoch_diagnostics}
 max_epochs: {max_epochs}
-n_forward_steps: 2
 logging:
   log_to_screen: true
   log_to_wandb: {log_to_wandb}
@@ -245,6 +244,7 @@ optimization:
       kwargs:
         T_max: 1
 stepper_training:
+  n_forward_steps: 2
   loss:
     type: "MSE"
 stepper:
@@ -328,7 +328,7 @@ validation:
       spatial_dimensions: latlon
     batch_size: 2
   stepper_training:
-    train_n_forward_steps: 2
+    n_forward_steps: 2
   aggregator:
     log_snapshots: false
     log_mean_maps: false

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -265,16 +265,14 @@ def _get_test_yaml_files(
         )
 
     if use_time_length_probabilities:
-        train_n_forward_steps: TimeLength | TimeLengthSchedule = (
-            TimeLengthProbabilities(
-                outcomes=[
-                    TimeLengthProbability(steps=1, probability=0.5),
-                    TimeLengthProbability(steps=n_forward_steps, probability=0.5),
-                ]
-            )
+        n_forward_steps_arg: TimeLength | TimeLengthSchedule = TimeLengthProbabilities(
+            outcomes=[
+                TimeLengthProbability(steps=1, probability=0.5),
+                TimeLengthProbability(steps=n_forward_steps, probability=0.5),
+            ]
         )
     elif use_schedule:
-        train_n_forward_steps = TimeLengthSchedule(
+        n_forward_steps_arg = TimeLengthSchedule(
             start_value=TimeLengthProbabilities(
                 outcomes=[
                     TimeLengthProbability(steps=1, probability=0.5),
@@ -285,7 +283,7 @@ def _get_test_yaml_files(
         )
         max_epochs = 2
     else:
-        train_n_forward_steps = n_forward_steps
+        n_forward_steps_arg = n_forward_steps
 
     if crps_training:
         loss = StepLossConfig(
@@ -373,7 +371,7 @@ def _get_test_yaml_files(
         stepper_training=TrainStepperConfig(
             loss=loss,
             n_ensemble=n_ensemble,
-            train_n_forward_steps=train_n_forward_steps,
+            n_forward_steps=n_forward_steps_arg,
         ),
         inference=inline_inference_config,
         weather_evaluation=weather_evaluation_config,

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -298,6 +298,11 @@ class TrainConfig:
                 f"During training, experiment_dir must currently be a local "
                 f"directory, got {self.experiment_dir!r}."
             )
+        if self.stepper_training.train_n_forward_steps is None:
+            raise ValueError(
+                "train_n_forward_steps must be specified in stepper_training "
+                "to determine data loading requirements."
+            )
 
     def set_random_seed(self):
         if self.seed is not None:
@@ -347,6 +352,11 @@ class TrainBuilders:
 
     def _get_n_forward_steps(self) -> int | IntSchedule:
         """Get n_forward_steps for data loading requirements."""
+        if self.config.stepper_training.train_n_forward_steps_schedule is None:
+            raise ValueError(
+                "train_n_forward_steps must be specified in stepper_training "
+                "to determine data loading requirements."
+            )
         schedule = self.config.stepper_training.train_n_forward_steps_schedule
         return schedule.max_n_forward_steps
 

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -189,8 +189,6 @@ class TrainConfig:
             used to select checkpoints, but is used to provide metrics.
         stepper_training: Training-specific configuration including loss, ensemble
             settings, parameter initialization, and forward step scheduling.
-        n_forward_steps: Number of forward steps during training. Cannot be given
-            at the same time as train_n_forward_steps in stepper_training.
         train_aggregator: Configuration for the train aggregator.
         seed: Random seed for reproducibility. If set, is used for all types of
             randomization, including data shuffling and model initialization.
@@ -245,7 +243,6 @@ class TrainConfig:
     stepper_training: TrainStepperConfig = dataclasses.field(
         default_factory=lambda: TrainStepperConfig()
     )
-    n_forward_steps: int | None = None
     train_aggregator: TrainAggregatorConfig = dataclasses.field(
         default_factory=lambda: TrainAggregatorConfig()
     )
@@ -272,14 +269,6 @@ class TrainConfig:
     resume_results: ResumeResultsConfig | None = None
 
     def __post_init__(self):
-        if (
-            self.stepper_training.train_n_forward_steps is not None
-            and self.n_forward_steps is not None
-        ):
-            raise ValueError(
-                "stepper_training.train_n_forward_steps may not be given at the same "
-                "time as n_forward_steps at the top level"
-            )
         if self.train_loader.using_labels != self.validation_loader.using_labels:
             raise ValueError(
                 "train_loader and validation_loader must both use labels or both not "
@@ -359,12 +348,7 @@ class TrainBuilders:
     def _get_n_forward_steps(self) -> int | IntSchedule:
         """Get n_forward_steps for data loading requirements."""
         schedule = self.config.stepper_training.train_n_forward_steps_schedule
-        if schedule is not None:
-            return schedule.max_n_forward_steps
-        assert isinstance(
-            self.config.n_forward_steps, int
-        )  # this is already validated in TrainConfig.__post_init__
-        return self.config.n_forward_steps
+        return schedule.max_n_forward_steps
 
     def _get_train_window_data_requirements(self) -> DataRequirements:
         n_forward_steps = self._get_n_forward_steps()

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -303,6 +303,11 @@ class TrainConfig:
                 "n_forward_steps must be specified in stepper_training "
                 "to determine data loading requirements."
             )
+        if self.stepper_training.n_forward_steps_schedule is None:
+            raise RuntimeError(
+                "expected n_forward_steps_schedule to be defined when "
+                "n_forward_steps is not None, is there a bug?"
+            )
 
     def set_random_seed(self):
         if self.seed is not None:

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -298,9 +298,9 @@ class TrainConfig:
                 f"During training, experiment_dir must currently be a local "
                 f"directory, got {self.experiment_dir!r}."
             )
-        if self.stepper_training.train_n_forward_steps is None:
+        if self.stepper_training.n_forward_steps is None:
             raise ValueError(
-                "train_n_forward_steps must be specified in stepper_training "
+                "n_forward_steps must be specified in stepper_training "
                 "to determine data loading requirements."
             )
 
@@ -352,12 +352,12 @@ class TrainBuilders:
 
     def _get_n_forward_steps(self) -> int | IntSchedule:
         """Get n_forward_steps for data loading requirements."""
-        if self.config.stepper_training.train_n_forward_steps_schedule is None:
+        if self.config.stepper_training.n_forward_steps_schedule is None:
             raise ValueError(
-                "train_n_forward_steps must be specified in stepper_training "
+                "n_forward_steps must be specified in stepper_training "
                 "to determine data loading requirements."
             )
-        schedule = self.config.stepper_training.train_n_forward_steps_schedule
+        schedule = self.config.stepper_training.n_forward_steps_schedule
         return schedule.max_n_forward_steps
 
     def _get_train_window_data_requirements(self) -> DataRequirements:


### PR DESCRIPTION
TrainConfig.n_forward_steps has been deprecated for a while, as we've moved to specify this in the stepper configuration and now in the stepper training configuration, where stochastic sampling of forward step lengths is supported. This PR removes the deprecated option, requiring the new method of configuration.

Changes:
- TrainConfig.n_forward_steps is removed, and validation will fail if its TrainStepperConfig.train_n_forward_steps is not set.
- Renamed `TrainStepperConfig.train_n_forward_steps` to `TrainStepperConfig.n_forward_steps`, a breaking change for all train configs

- [ ] Tests added
