### PR TITLE
Update Beaker CI budget to ai2/atec-climate

### DIFF
--- a/.github/workflows/beaker.yaml
+++ b/.github/workflows/beaker.yaml
@@ -64,7 +64,7 @@ jobs:
             --dataset ${{ env.BEAKER_CHECKPOINT_TEST_DATASET }}:/test-data \
             --gpus 1 \
             --shared-memory 50GiB \
-            --budget ai2/climate \
+            --budget ai2/atec-climate \
             --system-python \
             --install "pip install --no-deps ." \
             -- python -I -m fme.ace.evaluator ${{ env.CONFIG_PATH }} \


### PR DESCRIPTION
The baseline configs were updated in #1080 to use the new budget name `ai2/atec-climate`, but the `ace-evaluator` Beaker CI workflow was missed and is now failing on `main` because the old `ai2/climate` budget name no longer works.

Changes:
- `.github/workflows/beaker.yaml`: update `--budget` from `ai2/climate` to `ai2/atec-climate`

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

No tests added: the workflow only runs on push to `main` or manual dispatch, so the fix can only be verified post-merge (or via `workflow_dispatch`).
