### PR TITLE
Add script to extract `Stepper` checkpoints from an `CoupledStepper` checkpoint

### DIFF
--- a/scripts/coupled/create_decoupled_checkpoint.py
+++ b/scripts/coupled/create_decoupled_checkpoint.py
@@ -1,0 +1,41 @@
+import argparse
+import logging
+
+import torch
+
+from fme.coupled.stepper import load_coupled_stepper
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--component", type=str, help="Component to extract: 'ocean' or 'atmosphere'."
+    )
+    parser.add_argument(
+        "--input_path",
+        type=str,
+        help="Path to an existing CoupledStepper training checkpoint.",
+    )
+    parser.add_argument(
+        "--output_path", type=str, help="Path for the new component checkpoint."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    component = args.component
+    in_path = args.input_path
+    out_path = args.output_path
+
+    stepper = load_coupled_stepper(
+        in_path
+    )  # ensure this is a valid CoupledStepper checkpoint
+
+    if component == "atmosphere":
+        ckpt = {"stepper": stepper.atmosphere.get_state()}
+    elif component == "ocean":
+        ckpt = {"stepper": stepper.ocean.get_state()}
+    else:
+        raise ValueError(f"Unrecognized --component arg '{component}'")
+
+    torch.save(ckpt, out_path)
+    logging.info(f"New {component} saved to {out_path}")

--- a/scripts/coupled/create_decoupled_checkpoint_beaker.sh
+++ b/scripts/coupled/create_decoupled_checkpoint_beaker.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Download a CoupledStepper training results Beaker dataset, extract an
+# individual component Stepper, and create a new Beaker dataset with the
+# component checkpoint which can then be used for uncoupled inference.
+#
+# Usage:
+#   create_decoupled_checkpoint_beaker.sh [OPTIONS]
+#
+# Required Options:
+#   --id          CoupledStepper training Beaker dataset ID.
+#   --prefix      Path in the Beaker dataset to the checkpoint.
+#   --component   Component to extract: 'ocean' or 'atmosphere'.
+#
+# Example:
+#   bash create_decoupled_checkpoint_beaker.sh  \
+#       --id 01KCA5QX2K7FQ2NXDE4YTY3ZE6 \
+#       --prefix training_checkpoints/best_inference_ckpt.tar \
+#       --component atmosphere
+
+DESCRIPTION="$0 $*"
+echo "$DESCRIPTION"
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]
+do case $1 in
+    --id) DATASET_ID="$2"
+    shift;;
+    --prefix) PREFIX="$2"
+    shift;;
+    --component) COMPONENT="$2"
+    shift;;
+    *) echo "Unknown parameter passed: $1"
+    exit 1;;
+esac
+shift
+done
+
+UUID=$(uuidgen)
+OUTPUT_DIR=/tmp
+CKPT_PATH="$OUTPUT_DIR/$UUID/$PREFIX"
+
+mkdir -p "$(dirname "$CKPT_PATH")"
+
+set -e
+
+# Fetch checkpoint
+beaker dataset fetch "$DATASET_ID" --output "$OUTPUT_DIR/$DATASET_ID" --prefix "$PREFIX"
+
+python -u create_decoupled_checkpoint.py \
+    --component "$COMPONENT" \
+    --input_path "$OUTPUT_DIR/$DATASET_ID/$PREFIX" \
+    --output_path "$CKPT_PATH"
+
+beaker dataset create -b ai2/climate "$OUTPUT_DIR/$UUID" --desc "$DESCRIPTION"
+
+exit 0

--- a/scripts/test_distributed_context.py
+++ b/scripts/test_distributed_context.py
@@ -1,11 +1,11 @@
 import pathlib
 
-EXCLUDED_FILES: set[str] = set()
+EXCLUDED_FILES: set[str] = {"scripts/coupled/create_decoupled_checkpoint.py"}
 
 
 def _iter_python_files(root: pathlib.Path):
     for path in root.rglob("*.py"):
-        if path.name in EXCLUDED_FILES:
+        if str(path.relative_to(root)) in EXCLUDED_FILES:
             continue
         if path.name == pathlib.Path(__file__).name:
             continue
@@ -25,7 +25,7 @@ def _has_distributed_context(source: str) -> bool:
 
 
 def test_main_guard_requires_distributed_context():
-    root = pathlib.Path(__file__).parent
+    root = pathlib.Path(__file__).parent.parent
 
     failures = []
 
@@ -38,8 +38,7 @@ def test_main_guard_requires_distributed_context():
             and not _has_distributed_context(source)
         ):
             failure_path = str(path.relative_to(root))
-            if failure_path not in EXCLUDED_FILES:
-                failures.append(failure_path)
+            failures.append(failure_path)
 
     if failures:
         raise AssertionError(


### PR DESCRIPTION
Adds `scripts/coupled/create_decoupled_checkpoint.py` to create atmosphere or ocean `Stepper` checkpoints that are usable in `fme.ace` fine-tuning or inference.

Changes:
- Adds `scripts/coupled/create_decoupled_checkpoint_beaker.sh` convenience script for downloading the `CoupledStepper` checkpoint from beaker and uploading the extracted `Stepper` checkpoint as a new beaker dataset.
- Fixes bugs in `scripts/test_distributed_context.py`.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated