### PR TITLE
Use ValidateStepper callback for LR tuning

### DIFF
--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -99,6 +99,8 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
     inference_data = builder.get_evaluation_inference_data()
 
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
+    for data, name in zip((train_data, validation_data), ("train", "valid")):
+        data.log_info(name)
 
     dataset_info = train_data.dataset_info
     logging.info("Starting model initialization")

--- a/fme/core/generics/lr_tuning.py
+++ b/fme/core/generics/lr_tuning.py
@@ -2,16 +2,25 @@ import copy
 import dataclasses
 import logging
 from collections.abc import Callable
+from typing import Protocol
 
 import torch
 
 from fme.core.ema import EMATracker
-from fme.core.generics.aggregator import AggregatorABC
 from fme.core.generics.data import GriddedDataABC
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainStepperABC
-from fme.core.generics.validation import run_validation_loop
 from fme.core.typing_ import Slice
+
+
+class ValidateStepper(Protocol):
+    def __call__(
+        self,
+        stepper: TrainStepperABC,
+        ema: EMATracker,
+    ) -> float:
+        """Validate a stepper and return the validation loss."""
+        ...
 
 
 @dataclasses.dataclass
@@ -47,15 +56,13 @@ class LRTuningConfig:
 
 def run_lr_tuning_trial(
     train_data: GriddedDataABC,
-    valid_data: GriddedDataABC,
     optimization: OptimizationABC,
     copy_stepper: Callable[[], TrainStepperABC],
     build_optimization: Callable[[torch.nn.ModuleList], OptimizationABC],
     copy_ema: Callable[[torch.nn.ModuleList], EMATracker],
     config: LRTuningConfig,
     current_lr: float,
-    get_validation_aggregator: Callable[[], AggregatorABC],
-    validate_using_ema: bool,
+    validate_stepper: ValidateStepper,
 ) -> float | None:
     """
     Run an isolated LR tuning trial comparing the current LR against a candidate.
@@ -67,7 +74,6 @@ def run_lr_tuning_trial(
     Args:
         train_data: Training data; ``subset_loader`` is used for the first N
             batches. The caller must have already called ``set_epoch``.
-        valid_data: Validation data.
         optimization: The current optimization (used to copy momentum state
             into the forks).
         copy_stepper: Factory that returns a new stepper initialized from the
@@ -80,8 +86,8 @@ def run_lr_tuning_trial(
             current EMA state but tracking the given modules. Called twice.
         config: The LR tuning configuration.
         current_lr: The current learning rate.
-        get_validation_aggregator: Factory for validation aggregators.
-        validate_using_ema: Whether to use EMA parameters during validation.
+        validate_stepper: Callback that validates a stepper and returns the
+            validation loss. Called twice (baseline and candidate).
 
     Returns:
         The candidate learning rate if the candidate wins, otherwise None.
@@ -103,7 +109,6 @@ def run_lr_tuning_trial(
     baseline_ema = copy_ema(baseline_stepper.modules)
     candidate_ema = copy_ema(candidate_stepper.modules)
 
-    # Train both forks
     baseline_stepper.set_train()
     candidate_stepper.set_train()
     for batch in train_data.subset_loader(stop_batch=config.num_batches):
@@ -113,29 +118,8 @@ def run_lr_tuning_trial(
         candidate_stepper.train_on_batch(batch, candidate_opt)
         candidate_ema(candidate_stepper.modules)
 
-    # Validate both forks
-    baseline_agg = get_validation_aggregator()
-    run_validation_loop(
-        stepper=baseline_stepper,
-        valid_data=valid_data,
-        aggregator=baseline_agg,
-        ema=baseline_ema,
-        validate_using_ema=validate_using_ema,
-    )
-    baseline_val_logs = baseline_agg.get_logs(label="val")
-
-    candidate_agg = get_validation_aggregator()
-    run_validation_loop(
-        stepper=candidate_stepper,
-        valid_data=valid_data,
-        aggregator=candidate_agg,
-        ema=candidate_ema,
-        validate_using_ema=validate_using_ema,
-    )
-    candidate_val_logs = candidate_agg.get_logs(label="val")
-
-    baseline_val_loss = baseline_val_logs["val/mean/loss"]
-    candidate_val_loss = candidate_val_logs["val/mean/loss"]
+    baseline_val_loss = validate_stepper(baseline_stepper, baseline_ema)
+    candidate_val_loss = validate_stepper(candidate_stepper, candidate_ema)
 
     threshold = baseline_val_loss - config.improvement_threshold * baseline_val_loss
 

--- a/fme/core/generics/test_lr_tuning.py
+++ b/fme/core/generics/test_lr_tuning.py
@@ -347,32 +347,6 @@ def test_uses_subset_loader_with_num_batches():
     train_data.subset_loader.assert_called_once_with(stop_batch=4)
 
 
-def test_with_ema_validation():
-    """Trial should work when validate_stepper closes over EMA validation."""
-    stepper = _Stepper()
-    train_data = _TrainData(n_batches=5)
-    optimization = _build_optimization(stepper.modules)
-    config = LRTuningConfig(
-        epochs=Slice(),
-        lr_factor=0.5,
-        num_batches=3,
-        improvement_threshold=0.1,
-    )
-
-    result = run_lr_tuning_trial(
-        train_data=train_data,
-        optimization=optimization,
-        copy_stepper=_make_copy_stepper(stepper),
-        build_optimization=_build_optimization,
-        copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
-        config=config,
-        current_lr=0.01,
-        validate_stepper=_make_validate_stepper(0.8, 0.5),
-    )
-
-    assert result == 0.01 * 0.5
-
-
 def test_trial_does_not_mutate_original_ema_num_updates():
     """The original EMA's num_updates must not be modified by the trial."""
     stepper = _Stepper()

--- a/fme/core/generics/test_lr_tuning.py
+++ b/fme/core/generics/test_lr_tuning.py
@@ -9,7 +9,6 @@ import torch
 
 from fme.core.device import get_device
 from fme.core.ema import EMATracker
-from fme.core.generics.aggregator import AggregatorABC
 from fme.core.generics.data import DataLoader, GriddedDataABC
 from fme.core.generics.lr_tuning import LRTuningConfig, run_lr_tuning_trial
 from fme.core.generics.optimization import OptimizationABC
@@ -81,7 +80,6 @@ class _Stepper(TrainStepperABC["None", "_BatchData", "None", "None", "_TrainOutp
         optimization: OptimizationABC,
         compute_derived_variables: bool = False,
     ) -> _TrainOutput:
-        # Produce a loss with a grad_fn so Optimization.step_weights can backward
         x = torch.ones(1, 1, device=get_device())
         loss = self._modules[0](x).sum()
         optimization.accumulate_loss(loss)
@@ -113,20 +111,6 @@ class _Stepper(TrainStepperABC["None", "_BatchData", "None", "None", "_TrainOutp
         pass
 
 
-class _ValidationAggregator(AggregatorABC["_TrainOutput"]):
-    def __init__(self, loss: float):
-        self._loss = loss
-
-    def record_batch(self, batch: "_TrainOutput") -> None:
-        pass
-
-    def get_logs(self, label: str) -> dict[str, float]:
-        return {f"{label}/mean/loss": self._loss}
-
-    def flush_diagnostics(self, subdir: str | None) -> None:
-        pass
-
-
 def _build_optimization(modules: torch.nn.ModuleList) -> Optimization:
     return Optimization(
         parameters=itertools.chain(*[m.parameters() for m in modules]),
@@ -140,9 +124,6 @@ def _build_optimization(modules: torch.nn.ModuleList) -> Optimization:
 
 
 def _make_copy_ema(ema: EMATracker):
-    """Return a callable that creates a copy of the EMA via state APIs,
-    matching the real Trainer._copy_ema pattern."""
-
     def copy_ema(modules: torch.nn.ModuleList) -> EMATracker:
         return EMATracker.from_state(ema.get_state(), modules)
 
@@ -150,9 +131,6 @@ def _make_copy_ema(ema: EMATracker):
 
 
 def _make_copy_stepper(stepper: _Stepper):
-    """Return a callable that creates a copy of the stepper via state APIs,
-    matching the real Trainer._copy_stepper pattern (deepcopy + load_state)."""
-
     def copy_stepper() -> _Stepper:
         new = copy.deepcopy(stepper)
         new.load_state(copy.deepcopy(stepper.get_state()))
@@ -161,21 +139,20 @@ def _make_copy_stepper(stepper: _Stepper):
     return copy_stepper
 
 
-def _make_aggregator_factory(*losses: float):
-    """Return a get_validation_aggregator callable that yields the given losses."""
+def _make_validate_stepper(*losses: float):
+    """Return a ValidateStepper callback that returns the given losses in order."""
     it = iter(losses)
 
-    def factory():
-        return _ValidationAggregator(next(it))
+    def validate_stepper(stepper, ema):
+        return next(it)
 
-    return factory
+    return validate_stepper
 
 
 def test_candidate_wins():
     """Candidate wins when its loss is below baseline - threshold * baseline."""
     stepper = _Stepper()
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -188,15 +165,13 @@ def test_candidate_wins():
     # threshold = 0.8 - 0.1*0.8 = 0.72; candidate 0.5 < 0.72 → candidate wins
     result = run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.5),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.8, 0.5),
     )
 
     assert result == 0.01 * 0.5
@@ -206,7 +181,6 @@ def test_candidate_below_threshold():
     """Candidate improves but not enough to beat the threshold."""
     stepper = _Stepper()
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -219,15 +193,13 @@ def test_candidate_below_threshold():
     # threshold = 0.8 - 0.5*0.8 = 0.4; candidate 0.75 > 0.4 → baseline wins
     result = run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.75),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.8, 0.75),
     )
 
     assert result is None
