### PR TITLE
Allow any network type in SecondaryDecoderConfig

### DIFF
--- a/fme/core/step/secondary_decoder.py
+++ b/fme/core/step/secondary_decoder.py
@@ -12,8 +12,6 @@ from fme.core.registry import ModuleSelector
 from fme.core.registry.module import Module
 from fme.core.typing_ import TensorDict
 
-_VALID_NETWORK_TYPES = {"MLP"}
-
 
 @dataclasses.dataclass
 class SecondaryDecoderConfig:
@@ -31,21 +29,16 @@ class SecondaryDecoderConfig:
     secondary_diagnostic_names: list[str]
     network: ModuleSelector
 
-    def __post_init__(self):
-        if self.network.type not in _VALID_NETWORK_TYPES:
-            raise ValueError(
-                f"Invalid network type '{self.network.type}'. "
-                f"Valid types are: {_VALID_NETWORK_TYPES}"
-            )
-
     def build(
         self,
         n_in_channels: int,
+        dataset_info: DatasetInfo,
     ) -> "SecondaryDecoder":
         return SecondaryDecoder(
             in_dim=n_in_channels,
             out_names=self.secondary_diagnostic_names,
             network=self.network,
+            dataset_info=dataset_info,
         )
 
 
@@ -64,18 +57,22 @@ class SecondaryDecoder:
         in_dim: int,
         out_names: list[str],
         network: ModuleSelector,
+        dataset_info: DatasetInfo,
     ):
         """
         Args:
             in_dim: Number of input channels (should match main module output).
             out_names: Names of the diagnostic variables this decoder produces.
             network: ModuleSelector specifying the network architecture.
+            dataset_info: Information about the dataset, forwarded to the
+                underlying network builder. Some networks (e.g. MLP) ignore
+                this, while others (e.g. SFNO) require horizontal coordinates.
         """
         out_dim = len(out_names)
         self._module: Module = network.build(
             n_in_channels=in_dim,
             n_out_channels=out_dim,
-            dataset_info=DatasetInfo(),  # Not needed for MLP
+            dataset_info=dataset_info,
         )
         self._packer = Packer(out_names)
 

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -314,6 +314,7 @@ class SecondaryModuleStep(StepABC):
             self.secondary_decoder: SecondaryDecoder | NoSecondaryDecoder = (
                 config.secondary_decoder.build(
                     n_in_channels=n_out_channels,
+                    dataset_info=dataset_info,
                 ).to(get_device())
             )
         else:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -271,6 +271,7 @@ class SingleModuleStep(StepABC):
             self.secondary_decoder: SecondaryDecoder | NoSecondaryDecoder = (
                 config.secondary_decoder.build(
                     n_in_channels=n_out_channels,
+                    dataset_info=dataset_info,
                 ).to(get_device())
             )
         else:

--- a/fme/core/step/test_secondary_decoder.py
+++ b/fme/core/step/test_secondary_decoder.py
@@ -1,28 +1,25 @@
-import pytest
 import torch
 
+from fme.core.dataset_info import DatasetInfo
 from fme.core.registry import ModuleSelector
 
 from .secondary_decoder import SecondaryDecoder, SecondaryDecoderConfig
 
 
 class TestSecondaryDecoderConfig:
-    def test_valid_mlp_network_type(self):
-        # Should not raise
+    def test_mlp_network_type(self):
         config = SecondaryDecoderConfig(
             secondary_diagnostic_names=["diag1", "diag2"],
             network=ModuleSelector(type="MLP", config={}),
         )
         assert config.secondary_diagnostic_names == ["diag1", "diag2"]
 
-    def test_invalid_network_type_raises_error(self):
-        with pytest.raises(ValueError, match="Invalid network type"):
-            SecondaryDecoderConfig(
-                secondary_diagnostic_names=["diag1"],
-                network=ModuleSelector(
-                    type="SphericalFourierNeuralOperatorNet", config={}
-                ),
-            )
+    def test_non_mlp_network_type_is_accepted(self):
+        config = SecondaryDecoderConfig(
+            secondary_diagnostic_names=["diag1"],
+            network=ModuleSelector(type="SphericalFourierNeuralOperatorNet", config={}),
+        )
+        assert config.network.type == "SphericalFourierNeuralOperatorNet"
 
 
 class TestSecondaryDecoder:
@@ -32,6 +29,7 @@ class TestSecondaryDecoder:
             in_dim=4,
             out_names=["diag1", "diag2"],
             network=network,
+            dataset_info=DatasetInfo(),
         )
         # Input: [batch, channels, height, width]
         x = torch.randn(2, 4, 8, 8)
@@ -47,6 +45,7 @@ class TestSecondaryDecoder:
             in_dim=4,
             out_names=["diag1"],
             network=network,
+            dataset_info=DatasetInfo(),
         )
         assert isinstance(decoder.torch_modules, torch.nn.ModuleList)
 
@@ -56,11 +55,13 @@ class TestSecondaryDecoder:
             in_dim=4,
             out_names=["diag1", "diag2"],
             network=network,
+            dataset_info=DatasetInfo(),
         )
         decoder2 = SecondaryDecoder(
             in_dim=4,
             out_names=["diag1", "diag2"],
             network=network,
+            dataset_info=DatasetInfo(),
         )
         # Save state from decoder1, load into decoder2
         state = decoder1.get_module_state()
@@ -75,6 +76,7 @@ class TestSecondaryDecoder:
             in_dim=4,
             out_names=["diag1"],
             network=network,
+            dataset_info=DatasetInfo(),
         )
         # Just test that to() returns self and doesn't error
         result = decoder.to("cpu")


### PR DESCRIPTION
Removes the hard-coded restriction that limited `SecondaryDecoderConfig` (and the secondary decoder it builds) to the `MLP` network type, so any registered network can now be used. To support networks that need real dataset metadata (e.g. SFNO needs horizontal coordinates), `DatasetInfo` is now threaded from the parent step into the secondary decoder instead of substituting an empty placeholder.

Changes:
- `fme.core.step.secondary_decoder.SecondaryDecoderConfig`: drop the `_VALID_NETWORK_TYPES` allowlist and the `__post_init__` validator that rejected non-MLP types; `build` now takes a `dataset_info: DatasetInfo` argument.
- `fme.core.step.secondary_decoder.SecondaryDecoder.__init__`: now requires a `dataset_info` argument, which is forwarded to `network.build` instead of constructing an empty `DatasetInfo()`.
- `fme.core.step.single_module.SingleModuleStep` and `fme.core.step.secondary_module.SecondaryModuleStep`: pass the step's `dataset_info` when building the secondary decoder.
- `fme.core.step.test_secondary_decoder`: replace the "invalid network type" test with one asserting non-MLP types are accepted; update existing tests to pass `dataset_info`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErnQniFxAhoTCk3eeKzPf5)_