### PR TITLE
Log power spectrum diagnostics in inference entrypoint

### DIFF
--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -32,7 +32,10 @@ from .enso import (
 from .histogram import HistogramAggregator
 from .reduced import MeanAggregator, SingleTargetMeanAggregator
 from .seasonal import SeasonalAggregator
-from .spectrum import PairedSphericalPowerSpectrumAggregator
+from .spectrum import (
+    PairedSphericalPowerSpectrumAggregator,
+    SphericalPowerSpectrumAggregator,
+)
 from .time_mean import TimeMeanAggregator, TimeMeanEvaluatorAggregator
 from .video import VideoAggregator
 from .zonal_mean import ZonalMeanAggregator
@@ -700,6 +703,16 @@ class InferenceAggregator(
             dataset_info.timestep,
             dataset_info.variable_metadata,
         )
+        try:
+            aggregators["power_spectrum"] = SphericalPowerSpectrumAggregator(
+                gridded_operations=gridded_operations,
+                nan_fill_fn=SmoothFloodFill(num_steps=4),
+            )
+        except NotImplementedError:
+            logging.warning(
+                "Power spectrum aggregator not implemented for this grid type, "
+                "omitting."
+            )
         if (
             isinstance(horizontal_coordinates, LatLonCoordinates)
             and isinstance(gridded_operations, LatLonOperations)
@@ -718,7 +731,7 @@ class InferenceAggregator(
         self._aggregators = aggregators
         self._summary_aggregators = {
             name: aggregators[name]
-            for name in ["time_mean", "annual", "enso_index"]
+            for name in ["time_mean", "annual", "enso_index", "power_spectrum"]
             if name in aggregators
         }
         self._time_dependent_aggregator_names = ["annual", "enso_index"]

--- a/fme/ace/aggregator/inference/spectrum.py
+++ b/fme/ace/aggregator/inference/spectrum.py
@@ -30,7 +30,7 @@ class SphericalPowerSpectrumAggregator:
         self._nan_fill_fn = nan_fill_fn
 
     @torch.no_grad()
-    def record_batch(self, data: TensorMapping):
+    def record_batch(self, data: TensorMapping, i_time_start: int = 0):
         for name in data:
             batch_size = data[name].shape[0]
             time_size = data[name].shape[1]
@@ -59,6 +59,23 @@ class SphericalPowerSpectrumAggregator:
                 _mean_spectrum = dist.reduce_mean(_mean_spectrum)
             logs[name] = _mean_spectrum
         return logs
+
+    @torch.no_grad()
+    def get_logs(self, label: str) -> dict[str, plt.Figure]:
+        logs: dict[str, plt.Figure] = {}
+        for name, spectrum in self.get_mean().items():
+            fig = _plot_spectrum_pair(spectrum.cpu(), target=None)
+            logs[f"{label}/{name}"] = fig
+            plt.close(fig)
+        return logs
+
+    @torch.no_grad()
+    def get_dataset(self) -> xr.Dataset:
+        logging.debug(
+            "get_dataset not implemented for SphericalPowerSpectrumAggregator. "
+            "Returning an empty dataset."
+        )
+        return xr.Dataset()
 
 
 class PairedSphericalPowerSpectrumAggregator:

--- a/fme/ace/aggregator/inference/test_inference.py
+++ b/fme/ace/aggregator/inference/test_inference.py
@@ -49,7 +49,7 @@ def test_logs_labels_exist():
             expected_step_keys
         )
     summary_logs = agg.get_summary_logs()
-    expected_summary_keys = ["time_mean/gen_map/a", "annual/a"]
+    expected_summary_keys = ["time_mean/gen_map/a", "annual/a", "power_spectrum/a"]
     for key in expected_summary_keys:
         assert key in summary_logs, key
     assert len(summary_logs) == len(expected_summary_keys), set(
@@ -107,6 +107,7 @@ def test_logs_labels_exist_with_reference_time_means():
         "time_mean/ref_bias/a",
         "time_mean/ref_rmse/a",
         "annual/a",
+        "power_spectrum/a",
     ]
     for key in expected_summary_keys:
         assert key in summary_logs, key


### PR DESCRIPTION
This PR implements what is necessary to add the `SphericalPowerSpectrumAggregator` to the `InferenceAggregator`, so that we can now log power spectra in runs launched with the inference entrypoint.

Changes:
- Adds `get_logs` and `get_dataset` methods to the `SphericalPowerSpectrumAggregator`.
- Adds `SphericalPowerSpectrumAggregator` to the `InferenceAggregator`.

- [x] Tests added

Resolves #1077