@@ -237,7 +209,6 @@ def test_candidate_worsens():
     """Candidate worsens validation loss -> baseline wins."""
     stepper = _Stepper()
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -250,15 +221,13 @@ def test_candidate_worsens():
     # threshold = 0.9 - 0.1*0.9 = 0.81; candidate 1.1 > 0.81 → baseline wins
     result = run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.9, 1.1),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.9, 1.1),
     )
 
     assert result is None
@@ -268,7 +237,6 @@ def test_both_worsen():
     """Both worsen -> baseline wins."""
     stepper = _Stepper()
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -281,15 +249,13 @@ def test_both_worsen():
     # threshold = 1.2 - 0.1*1.2 = 1.08; candidate 1.3 > 1.08 → baseline wins
     result = run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(1.2, 1.3),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(1.2, 1.3),
     )
 
     assert result is None
@@ -299,7 +265,6 @@ def test_baseline_worsens_candidate_improves():
     """Baseline worsens but candidate improves enough -> candidate wins."""
     stepper = _Stepper()
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -312,15 +277,13 @@ def test_baseline_worsens_candidate_improves():
     # threshold = 1.1 - 0.1*1.1 = 0.99; candidate 0.5 < 0.99 → candidate wins
     result = run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(1.1, 0.5),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(1.1, 0.5),
     )
 
     assert result == 0.01 * 0.5
@@ -333,7 +296,6 @@ def test_does_not_mutate_original_stepper():
     original_weight = stepper.modules[0].weight.data.clone()
 
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -344,15 +306,13 @@ def test_does_not_mutate_original_stepper():
 
     run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.5),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.8, 0.5),
     )
 
     assert torch.allclose(stepper.modules[0].weight.data, original_weight)
@@ -365,7 +325,6 @@ def test_uses_subset_loader_with_num_batches():
     train_data.subset_loader = unittest.mock.MagicMock(  # type: ignore
         wraps=train_data.subset_loader
     )
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -376,25 +335,22 @@ def test_uses_subset_loader_with_num_batches():
 
     run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.9, 0.8),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.9, 0.8),
     )
 
     train_data.subset_loader.assert_called_once_with(stop_batch=4)
 
 
 def test_with_ema_validation():
-    """Trial should pass validate_using_ema through to run_validation."""
+    """Trial should work when validate_stepper closes over EMA validation."""
     stepper = _Stepper()
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -403,18 +359,15 @@ def test_with_ema_validation():
         improvement_threshold=0.1,
     )
 
-    # This should not raise even with validate_using_ema=True
     result = run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(EMATracker(stepper.modules, decay=0.9999)),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.5),
-        validate_using_ema=True,
+        validate_stepper=_make_validate_stepper(0.8, 0.5),
     )
 
     assert result == 0.01 * 0.5
@@ -424,13 +377,11 @@ def test_trial_does_not_mutate_original_ema_num_updates():
     """The original EMA's num_updates must not be modified by the trial."""
     stepper = _Stepper()
     ema = EMATracker(stepper.modules, decay=0.9999)
-    # Simulate some prior training updates
     for _ in range(5):
         ema(stepper.modules)
     original_num_updates = ema.num_updates.clone()
 
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -441,15 +392,13 @@ def test_trial_does_not_mutate_original_ema_num_updates():
 
     run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(ema),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.5),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.8, 0.5),
     )
 
     assert torch.equal(ema.num_updates, original_num_updates)
@@ -466,7 +415,6 @@ def test_trial_does_not_mutate_original_ema_params():
     }
 
     train_data = _TrainData(n_batches=5)
-    valid_data = _TrainData(n_batches=3)
     optimization = _build_optimization(stepper.modules)
     config = LRTuningConfig(
         epochs=Slice(),
@@ -477,15 +425,13 @@ def test_trial_does_not_mutate_original_ema_params():
 
     run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(ema),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.5),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.8, 0.5),
     )
 
     for name in original_ema_params:
@@ -540,7 +486,6 @@ def test_trial_does_not_mutate_original_optimizer_state():
 
     original_state = copy.deepcopy(optimization.get_state())
 
