### PR TITLE
Fix latents, inputs order in mixture of experts `generate`

### DIFF
--- a/fme/downscaling/predictors/serial_denoising.py
+++ b/fme/downscaling/predictors/serial_denoising.py
@@ -222,7 +222,7 @@ class DenoisingMoEPredictor:
         static_inputs: StaticInputs | None,
         n_samples: int = 1,
     ) -> tuple[TensorDict, torch.Tensor, list[torch.Tensor]]:
-        latents, inputs = self._primary.prepare_generation_inputs(
+        inputs, latents = self._primary.prepare_generation_inputs(
             coarse_data, static_inputs, n_samples
         )
         generated_norm, latent_steps = edm_sampler(


### PR DESCRIPTION
`DiffusionModel.prepare_generation_inputs` returns tensors in order `inputs, latents` but the mixture of experts predictor swapped the return order. This PR fixes that bug.