### PR TITLE
Install cuhpx weights

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ version = {attr = "fme.__version__"}
 [tool.setuptools.packages]
 find = {}
 
+[tool.setuptools.package-data]
+"fme.core.cuhpx" = ["data/*.npy", "data/*.fits"]
+
 [tool.uv]
 cache-keys = [
     { file = "pyproject.toml" },


### PR DESCRIPTION
Currently, the `.fits` and `.npy` files in `ace/fme/core/cuhpx/data/` which are used for the `cuhpx` quadrature weights are not included when installing the repository using `pyproject.toml`. This causes downstream errors for things like computing spectral transforms of HEALPix data during inline inference. This PR ensures these weight files are shipped with the rest of the package.
