### PR TITLE
Add `EMAConfig.resume_ema_ckpt_path`

### DIFF
--- a/fme/core/ema.py
+++ b/fme/core/ema.py
@@ -54,12 +54,23 @@ class EMAConfig:
 
     Parameters:
         decay: decay rate for the moving average
+        resume_ema_ckpt_path: Optional path to a training checkpoint
+            (``ckpt.tar``) whose EMA running state (averaged weights and
+            update counter) should be loaded into the freshly-built
+            ``EMATracker`` for fine-tuning. The current config's ``decay``
+            is kept; only the running state is transferred. Intended for
+            non-resuming jobs; preemption resume in the Trainer overrides
+            this state via ``EMATracker.from_state``.
     """
 
     decay: float = 0.9999
+    resume_ema_ckpt_path: str | None = None
 
     def build(self, model: HasNamedParameters):
-        return EMATracker(model, decay=self.decay, faster_decay_at_start=True)
+        ema = EMATracker(model, decay=self.decay, faster_decay_at_start=True)
+        if self.resume_ema_ckpt_path is not None:
+            _load_finetune_ema_state(ema, self.resume_ema_ckpt_path)
+        return ema
 
 
 class EMATracker:
@@ -208,6 +219,38 @@ class EMATracker:
             },
         }
 
+    def load_ema_state_for_finetuning(self, state: dict):
+        """Load EMA running state from a checkpoint for fine-tuning.
+
+        Restores the averaged parameter weights and update counter from
+        a previously saved EMA state. The current tracker's ``decay`` and
+        ``faster_decay_at_start`` (set at construction from the current
+        config) are preserved; only the running state is transferred.
+
+        Args:
+            state: The EMA state dict as saved by ``get_state()``,
+                containing at least ``"ema_params"``, ``"num_updates"``,
+                and ``"module_name_to_ema_name"``.
+
+        Raises:
+            ValueError: If the state does not contain ``"ema_params"``
+                (e.g. from a checkpoint saved without
+                ``include_optimization=True``).
+        """
+        if "ema_params" not in state:
+            raise ValueError(
+                "EMA state does not contain ema_params. Only ckpt.tar "
+                "checkpoints (saved with include_optimization=True) "
+                "contain the full EMA state needed for fine-tuning."
+            )
+        device = get_device()
+        self.num_updates = state["num_updates"].to(device, copy=True)
+        self._module_name_to_ema_name = state["module_name_to_ema_name"]
+        self._ema_params = {
+            name: param.to(device, copy=True)
+            for name, param in state["ema_params"].items()
+        }
+
     @classmethod
     def from_state(cls, state, model) -> "EMATracker":
         """
@@ -233,3 +276,24 @@ class EMATracker:
         else:
             logging.warning("EMA params not found in state and will not be restored.")
         return ema