-    valid_data = _TrainData(n_batches=3)
     config = LRTuningConfig(
         epochs=Slice(),
         lr_factor=0.5,
@@ -550,15 +495,13 @@ def test_trial_does_not_mutate_original_optimizer_state():
 
     run_lr_tuning_trial(
         train_data=train_data,
-        valid_data=valid_data,
         optimization=optimization,
         copy_stepper=_make_copy_stepper(stepper),
         build_optimization=_build_optimization,
         copy_ema=_make_copy_ema(ema),
         config=config,
         current_lr=0.01,
-        get_validation_aggregator=_make_aggregator_factory(0.8, 0.5),
-        validate_using_ema=False,
+        validate_stepper=_make_validate_stepper(0.8, 0.5),
     )
 
     current_state = optimization.get_state()

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -488,8 +488,6 @@ def test_trainer(tmp_path: str, checkpoint_save_epochs: Slice | None):
         unittest.mock.call(i) for i in range(1, config.max_epochs + 1)
     ]
     assert valid_data.set_epoch_mock.mock_calls == train_data.set_epoch_mock.mock_calls
-    assert train_data.log_info_mock.called
-    assert valid_data.log_info_mock.called
     assert trainer._end_of_epoch_callback.mock_calls == [  # type: ignore
         unittest.mock.call(i) for i in range(1, config.max_epochs + 1)
     ]

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -71,7 +71,7 @@ from fme.core.generics.inference import run_inference
 from fme.core.generics.lr_tuning import LRTuningConfig, run_lr_tuning_trial
 from fme.core.generics.metrics_aggregator import MetricsAggregator
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
-from fme.core.generics.validation import run_validation
+from fme.core.generics.validation import run_validation, run_validation_loop
 from fme.core.optimization import NullOptimization, Optimization
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingJob
@@ -237,10 +237,6 @@ class Trainer:
 
         self.train_data = train_data
         self.valid_data = validation_data
-        for gridded_data, name in zip(
-            (self.train_data, self.valid_data), ("train", "valid")
-        ):
-            gridded_data.log_info(name)
 
         self.num_batches_seen = 0
         self._start_epoch = 0
@@ -322,6 +318,18 @@ class Trainer:
         """Create a new EMATracker initialized from the current EMA state."""
         return EMATracker.from_state(self._ema.get_state(), modules)
 
+    def _validate_stepper(self, stepper: TrainStepperABC, ema: EMATracker) -> float:
+        aggregator = self._aggregator_builder.get_validation_aggregator()
+        run_validation_loop(
+            stepper=stepper,
+            valid_data=self.valid_data,
+            aggregator=aggregator,
+            ema=ema,
+            validate_using_ema=self.config.validate_using_ema,
+        )
+        val_logs = aggregator.get_logs(label="val")
+        return val_logs["val/mean/loss"]
+
     def _maybe_tune_lr(self):
         cfg = self.config.lr_tuning
         if cfg is None:
@@ -335,17 +343,13 @@ class Trainer:
         self.train_data.set_epoch(self._epochs_trained + 1)
         new_lr = run_lr_tuning_trial(
             train_data=self.train_data,
-            valid_data=self.valid_data,
             optimization=self.optimization,
             copy_stepper=self._copy_stepper,
             build_optimization=self._build_optimization,
             copy_ema=self._copy_ema,
             config=cfg,
             current_lr=self.optimization.learning_rate,
-            get_validation_aggregator=(
-                self._aggregator_builder.get_validation_aggregator
-            ),
-            validate_using_ema=self.config.validate_using_ema,
+            validate_stepper=self._validate_stepper,
         )
         if new_lr is not None:
             logging.info(f"LR tuning: adopting candidate LR {new_lr}")

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -38,6 +38,8 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     inference_data = builder.get_evaluation_inference_data()
 
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
+    for data, name in zip((train_data, validation_data), ("train", "valid")):
+        data.log_info(name)
     logging.info("Starting model initialization")
     stepper = builder.get_stepper(dataset_info)
     end_of_batch_ops = builder.get_end_of_batch_ops(stepper.modules)


### PR DESCRIPTION
Decouple `run_lr_tuning_trial` from validation data and aggregator details by replacing those parameters with a `ValidateStepper` callback protocol. Also move `log_info` calls out of the generic `Trainer.__init__` to the domain-specific `build_trainer` callers.

Changes:
- `fme.core.generics.lr_tuning.ValidateStepper`: new Protocol `(stepper, ema) -> float` for validation callbacks
- `fme.core.generics.lr_tuning.run_lr_tuning_trial`: replace `valid_data`, `get_validation_aggregator`, and `validate_using_ema` params with `validate_stepper`
- `fme.core.generics.trainer.Trainer._validate_stepper`: new method that closes over validation data, aggregator builder, and EMA config
- `fme.core.generics.trainer.Trainer.__init__`: remove `log_info` calls
- `fme.ace.train.train.build_trainer`, `fme.coupled.train.train.build_trainer`: add `log_info` calls

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
