### PR TITLE
Add isotropic Morlet filter basis for DISCO

### DIFF
--- a/fme/core/disco/_filter_basis.py
+++ b/fme/core/disco/_filter_basis.py
@@ -61,6 +61,8 @@ def get_filter_basis(
         return PiecewiseLinearFilterBasis(kernel_shape=kernel_shape)
     elif basis_type == "morlet":
         return MorletFilterBasis(kernel_shape=kernel_shape)
+    elif basis_type == "isotropic morlet":
+        return IsotropicMorletFilterBasis(kernel_shape=kernel_shape)
     elif basis_type == "zernike":
         return ZernikeFilterBasis(kernel_shape=kernel_shape)
     else:
@@ -219,6 +221,66 @@ class MorletFilterBasis(FilterBasis):
         )
 
         vals = self.hann_window(r, width=width) * harmonic
+        return iidx, vals
+
+
+class IsotropicMorletFilterBasis(FilterBasis):
+    """Morlet-style filter basis using only radial modes.
+
+    Each basis function is a product of a Hann radial window and a 1-D
+    Fourier harmonic in the normalised radial coordinate ``r / r_cutoff``.
+    Because none of the basis functions depend on the azimuthal angle
+    ``phi``, any learned linear combination is guaranteed to be isotropic
+    (radially symmetric).
+
+    ``kernel_shape`` is a single integer giving the number of radial modes.
+    If a tuple is provided, only the first element is used.
+    """
+
+    kernel_shape: int
+
+    def __init__(self, kernel_shape: int | list[int] | tuple[int, ...]):
+        if isinstance(kernel_shape, list | tuple):
+            kernel_shape = kernel_shape[0]
+        if not isinstance(kernel_shape, int):
+            raise ValueError(
+                f"expected kernel_shape to be an integer "
+                f"but got {kernel_shape} instead."
+            )
+        super().__init__(kernel_shape=kernel_shape)
+
+    @property
+    def kernel_size(self) -> int:
+        return self.kernel_shape
+
+    def compute_support_vals(
+        self,
+        r: torch.Tensor,
+        phi: torch.Tensor,
+        r_cutoff: float,
+        width: float = 1.0,
+    ):
+        ikernel = torch.arange(self.kernel_size, device=r.device).reshape(-1, 1, 1)
+
+        iidx = torch.argwhere(
+            (r <= r_cutoff)
+            & torch.full_like(ikernel, True, dtype=torch.bool, device=r.device)
+        )
+
+        r_norm = r[iidx[:, 1], iidx[:, 2]] / r_cutoff
+        n = ikernel[iidx[:, 0], 0, 0]
+
+        # Radial Fourier modes: cos/sin pattern identical to Morlet but in r.
+        harmonic = torch.where(
+            n % 2 == 1,
+            torch.sin(torch.ceil(n / 2) * math.pi * r_norm / width),
+            torch.cos(torch.ceil(n / 2) * math.pi * r_norm / width),
+        )
+
+        # Hann radial envelope
+        window = torch.cos(0.5 * torch.pi * r_norm / width) ** 2
+        vals = window * harmonic
+
         return iidx, vals
 
 

--- a/fme/core/models/conditional_sfno/sfnonet.py
+++ b/fme/core/models/conditional_sfno/sfnonet.py
@@ -119,6 +119,7 @@ def _compute_cutoff_radius(nlat, kernel_shape, basis_type):
     theta_cutoff_factor = {
         "piecewise linear": 0.5,
         "morlet": 0.5,
+        "isotropic morlet": 0.5,
         "zernike": math.sqrt(2.0),
     }
 

--- a/fme/core/models/conditional_sfno/test_localnet.py
+++ b/fme/core/models/conditional_sfno/test_localnet.py
@@ -9,6 +9,7 @@ from fme.core.testing.regression import validate_tensor
 
 from .layers import Context, ContextConfig
 from .localnet import LocalNetConfig, get_lat_lon_localnet
+from .sfnonet import DiscreteContinuousConvS2, _compute_cutoff_radius
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -263,6 +264,71 @@ def test_can_call_localnet_with_kernel_shape(kernel_shape, basis_type):
     )
     output = model(x, context)
     assert output.shape == (n_samples, output_channels, *img_shape)
+
+
+def test_isotropic_disco_conv_commutes_with_latitude_reflection():
+    """An isotropic DISCO conv must commute with latitude reflection.
+
+    Latitude reflection (θ → π−θ) is an isometry of the sphere that maps
+    equiangular grid points exactly onto other grid points.  For an
+    isotropic filter the convolution kernel depends only on geodesic
+    distance, which is preserved by the reflection, so
+    ``flip(conv(x)) == conv(flip(x))``.  An anisotropic filter also
+    depends on the local azimuthal angle, which the reflection reverses,
+    so the equality generally fails.
+    """
+    torch.manual_seed(0)
+    img_shape = (16, 32)
+    embed_dim = 4
+    kernel_shape = (3, 3)
+    data_grid = "equiangular"
+    lat_dim = 2  # dimension index for latitude in (batch, channel, lat, lon)
+
+    def make_disco_conv(basis_type):
+        theta_cutoff = 2 * _compute_cutoff_radius(
+            nlat=img_shape[0],
+            kernel_shape=kernel_shape,
+            basis_type=basis_type,
+        )
+        return DiscreteContinuousConvS2(
+            embed_dim,
+            embed_dim,
+            in_shape=img_shape,
+            out_shape=img_shape,
+            kernel_shape=kernel_shape,
+            basis_type=basis_type,
+            basis_norm_mode="mean",
+            groups=1,
+            grid_in=data_grid,
+            grid_out=data_grid,
+            bias=False,
+            theta_cutoff=theta_cutoff,
+        )
+
+    x = torch.randn(1, embed_dim, *img_shape)
+    x_flipped = torch.flip(x, dims=[lat_dim])
+
+    # Isotropic basis: convolution must commute with the reflection.
+    iso_conv = make_disco_conv("isotropic morlet")
+    with torch.no_grad():
+        out, _ = iso_conv(x)
+        out_from_flipped, _ = iso_conv(x_flipped)
+    torch.testing.assert_close(
+        torch.flip(out, dims=[lat_dim]),
+        out_from_flipped,
+    )
+
+    # Anisotropic basis: convolution should NOT commute (random weights
+    # activate the azimuthal modes that break the symmetry).
+    aniso_conv = make_disco_conv("morlet")
+    with torch.no_grad():
+        out, _ = aniso_conv(x)
+        out_from_flipped, _ = aniso_conv(x_flipped)
+    assert not torch.allclose(
+        torch.flip(out, dims=[lat_dim]),
+        out_from_flipped,
+        atol=1e-5,
+    )
 
 
 def test_unknown_filter_type_raises():


### PR DESCRIPTION
Add an isotropic Morlet filter basis for DISCO convolutions, enabling radially symmetric learned filters on the sphere. The standard Morlet basis includes azimuthal modes that break isotropy; the new basis uses only radial Fourier harmonics windowed by a Hann envelope, guaranteeing that any learned linear combination depends only on geodesic distance.

Changes:
- `fme.core.disco.IsotropicMorletFilterBasis` and `get_filter_basis` factory registration for `"isotropic morlet"` basis type
- `fme.core.models.conditional_sfno.sfnonet._compute_cutoff_radius` extended with `"isotropic morlet"` entry
- Test verifying isotropic DISCO conv commutes with latitude reflection while anisotropic Morlet does not

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated