### PR TITLE
Add bottleneck_attention option to diffusion model config

### DIFF
--- a/fme/downscaling/modules/diffusion_registry.py
+++ b/fme/downscaling/modules/diffusion_registry.py
@@ -56,6 +56,7 @@ class UNetDiffusionSong:
     encoder_type: str = "standard"
     decoder_type: str = "standard"
     resample_filter: list[int] = dataclasses.field(default_factory=lambda: [1, 1])
+    bottleneck_attention: bool = True
 
     def build(
         self,
@@ -85,6 +86,7 @@ class UNetDiffusionSong:
             encoder_type=self.encoder_type,
             decoder_type=self.decoder_type,
             resample_filter=self.resample_filter,
+            bottleneck_attention=self.bottleneck_attention,
         )
         return UNetDiffusionModule(
             EDMPrecond(
@@ -113,6 +115,7 @@ class UNetDiffusionSongv2:
     resample_filter: list[int] = dataclasses.field(default_factory=lambda: [1, 1])
     act: str = "silu"
     use_apex_gn: bool = True
+    bottleneck_attention: bool = True
 
     def build(
         self,
@@ -149,6 +152,7 @@ class UNetDiffusionSongv2:
             act=self.act,
             use_apex_gn=self.use_apex_gn,
             amp_mode=use_amp_bf16,
+            bottleneck_attention=self.bottleneck_attention,
         )
         module = UNetDiffusionModule(
             EDMPrecond(

--- a/fme/downscaling/modules/physicsnemo_unets_v1/unets.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v1/unets.py
@@ -145,6 +145,7 @@ class SongUNet(torch.nn.Module):
         resample_filter: List[int] = [1, 1],
         checkpoint_level: int = 0,
         additive_pos_embed: bool = False,
+        bottleneck_attention: bool = True,
     ):
         valid_embedding_types = ["fourier", "positional", "zero"]
         if embedding_type not in valid_embedding_types:
@@ -296,7 +297,7 @@ class SongUNet(torch.nn.Module):
             res = self.img_shape_y >> level
             if level == len(channel_mult) - 1:
                 self.dec[f"{res}x{res}_in0"] = UNetBlock(
-                    in_channels=cout, out_channels=cout, attention=True, **block_kwargs
+                    in_channels=cout, out_channels=cout, attention=bottleneck_attention, **block_kwargs
                 )
                 self.dec[f"{res}x{res}_in1"] = UNetBlock(
                     in_channels=cout, out_channels=cout, **block_kwargs

--- a/fme/downscaling/modules/physicsnemo_unets_v2/unets.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v2/unets.py
@@ -202,6 +202,10 @@ class SongUNetv2(torch.nn.Module):
     additive_pos_embed : bool, optional, default=False
         If ``True``, adds a learnable positional embedding after the first
         convolution layer. Used in StormCast model.
+    bottleneck_attention : bool, optional, default=True
+        If ``True``, applies self-attention in the bottleneck decoder block
+        (``_in0``), matching the original EDM implementation. Set to ``False``
+        to disable attention at the bottleneck.
 
         *Note:* Those positional embeddings encode spatial position information
         of the image pixels, unlike the ``embedding_type`` parameter which encodes
@@ -315,6 +319,7 @@ class SongUNetv2(torch.nn.Module):
         act: str = "silu",
         profile_mode: bool = False,
         amp_mode: bool = True,
+        bottleneck_attention: bool = True,
     ):
         valid_embedding_types = ["fourier", "positional", "zero"]
         if embedding_type not in valid_embedding_types:
@@ -497,7 +502,7 @@ class SongUNetv2(torch.nn.Module):
             res = self.img_shape_y >> level
             if level == len(channel_mult) - 1:
                 self.dec[f"{res}x{res}_in0"] = UNetBlock(
-                    in_channels=cout, out_channels=cout, attention=True, **block_kwargs
+                    in_channels=cout, out_channels=cout, attention=bottleneck_attention, **block_kwargs
                 )
                 self.dec[f"{res}x{res}_in1"] = UNetBlock(
                     in_channels=cout, out_channels=cout, **block_kwargs

--- a/fme/downscaling/modules/registry.py
+++ b/fme/downscaling/modules/registry.py
@@ -111,6 +111,7 @@ class UNetRegressionSong:
     encoder_type: str = "standard"
     decoder_type: str = "standard"
     resample_filter: list[int] = dataclasses.field(default_factory=lambda: [1, 1])
+    bottleneck_attention: bool = True
 
     def build(
         self,
@@ -136,6 +137,7 @@ class UNetRegressionSong:
             encoder_type=self.encoder_type,
             decoder_type=self.decoder_type,
             resample_filter=self.resample_filter,
+            bottleneck_attention=self.bottleneck_attention,
         )
         return UNetRegressionModule(
             unet,


### PR DESCRIPTION
Previously, attention=True was hardcoded in the bottleneck UNet layer. When I set `attn_resolutions=[]` in older model configs, I thought I was removing all attention blocks from the model but this was not the case- they had attention hard coded for the 8x8 layers. I removed this resolution from the 32x downscaling model, and do not want attention at the 16x16 resolution layer. 

This PR adds a config option `DiffusionModelConfig.bottleneck_attention` to control whether the bottleneck has attention. It defaults to True to preserve current behavior.
 