### PR TITLE
Reduce `fme.coupled` default `train_evaluation_samples` to 100

### DIFF
--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -149,7 +149,7 @@ class TrainConfig:
     checkpoint_save_epochs: Slice | None = None
     ema_checkpoint_save_epochs: Slice | None = None
     log_train_every_n_batches: int = 100
-    train_evaluation_samples: int = 1000
+    train_evaluation_samples: int = 100
     checkpoint_every_n_batches: int = 1000
     segment_epochs: int | None = None
     save_per_epoch_diagnostics: bool = False


### PR DESCRIPTION
Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

Changes:
- symbol (e.g. `fme.core.my_function`) or script and concise description of changes or added feature
- Can group multiple related symbols on a single bullet

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)