+
+
+def _load_finetune_ema_state(ema: EMATracker, checkpoint_path: str):
+    """Load EMA running state from a training checkpoint for fine-tuning.
+
+    Only loads the EMA averaged weights and update counter from the
+    checkpoint. The current tracker's decay and faster_decay_at_start
+    are preserved from the current config.
+
+    The checkpoint is loaded on CPU so that only the EMA state (not model
+    weights, optimizer, etc.) is transferred to the training device.
+    """
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if "ema" not in checkpoint:
+        raise ValueError(
+            f"Checkpoint at {checkpoint_path} does not contain EMA state. "
+            "Only training checkpoints (ckpt.tar) contain EMA state."
+        )
+    ema_state = checkpoint["ema"]
+    del checkpoint
+    ema.load_ema_state_for_finetuning(ema_state)

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 from fme.core.device import get_device
-from fme.core.ema import EMATracker
+from fme.core.ema import EMAConfig, EMATracker
 from fme.core.generics.aggregator import (
     AggregatorABC,
     InferenceAggregatorABC,
@@ -234,6 +234,7 @@ class Config:
     segment_epochs: int | None = None
     evaluate_before_training: bool = False
     save_best_inference_epoch_checkpoints: bool = False
+    ema: EMAConfig = dataclasses.field(default_factory=EMAConfig)
     lr_tuning: LRTuningConfig | None = None
 
     def __post_init__(self):
@@ -343,6 +344,7 @@ def get_trainer(
     save_checkpoint: bool = True,
     lr_tuning: LRTuningConfig | None = None,
     resume_optimizer_ckpt_path: str | None = None,
+    resume_ema_ckpt_path: str | None = None,
     lr: float = 0.01,
 ) -> tuple[TrainConfigProtocol, Trainer]:
     if checkpoint_dir is None:
@@ -414,8 +416,10 @@ def get_trainer(
         opt.step_weights = unittest.mock.MagicMock(side_effect=step_weights_side_effect)  # type: ignore
         return opt
 
+    ema_config = EMAConfig(decay=ema_decay, resume_ema_ckpt_path=resume_ema_ckpt_path)
+
     def build_ema(modules: torch.nn.ModuleList) -> EMATracker:
-        return EMATracker(modules, decay=ema_decay)
+        return ema_config.build(modules)
 
     config: TrainConfigProtocol = Config(
         experiment_dir=tmp_path,
@@ -428,6 +432,7 @@ def get_trainer(
         evaluate_before_training=evaluate_before_training,
         save_best_inference_epoch_checkpoints=save_best_inference_epoch_checkpoints,
         save_checkpoint=save_checkpoint,
+        ema=ema_config,
         lr_tuning=lr_tuning,
     )
     aggregator_builder = AggregatorBuilder(
@@ -1488,3 +1493,53 @@ def test_finetune_optimization_checkpoint_loads_optimizer_state(tmp_path: str):
         stage2_trainer.optimization.scheduler.state_dict()
         == fresh_scheduler.state_dict()
     )
+
+
+def test_finetune_ema_checkpoint_loads_ema_state(tmp_path: str):
+    """Trainer loads EMA state from a finetune checkpoint while keeping
+    training counters fresh and preserving the configured decay."""
+    n_train_batches = 4
+    stage1_decay = 0.99
+    stage2_decay = 0.9999
+
+    stage1_dir = os.path.join(tmp_path, "stage1")
+    _, stage1_trainer = get_trainer(
+        stage1_dir,
+        max_epochs=1,
+        n_train_batches=n_train_batches,
+        stepper_module_values=np.array([1.0]),
+        ema_decay=stage1_decay,
+    )
+    stage1_trainer.train()
+
+    stage1_ema_state = stage1_trainer._ema.get_state()
+    assert int(stage1_ema_state["num_updates"]) == n_train_batches
+
+    stage1_trainer._save_restart_checkpoints()
+    stage1_ckpt_path = stage1_trainer.paths.latest_checkpoint_path
+
+    stage2_dir = os.path.join(tmp_path, "stage2")
+    _, stage2_trainer = get_trainer(
+        stage2_dir,
+        max_epochs=1,
+        n_train_batches=n_train_batches,
+        stepper_module_values=np.array([2.0]),
+        ema_decay=stage2_decay,
+        resume_ema_ckpt_path=stage1_ckpt_path,
+    )
+
+    assert stage2_trainer._epochs_trained == 0
+    assert stage2_trainer._start_epoch == 0
+    assert stage2_trainer.num_batches_seen == 0
+
+    # EMA state loaded from stage1 checkpoint
+    stage2_ema_state = stage2_trainer._ema.get_state()
+    assert int(stage2_ema_state["num_updates"]) == n_train_batches
+    for key in stage1_ema_state["ema_params"]:
+        torch.testing.assert_close(
+            stage2_ema_state["ema_params"][key],
+            stage1_ema_state["ema_params"][key],
+        )
+
+    # decay is from stage2 config, not the checkpoint
+    assert float(stage2_ema_state["decay"]) == pytest.approx(stage2_decay)

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -64,7 +64,7 @@ import torch
 
 import fme
 from fme.core.distributed import Distributed
-from fme.core.ema import EMATracker
+from fme.core.ema import EMAConfig, EMATracker
 from fme.core.generics.aggregator import AggregatorABC, InferenceAggregatorABC
 from fme.core.generics.data import GriddedDataABC, InferenceDataABC
 from fme.core.generics.inference import run_inference
@@ -135,6 +135,9 @@ class TrainConfigProtocol(Protocol):
 
     @property
     def save_best_inference_epoch_checkpoints(self) -> bool: ...
+
+    @property
+    def ema(self) -> EMAConfig: ...
 
     @property
     def lr_tuning(self) -> LRTuningConfig | None: ...

--- a/fme/core/test_ema.py
+++ b/fme/core/test_ema.py
@@ -1,9 +1,11 @@
+import os
+
 import pytest
 import torch
 from torch import nn
 
 from fme.core.device import get_device
-from fme.core.ema import EMATracker
+from fme.core.ema import EMAConfig, EMATracker
 
 
 class ExampleModel(nn.Module):
@@ -114,3 +116,113 @@ def test_from_state_decouples_memory():
     for name, param in state["ema_params"].items():
         param.fill_(float("nan"))
         assert not torch.isnan(restored._ema_params[name]).any()
+
+
+def test_load_ema_state_for_finetuning():
+    """load_ema_state_for_finetuning restores ema_params and num_updates
+    from a saved state while preserving the current tracker's decay."""
+    model = ExampleModel()
+    model.weight.data.fill_(1.0)
+    source_decay = 0.99
+    ema = EMATracker(model, decay=source_decay, faster_decay_at_start=True)
+    model.weight.data.fill_(0.0)
+    for _ in range(5):
+        ema(model)
+    saved_state = ema.get_state()
+
+    model2 = ExampleModel()
+    model2.weight.data.fill_(2.0)
+    target_decay = 0.9999
+    target_ema = EMATracker(model2, decay=target_decay, faster_decay_at_start=False)
+
+    target_ema.load_ema_state_for_finetuning(saved_state)
+
+    assert int(target_ema.num_updates) == 5
+    assert float(target_ema.decay) == pytest.approx(target_decay)
+    assert target_ema._faster_decay_at_start is False
+    for name in saved_state["ema_params"]:
+        torch.testing.assert_close(
+            target_ema._ema_params[name],
+            saved_state["ema_params"][name].to(get_device()),
+        )
+
+
+def test_load_ema_state_for_finetuning_missing_ema_params():
+    """load_ema_state_for_finetuning raises ValueError when ema_params is
+    missing (e.g. from a non-restart checkpoint)."""
+    model = ExampleModel()
+    ema = EMATracker(model, decay=0.999)
+    state = ema.get_state()
+    del state["ema_params"]
+
+    target_ema = EMATracker(model, decay=0.999)
+    with pytest.raises(ValueError, match="does not contain ema_params"):
+        target_ema.load_ema_state_for_finetuning(state)
+
+
+def test_load_ema_state_for_finetuning_places_tensors_on_device():
+    """Loaded EMA params are placed on the training device."""
+    model = ExampleModel()
+    ema = EMATracker(model, decay=0.999)
+    for _ in range(3):
+        ema(model)
+    state = ema.get_state()
+    state["num_updates"] = state["num_updates"].cpu()
+    state["ema_params"] = {k: v.cpu() for k, v in state["ema_params"].items()}
+
+    target_ema = EMATracker(model, decay=0.999)
+    target_ema.load_ema_state_for_finetuning(state)
+
+    device = get_device()
+    assert target_ema.num_updates.device == device
+    for param in target_ema._ema_params.values():
+        assert param.device == device
+
+
+def test_ema_config_build_no_resume_path():
+    """EMAConfig.build with resume_ema_ckpt_path=None creates a fresh tracker."""
+    model = ExampleModel()
+    config = EMAConfig(decay=0.99)
+    ema = config.build(model)
+    assert int(ema.num_updates) == 0
+    assert float(ema.decay) == pytest.approx(0.99)
+
+
+def test_ema_config_build_resumes_ema_state(tmp_path: str):
+    """EMAConfig.build with resume_ema_ckpt_path loads EMA state from
+    the checkpoint while preserving the configured decay."""
+    model = ExampleModel()
+    model.weight.data.fill_(1.0)
+    source_ema = EMATracker(model, decay=0.99, faster_decay_at_start=True)
+    model.weight.data.fill_(0.0)
+    for _ in range(5):
+        source_ema(model)
+
+    ckpt_path = os.path.join(tmp_path, "ckpt.tar")
+    torch.save({"ema": source_ema.get_state(), "stepper": {}}, ckpt_path)
+
+    model2 = ExampleModel()
+    model2.weight.data.fill_(2.0)
+    new_decay = 0.9999
+    config = EMAConfig(decay=new_decay, resume_ema_ckpt_path=ckpt_path)
+    loaded_ema = config.build(model2)
+
+    assert int(loaded_ema.num_updates) == 5
+    assert float(loaded_ema.decay) == pytest.approx(new_decay)
+    source_state = source_ema.get_state()
+    for name in source_state["ema_params"]:
+        torch.testing.assert_close(
+            loaded_ema._ema_params[name],
+            source_state["ema_params"][name].to(get_device()),
+        )
+
+
+def test_ema_config_build_missing_ema_key(tmp_path: str):
+    """EMAConfig.build raises ValueError when the checkpoint has no 'ema' key."""
+    ckpt_path = os.path.join(tmp_path, "bad_ckpt.tar")
+    torch.save({"stepper": {}, "optimization": {}}, ckpt_path)
+
+    model = ExampleModel()
+    config = EMAConfig(resume_ema_ckpt_path=ckpt_path)
+    with pytest.raises(ValueError, match="does not contain EMA state"):
+        config.build(model)


### PR DESCRIPTION
Adds `resume_ema_ckpt_path` to `EMAConfig`. When pointed to a checkpoint with the saved EMA state (i.e., `ckpt.tar` or `ckpt_xxxx.tar`), restores the `EMATracker` state and number of updates from the checkpoint. The `decay` configuration is set by the training config.

Changes:
- Adds the `ema` property to `TrainConfigProtocol`. This property is already implemented by `TrainConfig` in `fme.ace` and `fme.coupled`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated