### PR TITLE
Add LegacyFlagInferenceEvaluatorAggregatorConfig for backwards compat…

### DIFF
--- a/fme/ace/aggregator/__init__.py
+++ b/fme/ace/aggregator/__init__.py
@@ -1,4 +1,8 @@
-from .inference import InferenceEvaluatorAggregator, InferenceEvaluatorAggregatorConfig
+from .inference import (
+    InferenceEvaluatorAggregator,
+    InferenceEvaluatorAggregatorConfig,
+    LegacyFlagInferenceEvaluatorAggregatorConfig,
+)
 from .null import NullAggregator
 from .one_step import OneStepAggregator
 from .one_step.main import OneStepAggregatorConfig

--- a/fme/ace/aggregator/inference/__init__.py
+++ b/fme/ace/aggregator/inference/__init__.py
@@ -8,6 +8,7 @@ from .main import (
     InferenceAggregatorConfig,
     InferenceEvaluatorAggregator,
     InferenceEvaluatorAggregatorConfig,
+    LegacyFlagInferenceEvaluatorAggregatorConfig,
     MeanMetricConfig,
     MetricConfig,
     PowerSpectrumMetricConfig,

--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -629,6 +629,112 @@ class InferenceEvaluatorAggregatorConfig:
         )
 
 
+@dataclasses.dataclass
+class _LegacyStepMeanEntry:
+    step: int
+    name: str | None = None
+
+    def get_name(self) -> str:
+        return self.name or f"mean_step_{self.step}"
+
+
+@dataclasses.dataclass
+class LegacyFlagInferenceEvaluatorAggregatorConfig:
+    """Backwards-compatible aggregator config that uses the old boolean-flag
+    interface and translates it into the new typed-metric config at build time.
+    """
+
+    type: Literal["legacy"] = "legacy"
+    log_histograms: bool = False
+    log_video: bool = False
+    log_extended_video: bool = False
+    log_zonal_mean_images: bool | int = 4096
+    log_seasonal_means: bool = False
+    log_global_mean_time_series: bool = True
+    log_global_mean_norm_time_series: bool = True
+    monthly_reference_data: str | None = None
+    time_mean_reference_data: str | None = None
+    log_nino34_index: bool = True
+    log_step_means: list[_LegacyStepMeanEntry] = dataclasses.field(
+        default_factory=lambda: [_LegacyStepMeanEntry(step=20)]
+    )
+
+    def _build_metrics(
+        self,
+        n_forward_steps: int,
+    ) -> list[MetricConfig]:
+        metrics: list[MetricConfig] = []
+        if self.log_global_mean_time_series:
+            metrics.append(MeanMetricConfig(target="denorm"))
+        if self.log_global_mean_norm_time_series:
+            metrics.append(MeanMetricConfig(target="norm"))
+        for entry in self.log_step_means:
+            if entry.step <= n_forward_steps:
+                metrics.append(
+                    StepMeanMetricConfig(
+                        step=entry.step, name=entry.get_name(), target="denorm"
+                    )
+                )
+                metrics.append(
+                    StepMeanMetricConfig(
+                        step=entry.step,
+                        name=f"{entry.get_name()}_norm",
+                        target="norm",
+                    )
+                )
+        metrics.append(PowerSpectrumMetricConfig())
+        if self.log_zonal_mean_images:
+            zonal_max = (
+                self.log_zonal_mean_images
+                if isinstance(self.log_zonal_mean_images, int)
+                else 4096
+            )
+            metrics.append(ZonalMeanMetricConfig(zonal_mean_max_size=zonal_max))
+        metrics.append(TimeMeanMetricConfig(target="denorm"))
+        metrics.append(TimeMeanMetricConfig(target="norm"))
+        if self.log_video:
+            metrics.append(
+                VideoMetricConfig(enable_extended_videos=self.log_extended_video)
+            )
+        if self.log_histograms:
+            metrics.append(HistogramMetricConfig())
+        if self.log_seasonal_means:
+            metrics.append(SeasonalMetricConfig())
+        return metrics
+
+    def build(
+        self,
+        dataset_info: DatasetInfo,
+        n_ic_steps: int,
+        n_forward_steps: int,
+        initial_time: xr.DataArray,
+        normalize: Callable[[TensorMapping], TensorDict],
+        output_dir: str | None = None,
+        channel_mean_names: Sequence[str] | None = None,
+        save_diagnostics: bool = True,
+        n_ensemble_per_ic: int = 1,
+        enable_time_series: bool = True,
+    ) -> "InferenceEvaluatorAggregator":
+        metrics = self._build_metrics(n_forward_steps)
+        new_config = InferenceEvaluatorAggregatorConfig(
+            metrics=metrics,
+            monthly_reference_data=self.monthly_reference_data,
+            time_mean_reference_data=self.time_mean_reference_data,
+        )
+        return new_config.build(
+            dataset_info=dataset_info,
+            n_ic_steps=n_ic_steps,
+            n_forward_steps=n_forward_steps,
+            initial_time=initial_time,
+            normalize=normalize,
+            output_dir=output_dir,
+            channel_mean_names=channel_mean_names,
+            save_diagnostics=save_diagnostics,
+            n_ensemble_per_ic=n_ensemble_per_ic,
+            enable_time_series=enable_time_series,
+        )
+
+
 class InferenceEvaluatorAggregator(
     InferenceAggregatorABC[PairedData | PrognosticState, PairedData]
 ):

--- a/fme/ace/aggregator/inference/test_evaluator.py
+++ b/fme/ace/aggregator/inference/test_evaluator.py
@@ -10,6 +10,7 @@ import xarray as xr
 from fme.ace.aggregator.inference import (
     HistogramMetricConfig,
     InferenceEvaluatorAggregatorConfig,
+    LegacyFlagInferenceEvaluatorAggregatorConfig,
     MeanMetricConfig,
     PowerSpectrumMetricConfig,
     StepMeanMetricConfig,
@@ -251,6 +252,49 @@ def test_inference_logs_labels_exist():
     assert "mean_norm/series" not in logs[0]
     assert "reduced/series" not in logs[0]
     assert "reduced_norm/series" not in logs[0]
+
+
+def test_legacy_flag_config_produces_same_metrics():
+    """LegacyFlagInferenceEvaluatorAggregatorConfig with defaults should produce
+    the same step-level logs as an equivalent new-style config."""
+    n_sample = 2
+    n_time = 22
+    nx = 90
+    ny = 45
+    ds_info = get_ds_info(nx, ny)
+    initial_time = get_zero_time(shape=[n_sample, 0], dims=["sample", "time"])
+
+    legacy_config = LegacyFlagInferenceEvaluatorAggregatorConfig(
+        log_video=True,
+        log_zonal_mean_images=LOG_ZONAL_MEAN_IMAGES,
+    )
+    agg = legacy_config.build(
+        dataset_info=ds_info,
+        n_ic_steps=1,
+        n_forward_steps=n_time - 1,
+        initial_time=initial_time,
+        normalize=lambda x: dict(x),
+        save_diagnostics=False,
+    )
+    data = PairedData.new_on_device(
+        prediction={"a": torch.randn(n_sample, n_time, ny, nx, device=get_device())},
+        reference={"a": torch.randn(n_sample, n_time, ny, nx, device=get_device())},
+        time=xr.DataArray(np.zeros((n_sample, n_time)), dims=["sample", "time"]),
+        labels=None,
+    )
+    logs = agg.record_batch(data=data)
+    assert isinstance(logs, list)
+    assert len(logs) == n_time
+    assert "mean/weighted_bias/a" in logs[0]
+    assert "mean/weighted_rmse/a" in logs[0]
+    assert "mean_norm/weighted_rmse/a" in logs[0]
+
+    summary_logs = agg.get_summary_logs()
+    assert "video/a" in summary_logs
+    assert "zonal_mean/error/a" in summary_logs
+    assert "mean_step_20/weighted_rmse/a" in summary_logs
+    assert "time_mean/rmse/a" in summary_logs
+    assert "power_spectrum/a" in summary_logs
 
 
 @pytest.mark.parametrize(

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -12,7 +12,10 @@ import torch
 
 import fme
 from fme.ace.aggregator import OneStepAggregatorConfig
-from fme.ace.aggregator.inference import InferenceEvaluatorAggregatorConfig
+from fme.ace.aggregator.inference import (
+    InferenceEvaluatorAggregatorConfig,
+    LegacyFlagInferenceEvaluatorAggregatorConfig,
+)
 from fme.ace.data_loading.batch_data import BatchData, PrognosticState
 from fme.ace.data_loading.config import DataLoaderConfig
 from fme.ace.data_loading.getters import get_gridded_data, get_inference_data
@@ -225,9 +228,10 @@ class InferenceEvaluatorConfig:
     data_writer: DataWriterConfig = dataclasses.field(
         default_factory=lambda: DataWriterConfig()
     )
-    aggregator: InferenceEvaluatorAggregatorConfig = dataclasses.field(
-        default_factory=lambda: InferenceEvaluatorAggregatorConfig()
-    )
+    aggregator: (
+        InferenceEvaluatorAggregatorConfig
+        | LegacyFlagInferenceEvaluatorAggregatorConfig
+    ) = dataclasses.field(default_factory=lambda: InferenceEvaluatorAggregatorConfig())
     stepper_override: StepperOverrideConfig | None = None
     allow_incompatible_dataset: bool = False
     validation: ValidationConfig | None = None
@@ -368,7 +372,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
                     f"error. The incompatiblity found was: {str(err)}"
                 ) from err
 
-        aggregator_config: InferenceEvaluatorAggregatorConfig = config.aggregator
+        aggregator_config = config.aggregator
         for batch in data.loader:
             initial_time = batch.time.isel(time=0)
             break

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -66,6 +66,7 @@ from fme.ace.aggregator import (
 from fme.ace.aggregator.inference.main import (
     InferenceEvaluatorAggregator,
     InferenceEvaluatorAggregatorConfig,
+    LegacyFlagInferenceEvaluatorAggregatorConfig,
 )
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
@@ -183,7 +184,9 @@ class AggregatorBuilder(
     def __init__(
         self,
         train_config: TrainAggregatorConfig,
-        inference_config: InferenceEvaluatorAggregatorConfig | None,
+        inference_config: InferenceEvaluatorAggregatorConfig
+        | LegacyFlagInferenceEvaluatorAggregatorConfig
+        | None,
         dataset_info: DatasetInfo,
         initial_inference_time: xr.DataArray | None,
         n_ic_steps: int,
@@ -230,7 +233,11 @@ class AggregatorBuilder(
     def get_inference_aggregator(
         self,
     ) -> InferenceEvaluatorAggregator:
-        if isinstance(self.inference_config, InferenceEvaluatorAggregatorConfig):
+        if isinstance(
+            self.inference_config,
+            InferenceEvaluatorAggregatorConfig
+            | LegacyFlagInferenceEvaluatorAggregatorConfig,
+        ):
             return self.inference_config.build(
                 dataset_info=self.dataset_info,
                 initial_time=self.initial_inference_time,

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -7,6 +7,7 @@ import torch
 
 from fme.ace.aggregator import (
     InferenceEvaluatorAggregatorConfig,
+    LegacyFlagInferenceEvaluatorAggregatorConfig,
     OneStepAggregatorConfig,
 )
 from fme.ace.aggregator.inference import (
@@ -15,6 +16,10 @@ from fme.ace.aggregator.inference import (
     StepMeanMetricConfig,
     TimeMeanMetricConfig,
     ZonalMeanMetricConfig,
+)
+
+AnyAggregatorConfig = (
+    InferenceEvaluatorAggregatorConfig | LegacyFlagInferenceEvaluatorAggregatorConfig
 )
 from fme.ace.aggregator.inference.main import InferenceEvaluatorAggregator
 from fme.ace.aggregator.train import TrainAggregatorConfig
@@ -68,7 +73,7 @@ class InlineInferenceConfig:
     forward_steps_in_memory: int
     n_ensemble_per_ic: int = 1
     epochs: Slice = dataclasses.field(default_factory=lambda: Slice())
-    aggregator: InferenceEvaluatorAggregatorConfig = dataclasses.field(
+    aggregator: AnyAggregatorConfig = dataclasses.field(
         default_factory=lambda: InferenceEvaluatorAggregatorConfig(
             metrics=[
                 StepMeanMetricConfig(step=20, target="denorm"),
@@ -90,7 +95,10 @@ class InlineInferenceConfig:
                 f"{self.loader.start_indices.n_initial_conditions} and "
                 f"{dist.world_size}."
             )
-        if self.aggregator.metrics is not None:
+        if (
+            isinstance(self.aggregator, InferenceEvaluatorAggregatorConfig)
+            and self.aggregator.metrics is not None
+        ):
             self.aggregator.metrics = [
                 m
                 for m in self.aggregator.metrics
@@ -301,7 +309,7 @@ class TrainConfig:
         return self.inference.n_forward_steps
 
     @property
-    def inference_aggregator(self) -> InferenceEvaluatorAggregatorConfig | None:
+    def inference_aggregator(self) -> AnyAggregatorConfig | None:
         if self.inference is None:
             return None
         return self.inference.aggregator


### PR DESCRIPTION
…ibility

Adds a backwards-compatible aggregator config that accepts the old boolean-flag interface (log_video, log_zonal_mean_images, etc.) and translates it into a new-style InferenceEvaluatorAggregatorConfig at build time. Training and inference config classes accept either config type via a union, so old YAML files continue to work.

Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

Changes:
- symbol (e.g. `fme.core.my_function`) or script and concise description of changes or added feature
- Can group multiple related symbols on a single bullet

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)
