### PR TITLE
Set explicit 30-minute timeout on all init_process_group calls

### DIFF
--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -32,13 +32,13 @@ class TorchDistributed(DistributedBackend):
                     torch.distributed.init_process_group(
                         backend="nccl",
                         init_method="env://",
-                        timeout=timedelta(minutes=60),
+                        timeout=timedelta(minutes=30),
                     )
                 else:
                     torch.distributed.init_process_group(
                         backend="gloo",
                         init_method="env://",
-                        timeout=timedelta(minutes=60),
+                        timeout=timedelta(minutes=30),
                     )
             self.world_size = torch.distributed.get_world_size()
             local_rank = int(os.environ["LOCAL_RANK"])
@@ -56,7 +56,7 @@ class TorchDistributed(DistributedBackend):
                 init_method=f"file://{shared_dist_file}",
                 rank=self.rank,
                 world_size=self.world_size,
-                timeout=timedelta(minutes=60),
+                timeout=timedelta(minutes=30),
             )
             if using_gpu():
                 # this assumes one GPU per process in the SLURM setting

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -36,7 +36,9 @@ class TorchDistributed(DistributedBackend):
                     )
                 else:
                     torch.distributed.init_process_group(
-                        backend="gloo", init_method="env://"
+                        backend="gloo",
+                        init_method="env://",
+                        timeout=timedelta(minutes=60),
                     )
             self.world_size = torch.distributed.get_world_size()
             local_rank = int(os.environ["LOCAL_RANK"])
@@ -54,6 +56,7 @@ class TorchDistributed(DistributedBackend):
                 init_method=f"file://{shared_dist_file}",
                 rank=self.rank,
                 world_size=self.world_size,
+                timeout=timedelta(minutes=60),
             )
             if using_gpu():
                 # this assumes one GPU per process in the SLURM setting


### PR DESCRIPTION
The Gloo+torchrun and srun `init_process_group` paths had no explicit timeout, relying on PyTorch defaults (30 minutes). This makes all paths consistent with the NCCL+torchrun path, ensuring collective operations time out after 60 minutes when a peer dies.

Changes:
- `fme.core.distributed.TorchDistributed.__init__`: added `timeout=timedelta(minutes=60)` to the Gloo+torchrun and srun `init_process_group` calls

- [ ] Tests added