### PR TITLE
Fix TrainConfig.__post_init__ filesystem access via stepper_config

### DIFF
--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import os
 from collections.abc import Mapping
 from typing import Any
@@ -228,13 +229,14 @@ class TrainConfig:
     save_best_inference_epoch_checkpoints: bool = False
     lr_tuning: LRTuningConfig | None = None
     resume_results: ResumeResultsConfig | None = None
-    stepper_config: StepperConfig = dataclasses.field(init=False)
+
+    @functools.cached_property
+    def stepper_config(self) -> StepperConfig:
+        if isinstance(self.stepper, CheckpointStepperConfig):
+            return self.stepper.to_stepper_config()
+        return self.stepper
 
     def __post_init__(self):
-        if isinstance(self.stepper, CheckpointStepperConfig):
-            self.stepper_config = self.stepper.to_stepper_config()
-        else:
-            self.stepper_config = self.stepper
         if self.train_loader.using_labels != self.validation_loader.using_labels:
             raise ValueError(
                 "train_loader and validation_loader must both use labels or both not "


### PR DESCRIPTION
`TrainConfig.__post_init__` eagerly resolved `stepper_config`, which called `CheckpointStepperConfig.to_stepper_config()` and accessed the filesystem at construction time. This makes it a lazy `cached_property` so resolution is deferred until first access.

Changes:
- `fme.ace.train.train_config.TrainConfig.stepper_config`: replaced dataclass field with `functools.cached_property` to defer resolution

- [x] Tests added

Closes #1145