### PR TITLE
Add additional inference to coupled training

### DIFF
--- a/fme/coupled/__init__.py
+++ b/fme/coupled/__init__.py
@@ -7,6 +7,10 @@ from fme.coupled.inference.inference import (
     CoupledInitialConditionConfig,
     InferenceConfig,
 )
+from fme.coupled.train.train_config import (
+    AdditionalInferenceConfig,
+    InlineInferenceConfig,
+)
 
 # Get all the names defined in the current module
 module = sys.modules[__name__]

--- a/fme/coupled/test_train.py
+++ b/fme/coupled/test_train.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -12,6 +13,11 @@ from fme.core.testing.wandb import mock_wandb
 from .data_loading.test_data_loader import create_coupled_data_on_disk
 from .inference.evaluator import main as inference_evaluator_main
 from .train.train import main as train_main
+from .train.train_config import (
+    AdditionalInferenceConfig,
+    InlineInferenceConfig,
+    TrainConfig,
+)
 
 _TRAIN_CONFIG_TEMPLATE = """
 experiment_dir: {experiment_dir}
@@ -63,6 +69,22 @@ inference:
   n_coupled_steps: {inference_n_coupled_steps}
   aggregator:
     log_zonal_mean_images: True
+additional_inference:
+  - name: weather_eval
+    config:
+      loader:
+        dataset:
+          ocean:
+            data_path: {ocean_data_path}
+          atmosphere:
+            data_path: {atmosphere_data_path}
+        start_indices:
+          times:
+            - '1970-01-01T00:00:00'
+            - '1970-01-03T00:00:00'
+      n_coupled_steps: {inference_n_coupled_steps}
+      aggregator:
+        log_zonal_mean_images: True
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001
@@ -507,6 +529,31 @@ def test_train_and_inference(
             ds = xr.open_dataset(diagnostic_output, decode_timedelta=False)
             assert len(ds) > 0
 
+    weather_eval_keys = [k for k in epoch_logs if k.startswith("weather_eval/")]
+    assert (
+        weather_eval_keys
+    ), "expected at least one weather_eval metric in additional_inference epoch log"
+    assert "weather_eval/time_mean_norm/rmse/channel_mean" in epoch_logs
+    for domain in ("ocean", "atmosphere"):
+        weather_eval_output_dir = (
+            tmp_path
+            / "results"
+            / "output"
+            / "additional_inference"
+            / "weather_eval"
+            / domain
+            / "epoch_0001"
+        )
+        assert weather_eval_output_dir.exists()
+        for diagnostic in (
+            "time_mean",
+            "time_mean_norm",
+        ):
+            diagnostic_output = weather_eval_output_dir / f"{diagnostic}_diagnostics.nc"
+            assert diagnostic_output.exists()
+            ds = xr.open_dataset(diagnostic_output, decode_timedelta=False)
+            assert len(ds) > 0
+
     best_checkpoint_path = (
         tmp_path / "results" / "training_checkpoints" / "best_ckpt.tar"
     )
@@ -597,4 +644,34 @@ def test_train_and_inference(
             wm_gen,
             inference_logs[1][f"inference/mean/weighted_mean_gen/{name}"],
             atol=1e-4,
+        )
+
+
+def test_additional_inference_empty_name():
+    """AdditionalInferenceConfig should reject an empty name."""
+    inline_inference_config = MagicMock(spec=InlineInferenceConfig)
+    with pytest.raises(ValueError, match="must be non-empty"):
+        AdditionalInferenceConfig(name="", config=inline_inference_config)
+
+
+def test_train_config_duplicate_additional_inference_names():
+    """TrainConfig should reject additional_inference entries with duplicate names."""
+    inline_inference_config = MagicMock(spec=InlineInferenceConfig)
+    duplicate_entries = [
+        AdditionalInferenceConfig(name="dup", config=inline_inference_config),
+        AdditionalInferenceConfig(name="dup", config=inline_inference_config),
+    ]
+    with pytest.raises(ValueError, match="Duplicate additional_inference name"):
+        TrainConfig(
+            train_loader=MagicMock(),
+            validation_loader=MagicMock(),
+            stepper=MagicMock(),
+            stepper_training=MagicMock(),
+            optimization=MagicMock(),
+            logging=MagicMock(),
+            max_epochs=1,
+            save_checkpoint=False,
+            experiment_dir="/tmp/whatever",
+            inference=inline_inference_config,
+            additional_inference=duplicate_entries,
         )

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -11,9 +11,10 @@ import fme
 from fme.core.cli import prepare_config, prepare_directory
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
-from fme.core.generics.trainer import AggregatorBuilderABC, Trainer
+from fme.core.generics.trainer import AggregatorBuilderABC, Trainer, inference_one_epoch
 from fme.core.typing_ import TensorDict, TensorMapping
 from fme.coupled.aggregator import (
+    InferenceEvaluatorAggregator,
     InferenceEvaluatorAggregatorConfig,
     OneStepAggregator,
     TrainAggregator,
@@ -61,7 +62,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
         output_dir=config.output_dir,
     )
-    return Trainer(
+    trainer = Trainer(
         train_data=train_data,
         validation_data=validation_data,
         inference_data=inference_data,
@@ -72,6 +73,36 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         aggregator_builder=aggregator_builder,
         end_of_batch_callback=end_of_batch_ops,
     )
+
+    def inference(
+        data,
+        aggregator: InferenceEvaluatorAggregator,
+        label: str,
+        epoch: int,
+    ):
+        logging.info(f"Starting additional inference run {label!r}")
+        return inference_one_epoch(
+            stepper=stepper,
+            validation_context=trainer.validation_context,
+            dataset=data,
+            aggregator=aggregator,
+            label=label,
+            epoch=epoch,
+        )
+
+    end_of_epoch_ops = builder.get_end_of_epoch_callback(
+        inference,
+        ocean_normalize=stepper.ocean.normalizer.normalize,
+        atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
+        output_dir=config.output_dir,
+        variable_metadata=variable_metadata,
+        save_diagnostics=config.save_per_epoch_diagnostics,
+        n_ic_timesteps_ocean=stepper.ocean.n_ic_timesteps,
+        n_ic_timesteps_atmosphere=stepper.atmosphere.n_ic_timesteps,
+        n_inner_steps=stepper.n_inner_steps,
+    )
+    trainer.set_end_of_epoch_callback(end_of_epoch_ops)
+    return trainer
 
 
 class CoupledAggregatorBuilder(

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -1,20 +1,26 @@
 import dataclasses
 import datetime
 import os
+from collections.abc import Callable, Mapping
+from typing import Any
 
 import torch
 
 from fme.core.cli import ResumeResultsConfig
+from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.distributed import Distributed
 from fme.core.ema import EMAConfig, EMATracker
 from fme.core.generics.lr_tuning import LRTuningConfig
-from fme.core.generics.trainer import EndOfBatchCallback
+from fme.core.generics.trainer import EndOfBatchCallback, EndOfEpochCallback
 from fme.core.logging_utils import LoggingConfig
 from fme.core.optimization import Optimization, OptimizationConfig
 from fme.core.rand import set_seed
-from fme.core.typing_ import Slice
+from fme.core.typing_ import Slice, TensorDict, TensorMapping
 from fme.core.weight_ops import CopyWeightsConfig
-from fme.coupled.aggregator import InferenceEvaluatorAggregatorConfig
+from fme.coupled.aggregator import (
+    InferenceEvaluatorAggregator,
+    InferenceEvaluatorAggregatorConfig,
+)
 from fme.coupled.data_loading.config import CoupledDataLoaderConfig
 from fme.coupled.data_loading.getters import get_gridded_data, get_inference_data
 from fme.coupled.data_loading.gridded_data import GriddedData, InferenceGriddedData
@@ -71,6 +77,28 @@ class InlineInferenceConfig:
             self.aggregator.log_global_mean_time_series = False
             self.aggregator.log_global_mean_norm_time_series = False
 
+    def get_inference_data(
+        self,
+        window_requirements: CoupledDataRequirements,
+        initial_condition: CoupledPrognosticStateDataRequirements,
+    ) -> InferenceGriddedData:
+        return get_inference_data(
+            config=self.loader,
+            total_coupled_steps=self.n_coupled_steps,
+            window_requirements=window_requirements,
+            initial_condition=initial_condition,
+        )
+
+
+@dataclasses.dataclass
+class AdditionalInferenceConfig:
+    name: str
+    config: InlineInferenceConfig
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("AdditionalInferenceConfig name must be non-empty.")
+
 
 @dataclasses.dataclass
 class TrainConfig:
@@ -90,6 +118,10 @@ class TrainConfig:
             evaluation, and on catching a termination signal.
         experiment_dir: Directory where checkpoints and logs are saved.
         inference: Configuration for inline inference.
+        additional_inference: Configurations for additional inference runs.
+            Each entry has a name (used as wandb log prefix and output
+            subdirectory) and config. Not used to select checkpoints, but used
+            to provide metrics.
         n_coupled_steps: Number of coupled forward steps to take gradient over.
             This is equal to the number of forward steps of the ocean model.
         seed: Random seed for reproducibility. If set, is used for all types of
@@ -145,6 +177,9 @@ class TrainConfig:
         default_factory=lambda: CopyWeightsConfig(exclude=["*"])
     )
     ema: EMAConfig = dataclasses.field(default_factory=lambda: EMAConfig())
+    additional_inference: list[AdditionalInferenceConfig] = dataclasses.field(
+        default_factory=list
+    )
     validate_using_ema: bool = False
     checkpoint_save_epochs: Slice | None = None
     ema_checkpoint_save_epochs: Slice | None = None
@@ -159,6 +194,11 @@ class TrainConfig:
     resume_results: ResumeResultsConfig | None = None
 
     def __post_init__(self):
+        additional_inference_names: set[str] = set()
+        for entry in self.additional_inference:
+            if entry.name in additional_inference_names:
+                raise ValueError(f"Duplicate additional_inference name: {entry.name!r}")
+            additional_inference_names.add(entry.name)
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
             raise ValueError(
                 "lr_tuning and optimization.scheduler cannot both be specified; "
@@ -241,9 +281,7 @@ class TrainBuilders:
     def get_evaluation_inference_data(
         self,
     ) -> InferenceGriddedData:
-        return get_inference_data(
-            config=self.config.inference.loader,
-            total_coupled_steps=self.config.inference.n_coupled_steps,
+        return self.config.inference.get_inference_data(
             window_requirements=self._get_evaluation_window_data_requirements(),
             initial_condition=self._get_initial_condition_data_requirements(),
         )
@@ -272,3 +310,72 @@ class TrainBuilders:
         self, modules: list[torch.nn.Module]
     ) -> EndOfBatchCallback:
         return lambda: None
+
+    def get_end_of_epoch_callback(
+        self,
+        inference_one_epoch: Callable[
+            [InferenceGriddedData, InferenceEvaluatorAggregator, str, int],
+            Mapping[str, Any],
+        ],
+        ocean_normalize: Callable[[TensorMapping], TensorDict],
+        atmosphere_normalize: Callable[[TensorMapping], TensorDict],
+        output_dir: str,
+        variable_metadata: Mapping[str, VariableMetadata],
+        save_diagnostics: bool,
+        n_ic_timesteps_ocean: int,
+        n_ic_timesteps_atmosphere: int,
+        n_inner_steps: int,
+    ) -> EndOfEpochCallback:
+        entries_data: list[
+            tuple[AdditionalInferenceConfig, InferenceGriddedData, CoupledDatasetInfo]
+        ] = []
+        for entry in self.config.additional_inference:
+            window_requirements = (
+                self.config.stepper.get_evaluation_window_data_requirements(
+                    entry.config.coupled_steps_in_memory
+                )
+            )
+            data = entry.config.get_inference_data(
+                window_requirements=window_requirements,
+                initial_condition=self._get_initial_condition_data_requirements(),
+            )
+            dataset_info = data.dataset_info.update_variable_metadata(
+                dict(variable_metadata)
+            )
+            entries_data.append((entry, data, dataset_info))
+
+        def end_of_epoch_ops(epoch: int) -> Mapping[str, Any]:
+            all_logs: dict[str, Any] = {}
+            for entry, data, dataset_info in entries_data:
+                if entry.config.epochs.contains(epoch):
+                    entry_output_dir = os.path.join(
+                        output_dir, "additional_inference", entry.name
+                    )
+                    n_timesteps_ocean = (
+                        entry.config.n_coupled_steps + n_ic_timesteps_ocean
+                    )
+                    n_timesteps_atmosphere = (
+                        entry.config.n_coupled_steps * n_inner_steps
+                        + n_ic_timesteps_atmosphere
+                    )
+                    aggregator = entry.config.aggregator.build(
+                        dataset_info=dataset_info,
+                        n_timesteps_ocean=n_timesteps_ocean,
+                        n_timesteps_atmosphere=n_timesteps_atmosphere,
+                        initial_time=data.initial_time,
+                        ocean_normalize=ocean_normalize,
+                        atmosphere_normalize=atmosphere_normalize,
+                        save_diagnostics=save_diagnostics,
+                        output_dir=entry_output_dir,
+                    )
+                    all_logs.update(
+                        inference_one_epoch(
+                            data,
+                            aggregator,
+                            entry.name,
+                            epoch,
+                        )
+                    )
+            return all_logs
+
+        return end_of_epoch_ops


### PR DESCRIPTION
Similar to #1096, we add additional inference to coupled training.

- New `AdditionalInferenceConfig` dataclass: wraps an `InlineInferenceConfig` with a name field
- New `additional_inference field` on `TrainConfig`: accepts a list of `AdditionalInferenceConfig` entries
- End-of-epoch callback wired into the coupled trainer
- `InlineInferenceConfig` now has a `get_inference_data` method

 
- [x] Tests added

