### PR TITLE
Unify coupled inference configs with name and weight

### DIFF
--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -139,6 +139,12 @@ def test_duplicate_inference_names_raises(tmp_path):
         )
 
 
+@pytest.mark.parametrize("reserved_name", ["train", "val"])
+def test_reserved_inference_name_raises(tmp_path, reserved_name):
+    with pytest.raises(ValueError, match="collide with reserved names"):
+        _make_train_config(tmp_path, [_make_inference_config(name=reserved_name)])
+
+
 def test_negative_weight_raises():
     with pytest.raises(ValueError, match="non-negative"):
         _make_inference_config(weight=-1.0)

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -236,6 +236,8 @@ class TrainConfig:
             return self.stepper.to_stepper_config()
         return self.stepper
 
+    _RESERVED_NAMES = {"train", "val"}
+
     def __post_init__(self):
         if self.train_loader.using_labels != self.validation_loader.using_labels:
             raise ValueError(
@@ -245,6 +247,12 @@ class TrainConfig:
         resolved_names = self.inference_names
         if len(resolved_names) != len(set(resolved_names)):
             raise ValueError(f"Duplicate inference names: {resolved_names}")
+        reserved_overlap = set(resolved_names) & self._RESERVED_NAMES
+        if reserved_overlap:
+            raise ValueError(
+                f"Inference names {sorted(reserved_overlap)} collide with "
+                f"reserved names {sorted(self._RESERVED_NAMES)}"
+            )
         for i, entry in enumerate(self.inference_list):
             if self.train_loader.using_labels != entry.using_labels:
                 name = resolved_names[i]

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -19,6 +19,21 @@ from fme.coupled.typing_ import CoupledOptionalInt
 from .train_config import _validate_loss_n_steps
 
 
+def _make_stepper_mock():
+    stepper = MagicMock()
+    stepper.n_inner_steps = 1
+    return stepper
+
+
+def _make_stepper_training_mock():
+    stepper_training = MagicMock()
+    stepper_training.n_coupled_steps = 1
+    stepper_training.component_n_steps_max = CoupledOptionalInt(
+        ocean=None, atmosphere=None
+    )
+    return stepper_training
+
+
 def _make_inference_config(
     name: str | None = None, weight: float = 1.0, epochs: Slice | None = None
 ) -> InlineInferenceConfig:
@@ -53,8 +68,8 @@ def _make_train_config(
     return TrainConfig(
         train_loader=MagicMock(),
         validation_loader=MagicMock(),
-        stepper=MagicMock(),
-        stepper_training=MagicMock(),
+        stepper=_make_stepper_mock(),
+        stepper_training=_make_stepper_training_mock(),
         optimization=MagicMock(has_lr_schedule=False),
         logging=MagicMock(),
         max_epochs=max_epochs,

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -1,13 +1,158 @@
+from unittest.mock import MagicMock
+
 import pytest
 
+from fme.ace.data_loading.inference import InferenceInitialConditionIndices
 from fme.ace.stepper.time_length_probabilities import (
     TimeLengthProbabilities,
     TimeLengthProbability,
 )
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.core.typing_ import Slice
+from fme.coupled.aggregator import InferenceEvaluatorAggregatorConfig
+from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
+from fme.coupled.data_loading.inference import InferenceDataLoaderConfig
 from fme.coupled.loss import LossContributionsConfig
+from fme.coupled.train.train_config import InlineInferenceConfig, TrainConfig
 from fme.coupled.typing_ import CoupledOptionalInt
 
 from .train_config import _validate_loss_n_steps
+
+
+def _make_inference_config(
+    name: str | None = None, weight: float = 1.0, epochs: Slice | None = None
+) -> InlineInferenceConfig:
+    dataset = CoupledDatasetWithOptionalOceanConfig(
+        atmosphere=XarrayDataConfig(data_path=""),
+        ocean=XarrayDataConfig(data_path=""),
+    )
+    return InlineInferenceConfig(
+        loader=InferenceDataLoaderConfig(
+            dataset=dataset,
+            start_indices=InferenceInitialConditionIndices(
+                first=0, n_initial_conditions=1, interval=1
+            ),
+        ),
+        n_coupled_steps=1,
+        coupled_steps_in_memory=1,
+        aggregator=InferenceEvaluatorAggregatorConfig(
+            log_global_mean_time_series=False,
+            log_global_mean_norm_time_series=False,
+        ),
+        epochs=epochs if epochs is not None else Slice(),
+        name=name,
+        weight=weight,
+    )
+
+
+def _make_train_config(
+    tmp_path,
+    inference: InlineInferenceConfig | list[InlineInferenceConfig],
+    max_epochs: int = 5,
+) -> TrainConfig:
+    return TrainConfig(
+        train_loader=MagicMock(),
+        validation_loader=MagicMock(),
+        stepper=MagicMock(),
+        stepper_training=MagicMock(),
+        optimization=MagicMock(has_lr_schedule=False),
+        logging=MagicMock(),
+        max_epochs=max_epochs,
+        save_checkpoint=False,
+        experiment_dir=str(tmp_path),
+        inference=inference,
+    )
+
+
+def test_negative_weight_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        _make_inference_config(weight=-1.0)
+
+
+def test_zero_weight_accepted():
+    config = _make_inference_config(weight=0.0)
+    assert config.weight == 0.0
+
+
+def test_default_weight_is_one():
+    config = _make_inference_config()
+    assert config.weight == 1.0
+
+
+def test_inference_single_config_gives_list(tmp_path):
+    config = _make_train_config(tmp_path, _make_inference_config())
+    assert isinstance(config.inference, InlineInferenceConfig)
+    assert isinstance(config.inference_list, list)
+    assert len(config.inference_list) == 1
+    assert config.inference_names == ["inference"]
+
+
+def test_inference_names_single_unnamed(tmp_path):
+    config = _make_train_config(tmp_path, [_make_inference_config()])
+    assert config.inference_names == ["inference"]
+
+
+def test_inference_names_multiple_unnamed(tmp_path):
+    config = _make_train_config(
+        tmp_path, [_make_inference_config(), _make_inference_config()]
+    )
+    assert config.inference_names == ["inference_0", "inference_1"]
+
+
+def test_inference_names_explicit(tmp_path):
+    config = _make_train_config(
+        tmp_path,
+        [_make_inference_config(name="weather"), _make_inference_config(name="clim")],
+    )
+    assert config.inference_names == ["weather", "clim"]
+
+
+def test_inference_names_mixed(tmp_path):
+    config = _make_train_config(
+        tmp_path,
+        [_make_inference_config(name="weather"), _make_inference_config()],
+    )
+    assert config.inference_names == ["weather", "inference_1"]
+
+
+def test_inference_names_empty(tmp_path):
+    config = _make_train_config(tmp_path, [])
+    assert config.inference_names == []
+
+
+def test_duplicate_inference_names_raises(tmp_path):
+    with pytest.raises(ValueError, match="Duplicate inference names"):
+        _make_train_config(
+            tmp_path,
+            [_make_inference_config(name="same"), _make_inference_config(name="same")],
+        )
+
+
+def test_get_inference_epoch_sets_empty(tmp_path):
+    config = _make_train_config(tmp_path, [], max_epochs=5)
+    assert config.get_inference_epoch_sets() == []
+    assert config.get_inference_epochs() == []
+
+
+def test_get_inference_epoch_sets_single_default(tmp_path):
+    config = _make_train_config(tmp_path, [_make_inference_config()], max_epochs=3)
+    assert config.get_inference_epoch_sets() == [{0, 1, 2, 3}]
+    assert config.get_inference_epochs() == [0, 1, 2, 3]
+
+
+def test_get_inference_epoch_sets_per_config(tmp_path):
+    config = _make_train_config(
+        tmp_path,
+        [
+            _make_inference_config(epochs=Slice(step=2)),
+            _make_inference_config(epochs=Slice(step=3)),
+        ],
+        max_epochs=6,
+    )
+    epoch_sets = config.get_inference_epoch_sets()
+    assert epoch_sets[0] == {0, 2, 4, 6}
+    assert epoch_sets[1] == {0, 3, 6}
+    assert config.get_inference_epochs() == [0, 2, 3, 4, 6]
 
 
 def test_validate_loss_n_steps_passes_when_unbounded():
@@ -19,8 +164,6 @@ def test_validate_loss_n_steps_passes_when_unbounded():
 
 
 def test_validate_loss_n_steps_passes_at_limit():
-    # Equality is allowed: n_steps==n_coupled_steps means losses for steps
-    # 0..n_steps-1, all within range.
     _validate_loss_n_steps(
         n_coupled_steps=4,
         n_inner_steps=2,
@@ -77,10 +220,6 @@ def test_validate_loss_n_steps_uses_sampler_max_via_config():
 
 
 def test_validate_loss_n_steps_does_not_short_circuit_on_null_weight():
-    # A weight=0 component still has a non-None n_steps_max if a value was
-    # explicitly set, and the validator surfaces the misconfiguration even
-    # though the loss contribution is null. This avoids silently accepting
-    # confused configs.
     null_config = LossContributionsConfig(weight=0.0, n_steps=999)
     bounds = CoupledOptionalInt(ocean=null_config.n_steps_max, atmosphere=None)
     with pytest.raises(ValueError, match=r"ocean"):

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -143,6 +143,12 @@ def test_duplicate_inference_names_raises(tmp_path):
         )
 
 
+@pytest.mark.parametrize("reserved_name", ["train", "val"])
+def test_reserved_inference_name_raises(tmp_path, reserved_name):
+    with pytest.raises(ValueError, match="collide with reserved names"):
+        _make_train_config(tmp_path, [_make_inference_config(name=reserved_name)])
+
+
 def test_get_inference_epoch_sets_empty(tmp_path):
     config = _make_train_config(tmp_path, [], max_epochs=5)
     assert config.get_inference_epoch_sets() == []

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -2,12 +2,11 @@ import contextlib
 import dataclasses
 import logging
 import os
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 import dacite
 import torch
-import xarray as xr
 
 import fme
 from fme.core.cli import prepare_config, prepare_directory
@@ -15,12 +14,7 @@ from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
 from fme.core.generics.trainer import AggregatorBuilderABC, Trainer, inference_one_epoch
 from fme.core.generics.validation import run_validation
-from fme.core.typing_ import TensorDict, TensorMapping
-from fme.coupled.aggregator import (
-    InferenceEvaluatorAggregatorConfig,
-    OneStepAggregator,
-    TrainAggregator,
-)
+from fme.coupled.aggregator import OneStepAggregator, TrainAggregator
 from fme.coupled.dataset_info import CoupledDatasetInfo
 from fme.coupled.stepper import CoupledTrainOutput
 from fme.coupled.train.train_config import TrainBuilders, TrainConfig
@@ -32,37 +26,30 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     train_data = builder.get_train_data()
     logging.info("Initializing validation data loader")
     validation_data = builder.get_validation_data()
-    logging.info("Initializing inline inference data loader")
-    dataset_info = train_data.dataset_info
-    inference_data = builder.get_evaluation_inference_data()
 
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
+    dataset_info = train_data.dataset_info.update_variable_metadata(variable_metadata)
     for data, name in zip((train_data, validation_data), ("train", "valid")):
         data.log_info(name)
+
+    if config.inference_list:
+        logging.info("Initializing inline inference data loaders")
+    else:
+        logging.info("Skipping inline inference")
+    inference_entries = builder.get_inference_data()
+    inference_epochs = config.get_inference_epochs()
+    inference_epoch_sets = config.get_inference_epoch_sets()
+
     logging.info("Starting model initialization")
-    stepper = builder.get_stepper(dataset_info)
+    stepper = builder.get_stepper(train_data.dataset_info)
     end_of_batch_ops = builder.get_end_of_batch_ops(stepper.modules)
 
-    batch = next(iter(inference_data.loader))
-    initial_inference_times = batch.ocean_data.time.isel(time=0)
-    n_timesteps_ocean = config.inference_n_coupled_steps + stepper.ocean.n_ic_timesteps
-    n_timesteps_atmosphere = (
-        config.inference_n_coupled_steps * stepper.n_inner_steps
-        + stepper.atmosphere.n_ic_timesteps
-    )
     aggregator_builder = CoupledAggregatorBuilder(
-        inference_config=config.inference_aggregator,
-        dataset_info=dataset_info.update_variable_metadata(variable_metadata),
-        initial_inference_times=initial_inference_times,
-        n_timesteps_ocean=n_timesteps_ocean,
-        n_timesteps_atmosphere=n_timesteps_atmosphere,
-        ocean_normalize=stepper.ocean.normalizer.normalize,
-        atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
+        dataset_info=dataset_info,
         loss_scaling=stepper.effective_loss_scaling,
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
         output_dir=config.output_dir,
     )
-    inference_epochs = config.get_inference_epochs()
 
     def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
@@ -79,16 +66,46 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
             return {}, None
-        logs = inference_one_epoch(
-            stepper=stepper,
-            validation_context=contextlib.nullcontext,
-            dataset=inference_data,
-            aggregator=aggregator_builder.get_inference_aggregator(),
-            label="inference",
-            epoch=epoch,
-        )
-        error = logs.get("inference/time_mean_norm/rmse/channel_mean")
-        return logs, error
+        all_logs: dict[str, Any] = {}
+        weighted_error = 0.0
+        has_error = False
+        for i, (entry_config, data, name) in enumerate(inference_entries):
+            if epoch not in inference_epoch_sets[i]:
+                continue
+            batch = next(iter(data.loader))
+            initial_times = batch.ocean_data.time.isel(time=0)
+            n_timesteps_ocean = (
+                entry_config.n_coupled_steps + stepper.ocean.n_ic_timesteps
+            )
+            n_timesteps_atmosphere = (
+                entry_config.n_coupled_steps * stepper.n_inner_steps
+                + stepper.atmosphere.n_ic_timesteps
+            )
+            aggregator = entry_config.aggregator.build(
+                dataset_info=dataset_info,
+                n_timesteps_ocean=n_timesteps_ocean,
+                n_timesteps_atmosphere=n_timesteps_atmosphere,
+                initial_time=initial_times,
+                ocean_normalize=stepper.ocean.normalizer.normalize,
+                atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
+                save_diagnostics=config.save_per_epoch_diagnostics,
+                output_dir=os.path.join(config.output_dir, name),
+            )
+            logs = inference_one_epoch(
+                stepper=stepper,
+                validation_context=contextlib.nullcontext,
+                dataset=data,
+                aggregator=aggregator,
+                label=name,
+                epoch=epoch,
+            )
+            all_logs.update(logs)
+            error = logs.get(f"{name}/time_mean_norm/rmse/channel_mean")
+            if error is not None:
+                weighted_error += entry_config.weight * error
+                has_error = True
+
+        return all_logs, weighted_error if has_error else None
 
     return Trainer(
         train_data=train_data,
@@ -109,30 +126,14 @@ class CoupledAggregatorBuilder(
 ):
     def __init__(
         self,
-        inference_config: InferenceEvaluatorAggregatorConfig,
         dataset_info: CoupledDatasetInfo,
-        initial_inference_times: xr.DataArray,
-        n_timesteps_ocean: int,
-        n_timesteps_atmosphere: int,
         output_dir: str,
-        ocean_normalize: Callable[[TensorMapping], TensorDict],
-        atmosphere_normalize: Callable[[TensorMapping], TensorDict],
         loss_scaling: CoupledTensorMapping,
-        ocean_channel_mean_names: Sequence[str] | None = None,
-        atmosphere_channel_mean_names: Sequence[str] | None = None,
         save_per_epoch_diagnostics: bool = False,
     ):
-        self.inference_config = inference_config
         self.dataset_info = dataset_info
-        self.initial_inference_times = initial_inference_times
-        self.n_timesteps_ocean = n_timesteps_ocean
-        self.n_timesteps_atmosphere = n_timesteps_atmosphere
         self.output_dir = output_dir
-        self.ocean_normalize = ocean_normalize
-        self.atmosphere_normalize = atmosphere_normalize
         self.loss_scaling = loss_scaling
-        self.ocean_channel_mean_names = ocean_channel_mean_names
-        self.atmosphere_channel_mean_names = atmosphere_channel_mean_names
         self.save_per_epoch_diagnostics = save_per_epoch_diagnostics
 
     def get_train_aggregator(self) -> TrainAggregator:
@@ -144,22 +145,6 @@ class CoupledAggregatorBuilder(
             save_diagnostics=self.save_per_epoch_diagnostics,
             output_dir=os.path.join(self.output_dir, "val"),
             loss_scaling=self.loss_scaling,
-            ocean_channel_mean_names=self.ocean_channel_mean_names,
-            atmosphere_channel_mean_names=self.atmosphere_channel_mean_names,
-        )
-
-    def get_inference_aggregator(self):
-        return self.inference_config.build(
-            dataset_info=self.dataset_info,
-            n_timesteps_ocean=self.n_timesteps_ocean,
-            n_timesteps_atmosphere=self.n_timesteps_atmosphere,
-            initial_time=self.initial_inference_times,
-            ocean_normalize=self.ocean_normalize,
-            atmosphere_normalize=self.atmosphere_normalize,
-            save_diagnostics=self.save_per_epoch_diagnostics,
-            output_dir=os.path.join(self.output_dir, "inference"),
-            ocean_channel_mean_names=self.ocean_channel_mean_names,
-            atmosphere_channel_mean_names=self.atmosphere_channel_mean_names,
         )
 
 

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -214,10 +214,18 @@ class TrainConfig:
     lr_tuning: LRTuningConfig | None = None
     resume_results: ResumeResultsConfig | None = None
 
+    _RESERVED_NAMES = {"train", "val"}
+
     def __post_init__(self):
         resolved_names = self.inference_names
         if len(resolved_names) != len(set(resolved_names)):
             raise ValueError(f"Duplicate inference names: {resolved_names}")
+        reserved_overlap = set(resolved_names) & self._RESERVED_NAMES
+        if reserved_overlap:
+            raise ValueError(
+                f"Inference names {sorted(reserved_overlap)} collide with "
+                f"reserved names {sorted(self._RESERVED_NAMES)}"
+            )
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
             raise ValueError(
                 "lr_tuning and optimization.scheduler cannot both be specified; "

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -20,10 +20,7 @@ from fme.coupled.data_loading.getters import get_gridded_data, get_inference_dat
 from fme.coupled.data_loading.gridded_data import GriddedData, InferenceGriddedData
 from fme.coupled.data_loading.inference import InferenceDataLoaderConfig
 from fme.coupled.dataset_info import CoupledDatasetInfo
-from fme.coupled.requirements import (
-    CoupledDataRequirements,
-    CoupledPrognosticStateDataRequirements,
-)
+from fme.coupled.requirements import CoupledDataRequirements
 from fme.coupled.stepper import (
     CoupledStepperConfig,
     CoupledTrainStepper,
@@ -82,6 +79,13 @@ class InlineInferenceConfig:
             re-reading data from disk
         epochs: epochs on which to run inference. By default runs inference every epoch.
         aggregator: configuration of inline coupled inference aggregator.
+        name: name used as wandb log prefix and output subdirectory. If None,
+            defaults to "inference" when there is a single inference config
+            and "inference_{i}" when there are multiple. Note: adding a second
+            unnamed config will rename the first from "inference" to
+            "inference_0", changing its wandb keys and output directory.
+        weight: weight for this inference's error in the combined checkpoint
+            selection metric. Must be non-negative.
     """
 
     loader: InferenceDataLoaderConfig
@@ -93,8 +97,14 @@ class InlineInferenceConfig:
             log_global_mean_time_series=False, log_global_mean_norm_time_series=False
         )
     )
+    name: str | None = None
+    weight: float = 1.0
 
     def __post_init__(self):
+        if self.weight < 0:
+            raise ValueError(
+                f"InlineInferenceConfig weight must be non-negative, got {self.weight}"
+            )
         dist = Distributed.get_instance()
         if self.loader.start_indices.n_initial_conditions % dist.world_size != 0:
             raise ValueError(
@@ -130,7 +140,10 @@ class TrainConfig:
             true, checkpoints are saved at the end of the training loop, after
             evaluation, and on catching a termination signal.
         experiment_dir: Directory where checkpoints and logs are saved.
-        inference: Configuration for inline inference.
+        inference: Configuration(s) for inline inference runs. Accepts a single
+            InlineInferenceConfig or a list of them. The weighted sum of each
+            run's error is used for checkpoint selection. Each entry can specify
+            a name (used as wandb log prefix) and weight.
         n_coupled_steps: Number of coupled forward steps to take gradient over.
             This is equal to the number of forward steps of the ocean model.
         seed: Random seed for reproducibility. If set, is used for all types of
@@ -180,7 +193,9 @@ class TrainConfig:
     max_epochs: int
     save_checkpoint: bool
     experiment_dir: str
-    inference: InlineInferenceConfig
+    inference: InlineInferenceConfig | list[InlineInferenceConfig] = dataclasses.field(
+        default_factory=list
+    )
     seed: int | None = None
     copy_weights_after_batch: CopyWeightsConfig = dataclasses.field(
         default_factory=lambda: CopyWeightsConfig(exclude=["*"])
@@ -200,6 +215,9 @@ class TrainConfig:
     resume_results: ResumeResultsConfig | None = None
 
     def __post_init__(self):
+        resolved_names = self.inference_names
+        if len(resolved_names) != len(set(resolved_names)):
+            raise ValueError(f"Duplicate inference names: {resolved_names}")
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
             raise ValueError(
                 "lr_tuning and optimization.scheduler cannot both be specified; "
@@ -227,14 +245,6 @@ class TrainConfig:
     def output_dir(self) -> str:
         return os.path.join(self.experiment_dir, "output")
 
-    @property
-    def inference_aggregator(self) -> InferenceEvaluatorAggregatorConfig:
-        return self.inference.aggregator
-
-    @property
-    def inference_n_coupled_steps(self) -> int:
-        return self.inference.n_coupled_steps
-
     def set_random_seed(self):
         if self.seed is not None:
             set_seed(self.seed)
@@ -243,10 +253,38 @@ class TrainConfig:
     def train_evaluation_batches(self) -> int:
         return self.train_evaluation_samples // self.train_loader.batch_size
 
-    def get_inference_epochs(self) -> list[int]:
+    @property
+    def inference_list(self) -> list[InlineInferenceConfig]:
+        if isinstance(self.inference, InlineInferenceConfig):
+            return [self.inference]
+        return self.inference
+
+    @property
+    def inference_names(self) -> list[str]:
+        inference = self.inference_list
+        names = []
+        for i, entry in enumerate(inference):
+            if entry.name is not None:
+                names.append(entry.name)
+            elif len(inference) == 1:
+                names.append("inference")
+            else:
+                names.append(f"inference_{i}")
+        return names
+
+    def get_inference_epoch_sets(self) -> list[set[int]]:
+        inference = self.inference_list
+        if not inference:
+            return []
         start_epoch = 0 if self.evaluate_before_training else 1
         all_epochs = list(range(start_epoch, self.max_epochs + 1))
-        return all_epochs[self.inference.epochs.slice]
+        return [set(all_epochs[entry.epochs.slice]) for entry in inference]
+
+    def get_inference_epochs(self) -> list[int]:
+        epoch_sets = self.get_inference_epoch_sets()
+        if not epoch_sets:
+            return []
+        return sorted(set().union(*epoch_sets))
 
 
 class TrainBuilders:
@@ -257,16 +295,6 @@ class TrainBuilders:
         return self.config.stepper.get_evaluation_window_data_requirements(
             self.config.n_coupled_steps
         )
-
-    def _get_evaluation_window_data_requirements(self) -> CoupledDataRequirements:
-        return self.config.stepper.get_evaluation_window_data_requirements(
-            self.config.inference.coupled_steps_in_memory
-        )
-
-    def _get_initial_condition_data_requirements(
-        self,
-    ) -> CoupledPrognosticStateDataRequirements:
-        return self.config.stepper.get_prognostic_state_data_requirements()
 
     def get_train_data(self) -> GriddedData:
         data_requirements = self._get_train_window_data_requirements()
@@ -284,15 +312,26 @@ class TrainBuilders:
             train=False,
         )
 
-    def get_evaluation_inference_data(
+    def get_inference_data(
         self,
-    ) -> InferenceGriddedData:
-        return get_inference_data(
-            config=self.config.inference.loader,
-            total_coupled_steps=self.config.inference.n_coupled_steps,
-            window_requirements=self._get_evaluation_window_data_requirements(),
-            initial_condition=self._get_initial_condition_data_requirements(),
-        )
+    ) -> list[tuple[InlineInferenceConfig, InferenceGriddedData, str]]:
+        names = self.config.inference_names
+        initial_condition = self.config.stepper.get_prognostic_state_data_requirements()
+        entries: list[tuple[InlineInferenceConfig, InferenceGriddedData, str]] = []
+        for entry, name in zip(self.config.inference_list, names):
+            window_requirements = (
+                self.config.stepper.get_evaluation_window_data_requirements(
+                    entry.coupled_steps_in_memory
+                )
+            )
+            data = get_inference_data(
+                config=entry.loader,
+                total_coupled_steps=entry.n_coupled_steps,
+                window_requirements=window_requirements,
+                initial_condition=initial_condition,
+            )
+            entries.append((entry, data, name))
+        return entries
 
     def get_optimization(self, parameters) -> Optimization:
         return self.config.optimization.build(parameters, self.config.max_epochs)


### PR DESCRIPTION
Mirror the unified inference config changes from #1128 for the coupled training module, enabling multiple named and weighted inference runs for checkpoint selection.

Changes:
- `fme.coupled.train.train_config.InlineInferenceConfig`: add `name: str | None` and `weight: float` fields with validation
- `fme.coupled.train.train_config.TrainConfig`: change `inference` from required `InlineInferenceConfig` to optional `InlineInferenceConfig | list[InlineInferenceConfig]` (defaults to empty list); add `inference_list`, `inference_names`, `get_inference_epoch_sets` properties; remove `inference_aggregator` and `inference_n_coupled_steps` properties
- `fme.coupled.train.train_config.TrainBuilders`: replace `get_evaluation_inference_data` with `get_inference_data` returning list of `(config, data, name)` entries
- `fme.coupled.train.train.build_trainer`: refactor `inference_callback` to loop over entries with weighted error sum for checkpoint selection
- `fme.coupled.train.train.CoupledAggregatorBuilder`: remove inference-specific fields; aggregators now built inline per entry

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated