### PR TITLE
[job_runner] Migration to min-runtime

### DIFF
--- a/job_runner/README.md
+++ b/job_runner/README.md
@@ -172,12 +172,26 @@ This is useful for:
 
 Each job type reads from a pipe-delimited text file:
 
-- **Coupled training**: `pretraining.txt` (16 fields)
-- **Uncoupled training**: `training.txt` (10 fields)
-- **Coupled fine-tuning**: `finetuning.txt` (14 fields)
-- **Uncoupled fine-tuning**: `finetuning.txt` (14 fields)
-- **Resume**: `resuming.txt` (13 fields)
+- **Coupled training**: `pretraining.txt` (17 fields)
+- **Uncoupled training**: `training.txt` (11 fields)
+- **Coupled fine-tuning**: `finetuning.txt` (15 fields)
+- **Uncoupled fine-tuning**: `finetuning.txt` (15 fields)
+- **Resume**: `resuming.txt` (16 fields)
 - **Evaluate**: `experiments.txt` (10 fields)
+
+### `min_runtime` Field (Optional, Training Inputs)
+
+All training-related input files (`pretraining.txt`, `training.txt`, `finetuning.txt`,
+`resuming.txt`) include an optional `min_runtime` field as the last column. It is
+passed directly to gantry as `--min-runtime <value>` and controls how long a job
+is protected from preemption before it can be interrupted.
+
+- **Format**: A gantry-style duration string (e.g. `0`, `30m`, `1h`, `8h`).
+- **Default**: `0` (the server default — preemptible at any time).
+- **Auto-resume**: Training jobs always have auto-resume enabled (server default);
+  `--no-auto-resume` is never emitted on the training path.
+- **Example values**: `0` for short test runs, `1h` to protect a checkpoint cycle,
+  `8h` for a fully protected run.
 
 ### TAG Field (Optional)
 

--- a/job_runner/coupled_finetune.sh
+++ b/job_runner/coupled_finetune.sh
@@ -153,7 +153,7 @@ while read FINETUNING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--not-preemptible" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/coupled_finetune.sh
+++ b/job_runner/coupled_finetune.sh
@@ -158,7 +158,7 @@ while read FINETUNING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/coupled_finetune.sh
+++ b/job_runner/coupled_finetune.sh
@@ -79,6 +79,7 @@ while read FINETUNING; do
     WORKSPACE=$(echo "$FINETUNING" | cut -d"|" -f12)
     OVERRIDE_ARGS=$(echo "$FINETUNING" | cut -d"|" -f13)
     EXISTING_RESULTS_DATASET=$(echo "$FINETUNING" | cut -d"|" -f14)
+    MIN_RUNTIME=$(echo "$FINETUNING" | cut -d"|" -f15)
 
     if [[ "$STATUS" != "train" ]]; then
         SKIPPED_JOBS=$((SKIPPED_JOBS + 1))
@@ -89,6 +90,10 @@ while read FINETUNING; do
 
     if [[ -z $RETRIES ]]; then
         RETRIES=0
+    fi
+
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME=0
     fi
 
     JOB_GROUP="${GROUP}"
@@ -149,7 +154,7 @@ while read FINETUNING; do
     fi
 
     # Run the job (use relative path for CONFIG_PATH)
-    CONFIG_PATH="$CONFIG_PATH_REL" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run coupled fine-tuning: ${JOB_GROUP}")
+    CONFIG_PATH="$CONFIG_PATH_REL" MIN_RUNTIME="$MIN_RUNTIME" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run coupled fine-tuning: ${JOB_GROUP}")
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \

--- a/job_runner/coupled_train.sh
+++ b/job_runner/coupled_train.sh
@@ -86,6 +86,7 @@ while read PRETRAINING; do
     RETRIES=$(echo "$PRETRAINING" | cut -d"|" -f14)
     WORKSPACE=$(echo "$PRETRAINING" | cut -d"|" -f15)
     OVERRIDE_ARGS=$(echo "$PRETRAINING" | cut -d"|" -f16)
+    MIN_RUNTIME=$(echo "$PRETRAINING" | cut -d"|" -f17)
 
     if [[ "$STATUS" != "train" ]]; then
         SKIPPED_JOBS=$((SKIPPED_JOBS + 1))
@@ -96,6 +97,10 @@ while read PRETRAINING; do
 
     if [[ -z $RETRIES ]]; then
         RETRIES=0
+    fi
+
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME=0
     fi
 
     JOB_GROUP="${GROUP}"
@@ -161,7 +166,7 @@ while read PRETRAINING; do
     fi
 
     # Run the job (use relative path for CONFIG_PATH)
-    CONFIG_PATH="$CONFIG_PATH_REL" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run coupled training from uncoupled pretraining: ${JOB_GROUP}")
+    CONFIG_PATH="$CONFIG_PATH_REL" MIN_RUNTIME="$MIN_RUNTIME" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run coupled training from uncoupled pretraining: ${JOB_GROUP}")
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \

--- a/job_runner/coupled_train.sh
+++ b/job_runner/coupled_train.sh
@@ -170,7 +170,7 @@ while read PRETRAINING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/coupled_train.sh
+++ b/job_runner/coupled_train.sh
@@ -165,7 +165,7 @@ while read PRETRAINING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--not-preemptible" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/evaluate.sh
+++ b/job_runner/evaluate.sh
@@ -122,7 +122,7 @@ while read TRAIN_EXPER; do
     fi
 
     if [[ -z $PREEMPTIBLE ]]; then
-        PREEMPTIBLE=--not-preemptible
+        PREEMPTIBLE="--min-runtime 8h --no-auto-resume"
     fi
 
     if [[ -z $EXISTING_RESULTS_DATASET ]]; then

--- a/job_runner/evaluate.sh
+++ b/job_runner/evaluate.sh
@@ -72,7 +72,7 @@ while read TRAIN_EXPER; do
     STATUS=$(echo "$TRAIN_EXPER" | cut -d"|" -f4)
     CKPT=$(echo "$TRAIN_EXPER" | cut -d"|" -f5)
     PRIORITY=$(echo "$TRAIN_EXPER" | cut -d"|" -f6)
-    PREEMPTIBLE=$(echo "$TRAIN_EXPER" | cut -d"|" -f7)
+    MIN_RUNTIME=$(echo "$TRAIN_EXPER" | cut -d"|" -f7)
     OVERRIDE_ARGS=$(echo "$TRAIN_EXPER" | cut -d"|" -f8)
     EXISTING_RESULTS_DATASET=$(echo "$TRAIN_EXPER" | cut -d"|" -f9)
     WORKSPACE=$(echo "$TRAIN_EXPER" | cut -d"|" -f10)
@@ -121,8 +121,8 @@ while read TRAIN_EXPER; do
         PRIORITY=normal
     fi
 
-    if [[ -z $PREEMPTIBLE ]]; then
-        PREEMPTIBLE="--min-runtime 8h --no-auto-resume"
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME="--min-runtime 8h"
     fi
 
     if [[ -z $EXISTING_RESULTS_DATASET ]]; then
@@ -181,7 +181,7 @@ while read TRAIN_EXPER; do
         echo " - Training results dataset ID: ${EXISTING_RESULTS_DATASET}"
         echo " - Cluster: ${CLUSTER}"
         echo " - Priority: ${PRIORITY}"
-        echo " - ${PREEMPTIBLE}"
+        echo " - ${MIN_RUNTIME}"
         echo " - --override args: ${OVERRIDE_ARGS}"
 
         echo
@@ -198,7 +198,8 @@ while read TRAIN_EXPER; do
             --description "Run ${EXPERIMENT_DIR} evaluator" \
             --beaker-image "$(cat "$REPO_ROOT/latest_deps_only_image.txt")" \
             --priority "$PRIORITY" \
-            $PREEMPTIBLE \
+            $MIN_RUNTIME \
+            --no-auto-resume \
             "${CLUSTER_ARGS[@]}" \
             --workspace "$WORKSPACE" \
             --weka climate-default:/climate-default \

--- a/job_runner/inference.sh
+++ b/job_runner/inference.sh
@@ -72,7 +72,7 @@ while read TRAIN_EXPER; do
     STATUS=$(echo "$TRAIN_EXPER" | cut -d"|" -f4)
     CKPT=$(echo "$TRAIN_EXPER" | cut -d"|" -f5)
     PRIORITY=$(echo "$TRAIN_EXPER" | cut -d"|" -f6)
-    PREEMPTIBLE=$(echo "$TRAIN_EXPER" | cut -d"|" -f7)
+    MIN_RUNTIME=$(echo "$TRAIN_EXPER" | cut -d"|" -f7)
     OVERRIDE_ARGS=$(echo "$TRAIN_EXPER" | cut -d"|" -f8)
     EXISTING_RESULTS_DATASET=$(echo "$TRAIN_EXPER" | cut -d"|" -f9)
     WORKSPACE=$(echo "$TRAIN_EXPER" | cut -d"|" -f10)
@@ -121,8 +121,8 @@ while read TRAIN_EXPER; do
         PRIORITY=normal
     fi
 
-    if [[ -z $PREEMPTIBLE ]]; then
-        PREEMPTIBLE="--min-runtime 8h --no-auto-resume"
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME="--min-runtime 8h"
     fi
 
     if [[ -z $EXISTING_RESULTS_DATASET ]]; then
@@ -181,7 +181,7 @@ while read TRAIN_EXPER; do
         echo " - Training results dataset ID: ${EXISTING_RESULTS_DATASET}"
         echo " - Cluster: ${CLUSTER}"
         echo " - Priority: ${PRIORITY}"
-        echo " - ${PREEMPTIBLE}"
+        echo " - ${MIN_RUNTIME}"
         echo " - --override args: ${OVERRIDE_ARGS}"
 
         echo
@@ -198,7 +198,8 @@ while read TRAIN_EXPER; do
             --description "Run ${EXPERIMENT_DIR} inference" \
             --beaker-image "$(cat "$REPO_ROOT/latest_deps_only_image.txt")" \
             --priority "$PRIORITY" \
-            $PREEMPTIBLE \
+            $MIN_RUNTIME \
+            --no-auto-resume \
             "${CLUSTER_ARGS[@]}" \
             --workspace "$WORKSPACE" \
             --weka climate-default:/climate-default \

--- a/job_runner/inference.sh
+++ b/job_runner/inference.sh
@@ -122,7 +122,7 @@ while read TRAIN_EXPER; do
     fi
 
     if [[ -z $PREEMPTIBLE ]]; then
-        PREEMPTIBLE=--not-preemptible
+        PREEMPTIBLE="--min-runtime 8h --no-auto-resume"
     fi
 
     if [[ -z $EXISTING_RESULTS_DATASET ]]; then

