### PR TITLE
Make `faster_decay_at_start` configurable in `EMAConfig`

### DIFF
--- a/fme/core/ema.py
+++ b/fme/core/ema.py
@@ -57,9 +57,14 @@ class EMAConfig:
     """
 
     decay: float = 0.9999
+    faster_decay_at_start: bool = True
 
     def build(self, model: HasNamedParameters):
-        return EMATracker(model, decay=self.decay, faster_decay_at_start=True)
+        return EMATracker(
+            model,
+            decay=self.decay,
+            faster_decay_at_start=self.faster_decay_at_start,
+        )
 
 
 class EMATracker:


### PR DESCRIPTION
Makes the `EMATracker` init arg `faster_decay_at_start` configurable via an attribute of the same name on `EMAConfig`. This is potentially useful for fine-tuning EMA checkpoints to keep the EMA state close to the initialization.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated