### PR TITLE
Enable configuring time subsetting prior to time coarsening

### DIFF
--- a/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
@@ -110,5 +110,5 @@ time_coarsen:
     - land_fraction
     - latitude
     - longitude
-  time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
+  input_time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
     start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
@@ -17,23 +17,27 @@ time_coarsen:
     latitude: 180
     longitude: 360
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-03-19-era5-1deg-8layer-daily-1940-2025
-  stats_output_directory: gs://vcm-ml-intermediate/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019
+  data_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-1deg-8layer-daily-1940-2025
+  stats_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-1deg-8layer-daily-stats-1990-2019
   snapshot_names:
     - DPT2m
     - PRESsfc
+    - Q10
     - Q200
     - Q2m
     - Q500
     - Q850
+    - TMP10
     - TMP200
     - TMP2m
     - TMP500
     - TMP850
+    - UGRD10
     - UGRD10m
     - UGRD200
     - UGRD500
     - UGRD850
+    - VGRD10
     - VGRD10m
     - VGRD200
     - VGRD500
@@ -54,6 +58,7 @@ time_coarsen:
     - eastward_wind_5
     - eastward_wind_6
     - eastward_wind_7
+    - h10
     - h1000
     - h200
     - h250
@@ -105,3 +110,5 @@ time_coarsen:
     - land_fraction
     - latitude
     - longitude
+  time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
+    start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -9,23 +9,27 @@ stats:
   data_type: ERA5
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-03-19-era5-4deg-8layer-daily-1940-2022
-  stats_output_directory: gs://vcm-ml-intermediate/2026-03-19-era5-4deg-8layer-daily-stats-1990-2019
+  data_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-4deg-8layer-daily-1940-2022
+  stats_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019
   snapshot_names:
     - DPT2m
     - PRESsfc
+    - Q10
     - Q200
     - Q2m
     - Q500
     - Q850
+    - TMP10
     - TMP200
     - TMP2m
     - TMP500
     - TMP850
+    - UGRD10
     - UGRD10m
     - UGRD200
     - UGRD500
     - UGRD850
+    - VGRD10
     - VGRD10m
     - VGRD200
     - VGRD500
@@ -46,6 +50,7 @@ time_coarsen:
     - eastward_wind_5
     - eastward_wind_6
     - eastward_wind_7
+    - h10
     - h1000
     - h200
     - h250
@@ -97,3 +102,5 @@ time_coarsen:
     - land_fraction
     - latitude
     - longitude
+  time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
+    start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -102,5 +102,5 @@ time_coarsen:
     - land_fraction
     - latitude
     - longitude
-  time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
+  input_time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
     start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -9,7 +9,7 @@ stats:
   data_type: ERA5
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-4deg-8layer-daily-1940-2022
+  data_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-4deg-8layer-daily-1940-2025
   stats_output_directory: gs://vcm-ml-intermediate/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019
   snapshot_names:
     - DPT2m

--- a/scripts/data_process/test_time_coarsen.py
+++ b/scripts/data_process/test_time_coarsen.py
@@ -2,7 +2,7 @@ import json
 
 import numpy as np
 import xarray as xr
-from time_coarsen import TimeCoarsenConfig, process_path_pair
+from time_coarsen import TimeCoarsenConfig, TimeSlice, coarsen, process_path_pair
 from zarr.codecs import BloscCodec
 
 from fme.ace.testing import DimSize, DimSizes, get_nd_dataset
@@ -131,3 +131,33 @@ def test_process_path_pair() -> None:
     )
     assert ds_coarsened.attrs["coarsen_factor"] == config.factor
     assert len(ds_coarsened.attrs) == 6  # no unexpected attrs
+
+
+def test_coarsen_time_slice() -> None:
+    # Dataset with 6 daily timesteps starting 2000-01-01 (simulating an offset start)
+    times = xr.date_range("2000-01-01", periods=6, freq="1D")
+    ds = xr.Dataset(
+        {
+            "temp": xr.DataArray(np.arange(6.0), dims=["time"]),
+            "temp_tendency": xr.DataArray(np.arange(6.0), dims=["time"]),
+        },
+        coords={"time": times},
+    )
+    config = TimeCoarsenConfig(
+        factor=2,
+        data_output_directory="",
+        stats_output_directory="",
+        snapshot_names=["temp"],
+        window_names=["temp_tendency"],
+        constant_prefixes=[],
+        time_slice=TimeSlice(start="2000-01-02"),
+    )
+    ds_coarsened = coarsen(ds, config)
+    # Slicing to start at Jan 2 gives [Jan 2..6] (5 times).
+    # factor=2 with trim → 2 output snapshots at indices 1 and 3 of the sliced
+    # dataset, i.e. Jan 3 and Jan 5.
+    xr.testing.assert_equal(
+        ds_coarsened["time"], xr.DataArray(times[2::2], dims=["time"])  # Jan 3, Jan 5
+    )
+    assert ds_coarsened.attrs["time_slice.start"] == "2000-01-02"
+    assert ds_coarsened.attrs["time_slice.stop"] == "None"

--- a/scripts/data_process/test_time_coarsen.py
+++ b/scripts/data_process/test_time_coarsen.py
@@ -134,7 +134,6 @@ def test_process_path_pair() -> None:
 
 
 def test_coarsen_time_slice() -> None:
-    # Dataset with 6 daily timesteps starting 2000-01-01 (simulating an offset start)
     times = xr.date_range("2000-01-01", periods=6, freq="1D")
     ds = xr.Dataset(
         {

--- a/scripts/data_process/test_time_coarsen.py
+++ b/scripts/data_process/test_time_coarsen.py
@@ -133,7 +133,7 @@ def test_process_path_pair() -> None:
     assert len(ds_coarsened.attrs) == 6  # no unexpected attrs
 
 
-def test_coarsen_time_slice() -> None:
+def test_coarsen_input_time_slice() -> None:
     times = xr.date_range("2000-01-01", periods=6, freq="1D")
     ds = xr.Dataset(
         {
@@ -149,7 +149,7 @@ def test_coarsen_time_slice() -> None:
         snapshot_names=["temp"],
         window_names=["temp_tendency"],
         constant_prefixes=[],
-        time_slice=TimeSlice(start="2000-01-02"),
+        input_time_slice=TimeSlice(start="2000-01-02"),
     )
     ds_coarsened = coarsen(ds, config)
     # Slicing to start at Jan 2 gives [Jan 2..6] (5 times).
@@ -159,5 +159,4 @@ def test_coarsen_time_slice() -> None:
         ds_coarsened["time"],
         xr.DataArray(times[2::2], dims=["time"]),  # Jan 3, Jan 5
     )
-    assert ds_coarsened.attrs["time_slice.start"] == "2000-01-02"
-    assert ds_coarsened.attrs["time_slice.stop"] == "None"
+    assert "start='2000-01-02', stop=None" in ds_coarsened.attrs["history"]

--- a/scripts/data_process/test_time_coarsen.py
+++ b/scripts/data_process/test_time_coarsen.py
@@ -156,7 +156,8 @@ def test_coarsen_time_slice() -> None:
     # factor=2 with trim → 2 output snapshots at indices 1 and 3 of the sliced
     # dataset, i.e. Jan 3 and Jan 5.
     xr.testing.assert_equal(
-        ds_coarsened["time"], xr.DataArray(times[2::2], dims=["time"])  # Jan 3, Jan 5
+        ds_coarsened["time"],
+        xr.DataArray(times[2::2], dims=["time"]),  # Jan 3, Jan 5
     )
     assert ds_coarsened.attrs["time_slice.start"] == "2000-01-02"
     assert ds_coarsened.attrs["time_slice.stop"] == "None"

--- a/scripts/data_process/time_coarsen.py
+++ b/scripts/data_process/time_coarsen.py
@@ -24,6 +24,20 @@ except ImportError:
 
 
 @dataclasses.dataclass
+class TimeSlice:
+    """
+    Optional time slice to apply before coarsening.
+
+    Attributes:
+        start: Start time (ISO 8601 string, e.g. "2000-01-01T00:00:00"). Inclusive.
+        stop: Stop time (ISO 8601 string). Inclusive.
+    """
+
+    start: str | None = None
+    stop: str | None = None
+
+
+@dataclasses.dataclass
 class TimeCoarsenConfig:
     """
     Configuration for time coarsening of a dataset.
@@ -58,6 +72,7 @@ class TimeCoarsenConfig:
     sharding: dict[str, int] | None = dataclasses.field(
         default_factory=lambda: {"time": 360}
     )
+    time_slice: TimeSlice = dataclasses.field(default_factory=TimeSlice)
 
 
 @dataclasses.dataclass
@@ -92,6 +107,9 @@ def _set_attributes(
     attributes["window_names"] = json.dumps(config.window_names)
     attributes["constant_prefixes"] = json.dumps(config.constant_prefixes)
     attributes["coarsen_factor"] = config.factor
+    if config.time_slice.start is not None or config.time_slice.stop is not None:
+        attributes["time_slice.start"] = str(config.time_slice.start)
+        attributes["time_slice.stop"] = str(config.time_slice.stop)
     history_entry = (
         f"Dataset coarsened by a factor of {config.factor} "
         "by scripts/data_process/time_coarsen.py."
@@ -108,6 +126,8 @@ def coarsen(ds: xr.Dataset, config: TimeCoarsenConfig) -> xr.Dataset:
 
     Works with both eager (numpy) and lazy (dask) arrays.
     """
+    if config.time_slice.start is not None or config.time_slice.stop is not None:
+        ds = ds.sel(time=slice(config.time_slice.start, config.time_slice.stop))
     constant_names = [
         name
         for name in ds.data_vars

--- a/scripts/data_process/time_coarsen.py
+++ b/scripts/data_process/time_coarsen.py
@@ -72,7 +72,7 @@ class TimeCoarsenConfig:
     sharding: dict[str, int] | None = dataclasses.field(
         default_factory=lambda: {"time": 360}
     )
-    time_slice: TimeSlice = dataclasses.field(default_factory=TimeSlice)
+    input_time_slice: TimeSlice = dataclasses.field(default_factory=TimeSlice)
 
 
 @dataclasses.dataclass
@@ -107,13 +107,21 @@ def _set_attributes(
     attributes["window_names"] = json.dumps(config.window_names)
     attributes["constant_prefixes"] = json.dumps(config.constant_prefixes)
     attributes["coarsen_factor"] = config.factor
-    if config.time_slice.start is not None or config.time_slice.stop is not None:
-        attributes["time_slice.start"] = str(config.time_slice.start)
-        attributes["time_slice.stop"] = str(config.time_slice.stop)
     history_entry = (
         f"Dataset coarsened by a factor of {config.factor} "
         "by scripts/data_process/time_coarsen.py."
     )
+    if (
+        config.input_time_slice.start is not None
+        or config.input_time_slice.stop is not None
+    ):
+        history_entry += (
+            f" Input was time-subsetted to start={config.input_time_slice.start!r}, "
+            f"stop={config.input_time_slice.stop!r} prior to coarsening. "
+            "The time bounds of the resulting dataset will likely differ slightly "
+            "from this slice. Input subsetting is typically used to facilitate "
+            "aligning the times of different coarsened datasets."
+        )
     if "history" in attributes:
         attributes["history"] = attributes["history"] + " " + history_entry
     else:
@@ -126,8 +134,13 @@ def coarsen(ds: xr.Dataset, config: TimeCoarsenConfig) -> xr.Dataset:
 
     Works with both eager (numpy) and lazy (dask) arrays.
     """
-    if config.time_slice.start is not None or config.time_slice.stop is not None:
-        ds = ds.sel(time=slice(config.time_slice.start, config.time_slice.stop))
+    if (
+        config.input_time_slice.start is not None
+        or config.input_time_slice.stop is not None
+    ):
+        ds = ds.sel(
+            time=slice(config.input_time_slice.start, config.input_time_slice.stop)
+        )
     constant_names = [
         name
         for name in ds.data_vars


### PR DESCRIPTION
Some of our datasets start at unusual times.  For instance the ERA5 dataset starts on `"1940-01-01T12:00:00"`.  When time coarsening, this can lead to unconventional intervals, which could be inconsistent with other datasets.  For example for default daily coarsening of the ERA5 dataset this leads to times of `"1940-01-02T06:00:00"`, `"1940-01-03T06:00:00"`, and so on.

A way to address this is to apply a time slice prior to coarsening.  In the case of ERA5 that would be to provide a start time of `"1940-01-02T06:00:00"`, such that the daily coarsened data would start cleanly on `"1940-01-03T00:00:00"`.

We take the opportunity to add `"h10"`, `"Q10"`, `"TMP10"`, `"UGRD10"`, and `"VGRD10"` as snapshot variables to the ERA5 coarsening configurations as well.

Changes:
- Adds an optional `input_time_slice` attribute to `TimeCoarsenConfig`.
- Updates the ERA5 time coarsening configurations to include a `time_slice` as well as `"h10"`, `"Q10"`, `"TMP10"`, "UGRD10", and `"VGRD10"` as `snapshot_names`.

Argo workflows:
- 1° ERA5 time-coarsening/stats: `compute-fme-dataset-ensemble-gckg7`
- 4° ERA5 time-coarsening/stats: `compute-fme-dataset-ensemble-j8rxk`

- [x] Tests added