--- a/job_runner/lib.sh
+++ b/job_runner/lib.sh
@@ -257,9 +257,9 @@ build_job_name() {
 #   $6 - STATUS (e.g., "training")
 #   $7 - CHECKPOINT (e.g., "best_inference_ckpt")
 #   $8 - PRIORITY (e.g., "normal")
-#   $9 - PREEMPTIBLE_FLAG (e.g., "--min-runtime 8h --no-auto-resume")
+#   $9 - MIN_RUNTIME (e.g., "--min-runtime 8h")
 #   $10 - GIT_BRANCH
-# Example: append_to_experiments_file "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
+# Example: append_to_experiments_file "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h" "$GIT_BRANCH"
 append_to_experiments_file() {
     local EXPERIMENT_DIR="$1"
     local CONFIG_SUBDIR="$2"

--- a/job_runner/lib.sh
+++ b/job_runner/lib.sh
@@ -154,7 +154,7 @@ git_commit_and_push() {
 #   Optional:
 #     CHECKPOINT_DATASET_ARGS (array) - additional dataset mounts
 #     OVERRIDE_ARGS - config override arguments
-#     PREEMPTIBLE (default: --preemptible)
+#     PREEMPTIBLE (default: --min-runtime 0)
 #   Note: CONFIG_PATH must be relative to repo root for gantry run
 # Returns: Experiment ID
 run_gantry_training_job() {
@@ -255,9 +255,9 @@ build_job_name() {
 #   $6 - STATUS (e.g., "training")
 #   $7 - CHECKPOINT (e.g., "best_inference_ckpt")
 #   $8 - PRIORITY (e.g., "normal")
-#   $9 - PREEMPTIBLE_FLAG (e.g., "--not-preemptible")
+#   $9 - PREEMPTIBLE_FLAG (e.g., "--min-runtime 8h --no-auto-resume")
 #   $10 - GIT_BRANCH
-# Example: append_to_experiments_file "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--not-preemptible" "$GIT_BRANCH"
+# Example: append_to_experiments_file "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
 append_to_experiments_file() {
     local EXPERIMENT_DIR="$1"
     local CONFIG_SUBDIR="$2"

--- a/job_runner/lib.sh
+++ b/job_runner/lib.sh
@@ -154,13 +154,15 @@ git_commit_and_push() {
 #   Optional:
 #     CHECKPOINT_DATASET_ARGS (array) - additional dataset mounts
 #     OVERRIDE_ARGS - config override arguments
-#     PREEMPTIBLE (default: --min-runtime 0)
+#     MIN_RUNTIME (default: 0) - gantry --min-runtime value, e.g. "0", "30m", "1h", "8h"
 #   Note: CONFIG_PATH must be relative to repo root for gantry run
+#   Note: training jobs always keep auto-resume enabled (server default);
+#         we never emit --no-auto-resume on the training path.
 # Returns: Experiment ID
 run_gantry_training_job() {
     local REPO_ROOT=$(git rev-parse --show-toplevel)
     local DESCRIPTION="${1:-Training job}"
-    local PREEMPTIBLE="${PREEMPTIBLE:---min-runtime 0}"
+    local MIN_RUNTIME="${MIN_RUNTIME:-0}"
 
     # Build override string
     local OVERRIDE=""
@@ -179,7 +181,7 @@ run_gantry_training_job() {
             --description "$DESCRIPTION" \
             --beaker-image "$(cat "$REPO_ROOT/latest_deps_only_image.txt")" \
             --priority "$PRIORITY" \
-            $PREEMPTIBLE \
+            --min-runtime "$MIN_RUNTIME" \
             --retries "$RETRIES" \
             "${CLUSTER_ARGS[@]}" \
             --weka climate-default:/climate-default \
@@ -343,6 +345,7 @@ print_detailed_job_info() {
     echo "  N_GPUS: $N_GPUS"
     echo "  SHARED_MEM: $SHARED_MEM"
     echo "  RETRIES: $RETRIES"
+    echo "  MIN_RUNTIME: ${MIN_RUNTIME:-0}"
     echo "  WORKSPACE: $WORKSPACE"
     echo "  OVERRIDE_ARGS: ${OVERRIDE_ARGS:-(none)}"
     echo

--- a/job_runner/lib_init_exper.sh
+++ b/job_runner/lib_init_exper.sh
@@ -58,11 +58,11 @@ create_input_txt_files() {
     case "$TEMPLATE_TYPE" in
         ocean|atmos)
             # Create training.txt with header
-            echo "group|tag|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override_args" \
+            echo "group|tag|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override_args|min_runtime" \
                 > "$EXPERIMENT_DIR/training.txt"
 
             # Create finetuning.txt with header (note: 'tag' is second field)
-            echo "group|tag|wandb_project|wandb_id|ckpt_type|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset" \
+            echo "group|tag|wandb_project|wandb_id|ckpt_type|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset|min_runtime" \
                 > "$EXPERIMENT_DIR/finetuning.txt"
 
             # Create experiments.txt with header
@@ -70,17 +70,17 @@ create_input_txt_files() {
                 > "$EXPERIMENT_DIR/experiments.txt"
 
             # Create resuming.txt with header
-            echo "group|tag|wandb_project|wandb_id|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset" \
+            echo "group|tag|wandb_project|wandb_id|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset|results_dataset_ocean|results_dataset_atmos|min_runtime" \
                 > "$EXPERIMENT_DIR/resuming.txt"
             ;;
 
         coupled)
             # Create pretraining.txt with header (note: 'tag' is second field)
-            echo "group|tag|ocean_project|ocean_wandb_id|ocean_ckpt_type|atmos_project|atmos_wandb_id|atmos_ckpt_type|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override" \
+            echo "group|tag|ocean_project|ocean_wandb_id|ocean_ckpt_type|atmos_project|atmos_wandb_id|atmos_ckpt_type|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|min_runtime" \
                 > "$EXPERIMENT_DIR/pretraining.txt"
 
             # Create finetuning.txt with header (note: 'tag' is second field)
-            echo "group|tag|wandb_project|wandb_id|ckpt_type|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset" \
+            echo "group|tag|wandb_project|wandb_id|ckpt_type|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset|min_runtime" \
                 > "$EXPERIMENT_DIR/finetuning.txt"
 
             # Create experiments.txt with header
@@ -88,7 +88,7 @@ create_input_txt_files() {
                 > "$EXPERIMENT_DIR/experiments.txt"
 
             # Create resuming.txt with header
-            echo "group|tag|wandb_project|wandb_id|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset" \
+            echo "group|tag|wandb_project|wandb_id|skip_or_train|priority|cluster|n_gpus|shared_mem|retries|workspace|override|results_dataset|results_dataset_ocean|results_dataset_atmos|min_runtime" \
                 > "$EXPERIMENT_DIR/resuming.txt"
             ;;
 

--- a/job_runner/lib_init_exper.sh
+++ b/job_runner/lib_init_exper.sh
@@ -66,7 +66,7 @@ create_input_txt_files() {
                 > "$EXPERIMENT_DIR/finetuning.txt"
 
             # Create experiments.txt with header
-            echo "group|tag|experiment_id|status|checkpoint|priority|preemptible|override|results_dataset|workspace" \
+            echo "group|tag|experiment_id|status|checkpoint|priority|min_runtime|override|results_dataset|workspace" \
                 > "$EXPERIMENT_DIR/experiments.txt"
 
             # Create resuming.txt with header
@@ -84,7 +84,7 @@ create_input_txt_files() {
                 > "$EXPERIMENT_DIR/finetuning.txt"
 
             # Create experiments.txt with header
-            echo "group|tag|experiment_id|status|checkpoint|priority|preemptible|override|results_dataset|workspace" \
+            echo "group|tag|experiment_id|status|checkpoint|priority|min_runtime|override|results_dataset|workspace" \
                 > "$EXPERIMENT_DIR/experiments.txt"
 
             # Create resuming.txt with header
@@ -94,7 +94,7 @@ create_input_txt_files() {
 
         *)
             echo "Warning: Unknown template type '$TEMPLATE_TYPE', creating generic files" >&2
-            echo "group|tag|experiment_id|status|checkpoint|priority|preemptible|override|results_dataset|workspace" \
+            echo "group|tag|experiment_id|status|checkpoint|priority|min_runtime|override|results_dataset|workspace" \
                 > "$EXPERIMENT_DIR/experiments.txt"
             ;;
     esac

--- a/job_runner/resume.sh
+++ b/job_runner/resume.sh
@@ -164,7 +164,7 @@ while read RESUMING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/resume.sh
+++ b/job_runner/resume.sh
@@ -79,6 +79,7 @@ while read RESUMING; do
     EXISTING_RESULTS_DATASET=$(echo "$RESUMING" | cut -d"|" -f13)
     EXISTING_RESULTS_OCEAN_DATASET=$(echo "$RESUMING" | cut -d"|" -f14)
     EXISTING_RESULTS_ATMOS_DATASET=$(echo "$RESUMING" | cut -d"|" -f15)
+    MIN_RUNTIME=$(echo "$RESUMING" | cut -d"|" -f16)
 
     if [[ "$STATUS" != "train" ]]; then
         SKIPPED_JOBS=$((SKIPPED_JOBS + 1))
@@ -89,6 +90,10 @@ while read RESUMING; do
 
     if [[ -z $RETRIES ]]; then
         RETRIES=0
+    fi
+
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME=0
     fi
 
     JOB_GROUP="${GROUP}"
@@ -155,7 +160,7 @@ while read RESUMING; do
     OVERRIDE_ARGS="resume_results.existing_dir=/existing-results ${OVERRIDE_ARGS}"
 
     # Run the job using run_gantry_training_job
-    EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Resume ${EXPERIMENT_DIR} pretraining: ${JOB_GROUP}")
+    EXPERIMENT_ID=$(MIN_RUNTIME="$MIN_RUNTIME" run_gantry_training_job_with_dry_run "Resume ${EXPERIMENT_DIR} pretraining: ${JOB_GROUP}")
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \

--- a/job_runner/resume.sh
+++ b/job_runner/resume.sh
@@ -159,7 +159,7 @@ while read RESUMING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--not-preemptible" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/uncoupled_finetune.sh
+++ b/job_runner/uncoupled_finetune.sh
@@ -79,6 +79,7 @@ while read FINETUNING; do
     WORKSPACE=$(echo "$FINETUNING" | cut -d"|" -f12)
     OVERRIDE_ARGS=$(echo "$FINETUNING" | cut -d"|" -f13)
     EXISTING_RESULTS_DATASET=$(echo "$FINETUNING" | cut -d"|" -f14)
+    MIN_RUNTIME=$(echo "$FINETUNING" | cut -d"|" -f15)
 
     if [[ "$STATUS" != "train" ]]; then
         SKIPPED_JOBS=$((SKIPPED_JOBS + 1))
@@ -89,6 +90,10 @@ while read FINETUNING; do
 
     if [[ -z $RETRIES ]]; then
         RETRIES=0
+    fi
+
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME=0
     fi
 
     JOB_GROUP="${GROUP}"
@@ -149,7 +154,7 @@ while read FINETUNING; do
     fi
 
     # Run the job (use relative path for CONFIG_PATH)
-    CONFIG_PATH="$CONFIG_PATH_REL" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run uncoupled fine-tuning: ${JOB_GROUP}")
+    CONFIG_PATH="$CONFIG_PATH_REL" MIN_RUNTIME="$MIN_RUNTIME" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run uncoupled fine-tuning: ${JOB_GROUP}")
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \

--- a/job_runner/uncoupled_finetune.sh
+++ b/job_runner/uncoupled_finetune.sh
@@ -153,7 +153,7 @@ while read FINETUNING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--not-preemptible" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/uncoupled_finetune.sh
+++ b/job_runner/uncoupled_finetune.sh
@@ -158,7 +158,7 @@ while read FINETUNING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/uncoupled_train.sh
+++ b/job_runner/uncoupled_train.sh
@@ -73,6 +73,7 @@ while read TRAINING; do
     RETRIES=$(echo "$TRAINING" | cut -d"|" -f8)
     WORKSPACE=$(echo "$TRAINING" | cut -d"|" -f9)
     OVERRIDE_ARGS=$(echo "$TRAINING" | cut -d"|" -f10)
+    MIN_RUNTIME=$(echo "$TRAINING" | cut -d"|" -f11)
 
     if [[ "$STATUS" != "train" ]]; then
         SKIPPED_JOBS=$((SKIPPED_JOBS + 1))
@@ -83,6 +84,10 @@ while read TRAINING; do
 
     if [[ -z $RETRIES ]]; then
         RETRIES=0
+    fi
+
+    if [[ -z $MIN_RUNTIME ]]; then
+        MIN_RUNTIME=0
     fi
 
     JOB_GROUP="${GROUP}"
@@ -127,7 +132,7 @@ while read TRAINING; do
     fi
 
     # Run the job (use relative path for CONFIG_PATH)
-    CONFIG_PATH="$CONFIG_PATH_REL" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run uncoupled pretraining: ${JOB_GROUP}")
+    CONFIG_PATH="$CONFIG_PATH_REL" MIN_RUNTIME="$MIN_RUNTIME" EXPERIMENT_ID=$(run_gantry_training_job_with_dry_run "Run uncoupled pretraining: ${JOB_GROUP}")
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \

--- a/job_runner/uncoupled_train.sh
+++ b/job_runner/uncoupled_train.sh
@@ -136,7 +136,7 @@ while read TRAINING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 

--- a/job_runner/uncoupled_train.sh
+++ b/job_runner/uncoupled_train.sh
@@ -131,7 +131,7 @@ while read TRAINING; do
 
     # Append to experiments.txt
     append_to_experiments_file_with_dry_run "$EXPERIMENT_DIR" "$CONFIG_SUBDIR" "$JOB_GROUP" "$TAG" \
-        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--not-preemptible" "$GIT_BRANCH"
+        "$EXPERIMENT_ID" "training" "best_inference_ckpt" "normal" "--min-runtime 8h --no-auto-resume" "$GIT_BRANCH"
 
 done <"$INPUT_PATH"
 


### PR DESCRIPTION
See [migration guide](https://beaker-docs.apps.allenai.org/concept/experiments.html#context) from beaker on how min-runtime is being handled. As it stands, inference/evaluation jobs using `--not-preemptible` is now only slotted for 8h. We will need to add a automatic restart/segment run mechanism for jobs that need longer than 8h.