### PR TITLE
Downscaling loss weighting

### DIFF
--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -413,6 +413,7 @@ class DiffusionModel:
         self,
         batch: PairedBatchData,
         optimizer: Optimization | NullOptimization,
+        loss_weight_exponent: float = 1.0,
     ) -> ModelOutputs:
         """Performs a denoising training step on a batch of data."""
         _static_inputs = self._subset_static_if_available(batch.coarse)
@@ -435,7 +436,10 @@ class DiffusionModel:
             targets_norm = targets_norm - base_prediction
 
         conditioned_target = condition_with_noise_for_training(
-            targets_norm, self.config.noise_distribution, self.sigma_data
+            targets_norm,
+            self.config.noise_distribution,
+            self.sigma_data,
+            loss_weight_exponent=loss_weight_exponent,
         )
 
         denoised_norm = self.module(

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -69,6 +69,24 @@ def _build_variable_loss_weight_tensor(
 
 
 @dataclasses.dataclass
+class LossWeightsConfig:
+    """
+    Configuration for loss weighting during training.
+
+    Parameters:
+        output_channels: Per-variable multiplicative weights applied to the loss.
+            Keys are variable names from out_names; variables not listed default to 1.0.
+        noise_weight_exponent: Exponent applied to the EDM noise-level loss weight
+            ``(sigma^2 + sigma_data^2) / (sigma * sigma_data)^2``. The default
+            of 1.0 gives the standard EDM weighting (~1/sigma^2 for small sigma).
+            Use values less than 1.0 to reduce relative weighting of low-noise steps.
+    """
+
+    output_channels: dict[str, float] = dataclasses.field(default_factory=dict)
+    noise_weight_exponent: float = 1.0
+
+
+@dataclasses.dataclass
 class PairedNormalizationConfig:
     fine: NormalizationConfig
     coarse: NormalizationConfig
@@ -117,9 +135,8 @@ class DiffusionModelConfig:
         use_fine_topography: Whether to use fine topography in the model.
         use_amp_bf16: Whether to use automatic mixed precision (bfloat16) in the
             UNetDiffusionModule.
-        loss_weights: Per-variable weights applied to the loss. Keys are
-            variable names from out_names and values are multiplicative
-            weights. Variables not listed default to 1.0.
+        loss_weights: Weighting configuration for the training loss, including
+            per-variable channel weights and the noise-level weight exponent.
         training_noise_distribution: Noise distribution to use during training.
         p_mean: The mean of noise distribution used during training.
             Deprecated. Use training_noise_distribution field instead.
@@ -141,7 +158,9 @@ class DiffusionModelConfig:
     predict_residual: bool
     use_fine_topography: bool = False
     use_amp_bf16: bool = False
-    loss_weights: dict[str, float] = dataclasses.field(default_factory=dict)
+    loss_weights: LossWeightsConfig = dataclasses.field(
+        default_factory=LossWeightsConfig
+    )
     training_noise_distribution: (
         LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
     ) = None
@@ -339,7 +358,7 @@ class DiffusionModel:
         self.full_fine_coords = full_fine_coords.to(get_device())
         self.static_inputs = static_inputs.to_device() if static_inputs else None
         self._loss_weight_tensor = _build_variable_loss_weight_tensor(
-            config.loss_weights, config.out_names
+            config.loss_weights.output_channels, config.out_names
         )
 
     @property
@@ -429,7 +448,6 @@ class DiffusionModel:
         self,
         batch: PairedBatchData,
         optimizer: Optimization | NullOptimization,
-        loss_weight_exponent: float = 1.0,
     ) -> ModelOutputs:
         """Performs a denoising training step on a batch of data."""
         _static_inputs = self._subset_static_if_available(batch.coarse)
@@ -455,7 +473,7 @@ class DiffusionModel:
             targets_norm,
             self.config.noise_distribution,
             self.sigma_data,
-            loss_weight_exponent=loss_weight_exponent,
+            loss_weight_exponent=self.config.loss_weights.noise_weight_exponent,
         )
 
         denoised_norm = self.module(

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -108,6 +108,9 @@ class DiffusionModelConfig:
         use_fine_topography: Whether to use fine topography in the model.
         use_amp_bf16: Whether to use automatic mixed precision (bfloat16) in the
             UNetDiffusionModule.
+        loss_weights: Per-variable weights applied to the loss. Keys are
+            variable names from out_names and values are multiplicative
+            weights. Variables not listed default to 1.0.
         training_noise_distribution: Noise distribution to use during training.
         p_mean: The mean of noise distribution used during training.
             Deprecated. Use training_noise_distribution field instead.
@@ -129,6 +132,7 @@ class DiffusionModelConfig:
     predict_residual: bool
     use_fine_topography: bool = False
     use_amp_bf16: bool = False
+    loss_weights: dict[str, float] = dataclasses.field(default_factory=dict)
     training_noise_distribution: (
         LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
     ) = None
@@ -325,6 +329,18 @@ class DiffusionModel:
         self._channel_axis = -3
         self.full_fine_coords = full_fine_coords.to(get_device())
         self.static_inputs = static_inputs.to_device() if static_inputs else None
+        self._loss_weight_tensor = self._build_loss_weight_tensor(
+            config.loss_weights, config.out_names
+        )
+
+    @staticmethod
+    def _build_loss_weight_tensor(
+        weights: dict[str, float], out_names: list[str]
+    ) -> torch.Tensor:
+        values = [weights.get(name, 1.0) for name in out_names]
+        return torch.tensor(values, dtype=torch.float32, device=get_device()).reshape(
+            1, len(out_names), 1, 1
+        )
 
     @property
     def modules(self) -> torch.nn.ModuleList:
@@ -445,8 +461,10 @@ class DiffusionModel:
         denoised_norm = self.module(
             conditioned_target.latents, inputs_norm, conditioned_target.sigma
         )
-        weighted_loss = conditioned_target.weight * self.loss(
-            denoised_norm, targets_norm
+        weighted_loss = (
+            conditioned_target.weight
+            * self._loss_weight_tensor
+            * self.loss(denoised_norm, targets_norm)
         )
         loss = torch.mean(weighted_loss)
         optimizer.accumulate_loss(loss)

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -59,6 +59,15 @@ def _rename_normalizer(
     return StandardNormalizer(means=new_means, stds=new_stds)
 
 
+def _build_variable_loss_weight_tensor(
+    weights: dict[str, float], out_names: list[str]
+) -> torch.Tensor:
+    values = [weights.get(name, 1.0) for name in out_names]
+    return torch.tensor(values, dtype=torch.float32, device=get_device()).reshape(
+        1, len(out_names), 1, 1
+    )
+
+
 @dataclasses.dataclass
 class PairedNormalizationConfig:
     fine: NormalizationConfig
@@ -329,17 +338,8 @@ class DiffusionModel:
         self._channel_axis = -3
         self.full_fine_coords = full_fine_coords.to(get_device())
         self.static_inputs = static_inputs.to_device() if static_inputs else None
-        self._loss_weight_tensor = self._build_loss_weight_tensor(
+        self._loss_weight_tensor = _build_variable_loss_weight_tensor(
             config.loss_weights, config.out_names
-        )
-
-    @staticmethod
-    def _build_loss_weight_tensor(
-        weights: dict[str, float], out_names: list[str]
-    ) -> torch.Tensor:
-        values = [weights.get(name, 1.0) for name in out_names]
-        return torch.tensor(values, dtype=torch.float32, device=get_device()).reshape(
-            1, len(out_names), 1, 1
         )
 
     @property
@@ -461,7 +461,7 @@ class DiffusionModel:
         denoised_norm = self.module(
             conditioned_target.latents, inputs_norm, conditioned_target.sigma
         )
-        weighted_loss = (
+        weighted_loss = (  # has dims (batch, channels, lat, lon)
             conditioned_target.weight
             * self._loss_weight_tensor
             * self.loss(denoised_norm, targets_norm)

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -62,6 +62,11 @@ def _rename_normalizer(
 def _build_variable_loss_weight_tensor(
     weights: dict[str, float], out_names: list[str]
 ) -> torch.Tensor:
+    for name in weights:
+        if name not in out_names:
+            raise ValueError(
+                f"Name {name} in loss_weights.output_channels is not in out_names"
+            )
     values = [weights.get(name, 1.0) for name in out_names]
     return torch.tensor(values, dtype=torch.float32, device=get_device()).reshape(
         1, len(out_names), 1, 1
@@ -80,6 +85,8 @@ class LossWeightsConfig:
             ``(sigma^2 + sigma_data^2) / (sigma * sigma_data)^2``. The default
             of 1.0 gives the standard EDM weighting (~1/sigma^2 for small sigma).
             Use values less than 1.0 to reduce relative weighting of low-noise steps.
+            We find that 0.75 improves performance for winds and sea level pressure,
+            which are dominated by low-noise samples in the default EDM weighting.
     """
 
     output_channels: dict[str, float] = dataclasses.field(default_factory=dict)

--- a/fme/downscaling/noise.py
+++ b/fme/downscaling/noise.py
@@ -60,6 +60,7 @@ def condition_with_noise_for_training(
     targets_norm: torch.Tensor,
     noise_distribution: NoiseDistribution,
     sigma_data: float,
+    loss_weight_exponent: float = 1.0,
 ) -> ConditionedTarget:
     """
     Condition the targets with noise for training.
@@ -69,12 +70,18 @@ def condition_with_noise_for_training(
         noise_distribution: The noise distribution to use for conditioning.
         sigma_data: The standard deviation of the data,
             used to determine loss weighting.
+        loss_weight_exponent: Exponent applied to the base EDM loss weight
+            ``(sigma^2 + sigma_data^2) / (sigma * sigma_data)^2``. The default
+            of 1.0 gives the standard EDM weighting (~1/sigma^2 for small
+            sigma). Use 0.5 for ~1/sigma weighting (square root of EDM weight).
 
     Returns:
         The conditioned targets and the loss weighting.
     """
     sigma = noise_distribution.sample(targets_norm.shape[0], targets_norm.device)
-    weight = (sigma**2 + sigma_data**2) / (sigma * sigma_data) ** 2
+    weight = (
+        (sigma**2 + sigma_data**2) / (sigma * sigma_data) ** 2
+    ) ** loss_weight_exponent
     noise = randn_like(targets_norm) * sigma
     latents = targets_norm + noise
     return ConditionedTarget(latents=latents, sigma=sigma, weight=weight)

--- a/fme/downscaling/test_models.py
+++ b/fme/downscaling/test_models.py
@@ -22,6 +22,7 @@ from fme.downscaling.models import (
     DiffusionModel,
     DiffusionModelConfig,
     PairedNormalizationConfig,
+    _build_variable_loss_weight_tensor,
     _repeat_batch_by_samples,
     _separate_interleaved_samples,
 )
@@ -329,99 +330,6 @@ def test_normalizer_serialization(tmp_path):
     assert model_from_disk.normalizer.fine.stds == {"x": 1}
     assert model_from_disk.normalizer.coarse.means == {"x": 0}
     assert model_from_disk.normalizer.coarse.stds == {"x": 1}
-
-
-def test_loss_weights_scale_channel_losses():
-    """Per-variable loss_weights should scale each channel's contribution."""
-    coarse_shape = (8, 16)
-    fine_shape = (16, 32)
-    batch_size = 2
-    out_names = ["a", "b"]
-
-    normalizer = PairedNormalizationConfig(
-        NormalizationConfig(means={"a": 0.0, "b": 0.0}, stds={"a": 1.0, "b": 1.0}),
-        NormalizationConfig(means={"a": 0.0, "b": 0.0}, stds={"a": 1.0, "b": 1.0}),
-    )
-    fine_coords = make_fine_coords(fine_shape)
-
-    def _build_model(loss_weights):
-        return DiffusionModelConfig(
-            module=DiffusionModuleRegistrySelector(
-                "unet_diffusion_song", {"model_channels": 4}
-            ),
-            loss=LossConfig(type="MSE"),
-            in_names=["a"],
-            out_names=out_names,
-            normalization=normalizer,
-            p_mean=-1.0,
-            p_std=1.0,
-            sigma_min=0.1,
-            sigma_max=1.0,
-            churn=0.5,
-            num_diffusion_generation_steps=3,
-            predict_residual=False,
-            use_fine_topography=False,
-            loss_weights=loss_weights,
-        ).build(
-            coarse_shape,
-            2,
-            full_fine_coords=fine_coords,
-        )
-
-    model_uniform = _build_model({})
-    model_weighted = _build_model({"a": 0.0, "b": 2.0})
-
-    # Copy weights so both models produce identical predictions
-    model_weighted.module.load_state_dict(model_uniform.module.state_dict())
-
-    def _make_batch():
-        coarse_data = {
-            "a": torch.randn(batch_size, *coarse_shape, device=get_device()),
-            "b": torch.randn(batch_size, *coarse_shape, device=get_device()),
-        }
-        fine_data = {
-            "a": torch.randn(batch_size, *fine_shape, device=get_device()),
-            "b": torch.randn(batch_size, *fine_shape, device=get_device()),
-        }
-        coarse_lat = _get_monotonic_coordinate(coarse_shape[0], stop=fine_shape[0])
-        coarse_lon = _get_monotonic_coordinate(coarse_shape[1], stop=fine_shape[1])
-        fine_lat = _get_monotonic_coordinate(fine_shape[0], stop=fine_shape[0])
-        fine_lon = _get_monotonic_coordinate(fine_shape[1], stop=fine_shape[1])
-        time = xr.DataArray(range(batch_size), dims=["batch"])
-        coarse_batch = BatchData(
-            data=coarse_data,
-            time=time,
-            latlon_coordinates=BatchedLatLonCoordinates(
-                lat=coarse_lat.unsqueeze(0).expand(batch_size, -1),
-                lon=coarse_lon.unsqueeze(0).expand(batch_size, -1),
-            ),
-        )
-        fine_batch = BatchData(
-            data=fine_data,
-            time=time,
-            latlon_coordinates=BatchedLatLonCoordinates(
-                lat=fine_lat.unsqueeze(0).expand(batch_size, -1),
-                lon=fine_lon.unsqueeze(0).expand(batch_size, -1),
-            ),
-        )
-        return PairedBatchData(fine=fine_batch, coarse=coarse_batch)
-
-    torch.manual_seed(0)
-    batch = _make_batch()
-    optimization = OptimizationConfig().build(
-        modules=[model_uniform.module], max_epochs=2
-    )
-    torch.manual_seed(42)
-    out_uniform = model_uniform.train_on_batch(batch, optimization)
-
-    optimization_w = OptimizationConfig().build(
-        modules=[model_weighted.module], max_epochs=2
-    )
-    torch.manual_seed(42)
-    out_weighted = model_weighted.train_on_batch(batch, optimization_w)
-
-    assert out_weighted.channel_losses["a"] == pytest.approx(0.0, abs=1e-7)
-    assert out_weighted.channel_losses["b"] > out_uniform.channel_losses["b"]
 
 
 def test_use_fine_topography_raises_when_module_does_not_use_interpolated_input():
@@ -760,3 +668,16 @@ def test_from_state_raises_for_unresolvable_old_checkpoint(tmp_path):
 
     with pytest.raises(ValueError, match="full_fine_coords"):
         DiffusionModel.from_state(state)
+
+
+def test__build_variable_loss_weight_tensor():
+    weights = {"x": 0.5, "z": 2.0}
+    out_names = ["x", "y", "z"]
+    n_out_channels = len(out_names)
+    result = _build_variable_loss_weight_tensor(weights, out_names)
+    assert result.shape == (1, n_out_channels, 1, 1)
+    loss = torch.rand(2, n_out_channels, 2, 2, device=get_device())
+    weighted_loss = loss * result
+    assert torch.allclose(weighted_loss[:, 0], loss[:, 0] * 0.5)
+    assert torch.allclose(weighted_loss[:, 1], loss[:, 1])
+    assert torch.allclose(weighted_loss[:, 2], loss[:, 2] * 2.0)

--- a/fme/downscaling/test_models.py
+++ b/fme/downscaling/test_models.py
@@ -331,6 +331,99 @@ def test_normalizer_serialization(tmp_path):
     assert model_from_disk.normalizer.coarse.stds == {"x": 1}
 
 
+def test_loss_weights_scale_channel_losses():
+    """Per-variable loss_weights should scale each channel's contribution."""
+    coarse_shape = (8, 16)
+    fine_shape = (16, 32)
+    batch_size = 2
+    out_names = ["a", "b"]
+
+    normalizer = PairedNormalizationConfig(
+        NormalizationConfig(means={"a": 0.0, "b": 0.0}, stds={"a": 1.0, "b": 1.0}),
+        NormalizationConfig(means={"a": 0.0, "b": 0.0}, stds={"a": 1.0, "b": 1.0}),
+    )
+    fine_coords = make_fine_coords(fine_shape)
+
+    def _build_model(loss_weights):
+        return DiffusionModelConfig(
+            module=DiffusionModuleRegistrySelector(
+                "unet_diffusion_song", {"model_channels": 4}
+            ),
+            loss=LossConfig(type="MSE"),
+            in_names=["a"],
+            out_names=out_names,
+            normalization=normalizer,
+            p_mean=-1.0,
+            p_std=1.0,
+            sigma_min=0.1,
+            sigma_max=1.0,
+            churn=0.5,
+            num_diffusion_generation_steps=3,
+            predict_residual=False,
+            use_fine_topography=False,
+            loss_weights=loss_weights,
+        ).build(
+            coarse_shape,
+            2,
+            full_fine_coords=fine_coords,
+        )
+
+    model_uniform = _build_model({})
+    model_weighted = _build_model({"a": 0.0, "b": 2.0})
+
+    # Copy weights so both models produce identical predictions
+    model_weighted.module.load_state_dict(model_uniform.module.state_dict())
+
+    def _make_batch():
+        coarse_data = {
+            "a": torch.randn(batch_size, *coarse_shape, device=get_device()),
+            "b": torch.randn(batch_size, *coarse_shape, device=get_device()),
+        }
+        fine_data = {
+            "a": torch.randn(batch_size, *fine_shape, device=get_device()),
+            "b": torch.randn(batch_size, *fine_shape, device=get_device()),
+        }
+        coarse_lat = _get_monotonic_coordinate(coarse_shape[0], stop=fine_shape[0])
+        coarse_lon = _get_monotonic_coordinate(coarse_shape[1], stop=fine_shape[1])
+        fine_lat = _get_monotonic_coordinate(fine_shape[0], stop=fine_shape[0])
+        fine_lon = _get_monotonic_coordinate(fine_shape[1], stop=fine_shape[1])
+        time = xr.DataArray(range(batch_size), dims=["batch"])
+        coarse_batch = BatchData(
+            data=coarse_data,
+            time=time,
+            latlon_coordinates=BatchedLatLonCoordinates(
+                lat=coarse_lat.unsqueeze(0).expand(batch_size, -1),
+                lon=coarse_lon.unsqueeze(0).expand(batch_size, -1),
+            ),
+        )
+        fine_batch = BatchData(
+            data=fine_data,
+            time=time,
+            latlon_coordinates=BatchedLatLonCoordinates(
+                lat=fine_lat.unsqueeze(0).expand(batch_size, -1),
+                lon=fine_lon.unsqueeze(0).expand(batch_size, -1),
+            ),
+        )
+        return PairedBatchData(fine=fine_batch, coarse=coarse_batch)
+
+    torch.manual_seed(0)
+    batch = _make_batch()
+    optimization = OptimizationConfig().build(
+        modules=[model_uniform.module], max_epochs=2
+    )
+    torch.manual_seed(42)
+    out_uniform = model_uniform.train_on_batch(batch, optimization)
+
+    optimization_w = OptimizationConfig().build(
+        modules=[model_weighted.module], max_epochs=2
+    )
+    torch.manual_seed(42)
+    out_weighted = model_weighted.train_on_batch(batch, optimization_w)
+
+    assert out_weighted.channel_losses["a"] == pytest.approx(0.0, abs=1e-7)
+    assert out_weighted.channel_losses["b"] > out_uniform.channel_losses["b"]
+
+
 def test_use_fine_topography_raises_when_module_does_not_use_interpolated_input():
     normalization_config = PairedNormalizationConfig(
         NormalizationConfig(means={"x": 0.0}, stds={"x": 1.0}),

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -180,7 +180,11 @@ class Trainer:
             self.num_batches_seen += 1
             if i % 10 == 0:
                 logging.info(f"Training on batch {i + 1}")
-            outputs = self.model.train_on_batch(batch, self.optimization)
+            outputs = self.model.train_on_batch(
+                batch,
+                self.optimization,
+                loss_weight_exponent=self.config.loss_weight_exponent,
+            )
             self.ema(self.model.modules)
             with torch.no_grad():
                 train_aggregator.record_batch(
@@ -254,7 +258,11 @@ class Trainer:
                 self.validation_data, random_offset=False, shuffle=False
             )
             for batch in validation_batch_generator:
-                outputs = self.model.train_on_batch(batch, self.null_optimization)
+                outputs = self.model.train_on_batch(
+                    batch,
+                    self.null_optimization,
+                    loss_weight_exponent=self.config.loss_weight_exponent,
+                )
                 validation_aggregator.record_batch(
                     outputs=outputs,
                     coarse=batch.coarse.data,
@@ -396,6 +404,7 @@ class TrainerConfig:
     experiment_dir: str
     save_checkpoints: bool
     logging: LoggingConfig
+    loss_weight_exponent: float = 1.0
     static_inputs: dict[str, str] = dataclasses.field(default_factory=dict)
     ema: EMAConfig = dataclasses.field(default_factory=EMAConfig)
     validate_using_ema: bool = False

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -183,7 +183,6 @@ class Trainer:
             outputs = self.model.train_on_batch(
                 batch,
                 self.optimization,
-                loss_weight_exponent=self.config.loss_weight_exponent,
             )
             self.ema(self.model.modules)
             with torch.no_grad():
@@ -261,7 +260,6 @@ class Trainer:
                 outputs = self.model.train_on_batch(
                     batch,
                     self.null_optimization,
-                    loss_weight_exponent=self.config.loss_weight_exponent,
                 )
                 validation_aggregator.record_batch(
                     outputs=outputs,
@@ -404,7 +402,6 @@ class TrainerConfig:
     experiment_dir: str
     save_checkpoints: bool
     logging: LoggingConfig
-    loss_weight_exponent: float = 1.0
     static_inputs: dict[str, str] = dataclasses.field(default_factory=dict)
     ema: EMAConfig = dataclasses.field(default_factory=EMAConfig)
     validate_using_ema: bool = False


### PR DESCRIPTION
This PR adds two configurable options to loss weighting in the downscaling training config, contained in the optional field `loss_weights`. Both were found to improve the generated outputs.

- `loss_weights.output_channels`: dict with key, value corresponding to output channel name and weight to multiply that variable's loss by. Output names not in this dict are not adjusted. Downweighting precipitation improves the overall outputs' CRPS and extreme values with no adverse effect on precip skill.
- `loss_weights.noise_weight_exponent`: power to raise the default EDM noise-weighted loss by. By default 1.0. Experiments indicate lowering this to ~0.75 improves the generation of pressure and wind extremes; these fields tend to have their noise vs loss dominated by small noise values if using the default EDM weighting.

