### PR TITLE
Thin coordinator: move builder logic to config.build()

### DIFF
--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
+import numpy as np
 import torch
 import xarray as xr
 
@@ -142,32 +143,173 @@ class InferenceEvaluatorAggregatorConfig:
                 self.monthly_reference_data, decode_timedelta=False
             )
         if self.time_mean_reference_data is None:
-            time_mean = None
+            time_mean_reference_data = None
         else:
-            time_mean = xr.open_dataset(
+            time_mean_reference_data = xr.open_dataset(
                 self.time_mean_reference_data, decode_timedelta=False
             )
-        return InferenceEvaluatorAggregator(
-            dataset_info=dataset_info,
-            n_ic_steps=n_ic_steps,
-            n_forward_steps=n_forward_steps,
-            initial_time=initial_time,
-            output_dir=output_dir,
-            log_histograms=self.log_histograms,
-            log_video=self.log_video,
-            enable_extended_videos=self.log_extended_video,
-            log_zonal_mean_images=self.log_zonal_mean_images,
-            log_seasonal_means=self.log_seasonal_means,
-            log_global_mean_time_series=self.log_global_mean_time_series,
-            log_global_mean_norm_time_series=self.log_global_mean_norm_time_series,
-            monthly_reference_data=monthly_reference_data,
-            time_mean_reference_data=time_mean,
-            log_step_means=self.log_step_means,
+
+        timestep = dataset_info.timestep
+        horizontal_coordinates = dataset_info.horizontal_coordinates
+        ops = dataset_info.gridded_operations
+        n_timesteps = n_ic_steps + n_forward_steps
+
+        aggregators: dict[str, SubAggregator] = {}
+        time_series_aggregators: dict[str, TimeSeriesLogs] = {}
+        ensemble_aggregators: dict[str, SelectStepEnsembleAggregator] = {}
+
+        if self.log_global_mean_time_series:
+            mean_agg = MeanAggregator(
+                ops,
+                target="denorm",
+                n_timesteps=n_timesteps,
+                variable_metadata=dataset_info.variable_metadata,
+            )
+            aggregators["mean"] = mean_agg
+            time_series_aggregators["mean"] = mean_agg
+        if self.log_global_mean_norm_time_series:
+            mean_norm_agg = MeanAggregator(
+                ops,
+                target="norm",
+                n_timesteps=n_timesteps,
+                variable_metadata=dataset_info.variable_metadata,
+            )
+            aggregators["mean_norm"] = mean_norm_agg
+            time_series_aggregators["mean_norm"] = mean_norm_agg
+        for step_mean_entry in self.log_step_means:
+            step_mean_entry.validate(n_forward_steps)
+            step = step_mean_entry.step
+            name = step_mean_entry.get_name()
+            # -1 because step 0 (after IC) is the first forward step
+            target_time = step + n_ic_steps - 1
+            aggregators[name] = _OneStepMeanAdapter(
+                OneStepMeanAggregator(
+                    ops,
+                    target_time=target_time,
+                    target="denorm",
+                    log_loss=False,
+                )
+            )
+            aggregators[name + "_norm"] = _OneStepMeanAdapter(
+                OneStepMeanAggregator(
+                    ops,
+                    target_time=target_time,
+                    target="norm",
+                    log_loss=False,
+                    include_bias=False,
+                    include_grad_mag_percent_diff=False,
+                    channel_mean_names=channel_mean_names,
+                )
+            )
+            if n_ensemble_per_ic > 1:
+                ensemble_aggregators["ensemble_step_20"] = (
+                    get_one_step_ensemble_aggregator(
+                        gridded_operations=ops,
+                        target_time=20,
+                        log_mean_maps=False,
+                        metadata=dataset_info.variable_metadata,
+                    )
+                )
+        try:
+            flood_fill = SmoothFloodFill(num_steps=4)
+            aggregators["power_spectrum"] = PairedSphericalPowerSpectrumAggregator(
+                gridded_operations=ops,
+                nan_fill_fn=flood_fill,
+                report_plot=True,
+                variable_metadata=dataset_info.variable_metadata,
+            )
+        except NotImplementedError:
+            logging.warning(
+                "Power spectrum aggregator not implemented for this grid type, "
+                "omitting."
+            )
+        if self.log_zonal_mean_images:
+            if ops.zonal_mean is None:
+                logging.warning(
+                    "Zonal mean aggregator not implemented for this grid type, "
+                    "omitting."
+                )
+            else:
+                aggregators["zonal_mean"] = ZonalMeanAggregator(
+                    zonal_mean=ops.zonal_mean,
+                    n_timesteps=n_timesteps,
+                    variable_metadata=dataset_info.variable_metadata,
+                    zonal_mean_max_size=self.log_zonal_mean_images,
+                )
+        if isinstance(horizontal_coordinates, LatLonCoordinates):
+            if self.log_video:
+                aggregators["video"] = VideoAggregator(
+                    n_timesteps=n_timesteps,
+                    enable_extended_videos=self.log_extended_video,
+                    variable_metadata=dataset_info.variable_metadata,
+                )
+        aggregators["time_mean"] = TimeMeanEvaluatorAggregator(
+            ops,
+            horizontal_dims=horizontal_coordinates.dims,
+            variable_metadata=dataset_info.variable_metadata,
+            reference_means=time_mean_reference_data,
+        )
+        aggregators["time_mean_norm"] = TimeMeanEvaluatorAggregator(
+            ops,
+            horizontal_dims=horizontal_coordinates.dims,
+            target="norm",
+            variable_metadata=dataset_info.variable_metadata,
             channel_mean_names=channel_mean_names,
-            log_nino34_index=self.log_nino34_index,
+        )
+        if self.log_histograms:
+            aggregators["histogram"] = HistogramAggregator()
+        if self.log_seasonal_means:
+            aggregators["seasonal"] = SeasonalAggregator(
+                ops=ops,
+                variable_metadata=dataset_info.variable_metadata,
+            )
+        if n_timesteps * timestep > APPROXIMATELY_TWO_YEARS:
+            aggregators["annual"] = PairedGlobalMeanAnnualAggregator(
+                ops=ops,
+                timestep=timestep,
+                variable_metadata=dataset_info.variable_metadata,
+                monthly_reference_data=monthly_reference_data,
+            )
+            if (
+                isinstance(horizontal_coordinates, LatLonCoordinates)
+                and isinstance(ops, LatLonOperations)
+                and self.log_nino34_index
+            ):
+                nino34_region = LatLonRegion(
+                    lat_bounds=NINO34_LAT,
+                    lon_bounds=NINO34_LON,
+                    lat=horizontal_coordinates.lat,
+                    lon=horizontal_coordinates.lon,
+                )
+                aggregators["enso_index"] = PairedRegionalIndexAggregator(
+                    target_aggregator=RegionalIndexAggregator(
+                        regional_weights=nino34_region.regional_weights,
+                        regional_mean=ops.regional_area_weighted_mean,
+                    ),
+                    prediction_aggregator=RegionalIndexAggregator(
+                        regional_weights=nino34_region.regional_weights,
+                        regional_mean=ops.regional_area_weighted_mean,
+                    ),
+                )
+        if n_timesteps * timestep > SLIGHTLY_LESS_THAN_FIVE_YEARS:
+            aggregators["enso_coefficient"] = EnsoCoefficientEvaluatorAggregator(
+                initial_time,
+                n_timesteps - 1,
+                timestep,
+                gridded_operations=ops,
+                variable_metadata=dataset_info.variable_metadata,
+            )
+
+        return InferenceEvaluatorAggregator(
+            aggregators=aggregators,
+            time_series_aggregators=time_series_aggregators,
+            coords=horizontal_coordinates.coords,
+            n_ic_steps=n_ic_steps,
             normalize=normalize,
             save_diagnostics=save_diagnostics,
+            output_dir=output_dir,
             n_ensemble_per_ic=n_ensemble_per_ic,
+            ensemble_aggregators=ensemble_aggregators,
         )
 
 
@@ -205,227 +347,37 @@ class InferenceEvaluatorAggregator(
 
     def __init__(
         self,
-        dataset_info: DatasetInfo,
+        aggregators: dict[str, SubAggregator],
+        time_series_aggregators: dict[str, TimeSeriesLogs],
+        coords: Mapping[str, np.ndarray],
         n_ic_steps: int,
-        n_forward_steps: int,
-        initial_time: xr.DataArray,
         normalize: Callable[[TensorMapping], TensorDict],
-        log_zonal_mean_images: bool | int,
-        log_step_means: list[StepMeanEntry],
-        output_dir: str | None = None,
-        log_video: bool = False,
-        enable_extended_videos: bool = False,
-        log_seasonal_means: bool = False,
-        log_global_mean_time_series: bool = True,
-        log_global_mean_norm_time_series: bool = True,
-        monthly_reference_data: xr.Dataset | None = None,
-        log_histograms: bool = False,
-        time_mean_reference_data: xr.Dataset | None = None,
-        channel_mean_names: Sequence[str] | None = None,
-        log_nino34_index: bool = True,
         save_diagnostics: bool = True,
+        output_dir: str | None = None,
         n_ensemble_per_ic: int = 1,
+        ensemble_aggregators: dict[str, SelectStepEnsembleAggregator] | None = None,
     ):
-        """
-        Args:
-            dataset_info: Dataset coordinates and metadata.
-            n_ic_steps: Number of initial condition steps in the data.
-            n_forward_steps: Number of forward steps in the data.
-            initial_time: Initial time for each sample.
-            output_dir: Directory to save diagnostic output.
-            normalize: Normalization function to use.
-            log_zonal_mean_images: Whether to log zonal-mean images (hovmollers) with a
-                time dimension.
-            log_step_means: List of StepMeanEntry objects specifying steps at which to
-                log mean metrics.
-            log_video: Whether to log videos of the state evolution.
-            enable_extended_videos: Whether to log videos of statistical
-                metrics of state evolution
-            log_seasonal_means: Whether to log seasonal means metrics and images.
-            log_global_mean_time_series: Whether to log global mean time series metrics.
-            log_global_mean_norm_time_series: Whether to log the normalized global mean
-                time series metrics.
-            monthly_reference_data: Reference monthly data for computing target stats.
-            log_histograms: Whether to aggregate histograms.
-            time_mean_reference_data: Reference time means for computing bias stats.
-            channel_mean_names: Names over which to compute channel means. If not
-                provided, all available variables will be used.
-            log_nino34_index: Whether to log the Nino34 index.
-            save_diagnostics: Whether to save reduced diagnostics to disk.
-            n_ensemble_per_ic: Number of ensemble members per initial condition.
-        """
         if save_diagnostics and output_dir is None:
             raise ValueError("Output directory must be set to save diagnostics")
-        self._channel_mean_names = channel_mean_names
-        self._aggregators: dict[str, SubAggregator] = {}
+        self._aggregators = aggregators
+        self._time_series_aggregators = time_series_aggregators
         self.n_ensemble_per_ic = n_ensemble_per_ic
-        self._ensemble_aggregators: dict[str, SelectStepEnsembleAggregator] = {}
-        self._save_diagnostics = save_diagnostics
-        self._output_dir = output_dir
-        timestep = dataset_info.timestep
-        horizontal_coordinates = dataset_info.horizontal_coordinates
-        self._coords = horizontal_coordinates.coords
-        ops = dataset_info.gridded_operations
-        self._log_time_series = (
-            log_global_mean_time_series or log_global_mean_norm_time_series
-        )
-        self.n_ic_steps = n_ic_steps
-        n_timesteps = n_ic_steps + n_forward_steps
-        self._time_series_aggregators: dict[str, TimeSeriesLogs] = {}
-        if log_global_mean_time_series:
-            mean_agg = MeanAggregator(
-                ops,
-                target="denorm",
-                n_timesteps=n_timesteps,
-                variable_metadata=dataset_info.variable_metadata,
-            )
-            self._aggregators["mean"] = mean_agg
-            self._time_series_aggregators["mean"] = mean_agg
-        if log_global_mean_norm_time_series:
-            mean_norm_agg = MeanAggregator(
-                ops,
-                target="norm",
-                n_timesteps=n_timesteps,
-                variable_metadata=dataset_info.variable_metadata,
-            )
-            self._aggregators["mean_norm"] = mean_norm_agg
-            self._time_series_aggregators["mean_norm"] = mean_norm_agg
-        for step_mean_entry in log_step_means:
-            step_mean_entry.validate(n_forward_steps)
-            step = step_mean_entry.step
-            name = step_mean_entry.get_name()
-            # -1 because step 0 (after IC) is the first forward step
-            target_time = step + n_ic_steps - 1
-            self._aggregators[name] = _OneStepMeanAdapter(
-                OneStepMeanAggregator(
-                    ops,
-                    target_time=target_time,
-                    target="denorm",
-                    log_loss=False,
-                )
-            )
-            self._aggregators[name + "_norm"] = _OneStepMeanAdapter(
-                OneStepMeanAggregator(
-                    ops,
-                    target_time=target_time,
-                    target="norm",
-                    log_loss=False,
-                    include_bias=False,
-                    include_grad_mag_percent_diff=False,
-                    channel_mean_names=self._channel_mean_names,
-                )
-            )
-            if n_ensemble_per_ic > 1:
-                self._ensemble_aggregators["ensemble_step_20"] = (
-                    get_one_step_ensemble_aggregator(
-                        gridded_operations=ops,
-                        target_time=20,
-                        log_mean_maps=False,
-                        metadata=dataset_info.variable_metadata,
-                    )
-                )
-        try:
-            flood_fill = SmoothFloodFill(num_steps=4)
-            self._aggregators["power_spectrum"] = (
-                PairedSphericalPowerSpectrumAggregator(
-                    gridded_operations=ops,
-                    nan_fill_fn=flood_fill,
-                    report_plot=True,
-                    variable_metadata=dataset_info.variable_metadata,
-                )
-            )
-        except NotImplementedError:
-            logging.warning(
-                "Power spectrum aggregator not implemented for this grid type, "
-                "omitting."
-            )
-        if log_zonal_mean_images:
-            if ops.zonal_mean is None:
-                logging.warning(
-                    "Zonal mean aggregator not implemented for this grid type, "
-                    "omitting."
-                )
-            else:
-                self._aggregators["zonal_mean"] = ZonalMeanAggregator(
-                    zonal_mean=ops.zonal_mean,
-                    n_timesteps=n_timesteps,
-                    variable_metadata=dataset_info.variable_metadata,
-                    zonal_mean_max_size=log_zonal_mean_images,
-                )
-        if isinstance(horizontal_coordinates, LatLonCoordinates):
-            if log_video:
-                self._aggregators["video"] = VideoAggregator(
-                    n_timesteps=n_timesteps,
-                    enable_extended_videos=enable_extended_videos,
-                    variable_metadata=dataset_info.variable_metadata,
-                )
-        self._aggregators["time_mean"] = TimeMeanEvaluatorAggregator(
-            ops,
-            horizontal_dims=horizontal_coordinates.dims,
-            variable_metadata=dataset_info.variable_metadata,
-            reference_means=time_mean_reference_data,
-        )
-        self._aggregators["time_mean_norm"] = TimeMeanEvaluatorAggregator(
-            ops,
-            horizontal_dims=horizontal_coordinates.dims,
-            target="norm",
-            variable_metadata=dataset_info.variable_metadata,
-            channel_mean_names=self._channel_mean_names,
-        )
-        if log_histograms:
-            self._aggregators["histogram"] = HistogramAggregator()
-        if log_seasonal_means:
-            self._aggregators["seasonal"] = SeasonalAggregator(
-                ops=ops,
-                variable_metadata=dataset_info.variable_metadata,
-            )
-        if n_timesteps * timestep > APPROXIMATELY_TWO_YEARS:
-            self._aggregators["annual"] = PairedGlobalMeanAnnualAggregator(
-                ops=ops,
-                timestep=timestep,
-                variable_metadata=dataset_info.variable_metadata,
-                monthly_reference_data=monthly_reference_data,
-            )
-            if (
-                isinstance(horizontal_coordinates, LatLonCoordinates)
-                and isinstance(ops, LatLonOperations)
-                and log_nino34_index
-            ):
-                nino34_region = LatLonRegion(
-                    lat_bounds=NINO34_LAT,
-                    lon_bounds=NINO34_LON,
-                    lat=horizontal_coordinates.lat,
-                    lon=horizontal_coordinates.lon,
-                )
-                self._aggregators["enso_index"] = PairedRegionalIndexAggregator(
-                    target_aggregator=RegionalIndexAggregator(
-                        regional_weights=nino34_region.regional_weights,
-                        regional_mean=ops.regional_area_weighted_mean,
-                    ),
-                    prediction_aggregator=RegionalIndexAggregator(
-                        regional_weights=nino34_region.regional_weights,
-                        regional_mean=ops.regional_area_weighted_mean,
-                    ),
-                )
-        if n_timesteps * timestep > SLIGHTLY_LESS_THAN_FIVE_YEARS:
-            self._aggregators["enso_coefficient"] = EnsoCoefficientEvaluatorAggregator(
-                initial_time,
-                n_timesteps - 1,
-                timestep,
-                gridded_operations=ops,
-                variable_metadata=dataset_info.variable_metadata,
-            )
-
+        self._ensemble_aggregators = ensemble_aggregators or {}
         summary_aggregators: dict[str, SubAggregator | SelectStepEnsembleAggregator] = {
             name: agg
-            for name, agg in self._aggregators.items()
-            if name not in self._time_series_aggregators
+            for name, agg in aggregators.items()
+            if name not in time_series_aggregators
         }
-        if self.n_ensemble_per_ic > 1:
+        if n_ensemble_per_ic > 1:
             summary_aggregators.update(self._ensemble_aggregators)
         self._summary_aggregators = summary_aggregators
-        self._n_timesteps_seen = 0
+        self._coords = coords
+        self.n_ic_steps = n_ic_steps
         self._normalize = normalize
+        self._save_diagnostics = save_diagnostics
+        self._output_dir = output_dir
+        self._log_time_series = len(time_series_aggregators) > 0
+        self._n_timesteps_seen = 0
 
     @property
     def log_time_series(self) -> bool:
@@ -608,7 +560,8 @@ class InferenceAggregatorConfig:
         self,
         dataset_info: DatasetInfo,
         n_timesteps: int,
-        output_dir: str,
+        output_dir: str | None = None,
+        save_diagnostics: bool = True,
     ) -> "InferenceAggregator":
         if self.time_mean_reference_data is not None:
             time_means = xr.open_dataset(
@@ -617,67 +570,24 @@ class InferenceAggregatorConfig:
             )
         else:
             time_means = None
-        return InferenceAggregator(
-            dataset_info=dataset_info,
-            n_timesteps=n_timesteps,
-            output_dir=output_dir,
-            time_mean_reference_data=time_means,
-            log_global_mean_time_series=self.log_global_mean_time_series,
-        )
 
-
-class InferenceAggregator(
-    InferenceAggregatorABC[
-        PrognosticState,
-        PairedData,
-    ]
-):
-    """
-    Aggregates statistics on a single timeseries of data.
-
-    To use, call `record_batch` on the results of each batch, then call
-    `get_logs` to get a dictionary of statistics when you're done.
-    """
-
-    def __init__(
-        self,
-        dataset_info: DatasetInfo,
-        n_timesteps: int,
-        save_diagnostics: bool = True,
-        output_dir: str | None = None,
-        time_mean_reference_data: xr.Dataset | None = None,
-        log_global_mean_time_series: bool = True,
-    ):
-        """
-        Args:
-            dataset_info: The coordinates of the dataset.
-            n_timesteps: Number of timesteps in the model.
-            save_diagnostics: Whether to save diagnostics.
-            output_dir: Directory to save diagnostic output.
-            time_mean_reference_data: Reference time means for computing bias stats.
-            log_global_mean_time_series: Whether to log global mean time series metrics.
-        """
-        if save_diagnostics and output_dir is None:
-            raise ValueError("Output directory must be set to save diagnostics")
-        self._log_time_series = log_global_mean_time_series
         horizontal_coordinates = dataset_info.horizontal_coordinates
-        self._coords = horizontal_coordinates.coords
-        self._save_diagnostics = save_diagnostics
-        self._output_dir = output_dir
-        aggregators: dict[str, SubAggregator] = {}
         gridded_operations = dataset_info.gridded_operations
-        self._time_series_aggregators: dict[str, TimeSeriesLogs] = {}
-        if log_global_mean_time_series:
+
+        aggregators: dict[str, SubAggregator] = {}
+        time_series_aggregators: dict[str, TimeSeriesLogs] = {}
+
+        if self.log_global_mean_time_series:
             mean_agg = SingleTargetMeanAggregator(
                 gridded_operations,
                 n_timesteps=n_timesteps,
             )
             aggregators["mean"] = mean_agg
-            self._time_series_aggregators["mean"] = mean_agg
+            time_series_aggregators["mean"] = mean_agg
         aggregators["time_mean"] = TimeMeanAggregator(
             gridded_operations=gridded_operations,
             variable_metadata=dataset_info.variable_metadata,
-            reference_means=time_mean_reference_data,
+            reference_means=time_means,
         )
         aggregators["annual"] = GlobalMeanAnnualAggregator(
             gridded_operations,
@@ -711,12 +621,50 @@ class InferenceAggregator(
                 regional_weights=nino34_region.regional_weights,
                 regional_mean=gridded_operations.regional_area_weighted_mean,
             )
+
+        return InferenceAggregator(
+            aggregators=aggregators,
+            time_series_aggregators=time_series_aggregators,
+            coords=horizontal_coordinates.coords,
+            save_diagnostics=save_diagnostics,
+            output_dir=output_dir,
+        )
+
+
+class InferenceAggregator(
+    InferenceAggregatorABC[
+        PrognosticState,
+        PairedData,
+    ]
+):
+    """
+    Aggregates statistics on a single timeseries of data.
+
+    To use, call `record_batch` on the results of each batch, then call
+    `get_logs` to get a dictionary of statistics when you're done.
+    """
+
+    def __init__(
+        self,
+        aggregators: dict[str, SubAggregator],
+        time_series_aggregators: dict[str, TimeSeriesLogs],
+        coords: Mapping[str, np.ndarray],
+        save_diagnostics: bool = True,
+        output_dir: str | None = None,
+    ):
+        if save_diagnostics and output_dir is None:
+            raise ValueError("Output directory must be set to save diagnostics")
         self._aggregators = aggregators
+        self._time_series_aggregators = time_series_aggregators
         self._summary_aggregators = {
-            name: aggregators[name]
-            for name in ["time_mean", "annual", "enso_index", "power_spectrum"]
-            if name in aggregators
+            name: agg
+            for name, agg in aggregators.items()
+            if name not in time_series_aggregators
         }
+        self._coords = coords
+        self._save_diagnostics = save_diagnostics
+        self._output_dir = output_dir
+        self._log_time_series = len(time_series_aggregators) > 0
         self._n_timesteps_seen = 0
 
     @property

--- a/fme/ace/aggregator/inference/test_evaluator.py
+++ b/fme/ace/aggregator/inference/test_evaluator.py
@@ -7,7 +7,10 @@ import pytest
 import torch
 import xarray as xr
 
-from fme.ace.aggregator.inference import InferenceEvaluatorAggregator, StepMeanEntry
+from fme.ace.aggregator.inference import (
+    InferenceEvaluatorAggregatorConfig,
+    StepMeanEntry,
+)
 from fme.ace.data_loading.batch_data import BatchData, PairedData
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -91,16 +94,17 @@ def test_logs_regression():
     ds_info = get_ds_info(nx, ny)
     initial_time = get_zero_time(shape=[n_sample, 0], dims=["sample", "time"])
 
-    agg = InferenceEvaluatorAggregator(
-        dataset_info=ds_info,
-        n_ic_steps=1,
-        n_forward_steps=n_time - 1,
-        initial_time=initial_time,
+    agg = InferenceEvaluatorAggregatorConfig(
         log_step_means=[
             StepMeanEntry(step=20),
             StepMeanEntry(step=4, name="one_day_mean"),
         ],
         log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
+    ).build(
+        dataset_info=ds_info,
+        n_ic_steps=1,
+        n_forward_steps=n_time - 1,
+        initial_time=initial_time,
         normalize=lambda x: dict(x),
         save_diagnostics=False,
     )
@@ -186,17 +190,18 @@ def test_inference_logs_labels_exist():
     ny = 45
     ds_info = get_ds_info(nx, ny)
     initial_time = (get_zero_time(shape=[n_sample, 0], dims=["sample", "time"]),)
-    agg = InferenceEvaluatorAggregator(
-        dataset_info=ds_info,
-        n_ic_steps=1,
-        n_forward_steps=n_time - 1,
-        initial_time=initial_time,
+    agg = InferenceEvaluatorAggregatorConfig(
         log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
         log_step_means=[
             StepMeanEntry(step=20),
             StepMeanEntry(step=4, name="one_day_mean"),
         ],
         log_video=True,
+    ).build(
+        dataset_info=ds_info,
+        n_ic_steps=1,
+        n_forward_steps=n_time - 1,
+        initial_time=initial_time,
         normalize=lambda x: dict(x),
         save_diagnostics=False,
     )
@@ -244,12 +249,13 @@ def test_inference_logs_length(window_len: int, n_windows: int):
     ds_info = get_ds_info(nx, ny)
     initial_time = (get_zero_time(shape=[2, 0], dims=["sample", "time"]),)
     n_forward_steps = window_len * n_windows - 1
-    agg = InferenceEvaluatorAggregator(
-        dataset_info=ds_info,
+    agg = InferenceEvaluatorAggregatorConfig(
         log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
+        log_step_means=[] if n_forward_steps < 20 else [StepMeanEntry(step=20)],
+    ).build(
+        dataset_info=ds_info,
         n_ic_steps=1,
         n_forward_steps=n_forward_steps,
-        log_step_means=[] if n_forward_steps < 20 else [StepMeanEntry(step=20)],
         initial_time=initial_time,
         normalize=lambda x: dict(x),
         save_diagnostics=False,
@@ -282,17 +288,18 @@ def test_flush_diagnostics(tmpdir):
     nx, ny, n_sample, n_time = 2, 2, 10, 21
     ds_info = get_ds_info(nx, ny)
     initial_time = get_zero_time(shape=[n_sample, 0], dims=["sample", "time"])
-    agg = InferenceEvaluatorAggregator(
+    agg = InferenceEvaluatorAggregatorConfig(
+        log_step_means=[StepMeanEntry(step=20)],
+        log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
+        log_video=True,
+        log_histograms=True,
+    ).build(
         dataset_info=ds_info,
         n_ic_steps=1,
         n_forward_steps=n_time - 1,
         initial_time=initial_time,
         normalize=lambda x: dict(x),
         output_dir=tmpdir,
-        log_step_means=[StepMeanEntry(step=20)],
-        log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
-        log_video=True,
-        log_histograms=True,
     )
     target_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
     gen_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
@@ -324,14 +331,15 @@ def test_agg_raises_without_output_dir():
     with pytest.raises(
         ValueError, match="Output directory must be set to save diagnostics"
     ):
-        InferenceEvaluatorAggregator(
-            dataset_info=ds_info,
+        InferenceEvaluatorAggregatorConfig(
             log_step_means=[],
+            log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
+        ).build(
+            dataset_info=ds_info,
             n_ic_steps=1,
             n_forward_steps=1,
             initial_time=get_zero_time(shape=[1, 0], dims=["sample", "time"]),
             normalize=lambda x: dict(x),
-            log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
             save_diagnostics=True,
             output_dir=None,
         )

--- a/fme/ace/aggregator/inference/test_inference.py
+++ b/fme/ace/aggregator/inference/test_inference.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import xarray as xr
 
-from fme.ace.aggregator.inference import InferenceAggregator
+from fme.ace.aggregator.inference import InferenceAggregatorConfig
 from fme.ace.data_loading.batch_data import PairedData
 from fme.core.device import get_device
 
@@ -24,7 +24,7 @@ def test_logs_labels_exist():
     nx = 2
     ny = 2
     ds_info = get_ds_info(nx, ny)
-    agg = InferenceAggregator(ds_info, n_time, save_diagnostics=False)
+    agg = InferenceAggregatorConfig().build(ds_info, n_time, save_diagnostics=False)
     target_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
     gen_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
     time = get_zero_time(shape=[n_sample, n_time], dims=["sample", "time"])
@@ -57,7 +57,7 @@ def test_logs_labels_exist():
     ).difference(expected_summary_keys)
 
 
-def test_logs_labels_exist_with_reference_time_means():
+def test_logs_labels_exist_with_reference_time_means(tmp_path):
     n_sample = 10
     n_time = 22
     nx = 2
@@ -71,10 +71,11 @@ def test_logs_labels_exist_with_reference_time_means():
             )
         }
     )
-    agg = InferenceAggregator(
+    ref_path = str(tmp_path / "reference_time_means.nc")
+    reference_time_means.to_netcdf(ref_path)
+    agg = InferenceAggregatorConfig(time_mean_reference_data=ref_path).build(
         ds_info,
         n_time,
-        time_mean_reference_data=reference_time_means,
         save_diagnostics=False,
     )
     target_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
@@ -119,7 +120,7 @@ def test_logs_labels_exist_with_reference_time_means():
 def test_flush_diagnostics(tmpdir):
     nx, ny, n_sample, n_time = 2, 2, 10, 21
     ds_info = get_ds_info(nx, ny)
-    agg = InferenceAggregator(ds_info, n_time, output_dir=tmpdir)
+    agg = InferenceAggregatorConfig().build(ds_info, n_time, output_dir=str(tmpdir))
     target_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
     gen_data = {"a": torch.randn(n_sample, n_time, nx, ny, device=get_device())}
     time = get_zero_time(shape=[n_sample, n_time], dims=["sample", "time"])
@@ -145,7 +146,7 @@ def test_agg_raises_without_output_dir():
     with pytest.raises(
         ValueError, match="Output directory must be set to save diagnostics"
     ):
-        InferenceAggregator(
+        InferenceAggregatorConfig().build(
             ds_info,
             n_timesteps=1,
             save_diagnostics=True,

--- a/fme/ace/aggregator/inference/test_main.py
+++ b/fme/ace/aggregator/inference/test_main.py
@@ -7,7 +7,7 @@ import torch
 import xarray as xr
 
 from fme.ace.aggregator.inference.main import (
-    InferenceEvaluatorAggregator,
+    InferenceEvaluatorAggregatorConfig,
     StepMeanEntry,
 )
 from fme.ace.data_loading.batch_data import BatchData, PairedData
@@ -38,12 +38,7 @@ def test_inference_evaluator_aggregator_channel_mean_names(
     ds_info = get_ds_info(nx, ny)
     initial_time = xr.DataArray(np.zeros((batch_size * n_ensemble,)), dims=["sample"])
 
-    agg = InferenceEvaluatorAggregator(
-        dataset_info=ds_info,
-        n_ic_steps=n_ic_steps,
-        n_forward_steps=n_forward_steps,
-        initial_time=initial_time,
-        normalize=lambda x: dict(x),
+    config = InferenceEvaluatorAggregatorConfig(
         log_zonal_mean_images=False,
         log_step_means=[],
         log_video=False,
@@ -51,8 +46,15 @@ def test_inference_evaluator_aggregator_channel_mean_names(
         log_global_mean_time_series=False,
         log_global_mean_norm_time_series=False,
         log_histograms=False,
-        channel_mean_names=channel_mean_names,
         log_nino34_index=False,
+    )
+    agg = config.build(
+        dataset_info=ds_info,
+        n_ic_steps=n_ic_steps,
+        n_forward_steps=n_forward_steps,
+        initial_time=initial_time,
+        normalize=lambda x: dict(x),
+        channel_mean_names=channel_mean_names,
         save_diagnostics=False,
         n_ensemble_per_ic=n_ensemble,
     )
@@ -113,23 +115,25 @@ def test_inference_evaluator_aggregator_ensemble():
     ds_info = get_ds_info(nx, ny)
     initial_time = xr.DataArray(np.zeros((batch_size,)), dims=["sample"])
 
-    agg = InferenceEvaluatorAggregator(
-        dataset_info=ds_info,
-        n_ic_steps=n_ic_steps,
-        n_forward_steps=n_forward_steps,
-        initial_time=initial_time,
-        normalize=lambda x: dict(x),
+    config = InferenceEvaluatorAggregatorConfig(
         log_zonal_mean_images=False,
         log_video=False,
         log_seasonal_means=False,
         log_global_mean_time_series=False,
         log_global_mean_norm_time_series=False,
         log_histograms=False,
-        channel_mean_names=channel_mean_names,
         log_nino34_index=False,
+        log_step_means=[StepMeanEntry(step=20)],
+    )
+    agg = config.build(
+        dataset_info=ds_info,
+        n_ic_steps=n_ic_steps,
+        n_forward_steps=n_forward_steps,
+        initial_time=initial_time,
+        normalize=lambda x: dict(x),
+        channel_mean_names=channel_mean_names,
         save_diagnostics=False,
         n_ensemble_per_ic=n_ensemble,
-        log_step_means=[StepMeanEntry(step=20)],
     )
 
     target_data = BatchData.new_for_testing(

--- a/fme/ace/aggregator/one_step/spectrum.py
+++ b/fme/ace/aggregator/one_step/spectrum.py
@@ -1,12 +1,40 @@
 from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import torch
 import xarray as xr
 
-from fme.ace.aggregator.inference.spectrum import PairedSphericalPowerSpectrumAggregator
+from fme.ace.aggregator.inference.data import InferenceBatchData
+from fme.ace.aggregator.inference.spectrum import (
+    PairedSphericalPowerSpectrumAggregator as _InferencePairedSpectrumAgg,
+)
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.typing_ import TensorMapping
+
+
+class PairedSphericalPowerSpectrumAggregator:
+    """Wraps the inference PairedSphericalPowerSpectrumAggregator for one-step use."""
+
+    def __init__(self, **kwargs: Any):
+        self._inner = _InferencePairedSpectrumAgg(**kwargs)
+
+    def record_batch(self, target_data: TensorMapping, gen_data: TensorMapping) -> None:
+        batch = InferenceBatchData(
+            prediction=gen_data,
+            prediction_norm=gen_data,
+            target=target_data,
+            target_norm=target_data,
+            time=None,
+            i_time_start=0,
+        )
+        self._inner.record_batch(batch)
+
+    def get_logs(self, label: str) -> dict[str, Any]:
+        return self._inner.get_logs(label)
+
+    def get_dataset(self) -> xr.Dataset:
+        return self._inner.get_dataset()
 
 
 class SpectrumAggregator:
@@ -16,7 +44,7 @@ class SpectrumAggregator:
         target_time: int = 1,
         nan_fill_fn: Callable[[torch.Tensor, str], torch.Tensor] = lambda x, _: x,
     ):
-        self._wrapped = PairedSphericalPowerSpectrumAggregator(
+        self._wrapped = _InferencePairedSpectrumAgg(
             gridded_operations=gridded_operations,
             report_plot=False,
             nan_fill_fn=nan_fill_fn,

--- a/fme/ace/aggregator/one_step/spectrum.py
+++ b/fme/ace/aggregator/one_step/spectrum.py
@@ -1,14 +1,15 @@
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import numpy as np
 import torch
 import xarray as xr
 
-from fme.ace.aggregator.inference.data import InferenceBatchData
+from fme.ace.aggregator.inference.data import InferenceBatchData, make_dummy_time
 from fme.ace.aggregator.inference.spectrum import (
     PairedSphericalPowerSpectrumAggregator as _InferencePairedSpectrumAgg,
 )
+from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.typing_ import TensorMapping
 
@@ -16,16 +17,27 @@ from fme.core.typing_ import TensorMapping
 class PairedSphericalPowerSpectrumAggregator:
     """Wraps the inference PairedSphericalPowerSpectrumAggregator for one-step use."""
 
-    def __init__(self, **kwargs: Any):
-        self._inner = _InferencePairedSpectrumAgg(**kwargs)
+    def __init__(
+        self,
+        gridded_operations: GriddedOperations,
+        report_plot: bool,
+        nan_fill_fn: Callable[[torch.Tensor, str], torch.Tensor] = lambda x, _: x,
+        variable_metadata: Mapping[str, VariableMetadata] | None = None,
+    ):
+        self._inner = _InferencePairedSpectrumAgg(
+            gridded_operations=gridded_operations,
+            report_plot=report_plot,
+            nan_fill_fn=nan_fill_fn,
+            variable_metadata=variable_metadata,
+        )
 
     def record_batch(self, target_data: TensorMapping, gen_data: TensorMapping) -> None:
+        first_tensor = next(iter(gen_data.values()))
+        n_sample, n_time = first_tensor.shape[0], first_tensor.shape[1]
         batch = InferenceBatchData(
             prediction=gen_data,
-            prediction_norm=gen_data,
             target=target_data,
-            target_norm=target_data,
-            time=None,
+            time=make_dummy_time(n_sample=n_sample, n_time=n_time),
             i_time_start=0,
         )
         self._inner.record_batch(batch)

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -10,7 +10,13 @@ from fme.ace.aggregator.inference.main import (
     InferenceAggregator as InferenceAggregator_,
 )
 from fme.ace.aggregator.inference.main import (
+    InferenceAggregatorConfig as AceInferenceAggregatorConfig,
+)
+from fme.ace.aggregator.inference.main import (
     InferenceEvaluatorAggregator as InferenceEvaluatorAggregator_,
+)
+from fme.ace.aggregator.inference.main import (
+    InferenceEvaluatorAggregatorConfig as AceInferenceEvaluatorAggregatorConfig,
 )
 from fme.ace.aggregator.inference.main import StepMeanEntry
 from fme.ace.aggregator.one_step.main import OneStepAggregator as OneStepAggregator_
@@ -238,19 +244,6 @@ class InferenceEvaluatorAggregatorConfig:
         ocean_channel_mean_names: Sequence[str] | None = None,
         atmosphere_channel_mean_names: Sequence[str] | None = None,
     ) -> "InferenceEvaluatorAggregator":
-        if self.monthly_reference_data is None:
-            monthly_reference_data = None
-        else:
-            monthly_reference_data = xr.open_dataset(
-                self.monthly_reference_data, decode_timedelta=False
-            )
-        if self.time_mean_reference_data is None:
-            time_mean = None
-        else:
-            time_mean = xr.open_dataset(
-                self.time_mean_reference_data, decode_timedelta=False
-            )
-
         if n_timesteps_atmosphere > 2**15 and self.log_zonal_mean_images:
             # matplotlib raises an error if image size is too large, and we plot
             # one pixel per timestep in the zonal mean images.
@@ -260,28 +253,71 @@ class InferenceEvaluatorAggregatorConfig:
                 "log_zonal_mean_images=False or "
                 "decrease n_coupled_steps to avoid this warning."
             )
-            log_zonal_mean_images = False
+            log_zonal_mean_images: bool | int = False
         else:
             log_zonal_mean_images = self.log_zonal_mean_images
 
-        return InferenceEvaluatorAggregator(
-            dataset_info=dataset_info,
-            n_timesteps_ocean=n_timesteps_ocean,
-            n_timesteps_atmosphere=n_timesteps_atmosphere,
-            initial_time=initial_time,
-            save_diagnostics=save_diagnostics,
-            output_dir=output_dir,
+        ocean_ace_config = AceInferenceEvaluatorAggregatorConfig(
             log_histograms=self.log_histograms,
             log_video=self.log_video,
-            enable_extended_videos=self.log_extended_video,
+            log_extended_video=self.log_extended_video,
             log_zonal_mean_images=log_zonal_mean_images,
             log_seasonal_means=self.log_seasonal_means,
             log_global_mean_time_series=self.log_global_mean_time_series,
             log_global_mean_norm_time_series=self.log_global_mean_norm_time_series,
-            monthly_reference_data=monthly_reference_data,
-            time_mean_reference_data=time_mean,
-            ocean_normalize=ocean_normalize,
-            atmosphere_normalize=atmosphere_normalize,
+            monthly_reference_data=self.monthly_reference_data,
+            time_mean_reference_data=self.time_mean_reference_data,
+            log_nino34_index=True,
+            log_step_means=[StepMeanEntry(step=20, name="mean_step_20")]
+            if n_timesteps_ocean >= 20
+            else [],
+        )
+        atmosphere_ace_config = AceInferenceEvaluatorAggregatorConfig(
+            log_histograms=self.log_histograms,
+            log_video=self.log_video,
+            log_extended_video=self.log_extended_video,
+            log_zonal_mean_images=log_zonal_mean_images,
+            log_seasonal_means=self.log_seasonal_means,
+            log_global_mean_time_series=self.log_global_mean_time_series,
+            log_global_mean_norm_time_series=self.log_global_mean_norm_time_series,
+            monthly_reference_data=self.monthly_reference_data,
+            time_mean_reference_data=self.time_mean_reference_data,
+            log_nino34_index=False,
+            log_step_means=[StepMeanEntry(step=20, name="mean_step_20")]
+            if n_timesteps_atmosphere >= 20
+            else [],
+        )
+
+        ocean_agg = ocean_ace_config.build(
+            dataset_info=dataset_info.ocean,
+            n_ic_steps=1,
+            n_forward_steps=n_timesteps_ocean - 1,
+            initial_time=initial_time,
+            normalize=ocean_normalize,
+            output_dir=(
+                os.path.join(output_dir, "ocean") if output_dir is not None else None
+            ),
+            channel_mean_names=ocean_channel_mean_names,
+            save_diagnostics=save_diagnostics,
+        )
+        atmosphere_agg = atmosphere_ace_config.build(
+            dataset_info=dataset_info.atmosphere,
+            n_ic_steps=1,
+            n_forward_steps=n_timesteps_atmosphere - 1,
+            initial_time=initial_time,
+            normalize=atmosphere_normalize,
+            output_dir=(
+                os.path.join(output_dir, "atmosphere")
+                if output_dir is not None
+                else None
+            ),
+            channel_mean_names=atmosphere_channel_mean_names,
+            save_diagnostics=save_diagnostics,
+        )
+
+        return InferenceEvaluatorAggregator(
+            ocean=ocean_agg,
+            atmosphere=atmosphere_agg,
             ocean_channel_mean_names=ocean_channel_mean_names,
             atmosphere_channel_mean_names=atmosphere_channel_mean_names,
         )
@@ -349,84 +385,12 @@ class InferenceEvaluatorAggregator(
 ):
     def __init__(
         self,
-        dataset_info: CoupledDatasetInfo,
-        n_timesteps_ocean: int,
-        n_timesteps_atmosphere: int,
-        initial_time: xr.DataArray,
-        ocean_normalize: Callable[[TensorMapping], TensorDict],
-        atmosphere_normalize: Callable[[TensorMapping], TensorDict],
-        save_diagnostics: bool = True,
-        output_dir: str | None = None,
-        log_video: bool = False,
-        enable_extended_videos: bool = False,
-        log_zonal_mean_images: bool = False,
-        log_seasonal_means: bool = False,
-        log_global_mean_time_series: bool = True,
-        log_global_mean_norm_time_series: bool = True,
-        monthly_reference_data: xr.Dataset | None = None,
-        log_histograms: bool = False,
-        time_mean_reference_data: xr.Dataset | None = None,
+        ocean: InferenceEvaluatorAggregator_,
+        atmosphere: InferenceEvaluatorAggregator_,
         ocean_channel_mean_names: Sequence[str] | None = None,
         atmosphere_channel_mean_names: Sequence[str] | None = None,
     ):
-        self._record_ocean_step_20 = n_timesteps_ocean >= 20
-        self._record_atmos_step_20 = n_timesteps_atmosphere >= 20
-
-        self._aggregators = {
-            "ocean": InferenceEvaluatorAggregator_(
-                dataset_info=dataset_info.ocean,
-                n_ic_steps=1,
-                n_forward_steps=n_timesteps_ocean - 1,
-                initial_time=initial_time,
-                log_histograms=log_histograms,
-                log_video=log_video,
-                enable_extended_videos=enable_extended_videos,
-                log_zonal_mean_images=log_zonal_mean_images,
-                log_seasonal_means=log_seasonal_means,
-                log_global_mean_time_series=log_global_mean_time_series,
-                log_global_mean_norm_time_series=log_global_mean_norm_time_series,
-                monthly_reference_data=monthly_reference_data,
-                time_mean_reference_data=time_mean_reference_data,
-                log_step_means=[StepMeanEntry(step=20, name="mean_step_20")]
-                if self._record_ocean_step_20
-                else [],
-                channel_mean_names=ocean_channel_mean_names,
-                normalize=ocean_normalize,
-                save_diagnostics=save_diagnostics,
-                output_dir=(
-                    os.path.join(output_dir, "ocean")
-                    if output_dir is not None
-                    else None
-                ),
-            ),
-            "atmosphere": InferenceEvaluatorAggregator_(
-                dataset_info=dataset_info.atmosphere,
-                n_ic_steps=1,
-                n_forward_steps=n_timesteps_atmosphere - 1,
-                initial_time=initial_time,
-                log_histograms=log_histograms,
-                log_video=log_video,
-                enable_extended_videos=enable_extended_videos,
-                log_zonal_mean_images=log_zonal_mean_images,
-                log_seasonal_means=log_seasonal_means,
-                log_global_mean_time_series=log_global_mean_time_series,
-                log_global_mean_norm_time_series=log_global_mean_norm_time_series,
-                monthly_reference_data=monthly_reference_data,
-                time_mean_reference_data=time_mean_reference_data,
-                log_step_means=[StepMeanEntry(step=20, name="mean_step_20")]
-                if self._record_atmos_step_20
-                else [],
-                channel_mean_names=atmosphere_channel_mean_names,
-                normalize=atmosphere_normalize,
-                save_diagnostics=save_diagnostics,
-                output_dir=(
-                    os.path.join(output_dir, "atmosphere")
-                    if output_dir is not None
-                    else None
-                ),
-                log_nino34_index=False,
-            ),
-        }
+        self._aggregators = {"ocean": ocean, "atmosphere": atmosphere}
         self._num_channels_ocean: int | None = None
         if ocean_channel_mean_names is not None:
             self._num_channels_ocean = len(ocean_channel_mean_names)
@@ -539,26 +503,29 @@ class InferenceAggregatorConfig:
         n_timesteps_atmosphere: int,
         output_dir: str,
     ) -> "InferenceAggregator":
-        if self.atmosphere_time_mean_reference_data is None:
-            atmos_time_mean = None
-        else:
-            atmos_time_mean = xr.open_dataset(
-                self.atmosphere_time_mean_reference_data, decode_timedelta=False
-            )
-        if self.ocean_time_mean_reference_data is None:
-            ocean_time_mean = None
-        else:
-            ocean_time_mean = xr.open_dataset(
-                self.ocean_time_mean_reference_data, decode_timedelta=False
-            )
-        return InferenceAggregator(
-            dataset_info=dataset_info,
-            n_timesteps_ocean=n_timesteps_ocean,
-            n_timesteps_atmosphere=n_timesteps_atmosphere,
-            output_dir=output_dir,
+        ocean_ace_config = AceInferenceAggregatorConfig(
+            time_mean_reference_data=self.ocean_time_mean_reference_data,
             log_global_mean_time_series=self.log_global_mean_time_series,
-            atmosphere_time_mean_reference_data=atmos_time_mean,
-            ocean_time_mean_reference_data=ocean_time_mean,
+        )
+        atmosphere_ace_config = AceInferenceAggregatorConfig(
+            time_mean_reference_data=self.atmosphere_time_mean_reference_data,
+            log_global_mean_time_series=self.log_global_mean_time_series,
+        )
+        ocean_agg = ocean_ace_config.build(
+            dataset_info=dataset_info.ocean,
+            n_timesteps=n_timesteps_ocean,
+            output_dir=os.path.join(output_dir, "ocean"),
+            save_diagnostics=True,
+        )
+        atmosphere_agg = atmosphere_ace_config.build(
+            dataset_info=dataset_info.atmosphere,
+            n_timesteps=n_timesteps_atmosphere,
+            output_dir=os.path.join(output_dir, "atmosphere"),
+            save_diagnostics=True,
+        )
+        return InferenceAggregator(
+            ocean=ocean_agg,
+            atmosphere=atmosphere_agg,
         )
 
 
@@ -577,57 +544,10 @@ class InferenceAggregator(
 
     def __init__(
         self,
-        dataset_info: CoupledDatasetInfo,
-        n_timesteps_ocean: int,
-        n_timesteps_atmosphere: int,
-        save_diagnostics: bool = True,
-        output_dir: str | None = None,
-        atmosphere_time_mean_reference_data: xr.Dataset | None = None,
-        ocean_time_mean_reference_data: xr.Dataset | None = None,
-        log_global_mean_time_series: bool = True,
+        ocean: InferenceAggregator_,
+        atmosphere: InferenceAggregator_,
     ):
-        """
-        Args:
-            dataset_info: The coordinates of the dataset.
-            n_timesteps_ocean: Number of timesteps for ocean.
-            n_timesteps_atmosphere: Number of timesteps for atmosphere.
-            save_diagnostics: Whether to save diagnostics.
-            output_dir: Directory to save diagnostic output.
-            atmosphere_time_mean_reference_data: Reference time means for atmosphere.
-            ocean_time_mean_reference_data: Reference time means for ocean.
-            log_global_mean_time_series: Whether to log global mean time series metrics.
-        """
-        if save_diagnostics and output_dir is None:
-            raise ValueError("Output directory must be set to save diagnostics")
-        self._log_time_series = log_global_mean_time_series
-        self._save_diagnostics = save_diagnostics
-        self._output_dir = output_dir
-        self._aggregators = {
-            "ocean": InferenceAggregator_(
-                dataset_info=dataset_info.ocean,
-                n_timesteps=n_timesteps_ocean,
-                save_diagnostics=save_diagnostics,
-                output_dir=(
-                    os.path.join(output_dir, "ocean")
-                    if output_dir is not None
-                    else None
-                ),
-                log_global_mean_time_series=log_global_mean_time_series,
-                time_mean_reference_data=ocean_time_mean_reference_data,
-            ),
-            "atmosphere": InferenceAggregator_(
-                dataset_info=dataset_info.atmosphere,
-                n_timesteps=n_timesteps_atmosphere,
-                save_diagnostics=save_diagnostics,
-                output_dir=(
-                    os.path.join(output_dir, "atmosphere")
-                    if output_dir is not None
-                    else None
-                ),
-                log_global_mean_time_series=log_global_mean_time_series,
-                time_mean_reference_data=atmosphere_time_mean_reference_data,
-            ),
-        }
+        self._aggregators = {"ocean": ocean, "atmosphere": atmosphere}
 
     @property
     def ocean(self) -> InferenceAggregator_:
@@ -639,7 +559,7 @@ class InferenceAggregator(
 
     @property
     def log_time_series(self) -> bool:
-        return self._log_time_series
+        return self.ocean.log_time_series
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -257,7 +257,7 @@ class InferenceEvaluatorAggregatorConfig:
         else:
             log_zonal_mean_images = self.log_zonal_mean_images
 
-        ocean_ace_config = AceInferenceEvaluatorAggregatorConfig(
+        base_ace_config = AceInferenceEvaluatorAggregatorConfig(
             log_histograms=self.log_histograms,
             log_video=self.log_video,
             log_extended_video=self.log_extended_video,
@@ -267,21 +267,16 @@ class InferenceEvaluatorAggregatorConfig:
             log_global_mean_norm_time_series=self.log_global_mean_norm_time_series,
             monthly_reference_data=self.monthly_reference_data,
             time_mean_reference_data=self.time_mean_reference_data,
+        )
+        ocean_ace_config = dataclasses.replace(
+            base_ace_config,
             log_nino34_index=True,
             log_step_means=[StepMeanEntry(step=20, name="mean_step_20")]
             if n_timesteps_ocean >= 20
             else [],
         )
-        atmosphere_ace_config = AceInferenceEvaluatorAggregatorConfig(
-            log_histograms=self.log_histograms,
-            log_video=self.log_video,
-            log_extended_video=self.log_extended_video,
-            log_zonal_mean_images=log_zonal_mean_images,
-            log_seasonal_means=self.log_seasonal_means,
-            log_global_mean_time_series=self.log_global_mean_time_series,
-            log_global_mean_norm_time_series=self.log_global_mean_norm_time_series,
-            monthly_reference_data=self.monthly_reference_data,
-            time_mean_reference_data=self.time_mean_reference_data,
+        atmosphere_ace_config = dataclasses.replace(
+            base_ace_config,
             log_nino34_index=False,
             log_step_means=[StepMeanEntry(step=20, name="mean_step_20")]
             if n_timesteps_atmosphere >= 20

--- a/fme/coupled/test_aggregator.py
+++ b/fme/coupled/test_aggregator.py
@@ -13,7 +13,7 @@ from fme.ace.testing import DimSizes, MonthlyReferenceData
 from fme.core.coordinates import DimSize, LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
-from fme.coupled.aggregator import InferenceEvaluatorAggregator, _combine_logs
+from fme.coupled.aggregator import InferenceEvaluatorAggregatorConfig, _combine_logs
 from fme.coupled.data_loading.batch_data import CoupledPairedData
 from fme.coupled.dataset_info import CoupledDatasetInfo
 
@@ -152,26 +152,27 @@ def test_inference_logs_labels_exist(tmpdir):
         ),
         n_ensemble=3,
     )
-    monthly_ds = xr.open_dataset(
-        monthly_reference_data.data_filename, decode_timedelta=False
-    )
+    time_mean_path = str(pathlib.Path(tmpdir) / "time_mean_reference.nc")
+    reference_time_means.to_netcdf(time_mean_path)
     coord = LatLonCoordinates(lon=torch.arange(nx), lat=torch.arange(ny))
     info = CoupledDatasetInfo(
         ocean=DatasetInfo(horizontal_coordinates=coord, timestep=TIMESTEP),
         atmosphere=DatasetInfo(horizontal_coordinates=coord, timestep=TIMESTEP),
     )
     output_dir = pathlib.Path(tmpdir) / "output"
-    agg = InferenceEvaluatorAggregator(
+    aggregator_config = InferenceEvaluatorAggregatorConfig(
+        log_video=True,
+        log_zonal_mean_images=True,
+        time_mean_reference_data=time_mean_path,
+        monthly_reference_data=str(monthly_reference_data.data_filename),
+    )
+    agg = aggregator_config.build(
         dataset_info=info,
         n_timesteps_ocean=n_time,
         n_timesteps_atmosphere=n_time,
         initial_time=initial_time,
         ocean_normalize=lambda x: dict(x),
         atmosphere_normalize=lambda x: dict(x),
-        log_video=True,
-        log_zonal_mean_images=True,
-        time_mean_reference_data=reference_time_means,
-        monthly_reference_data=monthly_ds,
         output_dir=str(output_dir),
     )
 


### PR DESCRIPTION
Move all sub-aggregator construction logic from aggregator constructors into `config.build()` methods, making `main.py` a thin coordinator loop. Adding new sub-aggregators now only requires changes in `config.py`.

Changes:
- `fme.ace.aggregator.inference.config.InferenceEvaluatorAggregatorConfig.build()` now handles all sub-aggregator construction, reference data loading, and conditional logic
- `fme.ace.aggregator.inference.config.InferenceAggregatorConfig.build()` same treatment for the non-evaluator aggregator
- `fme.ace.aggregator.inference.main.InferenceEvaluatorAggregator.__init__`, `InferenceAggregator.__init__` thinned to accept pre-built aggregator dicts
- `fme.ace.aggregator.one_step.spectrum.PairedSphericalPowerSpectrumAggregator` new wrapper adapting `InferenceBatchData` interface for training use
- `fme.coupled.aggregator` updated to build ace aggregators via ace config.build(), removing duplicated reference data loading

- [x] Tests added

PR 2 of 3 in the inference aggregator refactor series (based on #1097, followed by #1099).