### PR TITLE
Refactor generic trainer to use validation and inference callbacks

### DIFF
--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -48,6 +48,7 @@
 # Karthik Kashinath - NVIDIA Corporation
 # Animashree Anandkumar - California Institute of Technology, NVIDIA Corporation
 
+import contextlib
 import dataclasses
 import logging
 import os
@@ -158,8 +159,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
             aggregator=aggregator,
             diagnostics_subdir=f"epoch_{epoch:04d}",
             record_logs=lambda logs: None,
-            ema=trainer._ema,
-            validate_using_ema=config.validate_using_ema,
         )
         return logs, logs["val/mean/loss"]
 
@@ -170,7 +169,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
             return {}, None
         logs = inference_one_epoch(
             stepper=stepper,
-            validation_context=trainer.validation_context,
+            validation_context=contextlib.nullcontext,
             dataset=inference_data,
             aggregator=aggregator_builder.get_inference_aggregator(),
             label="inference",
@@ -191,7 +190,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         logging.info("Starting weather evaluation inference run")
         return inference_one_epoch(
             stepper=stepper,
-            validation_context=trainer.validation_context,
+            validation_context=contextlib.nullcontext,
             dataset=data,
             aggregator=aggregator,
             label=label,

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -171,7 +171,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         label: str,
         epoch: int,
     ):
-        logging.info("Starting weather evaluation inference run")
         return inference_one_epoch(
             stepper=stepper,
             validation_context=contextlib.nullcontext,

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -68,7 +68,7 @@ from fme.ace.aggregator.inference.main import (
     InferenceEvaluatorAggregatorConfig,
 )
 from fme.ace.aggregator.train import TrainAggregatorConfig
-from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
+from fme.ace.data_loading.batch_data import BatchData, PrognosticState
 from fme.ace.stepper import TrainOutput
 from fme.ace.train.train_config import TrainBuilders, TrainConfig
 from fme.core.cli import prepare_config, prepare_directory
@@ -82,6 +82,7 @@ from fme.core.generics.trainer import (
     Trainer,
     inference_one_epoch,
 )
+from fme.core.generics.validation import run_validation
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -138,7 +139,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
     trainer = Trainer(
         train_data=train_data,
         validation_data=validation_data,
-        inference_data=inference_data,
         stepper=stepper,
         build_optimization=builder.get_optimization,
         build_ema=builder.get_ema,
@@ -148,7 +148,40 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         do_gc_collect=do_gc_collect,
     )
 
-    def inference(
+    def validation_callback(epoch: int):
+        validation_data.set_epoch(epoch)
+        aggregator = aggregator_builder.get_validation_aggregator()
+        logs = run_validation(
+            train_stepper=stepper,
+            validation_data=validation_data,
+            aggregator=aggregator,
+            diagnostics_subdir=f"epoch_{epoch:04d}",
+            record_logs=lambda logs: None,
+            ema=trainer._ema,
+            validate_using_ema=config.validate_using_ema,
+        )
+        return logs, logs["val/mean/loss"]
+
+    inference_epochs = config.get_inference_epochs()
+
+    def inference_callback(epoch: int):
+        if epoch not in inference_epochs:
+            return {}, None
+        logs = inference_one_epoch(
+            stepper=stepper,
+            validation_context=trainer.validation_context,
+            dataset=inference_data,
+            aggregator=aggregator_builder.get_inference_aggregator(),
+            label="inference",
+            epoch=epoch,
+        )
+        error = logs.get("inference/time_mean_norm/rmse/channel_mean")
+        return logs, error
+
+    trainer.set_validation_callback(validation_callback)
+    trainer.set_inference_callback(inference_callback)
+
+    def _run_inference(
         data: InferenceDataABC[PrognosticState, BatchData],
         aggregator: InferenceEvaluatorAggregator,
         label: str,
@@ -165,7 +198,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         )
 
     end_of_epoch_ops = builder.get_end_of_epoch_callback(
-        inference,
+        _run_inference,
         normalize=stepper.normalizer.normalize,
         channel_mean_names=stepper.loss_names,
         output_dir=config.output_dir,
@@ -178,7 +211,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
 
 
 class AggregatorBuilder(
-    AggregatorBuilderABC[PrognosticState, TrainOutput, PairedData],
+    AggregatorBuilderABC[TrainOutput],
 ):
     def __init__(
         self,

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -52,6 +52,7 @@ import dataclasses
 import logging
 import os
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import dacite
 import torch
@@ -148,7 +149,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         do_gc_collect=do_gc_collect,
     )
 
-    def validation_callback(epoch: int):
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
         aggregator = aggregator_builder.get_validation_aggregator()
         logs = run_validation(
@@ -164,7 +165,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
 
     inference_epochs = config.get_inference_epochs()
 
-    def inference_callback(epoch: int):
+    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
             return {}, None
         logs = inference_one_epoch(

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -136,19 +136,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         validation_config=config.validation_aggregator,
         n_ensemble_per_ic=n_ensemble_per_ic,
     )
-    do_gc_collect = fme.get_device() != torch.device("cpu")
-    trainer_config: TrainConfigProtocol = config  # documenting trainer input type
-    trainer = Trainer(
-        train_data=train_data,
-        validation_data=validation_data,
-        stepper=stepper,
-        build_optimization=builder.get_optimization,
-        build_ema=builder.get_ema,
-        config=trainer_config,
-        aggregator_builder=aggregator_builder,
-        end_of_batch_callback=end_of_batch_ops,
-        do_gc_collect=do_gc_collect,
-    )
 
     def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
@@ -178,9 +165,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         error = logs.get("inference/time_mean_norm/rmse/channel_mean")
         return logs, error
 
-    trainer.set_validation_callback(validation_callback)
-    trainer.set_inference_callback(inference_callback)
-
     def _run_inference(
         data: InferenceDataABC[PrognosticState, BatchData],
         aggregator: InferenceEvaluatorAggregator,
@@ -206,8 +190,23 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         save_diagnostics=config.save_per_epoch_diagnostics,
         n_ic_timesteps=stepper.n_ic_timesteps,
     )
-    trainer.set_end_of_epoch_callback(end_of_epoch_ops)
-    return trainer
+
+    do_gc_collect = fme.get_device() != torch.device("cpu")
+    trainer_config: TrainConfigProtocol = config  # documenting trainer input type
+    return Trainer(
+        train_data=train_data,
+        validation_data=validation_data,
+        stepper=stepper,
+        build_optimization=builder.get_optimization,
+        build_ema=builder.get_ema,
+        config=trainer_config,
+        aggregator_builder=aggregator_builder,
+        validation_callback=validation_callback,
+        end_of_batch_callback=end_of_batch_ops,
+        end_of_epoch_callback=end_of_epoch_ops,
+        inference_callback=inference_callback,
+        do_gc_collect=do_gc_collect,
+    )
 
 
 class AggregatorBuilder(

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -459,8 +459,6 @@ def get_trainer(
             aggregator=val_agg,
             diagnostics_subdir=f"epoch_{epoch:04d}",
             record_logs=lambda logs: None,
-            ema=trainer._ema,
-            validate_using_ema=config.validate_using_ema,
         )
         return logs, logs["val/mean/loss"]
 
@@ -469,7 +467,7 @@ def get_trainer(
             return {}, None
         logs = inference_one_epoch(
             stepper=stepper,
-            validation_context=trainer.validation_context,
+            validation_context=contextlib.nullcontext,
             dataset=inference_data,
             aggregator=aggregator_builder.get_inference_aggregator(),
             label="inference",

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -30,7 +30,9 @@ from fme.core.generics.trainer import (
     TrainStepperABC,
     count_parameters,
     epoch_checkpoint_enabled,
+    inference_one_epoch,
 )
+from fme.core.generics.validation import run_validation
 from fme.core.logging_utils import LoggingConfig
 from fme.core.optimization import NullOptimization, Optimization
 from fme.core.scheduler import SchedulerConfig
@@ -239,9 +241,7 @@ class Config:
 
     def __post_init__(self):
         start_epoch = 0 if self.evaluate_before_training else 1
-        self.get_inference_epochs = unittest.mock.MagicMock(
-            return_value=[i for i in range(start_epoch, self.max_epochs + 1)]
-        )
+        self._inference_epochs = [i for i in range(start_epoch, self.max_epochs + 1)]
 
 
 _: TrainConfigProtocol = Config()
@@ -292,7 +292,7 @@ class InferenceAggregator(InferenceAggregatorABC[PSType, SDType]):
         pass
 
 
-class AggregatorBuilder(AggregatorBuilderABC[PSType, TrainOutput, SDType]):
+class AggregatorBuilder(AggregatorBuilderABC[TrainOutput]):
     def __init__(
         self,
         train_losses: np.ndarray,
@@ -407,7 +407,7 @@ def get_trainer(
     def build_ema(modules: torch.nn.ModuleList) -> EMATracker:
         return EMATracker(modules, decay=ema_decay)
 
-    config: TrainConfigProtocol = Config(
+    config = Config(
         experiment_dir=tmp_path,
         checkpoint_dir=checkpoint_dir,
         checkpoint_save_epochs=checkpoint_save_epochs,
@@ -425,10 +425,9 @@ def get_trainer(
         validation_losses=validation_losses,
         inference_losses=inference_losses,
     )
-    return config, Trainer(
+    trainer = Trainer(
         train_data=train_data,
         validation_data=validation_data,
-        inference_data=inference_data,
         stepper=stepper,
         build_optimization=build_optimization,
         build_ema=build_ema,
@@ -438,6 +437,41 @@ def get_trainer(
         end_of_epoch_callback=unittest.mock.MagicMock(side_effect=lambda epoch: {}),
         do_gc_collect=False,  # for much faster tests
     )
+
+    inference_epochs = config._inference_epochs
+
+    def validation_callback(epoch):
+        validation_data.set_epoch(epoch)
+        val_agg = aggregator_builder.get_validation_aggregator()
+        logs = run_validation(
+            train_stepper=stepper,
+            validation_data=validation_data,
+            aggregator=val_agg,
+            diagnostics_subdir=f"epoch_{epoch:04d}",
+            record_logs=lambda logs: None,
+            ema=trainer._ema,
+            validate_using_ema=config.validate_using_ema,
+        )
+        return logs, logs["val/mean/loss"]
+
+    def inference_cb(epoch):
+        if epoch not in inference_epochs:
+            return {}, None
+        logs = inference_one_epoch(
+            stepper=stepper,
+            validation_context=trainer.validation_context,
+            dataset=inference_data,
+            aggregator=aggregator_builder.get_inference_aggregator(),
+            label="inference",
+            epoch=epoch,
+        )
+        error = logs.get("inference/time_mean_norm/rmse/channel_mean")
+        return logs, error
+
+    trainer.set_validation_callback(validation_callback)
+    trainer.set_inference_callback(inference_cb)
+
+    return config, trainer
 
 
 @pytest.mark.parametrize(
@@ -549,7 +583,7 @@ def preempt_after_calls_patch(object, method: str, call_count: int):
 
 @pytest.mark.parametrize(
     "interrupt_method",
-    ["train_one_epoch", "validate_one_epoch", "inference_one_epoch"],
+    ["train_one_epoch", "_validation_callback", "_inference_callback"],
 )
 def test_resume_after_interrupted_training(tmp_path: str, interrupt_method: str):
     max_epochs = 4
@@ -663,7 +697,9 @@ def test_resume_after_interrupted_training_during_epoch(
     )
     with (
         unittest.mock.patch.object(
-            trainer, "validate_one_epoch", return_value={"val/mean/loss": 0.0}
+            trainer,
+            "_validation_callback",
+            return_value=({"val/mean/loss": 0.0}, 0.0),
         ),
     ):  # would throw off count for actual training batches seen
         trainer.train()
@@ -706,7 +742,7 @@ def test_resume_after_preemption_during_validation(
     ):  # would throw off count for actual training batches seen
         with preempt_after_calls_patch(
             trainer,
-            "validate_one_epoch",
+            "_validation_callback",
             1 + int(evaluate_before_training),
         ):
             trainer.train()
@@ -732,7 +768,9 @@ def test_resume_after_preemption_during_validation(
     )
     with (
         unittest.mock.patch.object(
-            trainer, "validate_one_epoch", return_value={"val/mean/loss": 0.0}
+            trainer,
+            "_validation_callback",
+            return_value=({"val/mean/loss": 0.0}, 0.0),
         ) as validate_mock,
     ):
         assert trainer._epochs_trained == 0

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -435,19 +435,6 @@ def get_trainer(
         validation_losses=validation_losses,
         inference_losses=inference_losses,
     )
-    trainer = Trainer(
-        train_data=train_data,
-        validation_data=validation_data,
-        stepper=stepper,
-        build_optimization=build_optimization,
-        build_ema=build_ema,
-        config=config,
-        aggregator_builder=aggregator_builder,
-        end_of_batch_callback=unittest.mock.MagicMock(),
-        end_of_epoch_callback=unittest.mock.MagicMock(side_effect=lambda epoch: {}),
-        do_gc_collect=False,  # for much faster tests
-    )
-
     inference_epochs = config._inference_epochs
 
     def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
@@ -476,8 +463,20 @@ def get_trainer(
         error = logs.get("inference/time_mean_norm/rmse/channel_mean")
         return logs, error
 
-    trainer.set_validation_callback(validation_callback)
-    trainer.set_inference_callback(inference_callback)
+    trainer = Trainer(
+        train_data=train_data,
+        validation_data=validation_data,
+        stepper=stepper,
+        build_optimization=build_optimization,
+        build_ema=build_ema,
+        config=config,
+        aggregator_builder=aggregator_builder,
+        validation_callback=validation_callback,
+        end_of_batch_callback=unittest.mock.MagicMock(),
+        end_of_epoch_callback=unittest.mock.MagicMock(side_effect=lambda epoch: {}),
+        inference_callback=inference_callback,
+        do_gc_collect=False,  # for much faster tests
+    )
 
     return config, trainer
 

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -440,7 +440,7 @@ def get_trainer(
 
     inference_epochs = config._inference_epochs
 
-    def validation_callback(epoch):
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
         val_agg = aggregator_builder.get_validation_aggregator()
         logs = run_validation(
@@ -454,7 +454,7 @@ def get_trainer(
         )
         return logs, logs["val/mean/loss"]
 
-    def inference_cb(epoch):
+    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
             return {}, None
         logs = inference_one_epoch(
@@ -469,7 +469,7 @@ def get_trainer(
         return logs, error
 
     trainer.set_validation_callback(validation_callback)
-    trainer.set_inference_callback(inference_cb)
+    trainer.set_inference_callback(inference_callback)
 
     return config, trainer
 

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -398,8 +398,9 @@ class Trainer:
             and self._current_epoch_num_batches_seen == 0
         ):
             logging.info("Starting evaluation before training")
-            valid_logs, valid_loss = validation_callback(self._epochs_trained)
-            inference_logs, _ = inference_callback(self._epochs_trained)
+            with self.validation_context():
+                valid_logs, valid_loss = validation_callback(self._epochs_trained)
+                inference_logs, _ = inference_callback(self._epochs_trained)
             logging.info(f"Validation loss before training: {valid_loss}")
             logging.info("Logging to wandb")
             all_logs = valid_logs | inference_logs | {"epoch": self._epochs_trained}
@@ -418,10 +419,13 @@ class Trainer:
             start_time = time.time()
             train_logs = self.train_one_epoch()
             train_end = time.time()
-            valid_logs, valid_loss = validation_callback(self._epochs_trained)
-            valid_end = time.time()
-            inference_logs, inference_error = inference_callback(self._epochs_trained)
-            inference_end: float | None = time.time() if inference_logs else None
+            with self.validation_context():
+                valid_logs, valid_loss = validation_callback(self._epochs_trained)
+                valid_end = time.time()
+                inference_logs, inference_error = inference_callback(
+                    self._epochs_trained
+                )
+                inference_end: float | None = time.time() if inference_logs else None
 
             train_loss = train_logs.get("train/mean/loss")
             # need to get the learning rate before stepping the scheduler
@@ -609,16 +613,13 @@ class Trainer:
     def _ema_context(self):
         """
         A context where the stepper uses the EMA model.
-
-        Reentrant: if we're already inside an EMA context (e.g. because
-        ``validation_context()`` was opened twice -- once by the trainer to
-        wrap an end-of-epoch callback, and once again by an inference helper
-        called from within that callback), nesting is a no-op so the EMA
-        weights are applied exactly once.
         """
         if self._in_ema_context:
-            yield
-            return
+            raise RuntimeError(
+                "_ema_context is not reentrant. The Trainer wraps all "
+                "callbacks in validation_context(), so callbacks should not "
+                "enter it themselves."
+            )
         self._in_ema_context = True
         try:
             with self._ema.applied_params(self.stepper.modules):

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -91,7 +91,7 @@ def null_end_of_epoch_callback(epoch: int) -> Mapping[str, Any]:
 
 
 class ValidationCallback(Protocol):
-    def __call__(self, epoch: int) -> tuple[Mapping[str, Any], float]:
+    def __call__(self, epoch: int) -> tuple[dict[str, Any], float]:
         """Run validation for the given epoch.
 
         Returns:
@@ -101,7 +101,7 @@ class ValidationCallback(Protocol):
 
 
 class InferenceCallback(Protocol):
-    def __call__(self, epoch: int) -> tuple[Mapping[str, Any], float | None]:
+    def __call__(self, epoch: int) -> tuple[dict[str, Any], float | None]:
         """Run inference for the given epoch.
 
         Returns:
@@ -111,7 +111,7 @@ class InferenceCallback(Protocol):
         ...
 
 
-def _null_inference_callback(epoch: int) -> tuple[Mapping[str, Any], float | None]:
+def _null_inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
     return {}, None
 
 
@@ -231,6 +231,8 @@ class Trainer:
         aggregator_builder: AggregatorBuilderABC[TO],
         end_of_batch_callback: EndOfBatchCallback = lambda: None,
         end_of_epoch_callback: EndOfEpochCallback = null_end_of_epoch_callback,
+        validation_callback: ValidationCallback | None = None,
+        inference_callback: InferenceCallback = _null_inference_callback,
         do_gc_collect: bool = True,
     ):
         logging.info(f"Current device is {fme.get_device()}")
@@ -289,8 +291,8 @@ class Trainer:
         self._do_gc_collect = do_gc_collect
         self._in_ema_context = False
         self._started_training = False
-        self._validation_callback: ValidationCallback | None = None
-        self._inference_callback: InferenceCallback = _null_inference_callback
+        self._validation_callback = validation_callback
+        self._inference_callback = inference_callback
 
         def on_terminate(signum, frame):
             dist = Distributed.get_instance()
@@ -400,7 +402,7 @@ class Trainer:
             inference_logs, _ = inference_callback(self._epochs_trained)
             logging.info(f"Validation loss before training: {valid_loss}")
             logging.info("Logging to wandb")
-            all_logs = {**valid_logs, **inference_logs, "epoch": self._epochs_trained}
+            all_logs = valid_logs | inference_logs | {"epoch": self._epochs_trained}
             wandb = WandB.get_instance()
             wandb.log(all_logs, step=self.num_batches_seen)
 

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -229,9 +229,9 @@ class Trainer:
         build_ema: Callable[[torch.nn.ModuleList], EMATracker],
         config: TrainConfigProtocol,
         aggregator_builder: AggregatorBuilderABC[TO],
+        validation_callback: ValidationCallback,
         end_of_batch_callback: EndOfBatchCallback = lambda: None,
         end_of_epoch_callback: EndOfEpochCallback = null_end_of_epoch_callback,
-        validation_callback: ValidationCallback | None = None,
         inference_callback: InferenceCallback = _null_inference_callback,
         do_gc_collect: bool = True,
     ):
@@ -291,8 +291,8 @@ class Trainer:
         self._do_gc_collect = do_gc_collect
         self._in_ema_context = False
         self._started_training = False
-        self._validation_callback = validation_callback
-        self._inference_callback = inference_callback
+        self._validation_callback: ValidationCallback = validation_callback
+        self._inference_callback: InferenceCallback = inference_callback
 
         def on_terminate(signum, frame):
             dist = Distributed.get_instance()
@@ -315,15 +315,6 @@ class Trainer:
 
         chain_signal_handler(signal.SIGTERM, on_terminate)
         chain_signal_handler(signal.SIGINT, on_terminate)
-
-    def set_end_of_epoch_callback(self, end_of_epoch_callback: EndOfEpochCallback):
-        self._end_of_epoch_callback = end_of_epoch_callback
-
-    def set_validation_callback(self, callback: ValidationCallback):
-        self._validation_callback = callback
-
-    def set_inference_callback(self, callback: InferenceCallback):
-        self._inference_callback = callback
 
     def switch_off_grad(self, model: torch.nn.Module):
         for param in model.parameters():
@@ -378,11 +369,6 @@ class Trainer:
         logging.info("Starting Training Loop...")
 
         validation_callback = self._validation_callback
-        if validation_callback is None:
-            raise RuntimeError(
-                "Validation callback must be set before training. "
-                "Call set_validation_callback()."
-            )
         inference_callback = self._inference_callback
 
         if self.config.segment_epochs is None:
@@ -397,9 +383,10 @@ class Trainer:
             and self._epochs_trained == 0
             and self._current_epoch_num_batches_seen == 0
         ):
-            logging.info("Starting evaluation before training")
+            logging.info("Starting validation before training")
             with self.validation_context():
                 valid_logs, valid_loss = validation_callback(self._epochs_trained)
+                logging.info("Starting inline inference before training")
                 inference_logs, _ = inference_callback(self._epochs_trained)
             logging.info(f"Validation loss before training: {valid_loss}")
             logging.info("Logging to wandb")
@@ -419,9 +406,17 @@ class Trainer:
             start_time = time.time()
             train_logs = self.train_one_epoch()
             train_end = time.time()
+            logging.info(
+                f"Starting validation step for model trained for "
+                f"{self._epochs_trained} epochs"
+            )
             with self.validation_context():
                 valid_logs, valid_loss = validation_callback(self._epochs_trained)
                 valid_end = time.time()
+                logging.info(
+                    f"Starting inference step for model trained for "
+                    f"{self._epochs_trained} epochs"
+                )
                 inference_logs, inference_error = inference_callback(
                     self._epochs_trained
                 )

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -71,7 +71,6 @@ from fme.core.generics.inference import run_inference
 from fme.core.generics.lr_tuning import LRTuningConfig, run_lr_tuning_trial
 from fme.core.generics.metrics_aggregator import MetricsAggregator
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
-from fme.core.generics.validation import run_validation
 from fme.core.optimization import NullOptimization, Optimization
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingJob
@@ -89,6 +88,31 @@ class EndOfEpochCallback(Protocol):
 
 def null_end_of_epoch_callback(epoch: int) -> Mapping[str, Any]:
     return {}
+
+
+class ValidationCallback(Protocol):
+    def __call__(self, epoch: int) -> tuple[Mapping[str, Any], float]:
+        """Run validation for the given epoch.
+
+        Returns:
+            A tuple of (logs, valid_loss).
+        """
+        ...
+
+
+class InferenceCallback(Protocol):
+    def __call__(self, epoch: int) -> tuple[Mapping[str, Any], float | None]:
+        """Run inference for the given epoch.
+
+        Returns:
+            A tuple of (logs, inference_error_or_none). When no inference runs
+            for this epoch, returns ({}, None).
+        """
+        ...
+
+
+def _null_inference_callback(epoch: int) -> tuple[Mapping[str, Any], float | None]:
+    return {}, None
 
 
 class TrainConfigProtocol(Protocol):
@@ -139,8 +163,6 @@ class TrainConfigProtocol(Protocol):
     @property
     def lr_tuning(self) -> LRTuningConfig | None: ...
 
-    def get_inference_epochs(self) -> list[int]: ...
-
 
 PS = TypeVar("PS", contravariant=True)  # prognostic state
 TO = TypeVar("TO", bound="TrainOutputABC")  # train output
@@ -149,17 +171,13 @@ FD = TypeVar("FD")  # forcing data for inference
 SD = TypeVar("SD")  # stepped data from inference
 
 
-class AggregatorBuilderABC(abc.ABC, Generic[PS, TO, SD]):
+class AggregatorBuilderABC(abc.ABC, Generic[TO]):
     @abc.abstractmethod
     def get_train_aggregator(self) -> AggregatorABC[TO]:
         pass
 
     @abc.abstractmethod
     def get_validation_aggregator(self) -> AggregatorABC[TO]:
-        pass
-
-    @abc.abstractmethod
-    def get_inference_aggregator(self) -> InferenceAggregatorABC[PS, SD]:
         pass
 
 
@@ -206,12 +224,11 @@ class Trainer:
         self,
         train_data: GriddedDataABC[BD],
         validation_data: GriddedDataABC[BD],
-        inference_data: InferenceDataABC[PS, FD],
         stepper: TrainStepperABC[PS, BD, FD, SD, TO],
         build_optimization: Callable[[torch.nn.ModuleList], Optimization],
         build_ema: Callable[[torch.nn.ModuleList], EMATracker],
         config: TrainConfigProtocol,
-        aggregator_builder: AggregatorBuilderABC[PS, TO, SD],
+        aggregator_builder: AggregatorBuilderABC[TO],
         end_of_batch_callback: EndOfBatchCallback = lambda: None,
         end_of_epoch_callback: EndOfEpochCallback = null_end_of_epoch_callback,
         do_gc_collect: bool = True,
@@ -269,10 +286,11 @@ class Trainer:
         n_params = count_parameters(self.stepper.modules)
         logging.info(f"Number of trainable model parameters: {n_params}")
 
-        self._inference_data = inference_data
         self._do_gc_collect = do_gc_collect
         self._in_ema_context = False
         self._started_training = False
+        self._validation_callback: ValidationCallback | None = None
+        self._inference_callback: InferenceCallback = _null_inference_callback
 
         def on_terminate(signum, frame):
             dist = Distributed.get_instance()
@@ -298,6 +316,12 @@ class Trainer:
 
     def set_end_of_epoch_callback(self, end_of_epoch_callback: EndOfEpochCallback):
         self._end_of_epoch_callback = end_of_epoch_callback
+
+    def set_validation_callback(self, callback: ValidationCallback):
+        self._validation_callback = callback
+
+    def set_inference_callback(self, callback: InferenceCallback):
+        self._inference_callback = callback
 
     def switch_off_grad(self, model: torch.nn.Module):
         for param in model.parameters():
@@ -351,7 +375,14 @@ class Trainer:
     def train(self):
         logging.info("Starting Training Loop...")
 
-        inference_epochs = self.config.get_inference_epochs()
+        validation_callback = self._validation_callback
+        if validation_callback is None:
+            raise RuntimeError(
+                "Validation callback must be set before training. "
+                "Call set_validation_callback()."
+            )
+        inference_callback = self._inference_callback
+
         if self.config.segment_epochs is None:
             segment_max_epochs = self.config.max_epochs
         else:
@@ -364,17 +395,12 @@ class Trainer:
             and self._epochs_trained == 0
             and self._current_epoch_num_batches_seen == 0
         ):
-            logging.info("Starting validation before training")
-            valid_logs = self.validate_one_epoch()
-            if self._epochs_trained in inference_epochs:
-                logging.info("Starting inline inference before training")
-                inference_logs = self.inference_one_epoch()
-            else:
-                inference_logs = {}
-            valid_loss = valid_logs["val/mean/loss"]
+            logging.info("Starting evaluation before training")
+            valid_logs, valid_loss = validation_callback(self._epochs_trained)
+            inference_logs, _ = inference_callback(self._epochs_trained)
             logging.info(f"Validation loss before training: {valid_loss}")
             logging.info("Logging to wandb")
-            all_logs = valid_logs | inference_logs | {"epoch": self._epochs_trained}
+            all_logs = {**valid_logs, **inference_logs, "epoch": self._epochs_trained}
             wandb = WandB.get_instance()
             wandb.log(all_logs, step=self.num_batches_seen)
 
@@ -390,20 +416,12 @@ class Trainer:
             start_time = time.time()
             train_logs = self.train_one_epoch()
             train_end = time.time()
-            valid_logs = self.validate_one_epoch()
+            valid_logs, valid_loss = validation_callback(self._epochs_trained)
             valid_end = time.time()
-            if self._epochs_trained in inference_epochs:
-                inference_logs = self.inference_one_epoch()
-                inference_end: float | None = time.time()
-            else:
-                inference_logs = {}
-                inference_end = None
+            inference_logs, inference_error = inference_callback(self._epochs_trained)
+            inference_end: float | None = time.time() if inference_logs else None
 
             train_loss = train_logs.get("train/mean/loss")
-            valid_loss = valid_logs["val/mean/loss"]
-            inference_error = inference_logs.get(
-                "inference/time_mean_norm/rmse/channel_mean", None
-            )
             # need to get the learning rate before stepping the scheduler
             lr = self.optimization.learning_rate
             self.optimization.step_scheduler(valid_loss=valid_loss, is_iteration=False)
@@ -596,49 +614,6 @@ class Trainer:
                 yield
         finally:
             self._in_ema_context = False
-
-    def validate_one_epoch(self):
-        if self._current_epoch_num_batches_seen > 0:
-            raise RuntimeError(
-                "Validation should only be called after a full epoch has been trained"
-            )
-        logging.info(
-            f"Starting validation step for model trained for "
-            f"{self._epochs_trained} epochs"
-        )
-        self.valid_data.set_epoch(self._epochs_trained)
-        aggregator = self._aggregator_builder.get_validation_aggregator()
-        logging.info("Starting loop over validation data")
-        return run_validation(
-            train_stepper=self.stepper,
-            validation_data=self.valid_data,
-            aggregator=aggregator,
-            diagnostics_subdir=f"epoch_{self._epochs_trained:04d}",
-            record_logs=lambda logs: None,
-            ema=self._ema,
-            validate_using_ema=self.config.validate_using_ema,
-        )
-
-    def inference_one_epoch(
-        self,
-    ):
-        if self._current_epoch_num_batches_seen > 0:
-            raise RuntimeError(
-                "Inference should only be called after a full epoch has been trained"
-            )
-        logging.info(
-            f"Starting inference step for model trained for "
-            f"{self._epochs_trained} epochs"
-        )
-        logging.info("Starting inline inference run")
-        return inference_one_epoch(
-            stepper=self.stepper,
-            validation_context=self.validation_context,
-            dataset=self._inference_data,
-            aggregator=self._aggregator_builder.get_inference_aggregator(),
-            label="inference",
-            epoch=self._epochs_trained,
-        )
 
     def save_checkpoint(
         self,

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -1,3 +1,4 @@
+import contextlib
 import dataclasses
 import logging
 import os
@@ -81,8 +82,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
             aggregator=aggregator,
             diagnostics_subdir=f"epoch_{epoch:04d}",
             record_logs=lambda logs: None,
-            ema=trainer._ema,
-            validate_using_ema=config.validate_using_ema,
         )
         return logs, logs["val/mean/loss"]
 
@@ -91,7 +90,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
             return {}, None
         logs = inference_one_epoch(
             stepper=stepper,
-            validation_context=trainer.validation_context,
+            validation_context=contextlib.nullcontext,
             dataset=inference_data,
             aggregator=aggregator_builder.get_inference_aggregator(),
             label="inference",

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -60,17 +60,6 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
         output_dir=config.output_dir,
     )
-    trainer = Trainer(
-        train_data=train_data,
-        validation_data=validation_data,
-        stepper=stepper,
-        build_optimization=builder.get_optimization,
-        build_ema=builder.get_ema,
-        config=config,
-        aggregator_builder=aggregator_builder,
-        end_of_batch_callback=end_of_batch_ops,
-    )
-
     inference_epochs = config.get_inference_epochs()
 
     def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
@@ -99,9 +88,18 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         error = logs.get("inference/time_mean_norm/rmse/channel_mean")
         return logs, error
 
-    trainer.set_validation_callback(validation_callback)
-    trainer.set_inference_callback(inference_callback)
-    return trainer
+    return Trainer(
+        train_data=train_data,
+        validation_data=validation_data,
+        stepper=stepper,
+        build_optimization=builder.get_optimization,
+        build_ema=builder.get_ema,
+        config=config,
+        aggregator_builder=aggregator_builder,
+        validation_callback=validation_callback,
+        end_of_batch_callback=end_of_batch_ops,
+        inference_callback=inference_callback,
+    )
 
 
 class CoupledAggregatorBuilder(

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -2,6 +2,7 @@ import dataclasses
 import logging
 import os
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import dacite
 import torch
@@ -71,7 +72,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
 
     inference_epochs = config.get_inference_epochs()
 
-    def validation_callback(epoch: int):
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
         aggregator = aggregator_builder.get_validation_aggregator()
         logs = run_validation(
@@ -85,7 +86,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         )
         return logs, logs["val/mean/loss"]
 
-    def inference_cb(epoch: int):
+    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
             return {}, None
         logs = inference_one_epoch(
@@ -100,7 +101,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         return logs, error
 
     trainer.set_validation_callback(validation_callback)
-    trainer.set_inference_callback(inference_cb)
+    trainer.set_inference_callback(inference_callback)
     return trainer
 
 

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -11,16 +11,13 @@ import fme
 from fme.core.cli import prepare_config, prepare_directory
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
-from fme.core.generics.trainer import AggregatorBuilderABC, Trainer
+from fme.core.generics.trainer import AggregatorBuilderABC, Trainer, inference_one_epoch
+from fme.core.generics.validation import run_validation
 from fme.core.typing_ import TensorDict, TensorMapping
 from fme.coupled.aggregator import (
     InferenceEvaluatorAggregatorConfig,
     OneStepAggregator,
     TrainAggregator,
-)
-from fme.coupled.data_loading.batch_data import (
-    CoupledPairedData,
-    CoupledPrognosticState,
 )
 from fme.coupled.dataset_info import CoupledDatasetInfo
 from fme.coupled.stepper import CoupledTrainOutput
@@ -61,10 +58,9 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
         output_dir=config.output_dir,
     )
-    return Trainer(
+    trainer = Trainer(
         train_data=train_data,
         validation_data=validation_data,
-        inference_data=inference_data,
         stepper=stepper,
         build_optimization=builder.get_optimization,
         build_ema=builder.get_ema,
@@ -73,9 +69,43 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         end_of_batch_callback=end_of_batch_ops,
     )
 
+    inference_epochs = config.get_inference_epochs()
+
+    def validation_callback(epoch: int):
+        validation_data.set_epoch(epoch)
+        aggregator = aggregator_builder.get_validation_aggregator()
+        logs = run_validation(
+            train_stepper=stepper,
+            validation_data=validation_data,
+            aggregator=aggregator,
+            diagnostics_subdir=f"epoch_{epoch:04d}",
+            record_logs=lambda logs: None,
+            ema=trainer._ema,
+            validate_using_ema=config.validate_using_ema,
+        )
+        return logs, logs["val/mean/loss"]
+
+    def inference_cb(epoch: int):
+        if epoch not in inference_epochs:
+            return {}, None
+        logs = inference_one_epoch(
+            stepper=stepper,
+            validation_context=trainer.validation_context,
+            dataset=inference_data,
+            aggregator=aggregator_builder.get_inference_aggregator(),
+            label="inference",
+            epoch=epoch,
+        )
+        error = logs.get("inference/time_mean_norm/rmse/channel_mean")
+        return logs, error
+
+    trainer.set_validation_callback(validation_callback)
+    trainer.set_inference_callback(inference_cb)
+    return trainer
+
 
 class CoupledAggregatorBuilder(
-    AggregatorBuilderABC[CoupledPrognosticState, CoupledTrainOutput, CoupledPairedData]
+    AggregatorBuilderABC[CoupledTrainOutput],
 ):
     def __init__(
         self,


### PR DESCRIPTION
Refactors the generic Trainer to use pluggable validation and inference callbacks instead of directly managing inference data and calling hardcoded methods. This decouples the trainer from inference specifics, setting the stage for weighted multi-inference checkpoint selection.

Changes:
- `fme.core.generics.trainer.ValidationCallback`, `InferenceCallback`: new callback protocols returning `(logs, loss/error)` tuples
- `fme.core.generics.trainer.AggregatorBuilderABC`: simplified from `Generic[PS, TO, SD]` to `Generic[TO]`, removed `get_inference_aggregator`
- `fme.core.generics.trainer.TrainConfigProtocol`: removed `get_inference_epochs` (epoch filtering moved to callbacks)
- `fme.core.generics.trainer.Trainer`: removed `inference_data` param and `validate_one_epoch`/`inference_one_epoch` instance methods; added `set_validation_callback`/`set_inference_callback` setters; `train()` now calls callbacks
- `fme.ace.train.train.build_trainer`, `fme.coupled.train.train.build_trainer`: build validation and inference callbacks as closures, set them on the trainer after construction

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated