### PR TITLE
Replace weather eval with additional inference

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -65,7 +65,6 @@ from fme.ace.stepper.time_length_probabilities import (
     TimeLengthProbability,
     TimeLengthSchedule,
 )
-from fme.ace.train.train_config import WeatherEvaluationConfig
 from fme.core.cli import ResumeResultsConfig
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.corrector.ice import IceCorrectorConfig

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -96,6 +96,7 @@ from . import step
 from .inference.inference import get_initial_condition
 from .train.train import run_train
 from .train.train_config import (
+    AdditionalInferenceConfig,
     CopyWeightsConfig,
     DataLoaderConfig,
     EMAConfig,

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -55,7 +55,12 @@ from fme.ace.testing import (
 )
 from fme.ace.train.train import build_trainer, prepare_directory
 from fme.ace.train.train import main as train_main
-from fme.ace.train.train_config import InlineInferenceConfig, TrainBuilders, TrainConfig
+from fme.ace.train.train_config import (
+    AdditionalInferenceConfig,
+    InlineInferenceConfig,
+    TrainBuilders,
+    TrainConfig,
+)
 from fme.core.coordinates import (
     HEALPixCoordinates,
     HorizontalCoordinates,
@@ -204,7 +209,7 @@ def _get_test_yaml_files(
     )
     if skip_inline_inference:
         inline_inference_config = None
-        additional_inference_config = None
+        additional_inference_configs: list[AdditionalInferenceConfig] = []
     else:
         inline_inference_config = InlineInferenceConfig(
             aggregator=InferenceEvaluatorAggregatorConfig(
@@ -232,32 +237,37 @@ def _get_test_yaml_files(
             n_forward_steps=inference_forward_steps,
             forward_steps_in_memory=2,
         )
-        additional_inference_config = InlineInferenceConfig(
-            aggregator=InferenceEvaluatorAggregatorConfig(
-                monthly_reference_data=(
-                    str(monthly_data_filename)
-                    if monthly_data_filename is not None
-                    else None
+        additional_inference_configs = [
+            AdditionalInferenceConfig(
+                name="weather_eval",
+                config=InlineInferenceConfig(
+                    aggregator=InferenceEvaluatorAggregatorConfig(
+                        monthly_reference_data=(
+                            str(monthly_data_filename)
+                            if monthly_data_filename is not None
+                            else None
+                        ),
+                        log_step_means=[]
+                        if inference_forward_steps < 20
+                        else [StepMeanEntry(step=20)],
+                    ),
+                    loader=InferenceDataLoaderConfig(
+                        dataset=XarrayDataConfig(
+                            data_path=str(valid_data_path),
+                            spatial_dimensions=spatial_dimensions_str,
+                            labels=["era5"] if conditional else None,
+                        ),
+                        start_indices=InferenceInitialConditionIndices(
+                            first=0,
+                            n_initial_conditions=2,
+                            interval=1,
+                        ),
+                    ),
+                    n_forward_steps=inference_forward_steps,
+                    forward_steps_in_memory=2,
                 ),
-                log_step_means=[]
-                if inference_forward_steps < 20
-                else [StepMeanEntry(step=20)],
             ),
-            loader=InferenceDataLoaderConfig(
-                dataset=XarrayDataConfig(
-                    data_path=str(valid_data_path),
-                    spatial_dimensions=spatial_dimensions_str,
-                    labels=["era5"] if conditional else None,
-                ),
-                start_indices=InferenceInitialConditionIndices(
-                    first=0,
-                    n_initial_conditions=2,
-                    interval=1,
-                ),
-            ),
-            n_forward_steps=inference_forward_steps,
-            forward_steps_in_memory=2,
-        )
+        ]
 
     if use_time_length_probabilities:
         n_forward_steps_arg: TimeLength | TimeLengthSchedule = TimeLengthProbabilities(
@@ -369,7 +379,7 @@ def _get_test_yaml_files(
             n_forward_steps=n_forward_steps_arg,
         ),
         inference=inline_inference_config,
-        additional_inference=additional_inference_config,
+        additional_inference=additional_inference_configs,
         max_epochs=max_epochs,
         segment_epochs=segment_epochs,
         save_checkpoint=True,

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -55,12 +55,7 @@ from fme.ace.testing import (
 )
 from fme.ace.train.train import build_trainer, prepare_directory
 from fme.ace.train.train import main as train_main
-from fme.ace.train.train_config import (
-    InlineInferenceConfig,
-    TrainBuilders,
-    TrainConfig,
-    WeatherEvaluationConfig,
-)
+from fme.ace.train.train_config import InlineInferenceConfig, TrainBuilders, TrainConfig
 from fme.core.coordinates import (
     HEALPixCoordinates,
     HorizontalCoordinates,
@@ -237,7 +232,7 @@ def _get_test_yaml_files(
             n_forward_steps=inference_forward_steps,
             forward_steps_in_memory=2,
         )
-        weather_evaluation_config = WeatherEvaluationConfig(
+        weather_evaluation_config = InlineInferenceConfig(
             aggregator=InferenceEvaluatorAggregatorConfig(
                 monthly_reference_data=(
                     str(monthly_data_filename)

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -266,6 +266,7 @@ def _get_test_yaml_files(
                     ),
                     n_forward_steps=inference_forward_steps,
                     forward_steps_in_memory=2,
+                    n_ensemble_per_ic=2,
                 ),
             ),
         ]
@@ -635,6 +636,18 @@ def test_train_and_inference(
         assert ensemble_step_20_keys, (
             "expected at least one ensemble_step_20 metric in inline inference "
             "epoch log"
+        )
+        weather_eval_keys = [k for k in epoch_logs if k.startswith("weather_eval/")]
+        assert weather_eval_keys, (
+            "expected at least one weather_eval metric in additional_inference "
+            "epoch log"
+        )
+        weather_eval_ensemble_keys = [
+            k for k in epoch_logs if "weather_eval/ensemble_step_20/" in k
+        ]
+        assert weather_eval_ensemble_keys, (
+            "expected at least one ensemble_step_20 metric in weather_eval "
+            "additional_inference epoch log"
         )
 
     validation_output_dir = tmp_path / "results" / "output" / "val" / "epoch_0001"

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -204,7 +204,7 @@ def _get_test_yaml_files(
     )
     if skip_inline_inference:
         inline_inference_config = None
-        weather_evaluation_config = None
+        additional_inference_config = None
     else:
         inline_inference_config = InlineInferenceConfig(
             aggregator=InferenceEvaluatorAggregatorConfig(
@@ -232,7 +232,7 @@ def _get_test_yaml_files(
             n_forward_steps=inference_forward_steps,
             forward_steps_in_memory=2,
         )
-        weather_evaluation_config = InlineInferenceConfig(
+        additional_inference_config = InlineInferenceConfig(
             aggregator=InferenceEvaluatorAggregatorConfig(
                 monthly_reference_data=(
                     str(monthly_data_filename)
@@ -369,7 +369,7 @@ def _get_test_yaml_files(
             n_forward_steps=n_forward_steps_arg,
         ),
         inference=inline_inference_config,
-        weather_evaluation=weather_evaluation_config,
+        additional_inference=additional_inference_config,
         max_epochs=max_epochs,
         segment_epochs=segment_epochs,
         save_checkpoint=True,

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -39,67 +39,6 @@ from fme.core.weight_ops import CopyWeightsConfig
 
 
 @dataclasses.dataclass
-class WeatherEvaluationConfig:
-    """
-    Parameters:
-        loader: configuration for the data loader used during weather evaluation
-        n_forward_steps: number of forward steps to take
-        forward_steps_in_memory: number of forward steps to take before
-            re-reading data from disk
-        epochs: epochs on which to run weather evaluation. By default runs
-            weather evaluation every epoch.
-        aggregator: configuration of weather evaluation aggregator.
-    """
-
-    loader: InferenceDataLoaderConfig
-    n_forward_steps: int
-    forward_steps_in_memory: int
-    epochs: Slice = dataclasses.field(default_factory=lambda: Slice())
-    aggregator: InferenceEvaluatorAggregatorConfig = dataclasses.field(
-        default_factory=lambda: InferenceEvaluatorAggregatorConfig(
-            log_global_mean_time_series=False, log_global_mean_norm_time_series=False
-        )
-    )
-
-    def __post_init__(self):
-        dist = Distributed.get_instance()
-        if self.loader.start_indices.n_initial_conditions % dist.world_size != 0:
-            raise ValueError(
-                "Number of inference initial conditions must be divisible by the "
-                "number of parallel workers, got "
-                f"{self.loader.start_indices.n_initial_conditions} and "
-                f"{dist.world_size}."
-            )
-        if (
-            self.aggregator.log_global_mean_time_series
-            or self.aggregator.log_global_mean_norm_time_series
-        ):
-            # Both of log_global_mean_time_series and
-            # log_global_mean_norm_time_series must be False for inline inference.
-            self.aggregator.log_global_mean_time_series = False
-            self.aggregator.log_global_mean_norm_time_series = False
-
-        for log_step_mean in self.aggregator.log_step_means:
-            log_step_mean.validate(self.n_forward_steps)
-
-    @property
-    def using_labels(self) -> bool:
-        return self.loader.using_labels
-
-    def get_inference_data(
-        self,
-        window_requirements: DataRequirements,
-        initial_condition: PrognosticStateDataRequirements,
-    ) -> InferenceGriddedData:
-        return get_inference_data(
-            config=self.loader,
-            total_forward_steps=self.n_forward_steps,
-            window_requirements=window_requirements,
-            initial_condition=initial_condition,
-        )
-
-
-@dataclasses.dataclass
 class InlineInferenceConfig:
     """
     Parameters:
@@ -247,7 +186,7 @@ class TrainConfig:
         default_factory=list
     )
     ema: EMAConfig = dataclasses.field(default_factory=lambda: EMAConfig())
-    weather_evaluation: WeatherEvaluationConfig | None = None
+    weather_evaluation: InlineInferenceConfig | None = None
     validate_using_ema: bool = False
     checkpoint_save_epochs: Slice | None = None
     ema_checkpoint_save_epochs: Slice | None = None

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -99,6 +99,16 @@ class InlineInferenceConfig:
 
 
 @dataclasses.dataclass
+class AdditionalInferenceConfig:
+    name: str
+    config: InlineInferenceConfig
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("AdditionalInferenceConfig name must be non-empty.")
+
+
+@dataclasses.dataclass
 class TrainConfig:
     """
     Configuration for training a model.
@@ -119,9 +129,9 @@ class TrainConfig:
         inference: Configuration for inline inference.
             If None, no inline inference is run,
             and no "best_inline_inference" checkpoint will be saved.
-        additional_inference: Configuration for additional inference.
-            If None, no additional inference is run. Additional inference is
-            not used to select checkpoints, but is used to provide metrics.
+        additional_inference: Configurations for additional inference runs.
+            Each entry has a name (used as wandb log prefix) and config.
+            Not used to select checkpoints, but used to provide metrics.
         stepper_training: Training-specific configuration including loss, ensemble
             settings, parameter initialization, and forward step scheduling.
         train_aggregator: Configuration for the train aggregator.
@@ -186,7 +196,9 @@ class TrainConfig:
         default_factory=list
     )
     ema: EMAConfig = dataclasses.field(default_factory=lambda: EMAConfig())
-    additional_inference: InlineInferenceConfig | None = None
+    additional_inference: list[AdditionalInferenceConfig] = dataclasses.field(
+        default_factory=list
+    )
     validate_using_ema: bool = False
     checkpoint_save_epochs: Slice | None = None
     ema_checkpoint_save_epochs: Slice | None = None
@@ -216,13 +228,16 @@ class TrainConfig:
                 "train_loader and inference loader must both use labels or both not "
                 "use labels"
             )
-        if self.additional_inference is not None and (
-            self.train_loader.using_labels != self.additional_inference.using_labels
-        ):
-            raise ValueError(
-                "train_loader and additional_inference loader must both use labels or "
-                "both not use labels"
-            )
+        additional_inference_names: set[str] = set()
+        for entry in self.additional_inference:
+            if entry.name in additional_inference_names:
+                raise ValueError(f"Duplicate additional_inference name: {entry.name!r}")
+            additional_inference_names.add(entry.name)
+            if self.train_loader.using_labels != entry.config.using_labels:
+                raise ValueError(
+                    f"train_loader and additional_inference {entry.name!r} loader "
+                    "must both use labels or both not use labels"
+                )
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
             raise ValueError(
                 "lr_tuning and optimization.scheduler cannot both be specified; "
@@ -391,39 +406,47 @@ class TrainBuilders:
         save_diagnostics: bool,
         n_ic_timesteps: int,
     ) -> EndOfEpochCallback:
-        if self.config.additional_inference is not None:
+        entries_data: list[
+            tuple[AdditionalInferenceConfig, InferenceGriddedData, DatasetInfo]
+        ] = []
+        for entry in self.config.additional_inference:
             window_requirements = (
                 self.config.stepper.get_evaluation_window_data_requirements(
-                    self.config.additional_inference.forward_steps_in_memory
+                    entry.config.forward_steps_in_memory
                 )
             )
-            data = self.config.additional_inference.get_inference_data(
+            data = entry.config.get_inference_data(
                 window_requirements=window_requirements,
                 initial_condition=self.config.stepper.get_prognostic_state_data_requirements(),
             )
             dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)
+            entries_data.append((entry, data, dataset_info))
 
-            def end_of_epoch_ops(epoch: int) -> Mapping[str, Any]:
-                if self.config.additional_inference is not None:
-                    if self.config.additional_inference.epochs.contains(epoch):
-                        aggregator = self.config.additional_inference.aggregator.build(
-                            dataset_info=dataset_info,
-                            n_ic_steps=n_ic_timesteps,
-                            n_forward_steps=self.config.additional_inference.n_forward_steps,
-                            initial_time=data.initial_time,
-                            normalize=normalize,
-                            output_dir=output_dir,
-                            channel_mean_names=channel_mean_names,
-                            save_diagnostics=save_diagnostics,
-                        )
-                        return inference_one_epoch(
+        def end_of_epoch_ops(epoch: int) -> Mapping[str, Any]:
+            all_logs: dict[str, Any] = {}
+            for entry, data, dataset_info in entries_data:
+                if entry.config.epochs.contains(epoch):
+                    entry_output_dir = os.path.join(
+                        output_dir, "additional_inference", entry.name
+                    )
+                    aggregator = entry.config.aggregator.build(
+                        dataset_info=dataset_info,
+                        n_ic_steps=n_ic_timesteps,
+                        n_forward_steps=entry.config.n_forward_steps,
+                        initial_time=data.initial_time,
+                        normalize=normalize,
+                        output_dir=entry_output_dir,
+                        channel_mean_names=channel_mean_names,
+                        save_diagnostics=save_diagnostics,
+                    )
+                    all_logs.update(
+                        inference_one_epoch(
                             data,
                             aggregator,
-                            "additional_inference",
+                            entry.name,
                             epoch,
                         )
-                return {}
+                    )
+            return all_logs
 
-            return end_of_epoch_ops
-
-        return lambda epoch: {}
+        return end_of_epoch_ops

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -19,11 +19,7 @@ from fme.ace.data_loading.gridded_data import (
     InferenceGriddedData,
 )
 from fme.ace.data_loading.inference import InferenceDataLoaderConfig
-from fme.ace.requirements import (
-    DataRequirements,
-    NullDataRequirements,
-    PrognosticStateDataRequirements,
-)
+from fme.ace.requirements import DataRequirements, PrognosticStateDataRequirements
 from fme.ace.stepper import TrainStepper
 from fme.ace.stepper.single_module import StepperConfig, TrainStepperConfig
 from fme.core.cli import ResumeResultsConfig
@@ -371,18 +367,6 @@ class TrainBuilders:
             n_forward_steps
         )
 
-    def _get_evaluation_window_data_requirements(self) -> DataRequirements:
-        if self.config.inference is None:
-            return NullDataRequirements
-        return self.config.stepper.get_evaluation_window_data_requirements(
-            self.config.inference.forward_steps_in_memory
-        )
-
-    def _get_initial_condition_data_requirements(
-        self,
-    ) -> PrognosticStateDataRequirements:
-        return self.config.stepper.get_prognostic_state_data_requirements()
-
     def get_train_data(self) -> GriddedData:
         data_requirements = self._get_train_window_data_requirements()
         return get_gridded_data(
@@ -405,9 +389,14 @@ class TrainBuilders:
         if self.config.inference is None:
             return ErrorInferenceData()  # type: ignore
         else:
+            window_requirements = (
+                self.config.stepper.get_evaluation_window_data_requirements(
+                    self.config.inference.forward_steps_in_memory
+                )
+            )
             return self.config.inference.get_inference_data(
-                window_requirements=self._get_evaluation_window_data_requirements(),
-                initial_condition=self._get_initial_condition_data_requirements(),
+                window_requirements=window_requirements,
+                initial_condition=self.config.stepper.get_prognostic_state_data_requirements(),
             )
 
     def get_optimization(self, modules: torch.nn.ModuleList) -> Optimization:
@@ -464,9 +453,14 @@ class TrainBuilders:
         n_ic_timesteps: int,
     ) -> EndOfEpochCallback:
         if self.config.weather_evaluation is not None:
+            window_requirements = (
+                self.config.stepper.get_evaluation_window_data_requirements(
+                    self.config.weather_evaluation.forward_steps_in_memory
+                )
+            )
             data = self.config.weather_evaluation.get_inference_data(
-                window_requirements=self._get_evaluation_window_data_requirements(),
-                initial_condition=self._get_initial_condition_data_requirements(),
+                window_requirements=window_requirements,
+                initial_condition=self.config.stepper.get_prognostic_state_data_requirements(),
             )
             dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)
             aggregator = self.config.weather_evaluation.aggregator.build(

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -447,6 +447,7 @@ class TrainBuilders:
                         output_dir=entry_output_dir,
                         channel_mean_names=channel_mean_names,
                         save_diagnostics=save_diagnostics,
+                        n_ensemble_per_ic=entry.config.n_ensemble_per_ic,
                     )
                     all_logs.update(
                         inference_one_epoch(

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -463,20 +463,20 @@ class TrainBuilders:
                 initial_condition=self.config.stepper.get_prognostic_state_data_requirements(),
             )
             dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)
-            aggregator = self.config.weather_evaluation.aggregator.build(
-                dataset_info=dataset_info,
-                n_ic_steps=n_ic_timesteps,
-                n_forward_steps=self.config.weather_evaluation.n_forward_steps,
-                initial_time=data.initial_time,
-                normalize=normalize,
-                output_dir=output_dir,
-                channel_mean_names=channel_mean_names,
-                save_diagnostics=save_diagnostics,
-            )
 
             def end_of_epoch_ops(epoch: int) -> Mapping[str, Any]:
                 if self.config.weather_evaluation is not None:
                     if self.config.weather_evaluation.epochs.contains(epoch):
+                        aggregator = self.config.weather_evaluation.aggregator.build(
+                            dataset_info=dataset_info,
+                            n_ic_steps=n_ic_timesteps,
+                            n_forward_steps=self.config.weather_evaluation.n_forward_steps,
+                            initial_time=data.initial_time,
+                            normalize=normalize,
+                            output_dir=output_dir,
+                            channel_mean_names=channel_mean_names,
+                            save_diagnostics=save_diagnostics,
+                        )
                         return inference_one_epoch(
                             data,
                             aggregator,

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -119,9 +119,9 @@ class TrainConfig:
         inference: Configuration for inline inference.
             If None, no inline inference is run,
             and no "best_inline_inference" checkpoint will be saved.
-        weather_evaluation: Configuration for weather evaluation.
-            If None, no weather evaluation is run. Weather evaluation is not
-            used to select checkpoints, but is used to provide metrics.
+        additional_inference: Configuration for additional inference.
+            If None, no additional inference is run. Additional inference is
+            not used to select checkpoints, but is used to provide metrics.
         stepper_training: Training-specific configuration including loss, ensemble
             settings, parameter initialization, and forward step scheduling.
         train_aggregator: Configuration for the train aggregator.
@@ -186,7 +186,7 @@ class TrainConfig:
         default_factory=list
     )
     ema: EMAConfig = dataclasses.field(default_factory=lambda: EMAConfig())
-    weather_evaluation: InlineInferenceConfig | None = None
+    additional_inference: InlineInferenceConfig | None = None
     validate_using_ema: bool = False
     checkpoint_save_epochs: Slice | None = None
     ema_checkpoint_save_epochs: Slice | None = None
@@ -216,11 +216,11 @@ class TrainConfig:
                 "train_loader and inference loader must both use labels or both not "
                 "use labels"
             )
-        if self.weather_evaluation is not None and (
-            self.train_loader.using_labels != self.weather_evaluation.using_labels
+        if self.additional_inference is not None and (
+            self.train_loader.using_labels != self.additional_inference.using_labels
         ):
             raise ValueError(
-                "train_loader and weather_evaluation loader must both use labels or "
+                "train_loader and additional_inference loader must both use labels or "
                 "both not use labels"
             )
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
@@ -391,25 +391,25 @@ class TrainBuilders:
         save_diagnostics: bool,
         n_ic_timesteps: int,
     ) -> EndOfEpochCallback:
-        if self.config.weather_evaluation is not None:
+        if self.config.additional_inference is not None:
             window_requirements = (
                 self.config.stepper.get_evaluation_window_data_requirements(
-                    self.config.weather_evaluation.forward_steps_in_memory
+                    self.config.additional_inference.forward_steps_in_memory
                 )
             )
-            data = self.config.weather_evaluation.get_inference_data(
+            data = self.config.additional_inference.get_inference_data(
                 window_requirements=window_requirements,
                 initial_condition=self.config.stepper.get_prognostic_state_data_requirements(),
             )
             dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)
 
             def end_of_epoch_ops(epoch: int) -> Mapping[str, Any]:
-                if self.config.weather_evaluation is not None:
-                    if self.config.weather_evaluation.epochs.contains(epoch):
-                        aggregator = self.config.weather_evaluation.aggregator.build(
+                if self.config.additional_inference is not None:
+                    if self.config.additional_inference.epochs.contains(epoch):
+                        aggregator = self.config.additional_inference.aggregator.build(
                             dataset_info=dataset_info,
                             n_ic_steps=n_ic_timesteps,
-                            n_forward_steps=self.config.weather_evaluation.n_forward_steps,
+                            n_forward_steps=self.config.additional_inference.n_forward_steps,
                             initial_time=data.initial_time,
                             normalize=normalize,
                             output_dir=output_dir,
@@ -419,7 +419,7 @@ class TrainBuilders:
                         return inference_one_epoch(
                             data,
                             aggregator,
-                            "weather_eval",
+                            "additional_inference",
                             epoch,
                         )
                 return {}


### PR DESCRIPTION
Replaces the single optional `weather_evaluation` config with a list of named `additional_inference` entries, each able to run an independent inference evaluation during training. Also fixes two bugs in the existing weather evaluation code path.

Changes:
- `TrainBuilders.get_evaluation_inference_data`, `TrainBuilders.get_end_of_epoch_callback`: fix weather evaluation using inline inference's data requirements instead of its own
- `TrainBuilders.get_end_of_epoch_callback`: fix aggregator being built once and reused across epochs instead of rebuilt each time
- `WeatherEvaluationConfig`: removed, was identical to `InlineInferenceConfig`
- `TrainConfig.weather_evaluation` renamed to `TrainConfig.additional_inference`, changed from `InlineInferenceConfig | None` to `list[AdditionalInferenceConfig]`
- `AdditionalInferenceConfig`: new dataclass with `name` (used as wandb log prefix and output subdirectory) and `config: InlineInferenceConfig`, with duplicate name validation
- `fme.ace.AdditionalInferenceConfig`: added to public API

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated