### PR TITLE
Refactor validation to support multiple weighted configs

### DIFF
--- a/configs/baselines/amip-c96-shield/train-ace2.yaml
+++ b/configs/baselines/amip-c96-shield/train-ace2.yaml
@@ -52,20 +52,21 @@ train_loader:
       - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0002
         subset:
           start_time: '2011-01-01'
-validation_loader:
-  batch_size: 128
-  num_data_workers: 8
-  prefetch_factor: 4
-  dataset:
-    concat:
-      - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0001
-        subset:
-          start_time: '1996-01-01'
-          stop_time: '2000-12-31'
-      - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0002
-        subset:
-          start_time: '1996-01-01'
-          stop_time: '2000-12-31'
+validation:
+  loader:
+    batch_size: 128
+    num_data_workers: 8
+    prefetch_factor: 4
+    dataset:
+      concat:
+        - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0001
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '2000-12-31'
+        - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0002
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '2000-12-31'
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/baselines/amip-c96-shield/train-baseline.yaml
+++ b/configs/baselines/amip-c96-shield/train-baseline.yaml
@@ -47,16 +47,17 @@ train_loader:
       - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0002
         subset:
           start_time: '2011-01-01'
-validation_loader:
-  batch_size: 64
-  num_data_workers: 8
-  prefetch_factor: 4
-  dataset:
-    concat:
-      - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0002
-        subset:
-          start_time: '1996-01-01'
-          stop_time: '2000-12-31'
+validation:
+  loader:
+    batch_size: 64
+    num_data_workers: 8
+    prefetch_factor: 4
+    dataset:
+      concat:
+        - data_path: /climate-default/2024-07-24-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset/netCDFs/ic_0002
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '2000-12-31'
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/baselines/climsst/train-baseline-4deg.yaml
+++ b/configs/baselines/climsst/train-baseline-4deg.yaml
@@ -59,14 +59,15 @@ train_loader:
       subset: *subset
     - data_path: /climate-default/2023-08-11-vertically-resolved-4deg-fme-ensemble-dataset/ic_0010
       subset: *subset
-validation_loader:
-  batch_size: 128
-  num_data_workers: 4
-  prefetch_factor: 4
-  dataset:
-    data_path: /climate-default/2023-08-11-vertically-resolved-4deg-fme-ensemble-dataset/ic_0011
-    subset:
-      stop: 1456
+validation:
+  loader:
+    batch_size: 128
+    num_data_workers: 4
+    prefetch_factor: 4
+    dataset:
+      data_path: /climate-default/2023-08-11-vertically-resolved-4deg-fme-ensemble-dataset/ic_0011
+      subset:
+        stop: 1456
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/baselines/climsst/train-baseline.yaml
+++ b/configs/baselines/climsst/train-baseline.yaml
@@ -58,14 +58,15 @@ train_loader:
       subset: *subset
     - data_path: /climate-default/2023-08-11-vertically-resolved-1deg-fme-ensemble-dataset/ic_0010
       subset: *subset
-validation_loader:
-  batch_size: 128
-  num_data_workers: 4
-  prefetch_factor: 4
-  dataset:
-    data_path: /climate-default/2023-08-11-vertically-resolved-1deg-fme-ensemble-dataset/ic_0011
-    subset:
-      stop: 1456
+validation:
+  loader:
+    batch_size: 128
+    num_data_workers: 4
+    prefetch_factor: 4
+    dataset:
+      data_path: /climate-default/2023-08-11-vertically-resolved-1deg-fme-ensemble-dataset/ic_0011
+      subset:
+        stop: 1456
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/baselines/cm4-piControl/finetune-config-template.yaml
+++ b/configs/baselines/cm4-piControl/finetune-config-template.yaml
@@ -78,39 +78,40 @@ train_loader:
         subset:
           start_time: '0151-01-06'
           stop_time: '0306-01-01'
-validation_loader:
-  batch_size: 16
-  num_data_workers: 4
-  prefetch_factor: 1
-  dataset:
-    ocean:
-      merge:
-      - data_path: /climate-default
-        file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
-      - data_path: /climate-default
-        file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
-    atmosphere:
-      merge:
-      - data_path: /climate-default
-        file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
-      - data_path: /climate-default
-        file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
+validation:
+  loader:
+    batch_size: 16
+    num_data_workers: 4
+    prefetch_factor: 1
+    dataset:
+      ocean:
+        merge:
+        - data_path: /climate-default
+          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
+        - data_path: /climate-default
+          file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
+      atmosphere:
+        merge:
+        - data_path: /climate-default
+          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
+        - data_path: /climate-default
+          file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.00001

--- a/configs/baselines/cm4-piControl/finetune-config.yaml
+++ b/configs/baselines/cm4-piControl/finetune-config.yaml
@@ -78,39 +78,40 @@ train_loader:
           subset:
             start_time: '0151-01-06'
             stop_time: '0306-01-01'
-validation_loader:
-  batch_size: 16
-  num_data_workers: 4
-  prefetch_factor: 1
-  dataset:
-    ocean:
-      merge:
-        - data_path: /climate-default
-          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
-        - data_path: /climate-default
-          file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
-    atmosphere:
-      merge:
-        - data_path: /climate-default
-          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
-        - data_path: /climate-default
-          file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
+validation:
+  loader:
+    batch_size: 16
+    num_data_workers: 4
+    prefetch_factor: 1
+    dataset:
+      ocean:
+        merge:
+          - data_path: /climate-default
+            file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
+          - data_path: /climate-default
+            file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
+      atmosphere:
+        merge:
+          - data_path: /climate-default
+            file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
+          - data_path: /climate-default
+            file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.00001

--- a/configs/baselines/cm4-piControl/train-config-template.yaml
+++ b/configs/baselines/cm4-piControl/train-config-template.yaml
@@ -78,39 +78,40 @@ train_loader:
         subset:
           start_time: '0151-01-06'
           stop_time: '0306-01-01'
-validation_loader:
-  batch_size: 16
-  num_data_workers: 4
-  prefetch_factor: 1
-  dataset:
-    ocean:
-      merge:
-      - data_path: /climate-default
-        file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
-      - data_path: /climate-default
-        file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
-    atmosphere:
-      merge:
-      - data_path: /climate-default
-        file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
-      - data_path: /climate-default
-        file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
-        engine: zarr
-        subset:
-          start_time: '0306-01-01'
-          stop_time: '0311-01-01'
+validation:
+  loader:
+    batch_size: 16
+    num_data_workers: 4
+    prefetch_factor: 1
+    dataset:
+      ocean:
+        merge:
+        - data_path: /climate-default
+          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
+        - data_path: /climate-default
+          file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
+      atmosphere:
+        merge:
+        - data_path: /climate-default
+          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
+        - data_path: /climate-default
+          file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
+          engine: zarr
+          subset:
+            start_time: '0306-01-01'
+            stop_time: '0311-01-01'
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/baselines/cm4-piControl/train-config.yaml
+++ b/configs/baselines/cm4-piControl/train-config.yaml
@@ -78,39 +78,40 @@ train_loader:
           subset:
             start_time: '0151-01-06'
             stop_time: '0306-01-01'
-validation_loader:
-  batch_size: 16
-  num_data_workers: 4
-  prefetch_factor: 1
-  dataset:
-    ocean:
-      merge:
-        - data_path: /climate-default
-          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
-        - data_path: /climate-default
-          file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
-    atmosphere:
-      merge:
-        - data_path: /climate-default
-          file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
-        - data_path: /climate-default
-          file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
-          engine: zarr
-          subset:
-            start_time: '0306-01-01'
-            stop_time: '0311-01-01'
+validation:
+  loader:
+    batch_size: 16
+    num_data_workers: 4
+    prefetch_factor: 1
+    dataset:
+      ocean:
+        merge:
+          - data_path: /climate-default
+            file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
+          - data_path: /climate-default
+            file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
+      atmosphere:
+        merge:
+          - data_path: /climate-default
+            file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
+          - data_path: /climate-default
+            file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
+            engine: zarr
+            subset:
+              start_time: '0306-01-01'
+              stop_time: '0311-01-01'
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/baselines/cm4-piControl/uncoupled-atmos/train-config.yaml
+++ b/configs/baselines/cm4-piControl/uncoupled-atmos/train-config.yaml
@@ -50,24 +50,25 @@ train_loader:
       engine: zarr
       subset:
         stop_time: '0306-01-01T06:00:00'
-validation_loader:
-  batch_size: 64
-  num_data_workers: 4
-  prefetch_factor: 4
-  dataset:
-    merge:
-    - data_path: /climate-default
-      file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
-      engine: zarr
-      subset:
-        start_time: '0306-01-01T06:00:00'
-        stop_time: '0311-01-01T06:00:00'
-    - data_path: /climate-default
-      file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
-      engine: zarr
-      subset:
-        start_time: '0306-01-01T06:00:00'
-        stop_time: '0311-01-01T06:00:00'
+validation:
+  loader:
+    batch_size: 64
+    num_data_workers: 4
+    prefetch_factor: 4
+    dataset:
+      merge:
+      - data_path: /climate-default
+        file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-interpolate_sst-atmosphere.zarr
+        engine: zarr
+        subset:
+          start_time: '0306-01-01T06:00:00'
+          stop_time: '0311-01-01T06:00:00'
+      - data_path: /climate-default
+        file_pattern: 2025-03-21-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
+        engine: zarr
+        subset:
+          start_time: '0306-01-01T06:00:00'
+          stop_time: '0311-01-01T06:00:00'
 optimization:
   use_gradient_accumulation: true
   enable_automatic_mixed_precision: false

--- a/configs/baselines/cm4-piControl/uncoupled-ocean/train-config.yaml
+++ b/configs/baselines/cm4-piControl/uncoupled-ocean/train-config.yaml
@@ -57,29 +57,30 @@ train_loader:
       engine: zarr
       subset:
         stop_time: '0306-01-01'
-validation_loader:
-  batch_size: 16
-  num_data_workers: 8
-  dataset:
-    merge:
-    - data_path: /climate-default
-      file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
-      engine: zarr
-      subset:
-        start_time: '0306-01-01'
-        stop_time: '0311-01-01'
-    - data_path: /climate-default
-      file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
-      engine: zarr
-      subset:
-        start_time: '0306-01-01'
-        stop_time: '0311-01-01'
-    - data_path: /climate-default
-      file_pattern: 2025-01-27-cm4-piControl-atmosphere-5daily-sfc-only/zarr_v3/data.zarr
-      engine: zarr
-      subset:
-        start_time: '0306-01-01'
-        stop_time: '0311-01-01'
+validation:
+  loader:
+    batch_size: 16
+    num_data_workers: 8
+    dataset:
+      merge:
+      - data_path: /climate-default
+        file_pattern: 2025-06-03-cm4-piControl-200yr-coupled-ocean.zarr
+        engine: zarr
+        subset:
+          start_time: '0306-01-01'
+          stop_time: '0311-01-01'
+      - data_path: /climate-default
+        file_pattern: 2025-04-16-cm4-piControl-ocean-200yr-dataset.zarr
+        engine: zarr
+        subset:
+          start_time: '0306-01-01'
+          stop_time: '0311-01-01'
+      - data_path: /climate-default
+        file_pattern: 2025-01-27-cm4-piControl-atmosphere-5daily-sfc-only/zarr_v3/data.zarr
+        engine: zarr
+        subset:
+          start_time: '0306-01-01'
+          stop_time: '0311-01-01'
 optimization:
   use_gradient_accumulation: true
   enable_automatic_mixed_precision: false

--- a/configs/baselines/era5/ace-train-config.yaml
+++ b/configs/baselines/era5/ace-train-config.yaml
@@ -48,15 +48,16 @@ train_loader:
     - data_path: /climate-default/2024-06-20-era5-1deg-8layer-1940-2022-netcdfs
       subset:
         start_time: '2021-01-01'
-validation_loader:
-  batch_size: 128
-  num_data_workers: 16
-  prefetch_factor: 4
-  dataset:
-    data_path: /climate-default/2024-06-20-era5-1deg-8layer-1940-2022-netcdfs
-    subset:
-      start_time: '1996-01-01'
-      stop_time: '1997-12-31'
+validation:
+  loader:
+    batch_size: 128
+    num_data_workers: 16
+    prefetch_factor: 4
+    dataset:
+      data_path: /climate-default/2024-06-20-era5-1deg-8layer-1940-2022-netcdfs
+      subset:
+        start_time: '1996-01-01'
+        stop_time: '1997-12-31'
 optimization:
   use_gradient_accumulation: true
   enable_automatic_mixed_precision: false

--- a/configs/baselines/shield-som/ace-train-config.yaml
+++ b/configs/baselines/shield-som/ace-train-config.yaml
@@ -50,24 +50,25 @@ train_loader:
       subset:
         start_time: "2073-01-01T06:00:00"
         stop_time: "2101-01-01T00:00:00"
-validation_loader:
-  batch_size: 32
-  num_data_workers: 4
-  prefetch_factor: 4
-  dataset:
-    concat:
-    - data_path: /climate-default/2025-03-22-vertically-resolved-1deg-c96-shield-som-3d-radiative-heating-rates-increasing-co2-fme-dataset
-      file_pattern: increasing-CO2.zarr
-      engine: zarr
-      subset:
-        start_time: "2059-01-01T06:00:00"
-        stop_time: "2061-01-01T00:00:00"
-    - data_path: /climate-default/2025-03-22-vertically-resolved-1deg-c96-shield-som-3d-radiative-heating-rates-increasing-co2-fme-dataset
-      file_pattern: increasing-CO2.zarr
-      engine: zarr
-      subset:
-        start_time: "2071-01-01T06:00:00"
-        stop_time: "2073-01-01T00:00:00"
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 4
+    prefetch_factor: 4
+    dataset:
+      concat:
+      - data_path: /climate-default/2025-03-22-vertically-resolved-1deg-c96-shield-som-3d-radiative-heating-rates-increasing-co2-fme-dataset
+        file_pattern: increasing-CO2.zarr
+        engine: zarr
+        subset:
+          start_time: "2059-01-01T06:00:00"
+          stop_time: "2061-01-01T00:00:00"
+      - data_path: /climate-default/2025-03-22-vertically-resolved-1deg-c96-shield-som-3d-radiative-heating-rates-increasing-co2-fme-dataset
+        file_pattern: increasing-CO2.zarr
+        engine: zarr
+        subset:
+          start_time: "2071-01-01T06:00:00"
+          stop_time: "2073-01-01T00:00:00"
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/configs/examples/perlmutter-conda/config-train.yaml
+++ b/configs/examples/perlmutter-conda/config-train.yaml
@@ -43,11 +43,12 @@ train_loader:
   num_data_workers: 4
   dataset:
     data_path: FME_TRAIN_DIR
-validation_loader:
-  batch_size: 32
-  num_data_workers: 4
-  dataset:
-    data_path: FME_VALID_DIR
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 4
+    dataset:
+      data_path: FME_VALID_DIR
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/docs/train-config.yaml
+++ b/docs/train-config.yaml
@@ -35,14 +35,15 @@ train_loader:
       - data_path: traindata/ic_0008
       - data_path: traindata/ic_0009
       - data_path: traindata/ic_0010
-validation_loader:
-  batch_size: 16
-  num_data_workers: 4
-  prefetch_factor: 4
-  dataset:
-    data_path: validation
-    subset:
-      step: 5
+validation:
+  loader:
+    batch_size: 16
+    num_data_workers: 4
+    prefetch_factor: 4
+    dataset:
+      data_path: validation
+      subset:
+        step: 5
 optimization:
   enable_automatic_mixed_precision: false
   lr: 0.0001

--- a/docs/training_config.rst
+++ b/docs/training_config.rst
@@ -56,7 +56,7 @@ In that example dataset, the  ``.nc`` files would correspond to files like ``tra
    )
    # these paths are used in the documentation on this page
    # if they change then update the docs!
-   assert config.validation_loader.dataset.data_path == "validation"
+   assert config.validation_list[0].loader.dataset.data_path == "validation"
    assert config.train_loader.dataset.concat[0].data_path == "traindata/ic_0001"
    assert config.train_loader.dataset.concat[1].data_path == "traindata/ic_0002"
    assert config.train_loader.dataset.concat[9].data_path == "traindata/ic_0010"
@@ -100,6 +100,10 @@ The top-level sub-configurations are:
    :noindex:
 
 .. autoclass:: fme.ace.LoggingConfig
+   :show-inheritance:
+   :noindex:
+
+.. autoclass:: fme.ace.InlineValidationConfig
    :show-inheritance:
    :noindex:
 

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -119,6 +119,7 @@ from .train.train_config import (
     DataLoaderConfig,
     EMAConfig,
     InlineInferenceConfig,
+    InlineValidationConfig,
     LoggingConfig,
     OptimizationConfig,
     TrainConfig,

--- a/fme/ace/test_ice_train.py
+++ b/fme/ace/test_ice_train.py
@@ -160,12 +160,13 @@ train_loader:
     spatial_dimensions: latlon
   batch_size: 2
   num_data_workers: 0
-validation_loader:
-  dataset:
-    data_path: '{valid_data_path}'
-    spatial_dimensions: latlon
-  batch_size: 2
-  num_data_workers: 0
+validation:
+- loader:
+    dataset:
+      data_path: '{valid_data_path}'
+      spatial_dimensions: latlon
+    batch_size: 2
+    num_data_workers: 0
 optimization:
   use_gradient_accumulation: true
   optimizer_type: "Adam"

--- a/fme/ace/test_ocean_train.py
+++ b/fme/ace/test_ocean_train.py
@@ -227,12 +227,13 @@ train_loader:
     spatial_dimensions: latlon
   batch_size: 2
   num_data_workers: 0
-validation_loader:
-  dataset:
-    data_path: '{valid_data_path}'
-    spatial_dimensions: latlon
-  batch_size: 2
-  num_data_workers: 0
+validation:
+- loader:
+    dataset:
+      data_path: '{valid_data_path}'
+      spatial_dimensions: latlon
+    batch_size: 2
+    num_data_workers: 0
 optimization:
   use_gradient_accumulation: true
   optimizer_type: "Adam"

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -57,7 +57,12 @@ from fme.ace.testing import (
 )
 from fme.ace.train.train import build_trainer, prepare_directory
 from fme.ace.train.train import main as train_main
-from fme.ace.train.train_config import InlineInferenceConfig, TrainBuilders, TrainConfig
+from fme.ace.train.train_config import (
+    InlineInferenceConfig,
+    InlineValidationConfig,
+    TrainBuilders,
+    TrainConfig,
+)
 from fme.core.coordinates import (
     HEALPixCoordinates,
     HorizontalCoordinates,
@@ -317,14 +322,20 @@ def _get_test_yaml_files(
             time_buffer=time_buffer,
             sample_with_replacement=10,
         ),
-        validation_loader=DataLoaderConfig(
-            dataset=XarrayDataConfig(
-                data_path=str(valid_data_path),
-                spatial_dimensions=spatial_dimensions_str,
-                labels=["era5"] if conditional else None,
+        validation=InlineValidationConfig(
+            loader=DataLoaderConfig(
+                dataset=XarrayDataConfig(
+                    data_path=str(valid_data_path),
+                    spatial_dimensions=spatial_dimensions_str,
+                    labels=["era5"] if conditional else None,
+                ),
+                batch_size=2,
+                num_data_workers=0,
             ),
-            batch_size=2,
-            num_data_workers=0,
+            aggregator=OneStepAggregatorConfig(
+                log_snapshots=log_validation_maps,
+                log_mean_maps=log_validation_maps,
+            ),
         ),
         optimization=OptimizationConfig(
             use_gradient_accumulation=True,
@@ -382,10 +393,6 @@ def _get_test_yaml_files(
         logging=logging_config,
         experiment_dir=str(results_dir),
         save_per_epoch_diagnostics=save_per_epoch_diagnostics,
-        validation_aggregator=OneStepAggregatorConfig(
-            log_snapshots=log_validation_maps,
-            log_mean_maps=log_validation_maps,
-        ),
     )
 
     inference_config = InferenceEvaluatorConfig(
@@ -1088,7 +1095,7 @@ def test_train_with_non_local_experiment_dir_error():
             experiment_dir=non_local_experiment_dir,
             stepper=stepper,
             train_loader=dummy_data_loader,
-            validation_loader=dummy_data_loader,
+            validation=InlineValidationConfig(loader=dummy_data_loader),
             optimization=OptimizationConfig(),
             logging=LoggingConfig(),
             max_epochs=1,
@@ -1109,7 +1116,7 @@ def test_train_config_with_checkpoint_stepper(tmp_path: pathlib.Path):
         stepper=CheckpointStepperConfig(checkpoint_path=str(checkpoint_path)),
         stepper_training=TrainStepperConfig(n_forward_steps=2),
         train_loader=dummy_data_loader,
-        validation_loader=dummy_data_loader,
+        validation=InlineValidationConfig(loader=dummy_data_loader),
         optimization=OptimizationConfig(),
         logging=LoggingConfig(),
         max_epochs=1,
@@ -1152,7 +1159,7 @@ def test_train_config_with_stepper_config_sets_stepper_config(tmp_path: pathlib.
         stepper=stepper,
         stepper_training=TrainStepperConfig(n_forward_steps=2),
         train_loader=dummy_data_loader,
-        validation_loader=dummy_data_loader,
+        validation=InlineValidationConfig(loader=dummy_data_loader),
         optimization=OptimizationConfig(),
         logging=LoggingConfig(),
         max_epochs=1,

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -610,14 +610,14 @@ def _setup(
 
 @pytest.mark.parametrize(
     "nettype, crps_training, log_validation_maps, \
-        use_healpix, use_schedule, validate_using_ema",
+        use_healpix, use_schedule, validate_using_ema, multi_validation",
     [
-        ("NoiseConditionedSFNO", True, False, False, True, False),
-        ("SphericalFourierNeuralOperatorNet", False, True, False, False, False),
-        ("HEALPixRecUNet", False, False, True, False, False),
-        ("Samudra", False, False, False, False, False),
-        ("NoiseConditionedSFNO", False, False, False, False, False),
-        ("NoiseConditionedSFNO", True, False, False, True, True),
+        ("NoiseConditionedSFNO", True, False, False, True, False, False),
+        ("SphericalFourierNeuralOperatorNet", False, True, False, False, False, True),
+        ("HEALPixRecUNet", False, False, True, False, False, False),
+        ("Samudra", False, False, False, False, False, False),
+        ("NoiseConditionedSFNO", False, False, False, False, False, False),
+        ("NoiseConditionedSFNO", True, False, False, True, True, False),
     ],
 )
 def test_train_and_inference(
@@ -628,6 +628,7 @@ def test_train_and_inference(
     use_healpix: bool,
     use_schedule: bool,
     validate_using_ema: bool,
+    multi_validation: bool,
     very_fast_only: bool,
 ):
     """Ensure that ACE training and subsequent standalone inference run without errors.
@@ -658,6 +659,7 @@ def test_train_and_inference(
         use_schedule=use_schedule,
         validate_using_ema=validate_using_ema,
         log_validation_maps=log_validation_maps,
+        multi_validation=multi_validation,
     )
     # using pdb requires calling main functions directly
     with mock_wandb() as wandb:
@@ -671,7 +673,10 @@ def test_train_and_inference(
 
         epoch_logs = wandb_logs[-1]
         assert "inference_0/mean_step_20_norm/weighted_rmse/channel_mean" in epoch_logs
-        assert "val/mean_norm/weighted_rmse/channel_mean" in epoch_logs
+        primary_val_name = "val_0" if multi_validation else "val"
+        assert f"{primary_val_name}/mean_norm/weighted_rmse/channel_mean" in epoch_logs
+        if multi_validation:
+            assert "val_extra/mean/loss" in epoch_logs
         ensemble_step_20_keys = [
             k for k in epoch_logs if "inference_0/ensemble_step_20/" in k
         ]
@@ -691,7 +696,9 @@ def test_train_and_inference(
             "inference epoch log"
         )
 
-    validation_output_dir = tmp_path / "results" / "output" / "val" / "epoch_0001"
+    validation_output_dir = (
+        tmp_path / "results" / "output" / primary_val_name / "epoch_0001"
+    )
     assert validation_output_dir.exists()
     validation_diags = ["mean"]
     validation_map_diags = ["snapshot", "mean_map"]

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -91,6 +91,47 @@ JOB_SUBMISSION_SCRIPT_PATH = (
 )
 
 
+def _make_validation_entries(
+    *,
+    valid_data_path,
+    spatial_dimensions_str,
+    conditional,
+    log_validation_maps,
+    multi_validation=False,
+) -> InlineValidationConfig | list[InlineValidationConfig]:
+    primary = InlineValidationConfig(
+        loader=DataLoaderConfig(
+            dataset=XarrayDataConfig(
+                data_path=str(valid_data_path),
+                spatial_dimensions=spatial_dimensions_str,
+                labels=["era5"] if conditional else None,
+            ),
+            batch_size=2,
+            num_data_workers=0,
+        ),
+        aggregator=OneStepAggregatorConfig(
+            log_snapshots=log_validation_maps,
+            log_mean_maps=log_validation_maps,
+        ),
+    )
+    if not multi_validation:
+        return primary
+    secondary = InlineValidationConfig(
+        loader=DataLoaderConfig(
+            dataset=XarrayDataConfig(
+                data_path=str(valid_data_path),
+                spatial_dimensions=spatial_dimensions_str,
+                labels=["era5"] if conditional else None,
+            ),
+            batch_size=2,
+            num_data_workers=0,
+        ),
+        name="val_extra",
+        weight=0.0,
+    )
+    return [primary, secondary]
+
+
 def _get_test_yaml_files(
     *,
     train_data_path,
@@ -118,6 +159,7 @@ def _get_test_yaml_files(
     use_schedule=False,
     validate_using_ema=False,
     derived_forcings=None,
+    multi_validation=False,
 ):
     input_time_size = 1
     output_time_size = 1
@@ -322,20 +364,12 @@ def _get_test_yaml_files(
             time_buffer=time_buffer,
             sample_with_replacement=10,
         ),
-        validation=InlineValidationConfig(
-            loader=DataLoaderConfig(
-                dataset=XarrayDataConfig(
-                    data_path=str(valid_data_path),
-                    spatial_dimensions=spatial_dimensions_str,
-                    labels=["era5"] if conditional else None,
-                ),
-                batch_size=2,
-                num_data_workers=0,
-            ),
-            aggregator=OneStepAggregatorConfig(
-                log_snapshots=log_validation_maps,
-                log_mean_maps=log_validation_maps,
-            ),
+        validation=_make_validation_entries(
+            valid_data_path=valid_data_path,
+            spatial_dimensions_str=spatial_dimensions_str,
+            conditional=conditional,
+            log_validation_maps=log_validation_maps,
+            multi_validation=multi_validation,
         ),
         optimization=OptimizationConfig(
             use_gradient_accumulation=True,
@@ -467,6 +501,7 @@ def _setup(
     use_schedule: bool = False,
     validate_using_ema: bool = False,
     stats_std_fill_value: float | None = None,
+    multi_validation: bool = False,
 ):
     if not path.exists():
         path.mkdir()
@@ -568,6 +603,7 @@ def _setup(
         derived_forcings=derived_forcings,
         use_schedule=use_schedule,
         validate_using_ema=validate_using_ema,
+        multi_validation=multi_validation,
     )
     return train_config_filename, inference_config_filename
 
@@ -1003,6 +1039,7 @@ def test_train_without_inline_inference(tmp_path, very_fast_only: bool):
         log_validation_maps=log_validation_maps,
         skip_inline_inference=True,
         time_buffer=2,
+        multi_validation=True,
     )
     with mock_wandb() as wandb:
         train_main(
@@ -1011,6 +1048,11 @@ def test_train_without_inline_inference(tmp_path, very_fast_only: bool):
         wandb_logs = wandb.get_logs()
     assert np.isinf(wandb_logs[-1]["best_inference_error"])
     assert not any("inference/" in key for key in wandb_logs[-1])
+    epoch_logs = wandb_logs[-1]
+    assert "val_0/mean/loss" in epoch_logs
+    assert "val_extra/mean/loss" in epoch_logs
+    val_extra_output = tmp_path / "results" / "output" / "val_extra" / "epoch_0001"
+    assert val_extra_output.exists()
 
 
 @pytest.mark.parametrize(

--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -1,4 +1,5 @@
 import dataclasses
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -293,3 +294,75 @@ def test_duplicate_validation_names_raises(tmp_path):
                 _make_validation_config(name="same"),
             ],
         )
+
+
+def test_empty_validation_raises(tmp_path):
+    with pytest.raises(ValueError, match="At least one validation entry"):
+        _make_train_config(tmp_path, [], validation=[])
+
+
+class TestGetValidationCallback:
+    @staticmethod
+    def _make_entry(name, weight=1.0):
+        config = _make_validation_config(name=name, weight=weight)
+        data = MagicMock()
+        return (config, data, name)
+
+    @staticmethod
+    def _call(entries, run_validation_side_effect):
+        from fme.ace.train.train import get_validation_callback
+
+        stepper = MagicMock()
+        with patch(
+            "fme.ace.train.train.run_validation",
+            side_effect=run_validation_side_effect,
+        ):
+            callback = get_validation_callback(
+                validation_entries=entries,
+                stepper=stepper,
+                dataset_info=MagicMock(),
+                loss_scaling=None,
+                loss_names=None,
+                save_per_epoch_diagnostics=False,
+                output_dir="/tmp/out",
+            )
+            return callback(epoch=1)
+
+    def test_single_entry(self):
+        entries = [self._make_entry("val")]
+        logs, loss = self._call(
+            entries,
+            [{"val/mean/loss": 0.5, "val/other": 1.0}],
+        )
+        assert loss == 0.5
+        assert logs == {"val/mean/loss": 0.5, "val/other": 1.0}
+
+    def test_zero_weight_excluded_from_loss(self):
+        entries = [
+            self._make_entry("val_0", weight=1.0),
+            self._make_entry("val_extra", weight=0.0),
+        ]
+        logs, loss = self._call(
+            entries,
+            [
+                {"val_0/mean/loss": 0.5},
+                {"val_extra/mean/loss": 999.0},
+            ],
+        )
+        assert loss == 0.5
+        assert "val_0/mean/loss" in logs
+        assert "val_extra/mean/loss" in logs
+
+    def test_multiple_weighted_entries(self):
+        entries = [
+            self._make_entry("a", weight=2.0),
+            self._make_entry("b", weight=3.0),
+        ]
+        logs, loss = self._call(
+            entries,
+            [
+                {"a/mean/loss": 0.1},
+                {"b/mean/loss": 0.2},
+            ],
+        )
+        assert loss == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)

--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -366,3 +366,116 @@ class TestGetValidationCallback:
             ],
         )
         assert loss == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
+
+
+class TestGetInferenceCallback:
+    @staticmethod
+    def _make_entry(name, weight=1.0):
+        config = MagicMock()
+        config.weight = weight
+        config.n_forward_steps = 1
+        config.n_ensemble_per_ic = 1
+        data = MagicMock()
+        dataset_info = MagicMock()
+        return (config, data, dataset_info, name)
+
+    @staticmethod
+    def _call(
+        entries,
+        inference_one_epoch_side_effect,
+        epoch=1,
+        inference_epochs=(1,),
+        inference_epoch_sets=None,
+    ):
+        from fme.ace.train.train import get_inference_callback
+
+        if inference_epoch_sets is None:
+            inference_epoch_sets = [{1} for _ in entries]
+        stepper = MagicMock()
+        with patch(
+            "fme.ace.train.train.inference_one_epoch",
+            side_effect=inference_one_epoch_side_effect,
+        ):
+            callback = get_inference_callback(
+                inference_entries=entries,
+                inference_epochs=list(inference_epochs),
+                inference_epoch_sets=list(inference_epoch_sets),
+                stepper=stepper,
+                output_dir="/tmp/out",
+                save_per_epoch_diagnostics=False,
+            )
+            return callback(epoch=epoch)
+
+    def test_epoch_not_in_inference_epochs_returns_empty(self):
+        entries = [self._make_entry("inference")]
+        logs, error = self._call(
+            entries,
+            inference_one_epoch_side_effect=[],
+            epoch=2,
+            inference_epochs=(1,),
+        )
+        assert logs == {}
+        assert error is None
+
+    def test_single_entry_weighted_error(self):
+        entries = [self._make_entry("inference", weight=2.0)]
+        logs, error = self._call(
+            entries,
+            [{"inference/time_mean_norm/rmse/channel_mean": 0.4}],
+        )
+        assert error == pytest.approx(2.0 * 0.4)
+        assert "inference/time_mean_norm/rmse/channel_mean" in logs
+
+    def test_zero_weight_excluded_from_error(self):
+        entries = [
+            self._make_entry("a", weight=1.0),
+            self._make_entry("b", weight=0.0),
+        ]
+        logs, error = self._call(
+            entries,
+            [
+                {"a/time_mean_norm/rmse/channel_mean": 0.3},
+                {"b/time_mean_norm/rmse/channel_mean": 999.0},
+            ],
+        )
+        assert error == pytest.approx(0.3)
+        assert "a/time_mean_norm/rmse/channel_mean" in logs
+        assert "b/time_mean_norm/rmse/channel_mean" in logs
+
+    def test_multiple_weighted_entries(self):
+        entries = [
+            self._make_entry("a", weight=2.0),
+            self._make_entry("b", weight=3.0),
+        ]
+        logs, error = self._call(
+            entries,
+            [
+                {"a/time_mean_norm/rmse/channel_mean": 0.1},
+                {"b/time_mean_norm/rmse/channel_mean": 0.2},
+            ],
+        )
+        assert error == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
+
+    def test_entry_skipped_when_not_in_epoch_set(self):
+        entries = [
+            self._make_entry("a", weight=1.0),
+            self._make_entry("b", weight=1.0),
+        ]
+        logs, error = self._call(
+            entries,
+            [{"a/time_mean_norm/rmse/channel_mean": 0.5}],
+            epoch=1,
+            inference_epochs=(1,),
+            inference_epoch_sets=[{1}, {2}],
+        )
+        assert error == pytest.approx(0.5)
+        assert "a/time_mean_norm/rmse/channel_mean" in logs
+        assert "b/time_mean_norm/rmse/channel_mean" not in logs
+
+    def test_weighted_entry_missing_metric_raises(self):
+        entries = [self._make_entry("a", weight=1.0)]
+        with pytest.raises(RuntimeError, match="did not produce expected metric key"):
+            self._call(
+                entries,
+                [{"a/other_metric": 1.0}],
+            )

--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -15,13 +15,27 @@ from fme.ace.stepper.single_module import (
     StepperConfig,
     TrainStepperConfig,
 )
-from fme.ace.train.train_config import InlineInferenceConfig, TrainConfig
+from fme.ace.train.train_config import (
+    InlineInferenceConfig,
+    InlineValidationConfig,
+    TrainConfig,
+)
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.logging_utils import LoggingConfig
 from fme.core.optimization import OptimizationConfig
 from fme.core.step.single_module import SingleModuleStepConfig
 from fme.core.step.step import StepSelector
 from fme.core.typing_ import Slice
+
+
+def _make_validation_config(
+    name: str | None = None, weight: float = 1.0
+) -> InlineValidationConfig:
+    return InlineValidationConfig(
+        loader=DataLoaderConfig(dataset=XarrayDataConfig(data_path=""), batch_size=1),
+        name=name,
+        weight=weight,
+    )
 
 
 def _make_inference_config(
@@ -68,16 +82,18 @@ def _make_train_config(
     tmp_path,
     inference: InlineInferenceConfig | list[InlineInferenceConfig],
     max_epochs: int = 5,
+    validation: InlineValidationConfig | list[InlineValidationConfig] | None = None,
 ) -> TrainConfig:
-    dummy_loader = DataLoaderConfig(
-        dataset=XarrayDataConfig(data_path=""), batch_size=1
-    )
+    if validation is None:
+        validation = _make_validation_config()
     return TrainConfig(
         experiment_dir=str(tmp_path),
         stepper=_make_stepper_config(),
         stepper_training=TrainStepperConfig(n_forward_steps=1),
-        train_loader=dummy_loader,
-        validation_loader=dummy_loader,
+        train_loader=DataLoaderConfig(
+            dataset=XarrayDataConfig(data_path=""), batch_size=1
+        ),
+        validation=validation,
         optimization=OptimizationConfig(),
         logging=LoggingConfig(),
         max_epochs=max_epochs,
@@ -206,4 +222,74 @@ def test_get_inference_epoch_sets_different_weighted_epochs_raises(tmp_path):
                 _make_inference_config(epochs=Slice(step=3), weight=1.0),
             ],
             max_epochs=6,
+        )
+
+
+def test_validation_negative_weight_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        _make_validation_config(weight=-1.0)
+
+
+def test_validation_zero_weight_accepted():
+    config = _make_validation_config(weight=0.0)
+    assert config.weight == 0.0
+
+
+def test_validation_default_weight_is_one():
+    config = _make_validation_config()
+    assert config.weight == 1.0
+
+
+def test_validation_single_config_gives_list(tmp_path):
+    config = _make_train_config(tmp_path, [], validation=_make_validation_config())
+    assert isinstance(config.validation, InlineValidationConfig)
+    assert isinstance(config.validation_list, list)
+    assert len(config.validation_list) == 1
+    assert config.validation_names == ["val"]
+
+
+def test_validation_names_single_unnamed(tmp_path):
+    config = _make_train_config(tmp_path, [], validation=[_make_validation_config()])
+    assert config.validation_names == ["val"]
+
+
+def test_validation_names_multiple_unnamed(tmp_path):
+    config = _make_train_config(
+        tmp_path,
+        [],
+        validation=[_make_validation_config(), _make_validation_config()],
+    )
+    assert config.validation_names == ["val_0", "val_1"]
+
+
+def test_validation_names_explicit(tmp_path):
+    config = _make_train_config(
+        tmp_path,
+        [],
+        validation=[
+            _make_validation_config(name="era5"),
+            _make_validation_config(name="obs"),
+        ],
+    )
+    assert config.validation_names == ["era5", "obs"]
+
+
+def test_validation_names_mixed(tmp_path):
+    config = _make_train_config(
+        tmp_path,
+        [],
+        validation=[_make_validation_config(name="era5"), _make_validation_config()],
+    )
+    assert config.validation_names == ["era5", "val_1"]
+
+
+def test_duplicate_validation_names_raises(tmp_path):
+    with pytest.raises(ValueError, match="Duplicate validation names"):
+        _make_train_config(
+            tmp_path,
+            [],
+            validation=[
+                _make_validation_config(name="same"),
+                _make_validation_config(name="same"),
+            ],
         )

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -85,11 +85,19 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
     # trainer, you can build it however you like. This is here for convenience.
     logging.info("Initializing training data loader")
     train_data = builder.get_train_data()
-    logging.info("Initializing validation data loader")
-    validation_data = builder.get_validation_data()
 
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
-    for data, name in zip((train_data, validation_data), ("train", "valid")):
+
+    if config.validation_list:
+        logging.info("Initializing validation data loaders")
+    else:
+        logging.info("Skipping validation")
+    validation_entries = builder.get_validation_data()
+
+    for data, name in zip(
+        [train_data] + [data for _, data, _ in validation_entries],
+        ["train"] + [name for _, _, name in validation_entries],
+    ):
         data.log_info(name)
 
     if config.inference_list:
@@ -109,6 +117,9 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         modules=stepper.modules, base_weights=stepper.get_base_weights()
     )
 
+    primary_validation_config = (
+        config.validation_list[0].aggregator if config.validation_list else None
+    )
     aggregator_builder = AggregatorBuilder(
         train_config=config.train_aggregator,
         dataset_info=dataset_info.update_variable_metadata(variable_metadata),
@@ -116,20 +127,41 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         loss_scaling=stepper.effective_loss_scaling,
         channel_mean_names=stepper.loss_names,
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
-        validation_config=config.validation_aggregator,
+        validation_config=primary_validation_config,
     )
 
     def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
-        validation_data.set_epoch(epoch)
-        aggregator = aggregator_builder.get_validation_aggregator()
-        logs = run_validation(
-            train_stepper=stepper,
-            validation_data=validation_data,
-            aggregator=aggregator,
-            diagnostics_subdir=f"epoch_{epoch:04d}",
-            record_logs=lambda logs: None,
-        )
-        return logs, logs["val/mean/loss"]
+        all_logs: dict[str, Any] = {}
+        weighted_loss = 0.0
+        for entry_config, data, name in validation_entries:
+            data.set_epoch(epoch)
+            aggregator = entry_config.aggregator.build(
+                dataset_info=dataset_info.update_variable_metadata(variable_metadata),
+                loss_scaling=stepper.effective_loss_scaling,
+                save_diagnostics=config.save_per_epoch_diagnostics,
+                output_dir=os.path.join(config.output_dir, name),
+                channel_mean_names=stepper.loss_names,
+            )
+            logs = run_validation(
+                train_stepper=stepper,
+                validation_data=data,
+                aggregator=aggregator,
+                label=name,
+                diagnostics_subdir=f"epoch_{epoch:04d}",
+                record_logs=lambda logs: None,
+            )
+            all_logs.update(logs)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is None:
+                    raise RuntimeError(
+                        f"Validation entry {name!r} with "
+                        f"weight={entry_config.weight} did not produce "
+                        f"expected metric key {metric_key!r}."
+                    )
+                weighted_loss += entry_config.weight * loss
+        return all_logs, weighted_loss
 
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
@@ -178,11 +210,12 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
 
         return all_logs, weighted_error
 
+    primary_validation_data = validation_entries[0][1]
     do_gc_collect = fme.get_device() != torch.device("cpu")
     trainer_config: TrainConfigProtocol = config  # documenting trainer input type
     return Trainer(
         train_data=train_data,
-        validation_data=validation_data,
+        validation_data=primary_validation_data,
         stepper=stepper,
         build_optimization=builder.get_optimization,
         build_ema=builder.get_ema,
@@ -206,9 +239,7 @@ class AggregatorBuilder(
         loss_scaling: dict[str, torch.Tensor] | None = None,
         channel_mean_names: Sequence[str] | None = None,
         save_per_epoch_diagnostics: bool = False,
-        validation_config: OneStepAggregatorConfig = dataclasses.field(
-            default_factory=lambda: OneStepAggregatorConfig(),
-        ),
+        validation_config: OneStepAggregatorConfig | None = None,
     ):
         self.train_config = train_config
         self.dataset_info = dataset_info
@@ -216,7 +247,7 @@ class AggregatorBuilder(
         self.channel_mean_names = channel_mean_names
         self.output_dir = output_dir
         self.save_per_epoch_diagnostics = save_per_epoch_diagnostics
-        self.validation_config = validation_config
+        self.validation_config = validation_config or OneStepAggregatorConfig()
 
     def get_train_aggregator(self) -> TrainAggregator:
         return TrainAggregator(

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -61,8 +61,10 @@ import torch
 import fme
 from fme.ace.aggregator import TrainAggregator
 from fme.ace.aggregator.train import TrainAggregatorConfig
-from fme.ace.stepper import TrainOutput
+from fme.ace.data_loading.gridded_data import InferenceGriddedData
+from fme.ace.stepper import TrainOutput, TrainStepper
 from fme.ace.train.train_config import (
+    InlineInferenceConfig,
     InlineValidationConfig,
     TrainBuilders,
     TrainConfig,
@@ -77,6 +79,7 @@ from fme.core.generics.lr_tuning import ValidateStepper
 from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import (
     AggregatorBuilderABC,
+    InferenceCallback,
     TrainConfigProtocol,
     Trainer,
     ValidationCallback,
@@ -143,6 +146,9 @@ def get_validate_stepper_callback(
     loss_names: Sequence[str] | None,
     validate_using_ema: bool,
 ) -> ValidateStepper:
+    # LR tuning passes trial stepper/EMA instances distinct from the Trainer's
+    # own stepper, so this callback manages its own EMA via run_validation_loop
+    # rather than relying on the Trainer's validation_context().
     def validate_stepper(stepper: TrainStepperABC, ema: EMATracker) -> float:
         weighted_loss = 0.0
         for entry_config, data, name in validation_entries:
@@ -169,6 +175,65 @@ def get_validate_stepper_callback(
         return weighted_loss
 
     return validate_stepper
+
+
+def get_inference_callback(
+    inference_entries: Sequence[
+        tuple[InlineInferenceConfig, InferenceGriddedData, DatasetInfo, str]
+    ],
+    inference_epochs: Sequence[int],
+    inference_epoch_sets: Sequence[set[int]],
+    stepper: TrainStepper,
+    output_dir: str,
+    save_per_epoch_diagnostics: bool,
+) -> InferenceCallback:
+    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
+        if epoch not in inference_epochs:
+            return {}, None
+        all_logs: dict[str, Any] = {}
+        weighted_error: float | None = None
+        for i, (entry_config, data, entry_dataset_info, name) in enumerate(
+            inference_entries
+        ):
+            if epoch not in inference_epoch_sets[i]:
+                continue
+            aggregator = entry_config.aggregator.build(
+                dataset_info=entry_dataset_info,
+                n_ic_steps=stepper.n_ic_timesteps,
+                n_forward_steps=entry_config.n_forward_steps,
+                initial_time=data.initial_time,
+                normalize=stepper.normalizer.normalize,
+                output_dir=os.path.join(output_dir, name),
+                channel_mean_names=stepper.loss_names,
+                save_diagnostics=save_per_epoch_diagnostics,
+                n_ensemble_per_ic=entry_config.n_ensemble_per_ic,
+                enable_time_series=False,
+            )
+            logs = inference_one_epoch(
+                stepper=stepper,
+                validation_context=contextlib.nullcontext,
+                dataset=data,
+                aggregator=aggregator,
+                label=name,
+                epoch=epoch,
+            )
+            all_logs.update(logs)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/time_mean_norm/rmse/channel_mean"
+                error = logs.get(metric_key)
+                if error is None:
+                    raise RuntimeError(
+                        f"Inference entry {name!r} with weight={entry_config.weight} "
+                        f"did not produce expected metric key {metric_key!r}. "
+                        f"Entries contributing to checkpoint selection must produce "
+                        f"this metric."
+                    )
+                if weighted_error is None:
+                    weighted_error = 0.0
+                weighted_error += entry_config.weight * error
+        return all_logs, weighted_error
+
+    return inference_callback
 
 
 def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
@@ -236,52 +301,14 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
             validate_using_ema=config.validate_using_ema,
         )
 
-    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
-        if epoch not in inference_epochs:
-            return {}, None
-        all_logs: dict[str, Any] = {}
-        weighted_error: float | None = None
-        for i, (entry_config, data, entry_dataset_info, name) in enumerate(
-            inference_entries
-        ):
-            if epoch not in inference_epoch_sets[i]:
-                continue
-            aggregator = entry_config.aggregator.build(
-                dataset_info=entry_dataset_info,
-                n_ic_steps=stepper.n_ic_timesteps,
-                n_forward_steps=entry_config.n_forward_steps,
-                initial_time=data.initial_time,
-                normalize=stepper.normalizer.normalize,
-                output_dir=os.path.join(config.output_dir, name),
-                channel_mean_names=stepper.loss_names,
-                save_diagnostics=config.save_per_epoch_diagnostics,
-                n_ensemble_per_ic=entry_config.n_ensemble_per_ic,
-                enable_time_series=False,
-            )
-            logs = inference_one_epoch(
-                stepper=stepper,
-                validation_context=contextlib.nullcontext,
-                dataset=data,
-                aggregator=aggregator,
-                label=name,
-                epoch=epoch,
-            )
-            all_logs.update(logs)
-            if entry_config.weight > 0:
-                metric_key = f"{name}/time_mean_norm/rmse/channel_mean"
-                error = logs.get(metric_key)
-                if error is None:
-                    raise RuntimeError(
-                        f"Inference entry {name!r} with weight={entry_config.weight} "
-                        f"did not produce expected metric key {metric_key!r}. "
-                        f"Entries contributing to checkpoint selection must produce "
-                        f"this metric."
-                    )
-                if weighted_error is None:
-                    weighted_error = 0.0
-                weighted_error += entry_config.weight * error
-
-        return all_logs, weighted_error
+    inference_callback = get_inference_callback(
+        inference_entries=inference_entries,
+        inference_epochs=inference_epochs,
+        inference_epoch_sets=inference_epoch_sets,
+        stepper=stepper,
+        output_dir=config.output_dir,
+        save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
+    )
 
     do_gc_collect = fme.get_device() != torch.device("cpu")
     trainer_config: TrainConfigProtocol = config  # documenting trainer input type

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -59,11 +59,7 @@ import dacite
 import torch
 
 import fme
-from fme.ace.aggregator import (
-    OneStepAggregator,
-    OneStepAggregatorConfig,
-    TrainAggregator,
-)
+from fme.ace.aggregator import TrainAggregator
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.stepper import TrainOutput
 from fme.ace.train.train_config import TrainBuilders, TrainConfig
@@ -71,6 +67,8 @@ from fme.core.cli import prepare_config, prepare_directory
 from fme.core.dataset_info import DatasetInfo
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
+from fme.core.ema import EMATracker
+from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import (
     AggregatorBuilderABC,
     TrainConfigProtocol,
@@ -117,30 +115,32 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         modules=stepper.modules, base_weights=stepper.get_base_weights()
     )
 
-    primary_validation_config = (
-        config.validation_list[0].aggregator if config.validation_list else None
-    )
+    loss_scaling = stepper.effective_loss_scaling
+    loss_names = stepper.loss_names
     aggregator_builder = AggregatorBuilder(
         train_config=config.train_aggregator,
         dataset_info=dataset_info.update_variable_metadata(variable_metadata),
         output_dir=config.output_dir,
-        loss_scaling=stepper.effective_loss_scaling,
-        channel_mean_names=stepper.loss_names,
+        loss_scaling=loss_scaling,
+        channel_mean_names=loss_names,
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
-        validation_config=primary_validation_config,
     )
 
-    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
+    def validation_callback(
+        epoch: int,
+        stepper: TrainStepperABC,
+        ema: EMATracker,
+    ) -> tuple[dict[str, Any], float]:
         all_logs: dict[str, Any] = {}
         weighted_loss = 0.0
         for entry_config, data, name in validation_entries:
             data.set_epoch(epoch)
             aggregator = entry_config.aggregator.build(
                 dataset_info=dataset_info.update_variable_metadata(variable_metadata),
-                loss_scaling=stepper.effective_loss_scaling,
+                loss_scaling=loss_scaling,
                 save_diagnostics=config.save_per_epoch_diagnostics,
                 output_dir=os.path.join(config.output_dir, name),
-                channel_mean_names=stepper.loss_names,
+                channel_mean_names=loss_names,
             )
             logs = run_validation(
                 train_stepper=stepper,
@@ -149,6 +149,8 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
                 label=name,
                 diagnostics_subdir=f"epoch_{epoch:04d}",
                 record_logs=lambda logs: None,
+                ema=ema,
+                validate_using_ema=config.validate_using_ema,
             )
             all_logs.update(logs)
             if entry_config.weight > 0:
@@ -210,12 +212,10 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
 
         return all_logs, weighted_error
 
-    primary_validation_data = validation_entries[0][1]
     do_gc_collect = fme.get_device() != torch.device("cpu")
     trainer_config: TrainConfigProtocol = config  # documenting trainer input type
     return Trainer(
         train_data=train_data,
-        validation_data=primary_validation_data,
         stepper=stepper,
         build_optimization=builder.get_optimization,
         build_ema=builder.get_ema,
@@ -239,7 +239,6 @@ class AggregatorBuilder(
         loss_scaling: dict[str, torch.Tensor] | None = None,
         channel_mean_names: Sequence[str] | None = None,
         save_per_epoch_diagnostics: bool = False,
-        validation_config: OneStepAggregatorConfig | None = None,
     ):
         self.train_config = train_config
         self.dataset_info = dataset_info
@@ -247,21 +246,11 @@ class AggregatorBuilder(
         self.channel_mean_names = channel_mean_names
         self.output_dir = output_dir
         self.save_per_epoch_diagnostics = save_per_epoch_diagnostics
-        self.validation_config = validation_config or OneStepAggregatorConfig()
 
     def get_train_aggregator(self) -> TrainAggregator:
         return TrainAggregator(
             config=self.train_config,
             operations=self.dataset_info.gridded_operations,
-        )
-
-    def get_validation_aggregator(self) -> OneStepAggregator:
-        return self.validation_config.build(
-            dataset_info=self.dataset_info,
-            loss_scaling=self.loss_scaling,
-            save_diagnostics=self.save_per_epoch_diagnostics,
-            output_dir=os.path.join(self.output_dir, "val"),
-            channel_mean_names=self.channel_mean_names,
         )
 
 

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -62,20 +62,113 @@ import fme
 from fme.ace.aggregator import TrainAggregator
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.stepper import TrainOutput
-from fme.ace.train.train_config import TrainBuilders, TrainConfig
+from fme.ace.train.train_config import (
+    InlineValidationConfig,
+    TrainBuilders,
+    TrainConfig,
+)
 from fme.core.cli import prepare_config, prepare_directory
 from fme.core.dataset_info import DatasetInfo
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
 from fme.core.ema import EMATracker
+from fme.core.generics.data import GriddedDataABC
+from fme.core.generics.lr_tuning import ValidateStepper
 from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import (
     AggregatorBuilderABC,
     TrainConfigProtocol,
     Trainer,
+    ValidationCallback,
     inference_one_epoch,
 )
-from fme.core.generics.validation import run_validation
+from fme.core.generics.validation import run_validation, run_validation_loop
+
+
+def get_validation_callback(
+    validation_entries: Sequence[tuple[InlineValidationConfig, GriddedDataABC, str]],
+    stepper: TrainStepperABC,
+    dataset_info: DatasetInfo,
+    loss_scaling: dict[str, torch.Tensor] | None,
+    loss_names: Sequence[str] | None,
+    save_per_epoch_diagnostics: bool,
+    output_dir: str,
+) -> ValidationCallback:
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
+        all_logs: dict[str, Any] = {}
+        weighted_loss = 0.0
+        for entry_config, data, name in validation_entries:
+            data.set_epoch(epoch)
+            aggregator = entry_config.aggregator.build(
+                dataset_info=dataset_info,
+                loss_scaling=loss_scaling,
+                save_diagnostics=save_per_epoch_diagnostics,
+                output_dir=os.path.join(output_dir, name),
+                channel_mean_names=loss_names,
+            )
+            logs = run_validation(
+                train_stepper=stepper,
+                validation_data=data,
+                aggregator=aggregator,
+                label=name,
+                diagnostics_subdir=f"epoch_{epoch:04d}",
+                record_logs=lambda logs: None,
+            )
+            overlap = all_logs.keys() & logs.keys()
+            if overlap:
+                raise RuntimeError(
+                    f"Validation entry {name!r} produced log keys that "
+                    f"overlap with earlier entries: {sorted(overlap)}"
+                )
+            all_logs.update(logs)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is None:
+                    raise RuntimeError(
+                        f"Validation entry {name!r} with "
+                        f"weight={entry_config.weight} did not produce "
+                        f"expected metric key {metric_key!r}."
+                    )
+                weighted_loss += entry_config.weight * loss
+        return all_logs, weighted_loss
+
+    return validation_callback
+
+
+def get_validate_stepper_callback(
+    validation_entries: Sequence[tuple[InlineValidationConfig, GriddedDataABC, str]],
+    dataset_info: DatasetInfo,
+    loss_scaling: dict[str, torch.Tensor] | None,
+    loss_names: Sequence[str] | None,
+    validate_using_ema: bool,
+) -> ValidateStepper:
+    def validate_stepper(stepper: TrainStepperABC, ema: EMATracker) -> float:
+        weighted_loss = 0.0
+        for entry_config, data, name in validation_entries:
+            aggregator = entry_config.aggregator.build(
+                dataset_info=dataset_info,
+                loss_scaling=loss_scaling,
+                save_diagnostics=False,
+                output_dir="",
+                channel_mean_names=loss_names,
+            )
+            run_validation_loop(
+                stepper=stepper,
+                valid_data=data,
+                aggregator=aggregator,
+                ema=ema,
+                validate_using_ema=validate_using_ema,
+            )
+            logs = aggregator.get_logs(label=name)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is not None:
+                    weighted_loss += entry_config.weight * loss
+        return weighted_loss
+
+    return validate_stepper
 
 
 def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
@@ -86,10 +179,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
 
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
 
-    if config.validation_list:
-        logging.info("Initializing validation data loaders")
-    else:
-        logging.info("Skipping validation")
+    logging.info("Initializing validation data loaders")
     validation_entries = builder.get_validation_data()
 
     for data, name in zip(
@@ -126,44 +216,25 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
     )
 
-    def validation_callback(
-        epoch: int,
-        stepper: TrainStepperABC,
-        ema: EMATracker,
-    ) -> tuple[dict[str, Any], float]:
-        all_logs: dict[str, Any] = {}
-        weighted_loss = 0.0
-        for entry_config, data, name in validation_entries:
-            data.set_epoch(epoch)
-            aggregator = entry_config.aggregator.build(
-                dataset_info=dataset_info.update_variable_metadata(variable_metadata),
-                loss_scaling=loss_scaling,
-                save_diagnostics=config.save_per_epoch_diagnostics,
-                output_dir=os.path.join(config.output_dir, name),
-                channel_mean_names=loss_names,
-            )
-            logs = run_validation(
-                train_stepper=stepper,
-                validation_data=data,
-                aggregator=aggregator,
-                label=name,
-                diagnostics_subdir=f"epoch_{epoch:04d}",
-                record_logs=lambda logs: None,
-                ema=ema,
-                validate_using_ema=config.validate_using_ema,
-            )
-            all_logs.update(logs)
-            if entry_config.weight > 0:
-                metric_key = f"{name}/mean/loss"
-                loss = logs.get(metric_key)
-                if loss is None:
-                    raise RuntimeError(
-                        f"Validation entry {name!r} with "
-                        f"weight={entry_config.weight} did not produce "
-                        f"expected metric key {metric_key!r}."
-                    )
-                weighted_loss += entry_config.weight * loss
-        return all_logs, weighted_loss
+    validation_callback = get_validation_callback(
+        validation_entries=validation_entries,
+        stepper=stepper,
+        dataset_info=dataset_info.update_variable_metadata(variable_metadata),
+        loss_scaling=loss_scaling,
+        loss_names=loss_names,
+        save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
+        output_dir=config.output_dir,
+    )
+
+    validate_stepper: ValidateStepper | None = None
+    if config.lr_tuning is not None:
+        validate_stepper = get_validate_stepper_callback(
+            validation_entries=validation_entries,
+            dataset_info=dataset_info.update_variable_metadata(variable_metadata),
+            loss_scaling=loss_scaling,
+            loss_names=loss_names,
+            validate_using_ema=config.validate_using_ema,
+        )
 
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
@@ -224,6 +295,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         validation_callback=validation_callback,
         end_of_batch_callback=end_of_batch_ops,
         inference_callback=inference_callback,
+        validate_stepper=validate_stepper,
         do_gc_collect=do_gc_collect,
     )
 

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -41,6 +41,39 @@ from fme.core.weight_ops import CopyWeightsConfig
 
 
 @dataclasses.dataclass
+class InlineValidationConfig:
+    """
+    Parameters:
+        loader: configuration for the data loader used during validation
+        aggregator: configuration of validation aggregator.
+        name: name used as wandb log prefix and output subdirectory. If None,
+            defaults to "val" when there is a single validation config
+            and "val_{i}" when there are multiple. Note: adding a second
+            unnamed config will rename the first from "val" to
+            "val_0", changing its wandb keys and output directory.
+        weight: weight for this validation's loss in the combined checkpoint
+            selection metric. Must be non-negative.
+    """
+
+    loader: DataLoaderConfig
+    aggregator: OneStepAggregatorConfig = dataclasses.field(
+        default_factory=lambda: OneStepAggregatorConfig()
+    )
+    name: str | None = None
+    weight: float = 1.0
+
+    def __post_init__(self):
+        if self.weight < 0:
+            raise ValueError(
+                f"InlineValidationConfig weight must be non-negative, got {self.weight}"
+            )
+
+    @property
+    def using_labels(self) -> bool:
+        return self.loader.using_labels
+
+
+@dataclasses.dataclass
 class InlineInferenceConfig:
     """
     Parameters:
@@ -116,7 +149,10 @@ class TrainConfig:
 
     Arguments:
         train_loader: Configuration for the training data loader.
-        validation_loader: Configuration for the validation data loader.
+        validation: Configuration(s) for inline validation runs. Accepts a single
+            InlineValidationConfig or a list of them. The weighted sum of each
+            run's loss is used for checkpoint selection. Each entry can specify
+            a name (used as wandb log prefix) and weight.
         stepper: Configuration for the stepper.
         optimization: Configuration for the optimization.
         logging: Configuration for logging.
@@ -162,7 +198,6 @@ class TrainConfig:
             must be run in segments, e.g. due to wall clock limit.
         save_per_epoch_diagnostics: Whether to save per-epoch diagnostics from
             training, validation and inline inference aggregators.
-        validation_aggregator: Configuration for the validation aggregator.
         evaluate_before_training: Whether to run validation and inline inference before
             any training is done.
         save_best_inference_epoch_checkpoints: Whether to save a separate checkpoint
@@ -176,7 +211,7 @@ class TrainConfig:
     """
 
     train_loader: DataLoaderConfig
-    validation_loader: DataLoaderConfig
+    validation: InlineValidationConfig | list[InlineValidationConfig]
     stepper: StepperConfig | CheckpointStepperConfig
     optimization: OptimizationConfig
     logging: LoggingConfig
@@ -205,9 +240,6 @@ class TrainConfig:
     checkpoint_every_n_batches: int = 1000
     segment_epochs: int | None = None
     save_per_epoch_diagnostics: bool = False
-    validation_aggregator: OneStepAggregatorConfig = dataclasses.field(
-        default_factory=lambda: OneStepAggregatorConfig()
-    )
     evaluate_before_training: bool = False
     save_best_inference_epoch_checkpoints: bool = False
     lr_tuning: LRTuningConfig | None = None
@@ -222,25 +254,30 @@ class TrainConfig:
     _RESERVED_NAMES = {"train", "val"}
 
     def __post_init__(self):
-        if self.train_loader.using_labels != self.validation_loader.using_labels:
-            raise ValueError(
-                "train_loader and validation_loader must both use labels or both not "
-                "use labels"
-            )
-        resolved_names = self.inference_names
-        if len(resolved_names) != len(set(resolved_names)):
-            raise ValueError(f"Duplicate inference names: {resolved_names}")
-        reserved_overlap = set(resolved_names) & self._RESERVED_NAMES
+        resolved_val_names = self.validation_names
+        if len(resolved_val_names) != len(set(resolved_val_names)):
+            raise ValueError(f"Duplicate validation names: {resolved_val_names}")
+        for i, entry in enumerate(self.validation_list):
+            if self.train_loader.using_labels != entry.using_labels:
+                name = resolved_val_names[i]
+                raise ValueError(
+                    f"train_loader and validation {name!r} loader "
+                    "must both use labels or both not use labels"
+                )
+        resolved_inf_names = self.inference_names
+        if len(resolved_inf_names) != len(set(resolved_inf_names)):
+            raise ValueError(f"Duplicate inference names: {resolved_inf_names}")
+        reserved_overlap = set(resolved_inf_names) & self._RESERVED_NAMES
         if reserved_overlap:
             raise ValueError(
                 f"Inference names {sorted(reserved_overlap)} collide with "
                 f"reserved names {sorted(self._RESERVED_NAMES)}"
             )
-        for i, entry in enumerate(self.inference_list):
-            if self.train_loader.using_labels != entry.using_labels:
-                name = resolved_names[i]
+        for i, inf_entry in enumerate(self.inference_list):
+            if self.train_loader.using_labels != inf_entry.using_labels:
+                inf_name = resolved_inf_names[i]
                 raise ValueError(
-                    f"train_loader and inference {name!r} loader "
+                    f"train_loader and inference {inf_name!r} loader "
                     "must both use labels or both not use labels"
                 )
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
@@ -287,6 +324,25 @@ class TrainConfig:
     @property
     def train_evaluation_batches(self) -> int:
         return self.train_evaluation_samples // self.train_loader.batch_size
+
+    @property
+    def validation_list(self) -> list[InlineValidationConfig]:
+        if isinstance(self.validation, InlineValidationConfig):
+            return [self.validation]
+        return self.validation
+
+    @property
+    def validation_names(self) -> list[str]:
+        validation = self.validation_list
+        names = []
+        for i, entry in enumerate(validation):
+            if entry.name is not None:
+                names.append(entry.name)
+            elif len(validation) == 1:
+                names.append("val")
+            else:
+                names.append(f"val_{i}")
+        return names
 
     @property
     def inference_list(self) -> list[InlineInferenceConfig]:
@@ -364,13 +420,20 @@ class TrainBuilders:
             train=True,
         )
 
-    def get_validation_data(self) -> GriddedData:
+    def get_validation_data(
+        self,
+    ) -> list[tuple[InlineValidationConfig, GriddedData, str]]:
         data_requirements = self._get_train_window_data_requirements()
-        return get_gridded_data(
-            self.config.validation_loader,
-            requirements=data_requirements,
-            train=False,
-        )
+        names = self.config.validation_names
+        entries: list[tuple[InlineValidationConfig, GriddedData, str]] = []
+        for entry, name in zip(self.config.validation_list, names):
+            data = get_gridded_data(
+                entry.loader,
+                requirements=data_requirements,
+                train=False,
+            )
+            entries.append((entry, data, name))
+        return entries
 
     def get_inference_data(
         self,

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -256,30 +256,30 @@ class TrainConfig:
     def __post_init__(self):
         if not self.validation_list:
             raise ValueError("At least one validation entry is required.")
-        resolved_val_names = self.validation_names
-        if len(resolved_val_names) != len(set(resolved_val_names)):
-            raise ValueError(f"Duplicate validation names: {resolved_val_names}")
+        resolved_validation_names = self.validation_names
+        if len(resolved_validation_names) != len(set(resolved_validation_names)):
+            raise ValueError(f"Duplicate validation names: {resolved_validation_names}")
         for i, entry in enumerate(self.validation_list):
             if self.train_loader.using_labels != entry.using_labels:
-                name = resolved_val_names[i]
+                name = resolved_validation_names[i]
                 raise ValueError(
                     f"train_loader and validation {name!r} loader "
                     "must both use labels or both not use labels"
                 )
-        resolved_inf_names = self.inference_names
-        if len(resolved_inf_names) != len(set(resolved_inf_names)):
-            raise ValueError(f"Duplicate inference names: {resolved_inf_names}")
-        reserved_overlap = set(resolved_inf_names) & self._RESERVED_NAMES
+        resolved_inference_names = self.inference_names
+        if len(resolved_inference_names) != len(set(resolved_inference_names)):
+            raise ValueError(f"Duplicate inference names: {resolved_inference_names}")
+        reserved_overlap = set(resolved_inference_names) & self._RESERVED_NAMES
         if reserved_overlap:
             raise ValueError(
                 f"Inference names {sorted(reserved_overlap)} collide with "
                 f"reserved names {sorted(self._RESERVED_NAMES)}"
             )
-        for i, inf_entry in enumerate(self.inference_list):
-            if self.train_loader.using_labels != inf_entry.using_labels:
-                inf_name = resolved_inf_names[i]
+        for i, inference_entry in enumerate(self.inference_list):
+            if self.train_loader.using_labels != inference_entry.using_labels:
+                inference_name = resolved_inference_names[i]
                 raise ValueError(
-                    f"train_loader and inference {inf_name!r} loader "
+                    f"train_loader and inference {inference_name!r} loader "
                     "must both use labels or both not use labels"
                 )
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -254,6 +254,8 @@ class TrainConfig:
     _RESERVED_NAMES = {"train", "val"}
 
     def __post_init__(self):
+        if not self.validation_list:
+            raise ValueError("At least one validation entry is required.")
         resolved_val_names = self.validation_names
         if len(resolved_val_names) != len(set(resolved_val_names)):
             raise ValueError(f"Duplicate validation names: {resolved_val_names}")

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -314,11 +314,6 @@ class AggregatorBuilder(AggregatorBuilderABC[TrainOutput]):
         self._train_calls += 1
         return ret
 
-    def get_validation_aggregator(self) -> AggregatorABC[TrainOutput]:
-        ret = ValidationAggregator(self.validation_losses[self._validation_calls])
-        self._validation_calls += 1
-        return ret
-
     def get_inference_aggregator(self) -> InferenceAggregatorABC[PSType, SDType]:
         ret = InferenceAggregator(self.inference_losses[self._inference_calls])
         self._inference_calls += 1
@@ -445,15 +440,24 @@ def get_trainer(
     )
     inference_epochs = config._inference_epochs
 
-    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
+    def validation_callback(
+        epoch: int,
+        stepper: TrainStepperABC,
+        ema: EMATracker,
+    ) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
-        val_agg = aggregator_builder.get_validation_aggregator()
+        val_agg = ValidationAggregator(
+            aggregator_builder.validation_losses[aggregator_builder._validation_calls]
+        )
+        aggregator_builder._validation_calls += 1
         logs = run_validation(
             train_stepper=stepper,
             validation_data=validation_data,
             aggregator=val_agg,
             diagnostics_subdir=f"epoch_{epoch:04d}",
             record_logs=lambda logs: None,
+            ema=ema,
+            validate_using_ema=config.validate_using_ema,
         )
         return logs, logs["val/mean/loss"]
 
@@ -473,7 +477,6 @@ def get_trainer(
 
     trainer = Trainer(
         train_data=train_data,
-        validation_data=validation_data,
         stepper=stepper,
         build_optimization=build_optimization,
         build_ema=build_ema,
@@ -517,11 +520,9 @@ def test_trainer(tmp_path: str, checkpoint_save_epochs: Slice | None):
             assert not os.path.exists(paths.epoch_checkpoint_path(i))
         assert not os.path.exists(paths.ema_epoch_checkpoint_path(i))
     train_data = cast(TrainData, trainer.train_data)
-    valid_data = cast(TrainData, trainer.valid_data)
     assert train_data.set_epoch_mock.mock_calls == [
         unittest.mock.call(i) for i in range(1, config.max_epochs + 1)
     ]
-    assert valid_data.set_epoch_mock.mock_calls == train_data.set_epoch_mock.mock_calls
     assert trainer._end_of_epoch_callback.mock_calls == [  # type: ignore
         unittest.mock.call(i) for i in range(1, config.max_epochs + 1)
     ]

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -18,7 +18,7 @@ from fme.core.generics.aggregator import (
     InferenceLogs,
 )
 from fme.core.generics.data import DataLoader, GriddedDataABC, InferenceDataABC
-from fme.core.generics.lr_tuning import LRTuningConfig
+from fme.core.generics.lr_tuning import LRTuningConfig, ValidateStepper
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.trainer import (
     AggregatorBuilderABC,
@@ -31,7 +31,7 @@ from fme.core.generics.trainer import (
     epoch_checkpoint_enabled,
     inference_one_epoch,
 )
-from fme.core.generics.validation import run_validation
+from fme.core.generics.validation import run_validation, run_validation_loop
 from fme.core.logging_utils import LoggingConfig
 from fme.core.optimization import NullOptimization, Optimization, OptimizationConfig
 from fme.core.scheduler import SchedulerConfig
@@ -440,11 +440,7 @@ def get_trainer(
     )
     inference_epochs = config._inference_epochs
 
-    def validation_callback(
-        epoch: int,
-        stepper: TrainStepperABC,
-        ema: EMATracker,
-    ) -> tuple[dict[str, Any], float]:
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
         validation_data.set_epoch(epoch)
         val_agg = ValidationAggregator(
             aggregator_builder.validation_losses[aggregator_builder._validation_calls]
@@ -456,8 +452,6 @@ def get_trainer(
             aggregator=val_agg,
             diagnostics_subdir=f"epoch_{epoch:04d}",
             record_logs=lambda logs: None,
-            ema=ema,
-            validate_using_ema=config.validate_using_ema,
         )
         return logs, logs["val/mean/loss"]
 
@@ -475,6 +469,28 @@ def get_trainer(
         error = logs.get("inference/time_mean_norm/rmse/channel_mean")
         return logs, error
 
+    validate_stepper_callback: ValidateStepper | None = None
+    if lr_tuning is not None:
+
+        def _vs(trial_stepper, trial_ema):
+            val_agg = ValidationAggregator(
+                aggregator_builder.validation_losses[
+                    aggregator_builder._validation_calls
+                ]
+            )
+            aggregator_builder._validation_calls += 1
+            run_validation_loop(
+                stepper=trial_stepper,
+                valid_data=validation_data,
+                aggregator=val_agg,
+                ema=trial_ema,
+                validate_using_ema=config.validate_using_ema,
+            )
+            logs = val_agg.get_logs(label="val")
+            return logs["val/mean/loss"]
+
+        validate_stepper_callback = _vs
+
     trainer = Trainer(
         train_data=train_data,
         stepper=stepper,
@@ -486,6 +502,7 @@ def get_trainer(
         end_of_batch_callback=unittest.mock.MagicMock(),
         end_of_epoch_callback=unittest.mock.MagicMock(side_effect=lambda epoch: {}),
         inference_callback=inference_callback,
+        validate_stepper=validate_stepper_callback,
         do_gc_collect=False,  # for much faster tests
     )
 

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -239,6 +239,36 @@ class Trainer:
         validate_stepper: ValidateStepper | None = None,
         do_gc_collect: bool = True,
     ):
+        """
+        Args:
+            train_data: Training data loader.
+            stepper: Training stepper.
+            build_optimization: Factory that builds the Optimization from the
+                stepper's modules.
+            build_ema: Factory that builds the EMATracker from the stepper's
+                modules.
+            config: Training configuration.
+            aggregator_builder: Builder for per-epoch aggregators.
+            validation_callback: Called once per epoch to run epoch-end
+                validation against ``self.stepper``. The Trainer wraps the
+                call in ``validation_context()`` so that EMA params are
+                applied exactly once for the entire validation+inference
+                block when ``validate_using_ema`` is True; the callback must
+                therefore not enter ``validation_context()`` itself.
+            end_of_batch_callback: Called after each training batch.
+            end_of_epoch_callback: Called after validation/inference each
+                epoch; may return additional logs.
+            inference_callback: Called once per epoch to run inline
+                inference. Like ``validation_callback``, runs inside
+                ``validation_context()`` and must not re-enter it.
+            validate_stepper: Optional callback used only by LR tuning. It
+                receives a *trial* stepper and a *trial* EMATracker (separate
+                from ``self.stepper`` / ``self._ema``) and is responsible for
+                managing EMA state on those trial instances itself, since the
+                Trainer's ``validation_context`` only applies EMA to the main
+                stepper. Required when ``config.lr_tuning`` is configured.
+            do_gc_collect: Whether to run a Python GC pass between epochs.
+        """
         logging.info(f"Current device is {fme.get_device()}")
         dist = Distributed.get_instance()
         if dist.is_root():

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -72,7 +72,6 @@ from fme.core.generics.inference import run_inference
 from fme.core.generics.lr_tuning import LRTuningConfig, run_lr_tuning_trial
 from fme.core.generics.metrics_aggregator import MetricsAggregator
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
-from fme.core.generics.validation import run_validation_loop
 from fme.core.optimization import NullOptimization, Optimization
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingJob
@@ -93,8 +92,18 @@ def null_end_of_epoch_callback(epoch: int) -> Mapping[str, Any]:
 
 
 class ValidationCallback(Protocol):
-    def __call__(self, epoch: int) -> tuple[dict[str, Any], float]:
+    def __call__(
+        self,
+        epoch: int,
+        stepper: TrainStepperABC,
+        ema: EMATracker,
+    ) -> tuple[dict[str, Any], float]:
         """Run validation for the given epoch.
+
+        Args:
+            epoch: The current epoch number.
+            stepper: The train stepper to evaluate.
+            ema: The EMA tracker for the stepper's modules.
 
         Returns:
             A tuple of (logs, valid_loss).
@@ -181,10 +190,6 @@ class AggregatorBuilderABC(abc.ABC, Generic[TO]):
     def get_train_aggregator(self) -> AggregatorABC[TO]:
         pass
 
-    @abc.abstractmethod
-    def get_validation_aggregator(self) -> AggregatorABC[TO]:
-        pass
-
 
 class CheckpointPaths:
     def __init__(self, checkpoint_dir: str):
@@ -228,7 +233,6 @@ class Trainer:
     def __init__(
         self,
         train_data: GriddedDataABC[BD],
-        validation_data: GriddedDataABC[BD],
         stepper: TrainStepperABC[PS, BD, FD, SD, TO],
         build_optimization: Callable[[torch.nn.ModuleList], Optimization],
         build_ema: Callable[[torch.nn.ModuleList], EMATracker],
@@ -259,7 +263,6 @@ class Trainer:
             )
 
         self.train_data = train_data
-        self.valid_data = validation_data
 
         self.num_batches_seen = 0
         self._start_epoch = 0
@@ -340,16 +343,8 @@ class Trainer:
         return EMATracker.from_state(self._ema.get_state(), modules)
 
     def _validate_stepper(self, stepper: TrainStepperABC, ema: EMATracker) -> float:
-        aggregator = self._aggregator_builder.get_validation_aggregator()
-        run_validation_loop(
-            stepper=stepper,
-            valid_data=self.valid_data,
-            aggregator=aggregator,
-            ema=ema,
-            validate_using_ema=self.config.validate_using_ema,
-        )
-        val_logs = aggregator.get_logs(label="val")
-        return val_logs["val/mean/loss"]
+        _, valid_loss = self._validation_callback(self._epochs_trained, stepper, ema)
+        return valid_loss
 
     def _maybe_tune_lr(self):
         cfg = self.config.lr_tuning
@@ -395,9 +390,11 @@ class Trainer:
             and self._current_epoch_num_batches_seen == 0
         ):
             logging.info("Starting validation before training")
+            valid_logs, valid_loss = validation_callback(
+                self._epochs_trained, self.stepper, self._ema
+            )
+            logging.info("Starting inline inference before training")
             with self.validation_context():
-                valid_logs, valid_loss = validation_callback(self._epochs_trained)
-                logging.info("Starting inline inference before training")
                 inference_logs, _ = inference_callback(self._epochs_trained)
             logging.info(f"Validation loss before training: {valid_loss}")
             logging.info("Logging to wandb")
@@ -421,13 +418,15 @@ class Trainer:
                 f"Starting validation step for model trained for "
                 f"{self._epochs_trained} epochs"
             )
+            valid_logs, valid_loss = validation_callback(
+                self._epochs_trained, self.stepper, self._ema
+            )
+            valid_end = time.time()
+            logging.info(
+                f"Starting inference step for model trained for "
+                f"{self._epochs_trained} epochs"
+            )
             with self.validation_context():
-                valid_logs, valid_loss = validation_callback(self._epochs_trained)
-                valid_end = time.time()
-                logging.info(
-                    f"Starting inference step for model trained for "
-                    f"{self._epochs_trained} epochs"
-                )
                 inference_logs, inference_error = inference_callback(
                     self._epochs_trained
                 )

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -69,7 +69,11 @@ from fme.core.ema import EMAConfig, EMATracker
 from fme.core.generics.aggregator import AggregatorABC, InferenceAggregatorABC
 from fme.core.generics.data import GriddedDataABC, InferenceDataABC
 from fme.core.generics.inference import run_inference
-from fme.core.generics.lr_tuning import LRTuningConfig, run_lr_tuning_trial
+from fme.core.generics.lr_tuning import (
+    LRTuningConfig,
+    ValidateStepper,
+    run_lr_tuning_trial,
+)
 from fme.core.generics.metrics_aggregator import MetricsAggregator
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
 from fme.core.optimization import NullOptimization, Optimization
@@ -92,18 +96,8 @@ def null_end_of_epoch_callback(epoch: int) -> Mapping[str, Any]:
 
 
 class ValidationCallback(Protocol):
-    def __call__(
-        self,
-        epoch: int,
-        stepper: TrainStepperABC,
-        ema: EMATracker,
-    ) -> tuple[dict[str, Any], float]:
+    def __call__(self, epoch: int) -> tuple[dict[str, Any], float]:
         """Run validation for the given epoch.
-
-        Args:
-            epoch: The current epoch number.
-            stepper: The train stepper to evaluate.
-            ema: The EMA tracker for the stepper's modules.
 
         Returns:
             A tuple of (logs, valid_loss).
@@ -242,6 +236,7 @@ class Trainer:
         end_of_batch_callback: EndOfBatchCallback = lambda: None,
         end_of_epoch_callback: EndOfEpochCallback = null_end_of_epoch_callback,
         inference_callback: InferenceCallback = _null_inference_callback,
+        validate_stepper: ValidateStepper | None = None,
         do_gc_collect: bool = True,
     ):
         logging.info(f"Current device is {fme.get_device()}")
@@ -299,6 +294,7 @@ class Trainer:
         self._started_training = False
         self._validation_callback: ValidationCallback = validation_callback
         self._inference_callback: InferenceCallback = inference_callback
+        self._validate_stepper_callback: ValidateStepper | None = validate_stepper
 
         def on_terminate(signum, frame):
             dist = Distributed.get_instance()
@@ -343,8 +339,11 @@ class Trainer:
         return EMATracker.from_state(self._ema.get_state(), modules)
 
     def _validate_stepper(self, stepper: TrainStepperABC, ema: EMATracker) -> float:
-        _, valid_loss = self._validation_callback(self._epochs_trained, stepper, ema)
-        return valid_loss
+        if self._validate_stepper_callback is None:
+            raise RuntimeError(
+                "validate_stepper callback is required when lr_tuning is configured"
+            )
+        return self._validate_stepper_callback(stepper, ema)
 
     def _maybe_tune_lr(self):
         cfg = self.config.lr_tuning
@@ -390,11 +389,9 @@ class Trainer:
             and self._current_epoch_num_batches_seen == 0
         ):
             logging.info("Starting validation before training")
-            valid_logs, valid_loss = validation_callback(
-                self._epochs_trained, self.stepper, self._ema
-            )
-            logging.info("Starting inline inference before training")
             with self.validation_context():
+                valid_logs, valid_loss = validation_callback(self._epochs_trained)
+                logging.info("Starting inline inference before training")
                 inference_logs, _ = inference_callback(self._epochs_trained)
             logging.info(f"Validation loss before training: {valid_loss}")
             logging.info("Logging to wandb")
@@ -418,15 +415,13 @@ class Trainer:
                 f"Starting validation step for model trained for "
                 f"{self._epochs_trained} epochs"
             )
-            valid_logs, valid_loss = validation_callback(
-                self._epochs_trained, self.stepper, self._ema
-            )
-            valid_end = time.time()
-            logging.info(
-                f"Starting inference step for model trained for "
-                f"{self._epochs_trained} epochs"
-            )
             with self.validation_context():
+                valid_logs, valid_loss = validation_callback(self._epochs_trained)
+                valid_end = time.time()
+                logging.info(
+                    f"Starting inference step for model trained for "
+                    f"{self._epochs_trained} epochs"
+                )
                 inference_logs, inference_error = inference_callback(
                     self._epochs_trained
                 )

--- a/fme/coupled/test_train.py
+++ b/fme/coupled/test_train.py
@@ -37,18 +37,19 @@ train_loader:
       data_path: {atmosphere_data_path}
       subset:
           start_time: '1970-01-01'
-validation_loader:
-  batch_size: 2
-  num_data_workers: 0
-  dataset:
-    ocean:
-      data_path: {ocean_data_path}
-      subset:
-          start_time: '1970-01-01'
-    atmosphere:
-      data_path: {atmosphere_data_path}
-      subset:
-          start_time: '1970-01-01'
+validation:
+- loader:
+    batch_size: 2
+    num_data_workers: 0
+    dataset:
+      ocean:
+        data_path: {ocean_data_path}
+        subset:
+            start_time: '1970-01-01'
+      atmosphere:
+        data_path: {atmosphere_data_path}
+        subset:
+            start_time: '1970-01-01'
 inference:
   loader:
     dataset:

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -355,3 +355,168 @@ def test_duplicate_validation_names_raises(tmp_path):
                 _make_validation_config(name="same"),
             ],
         )
+
+
+class TestGetValidationCallback:
+    @staticmethod
+    def _make_entry(name, weight=1.0):
+        config = _make_validation_config(name=name, weight=weight)
+        data = MagicMock()
+        return (config, data, name)
+
+    @staticmethod
+    def _call(entries, run_validation_side_effect):
+        from fme.coupled.train.train import get_validation_callback
+
+        stepper = MagicMock()
+        with patch(
+            "fme.coupled.train.train.run_validation",
+            side_effect=run_validation_side_effect,
+        ):
+            callback = get_validation_callback(
+                validation_entries=entries,
+                stepper=stepper,
+                dataset_info=MagicMock(),
+                loss_scaling=MagicMock(),
+                save_per_epoch_diagnostics=False,
+                output_dir="/tmp/out",
+            )
+            return callback(epoch=1)
+
+    def test_single_entry(self):
+        entries = [self._make_entry("val")]
+        logs, loss = self._call(
+            entries,
+            [{"val/mean/loss": 0.5, "val/other": 1.0}],
+        )
+        assert loss == 0.5
+        assert logs == {"val/mean/loss": 0.5, "val/other": 1.0}
+
+    def test_zero_weight_excluded_from_loss(self):
+        entries = [
+            self._make_entry("val_0", weight=1.0),
+            self._make_entry("val_extra", weight=0.0),
+        ]
+        logs, loss = self._call(
+            entries,
+            [
+                {"val_0/mean/loss": 0.5},
+                {"val_extra/mean/loss": 999.0},
+            ],
+        )
+        assert loss == 0.5
+        assert "val_0/mean/loss" in logs
+        assert "val_extra/mean/loss" in logs
+
+    def test_multiple_weighted_entries(self):
+        entries = [
+            self._make_entry("a", weight=2.0),
+            self._make_entry("b", weight=3.0),
+        ]
+        logs, loss = self._call(
+            entries,
+            [
+                {"a/mean/loss": 0.1},
+                {"b/mean/loss": 0.2},
+            ],
+        )
+        assert loss == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
+
+
+class TestGetInferenceCallback:
+    @staticmethod
+    def _make_entry(name, weight=1.0, n_coupled_steps=1):
+        config = MagicMock()
+        config.weight = weight
+        config.n_coupled_steps = n_coupled_steps
+        data = MagicMock()
+        # data.loader is iterated once to get a batch for initial_times
+        data.loader = iter([MagicMock()])
+        return (config, data, name)
+
+    @staticmethod
+    def _call(
+        entries,
+        inference_one_epoch_side_effect,
+        epoch=1,
+        inference_epochs=(1,),
+        inference_epoch_sets=None,
+    ):
+        from fme.coupled.train.train import get_inference_callback
+
+        if inference_epoch_sets is None:
+            inference_epoch_sets = [{1} for _ in entries]
+        stepper = MagicMock()
+        with patch(
+            "fme.coupled.train.train.inference_one_epoch",
+            side_effect=inference_one_epoch_side_effect,
+        ):
+            callback = get_inference_callback(
+                inference_entries=entries,
+                inference_epochs=list(inference_epochs),
+                inference_epoch_sets=list(inference_epoch_sets),
+                stepper=stepper,
+                dataset_info=MagicMock(),
+                output_dir="/tmp/out",
+                save_per_epoch_diagnostics=False,
+            )
+            return callback(epoch=epoch)
+
+    def test_epoch_not_in_inference_epochs_returns_empty(self):
+        entries = [self._make_entry("inference")]
+        logs, error = self._call(
+            entries,
+            inference_one_epoch_side_effect=[],
+            epoch=2,
+            inference_epochs=(1,),
+        )
+        assert logs == {}
+        assert error is None
+
+    def test_single_entry_weighted_error(self):
+        entries = [self._make_entry("inference", weight=2.0)]
+        logs, error = self._call(
+            entries,
+            [{"inference/time_mean_norm/rmse/channel_mean": 0.4}],
+        )
+        assert error == pytest.approx(2.0 * 0.4)
+        assert "inference/time_mean_norm/rmse/channel_mean" in logs
+
+    def test_missing_metric_returns_none_error(self):
+        entries = [self._make_entry("a", weight=1.0)]
+        logs, error = self._call(
+            entries,
+            [{"a/other_metric": 1.0}],
+        )
+        assert error is None
+        assert "a/other_metric" in logs
+
+    def test_multiple_weighted_entries(self):
+        entries = [
+            self._make_entry("a", weight=2.0),
+            self._make_entry("b", weight=3.0),
+        ]
+        logs, error = self._call(
+            entries,
+            [
+                {"a/time_mean_norm/rmse/channel_mean": 0.1},
+                {"b/time_mean_norm/rmse/channel_mean": 0.2},
+            ],
+        )
+        assert error == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
+
+    def test_entry_skipped_when_not_in_epoch_set(self):
+        entries = [
+            self._make_entry("a", weight=1.0),
+            self._make_entry("b", weight=1.0),
+        ]
+        logs, error = self._call(
+            entries,
+            [{"a/time_mean_norm/rmse/channel_mean": 0.5}],
+            epoch=1,
+            inference_epochs=(1,),
+            inference_epoch_sets=[{1}, {2}],
+        )
+        assert error == pytest.approx(0.5)
+        assert "a/time_mean_norm/rmse/channel_mean" in logs
+        assert "b/time_mean_norm/rmse/channel_mean" not in logs

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -10,13 +10,19 @@ from fme.ace.stepper.time_length_probabilities import (
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.typing_ import Slice
 from fme.coupled.aggregator import InferenceEvaluatorAggregatorConfig
-from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
+from fme.coupled.data_loading.config import (
+    CoupledDataLoaderConfig,
+    CoupledDatasetWithOptionalOceanConfig,
+)
 from fme.coupled.data_loading.inference import InferenceDataLoaderConfig
 from fme.coupled.loss import LossContributionsConfig
-from fme.coupled.train.train_config import InlineInferenceConfig, TrainConfig
+from fme.coupled.train.train_config import (
+    InlineInferenceConfig,
+    InlineValidationConfig,
+    TrainConfig,
+    _validate_loss_n_steps,
+)
 from fme.coupled.typing_ import CoupledOptionalInt
-
-from .train_config import _validate_loss_n_steps
 
 
 def _make_stepper_mock():
@@ -32,6 +38,16 @@ def _make_stepper_training_mock():
         ocean=None, atmosphere=None
     )
     return stepper_training
+
+
+def _make_validation_config(
+    name: str | None = None, weight: float = 1.0
+) -> InlineValidationConfig:
+    return InlineValidationConfig(
+        loader=MagicMock(spec=CoupledDataLoaderConfig),
+        name=name,
+        weight=weight,
+    )
 
 
 def _make_inference_config(
@@ -60,14 +76,32 @@ def _make_inference_config(
     )
 
 
-def _make_train_config(
+def _make_train_config_for_validation(
+    tmp_path,
+    validation: InlineValidationConfig | list[InlineValidationConfig],
+    max_epochs: int = 5,
+) -> TrainConfig:
+    return TrainConfig(
+        train_loader=MagicMock(),
+        validation=validation,
+        stepper=_make_stepper_mock(),
+        stepper_training=_make_stepper_training_mock(),
+        optimization=MagicMock(has_lr_schedule=False),
+        logging=MagicMock(),
+        max_epochs=max_epochs,
+        save_checkpoint=False,
+        experiment_dir=str(tmp_path),
+    )
+
+
+def _make_train_config_for_inference(
     tmp_path,
     inference: InlineInferenceConfig | list[InlineInferenceConfig],
     max_epochs: int = 5,
 ) -> TrainConfig:
     return TrainConfig(
         train_loader=MagicMock(),
-        validation_loader=MagicMock(),
+        validation=_make_validation_config(),
         stepper=_make_stepper_mock(),
         stepper_training=_make_stepper_training_mock(),
         optimization=MagicMock(has_lr_schedule=False),
@@ -95,7 +129,7 @@ def test_default_weight_is_one():
 
 
 def test_inference_single_config_gives_list(tmp_path):
-    config = _make_train_config(tmp_path, _make_inference_config())
+    config = _make_train_config_for_inference(tmp_path, _make_inference_config())
     assert isinstance(config.inference, InlineInferenceConfig)
     assert isinstance(config.inference_list, list)
     assert len(config.inference_list) == 1
@@ -103,19 +137,19 @@ def test_inference_single_config_gives_list(tmp_path):
 
 
 def test_inference_names_single_unnamed(tmp_path):
-    config = _make_train_config(tmp_path, [_make_inference_config()])
+    config = _make_train_config_for_inference(tmp_path, [_make_inference_config()])
     assert config.inference_names == ["inference"]
 
 
 def test_inference_names_multiple_unnamed(tmp_path):
-    config = _make_train_config(
+    config = _make_train_config_for_inference(
         tmp_path, [_make_inference_config(), _make_inference_config()]
     )
     assert config.inference_names == ["inference_0", "inference_1"]
 
 
 def test_inference_names_explicit(tmp_path):
-    config = _make_train_config(
+    config = _make_train_config_for_inference(
         tmp_path,
         [_make_inference_config(name="weather"), _make_inference_config(name="clim")],
     )
@@ -123,7 +157,7 @@ def test_inference_names_explicit(tmp_path):
 
 
 def test_inference_names_mixed(tmp_path):
-    config = _make_train_config(
+    config = _make_train_config_for_inference(
         tmp_path,
         [_make_inference_config(name="weather"), _make_inference_config()],
     )
@@ -131,13 +165,13 @@ def test_inference_names_mixed(tmp_path):
 
 
 def test_inference_names_empty(tmp_path):
-    config = _make_train_config(tmp_path, [])
+    config = _make_train_config_for_inference(tmp_path, [])
     assert config.inference_names == []
 
 
 def test_duplicate_inference_names_raises(tmp_path):
     with pytest.raises(ValueError, match="Duplicate inference names"):
-        _make_train_config(
+        _make_train_config_for_inference(
             tmp_path,
             [_make_inference_config(name="same"), _make_inference_config(name="same")],
         )
@@ -146,23 +180,27 @@ def test_duplicate_inference_names_raises(tmp_path):
 @pytest.mark.parametrize("reserved_name", ["train", "val"])
 def test_reserved_inference_name_raises(tmp_path, reserved_name):
     with pytest.raises(ValueError, match="collide with reserved names"):
-        _make_train_config(tmp_path, [_make_inference_config(name=reserved_name)])
+        _make_train_config_for_inference(
+            tmp_path, [_make_inference_config(name=reserved_name)]
+        )
 
 
 def test_get_inference_epoch_sets_empty(tmp_path):
-    config = _make_train_config(tmp_path, [], max_epochs=5)
+    config = _make_train_config_for_inference(tmp_path, [], max_epochs=5)
     assert config.get_inference_epoch_sets() == []
     assert config.get_inference_epochs() == []
 
 
 def test_get_inference_epoch_sets_single_default(tmp_path):
-    config = _make_train_config(tmp_path, [_make_inference_config()], max_epochs=3)
+    config = _make_train_config_for_inference(
+        tmp_path, [_make_inference_config()], max_epochs=3
+    )
     assert config.get_inference_epoch_sets() == [{0, 1, 2, 3}]
     assert config.get_inference_epochs() == [0, 1, 2, 3]
 
 
 def test_get_inference_epoch_sets_per_config(tmp_path):
-    config = _make_train_config(
+    config = _make_train_config_for_inference(
         tmp_path,
         [
             _make_inference_config(epochs=Slice(step=2)),
@@ -246,4 +284,74 @@ def test_validate_loss_n_steps_does_not_short_circuit_on_null_weight():
     with pytest.raises(ValueError, match=r"ocean"):
         _validate_loss_n_steps(
             n_coupled_steps=1, n_inner_steps=1, component_n_steps_max=bounds
+        )
+
+
+def test_validation_negative_weight_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        _make_validation_config(weight=-1.0)
+
+
+def test_validation_zero_weight_accepted():
+    config = _make_validation_config(weight=0.0)
+    assert config.weight == 0.0
+
+
+def test_validation_default_weight_is_one():
+    config = _make_validation_config()
+    assert config.weight == 1.0
+
+
+def test_validation_single_config_gives_list(tmp_path):
+    config = _make_train_config_for_validation(tmp_path, _make_validation_config())
+    assert isinstance(config.validation, InlineValidationConfig)
+    assert isinstance(config.validation_list, list)
+    assert len(config.validation_list) == 1
+    assert config.validation_names == ["val"]
+
+
+def test_validation_names_single_unnamed(tmp_path):
+    config = _make_train_config_for_validation(tmp_path, [_make_validation_config()])
+    assert config.validation_names == ["val"]
+
+
+def test_validation_names_multiple_unnamed(tmp_path):
+    config = _make_train_config_for_validation(
+        tmp_path, [_make_validation_config(), _make_validation_config()]
+    )
+    assert config.validation_names == ["val_0", "val_1"]
+
+
+def test_validation_names_explicit(tmp_path):
+    config = _make_train_config_for_validation(
+        tmp_path,
+        [
+            _make_validation_config(name="era5"),
+            _make_validation_config(name="obs"),
+        ],
+    )
+    assert config.validation_names == ["era5", "obs"]
+
+
+def test_validation_names_mixed(tmp_path):
+    config = _make_train_config_for_validation(
+        tmp_path,
+        [_make_validation_config(name="era5"), _make_validation_config()],
+    )
+    assert config.validation_names == ["era5", "val_1"]
+
+
+def test_validation_names_empty(tmp_path):
+    config = _make_train_config_for_validation(tmp_path, [])
+    assert config.validation_names == []
+
+
+def test_duplicate_validation_names_raises(tmp_path):
+    with pytest.raises(ValueError, match="Duplicate validation names"):
+        _make_train_config_for_validation(
+            tmp_path,
+            [
+                _make_validation_config(name="same"),
+                _make_validation_config(name="same"),
+            ],
         )

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -341,9 +341,9 @@ def test_validation_names_mixed(tmp_path):
     assert config.validation_names == ["era5", "val_1"]
 
 
-def test_validation_names_empty(tmp_path):
-    config = _make_train_config_for_validation(tmp_path, [])
-    assert config.validation_names == []
+def test_empty_validation_raises(tmp_path):
+    with pytest.raises(ValueError, match="At least one validation entry"):
+        _make_train_config_for_validation(tmp_path, [])
 
 
 def test_duplicate_validation_names_raises(tmp_path):

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -24,12 +24,20 @@ from fme.coupled.typing_ import CoupledTensorMapping
 def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     logging.info("Initializing training data loader")
     train_data = builder.get_train_data()
-    logging.info("Initializing validation data loader")
-    validation_data = builder.get_validation_data()
 
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
     dataset_info = train_data.dataset_info.update_variable_metadata(variable_metadata)
-    for data, name in zip((train_data, validation_data), ("train", "valid")):
+
+    if config.validation_list:
+        logging.info("Initializing validation data loaders")
+    else:
+        logging.info("Skipping validation")
+    validation_entries = builder.get_validation_data()
+
+    for data, name in zip(
+        [train_data] + [data for _, data, _ in validation_entries],
+        ["train"] + [name for _, _, name in validation_entries],
+    ):
         data.log_info(name)
 
     if config.inference_list:
@@ -52,16 +60,36 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     )
 
     def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
-        validation_data.set_epoch(epoch)
-        aggregator = aggregator_builder.get_validation_aggregator()
-        logs = run_validation(
-            train_stepper=stepper,
-            validation_data=validation_data,
-            aggregator=aggregator,
-            diagnostics_subdir=f"epoch_{epoch:04d}",
-            record_logs=lambda logs: None,
-        )
-        return logs, logs["val/mean/loss"]
+        all_logs: dict[str, Any] = {}
+        weighted_loss = 0.0
+        for entry_config, data, name in validation_entries:
+            data.set_epoch(epoch)
+            aggregator = OneStepAggregator(
+                dataset_info=dataset_info,
+                save_diagnostics=config.save_per_epoch_diagnostics,
+                output_dir=os.path.join(config.output_dir, name),
+                loss_scaling=stepper.effective_loss_scaling,
+            )
+            logs = run_validation(
+                train_stepper=stepper,
+                validation_data=data,
+                aggregator=aggregator,
+                label=name,
+                diagnostics_subdir=f"epoch_{epoch:04d}",
+                record_logs=lambda logs: None,
+            )
+            all_logs.update(logs)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is None:
+                    raise RuntimeError(
+                        f"Validation entry {name!r} with "
+                        f"weight={entry_config.weight} did not produce "
+                        f"expected metric key {metric_key!r}."
+                    )
+                weighted_loss += entry_config.weight * loss
+        return all_logs, weighted_loss
 
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
@@ -107,9 +135,10 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
 
         return all_logs, weighted_error if has_error else None
 
+    primary_validation_data = validation_entries[0][1]
     return Trainer(
         train_data=train_data,
-        validation_data=validation_data,
+        validation_data=primary_validation_data,
         stepper=stepper,
         build_optimization=builder.get_optimization,
         build_ema=builder.get_ema,

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -12,6 +12,8 @@ import fme
 from fme.core.cli import prepare_config, prepare_directory
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
+from fme.core.ema import EMATracker
+from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import AggregatorBuilderABC, Trainer, inference_one_epoch
 from fme.core.generics.validation import run_validation
 from fme.coupled.aggregator import OneStepAggregator, TrainAggregator
@@ -52,14 +54,19 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     stepper = builder.get_stepper(train_data.dataset_info)
     end_of_batch_ops = builder.get_end_of_batch_ops(stepper.modules)
 
+    loss_scaling = stepper.effective_loss_scaling
     aggregator_builder = CoupledAggregatorBuilder(
         dataset_info=dataset_info,
-        loss_scaling=stepper.effective_loss_scaling,
+        loss_scaling=loss_scaling,
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
         output_dir=config.output_dir,
     )
 
-    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
+    def validation_callback(
+        epoch: int,
+        stepper: TrainStepperABC,
+        ema: EMATracker,
+    ) -> tuple[dict[str, Any], float]:
         all_logs: dict[str, Any] = {}
         weighted_loss = 0.0
         for entry_config, data, name in validation_entries:
@@ -68,7 +75,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
                 dataset_info=dataset_info,
                 save_diagnostics=config.save_per_epoch_diagnostics,
                 output_dir=os.path.join(config.output_dir, name),
-                loss_scaling=stepper.effective_loss_scaling,
+                loss_scaling=loss_scaling,
             )
             logs = run_validation(
                 train_stepper=stepper,
@@ -77,6 +84,8 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
                 label=name,
                 diagnostics_subdir=f"epoch_{epoch:04d}",
                 record_logs=lambda logs: None,
+                ema=ema,
+                validate_using_ema=config.validate_using_ema,
             )
             all_logs.update(logs)
             if entry_config.weight > 0:
@@ -135,10 +144,8 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
 
         return all_logs, weighted_error if has_error else None
 
-    primary_validation_data = validation_entries[0][1]
     return Trainer(
         train_data=train_data,
-        validation_data=primary_validation_data,
         stepper=stepper,
         build_optimization=builder.get_optimization,
         build_ema=builder.get_ema,

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -13,14 +13,102 @@ from fme.core.cli import prepare_config, prepare_directory
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
 from fme.core.ema import EMATracker
+from fme.core.generics.data import GriddedDataABC
+from fme.core.generics.lr_tuning import ValidateStepper
 from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import AggregatorBuilderABC, Trainer, inference_one_epoch
-from fme.core.generics.validation import run_validation
+from fme.core.generics.validation import run_validation, run_validation_loop
 from fme.coupled.aggregator import OneStepAggregator, TrainAggregator
 from fme.coupled.dataset_info import CoupledDatasetInfo
 from fme.coupled.stepper import CoupledTrainOutput
-from fme.coupled.train.train_config import TrainBuilders, TrainConfig
+from fme.coupled.train.train_config import (
+    InlineValidationConfig,
+    TrainBuilders,
+    TrainConfig,
+)
 from fme.coupled.typing_ import CoupledTensorMapping
+
+
+def get_validation_callback(
+    validation_entries: Sequence[tuple[InlineValidationConfig, GriddedDataABC, str]],
+    stepper: TrainStepperABC,
+    dataset_info: CoupledDatasetInfo,
+    loss_scaling: CoupledTensorMapping,
+    save_per_epoch_diagnostics: bool,
+    output_dir: str,
+):
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
+        all_logs: dict[str, Any] = {}
+        weighted_loss = 0.0
+        for entry_config, data, name in validation_entries:
+            data.set_epoch(epoch)
+            aggregator = OneStepAggregator(
+                dataset_info=dataset_info,
+                save_diagnostics=save_per_epoch_diagnostics,
+                output_dir=os.path.join(output_dir, name),
+                loss_scaling=loss_scaling,
+            )
+            logs = run_validation(
+                train_stepper=stepper,
+                validation_data=data,
+                aggregator=aggregator,
+                label=name,
+                diagnostics_subdir=f"epoch_{epoch:04d}",
+                record_logs=lambda logs: None,
+            )
+            overlap = all_logs.keys() & logs.keys()
+            if overlap:
+                raise RuntimeError(
+                    f"Validation entry {name!r} produced log keys that "
+                    f"overlap with earlier entries: {sorted(overlap)}"
+                )
+            all_logs.update(logs)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is None:
+                    raise RuntimeError(
+                        f"Validation entry {name!r} with "
+                        f"weight={entry_config.weight} did not produce "
+                        f"expected metric key {metric_key!r}."
+                    )
+                weighted_loss += entry_config.weight * loss
+        return all_logs, weighted_loss
+
+    return validation_callback
+
+
+def get_validate_stepper_callback(
+    validation_entries: Sequence[tuple[InlineValidationConfig, GriddedDataABC, str]],
+    dataset_info: CoupledDatasetInfo,
+    loss_scaling: CoupledTensorMapping,
+    validate_using_ema: bool,
+) -> ValidateStepper:
+    def validate_stepper(stepper: TrainStepperABC, ema: EMATracker) -> float:
+        weighted_loss = 0.0
+        for entry_config, data, name in validation_entries:
+            aggregator = OneStepAggregator(
+                dataset_info=dataset_info,
+                save_diagnostics=False,
+                output_dir="",
+                loss_scaling=loss_scaling,
+            )
+            run_validation_loop(
+                stepper=stepper,
+                valid_data=data,
+                aggregator=aggregator,
+                ema=ema,
+                validate_using_ema=validate_using_ema,
+            )
+            logs = aggregator.get_logs(label=name)
+            if entry_config.weight > 0:
+                metric_key = f"{name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is not None:
+                    weighted_loss += entry_config.weight * loss
+        return weighted_loss
+
+    return validate_stepper
 
 
 def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
@@ -30,10 +118,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
     variable_metadata = get_derived_variable_metadata() | train_data.variable_metadata
     dataset_info = train_data.dataset_info.update_variable_metadata(variable_metadata)
 
-    if config.validation_list:
-        logging.info("Initializing validation data loaders")
-    else:
-        logging.info("Skipping validation")
+    logging.info("Initializing validation data loaders")
     validation_entries = builder.get_validation_data()
 
     for data, name in zip(
@@ -62,43 +147,23 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         output_dir=config.output_dir,
     )
 
-    def validation_callback(
-        epoch: int,
-        stepper: TrainStepperABC,
-        ema: EMATracker,
-    ) -> tuple[dict[str, Any], float]:
-        all_logs: dict[str, Any] = {}
-        weighted_loss = 0.0
-        for entry_config, data, name in validation_entries:
-            data.set_epoch(epoch)
-            aggregator = OneStepAggregator(
-                dataset_info=dataset_info,
-                save_diagnostics=config.save_per_epoch_diagnostics,
-                output_dir=os.path.join(config.output_dir, name),
-                loss_scaling=loss_scaling,
-            )
-            logs = run_validation(
-                train_stepper=stepper,
-                validation_data=data,
-                aggregator=aggregator,
-                label=name,
-                diagnostics_subdir=f"epoch_{epoch:04d}",
-                record_logs=lambda logs: None,
-                ema=ema,
-                validate_using_ema=config.validate_using_ema,
-            )
-            all_logs.update(logs)
-            if entry_config.weight > 0:
-                metric_key = f"{name}/mean/loss"
-                loss = logs.get(metric_key)
-                if loss is None:
-                    raise RuntimeError(
-                        f"Validation entry {name!r} with "
-                        f"weight={entry_config.weight} did not produce "
-                        f"expected metric key {metric_key!r}."
-                    )
-                weighted_loss += entry_config.weight * loss
-        return all_logs, weighted_loss
+    validation_callback = get_validation_callback(
+        validation_entries=validation_entries,
+        stepper=stepper,
+        dataset_info=dataset_info,
+        loss_scaling=loss_scaling,
+        save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
+        output_dir=config.output_dir,
+    )
+
+    validate_stepper: ValidateStepper | None = None
+    if config.lr_tuning is not None:
+        validate_stepper = get_validate_stepper_callback(
+            validation_entries=validation_entries,
+            dataset_info=dataset_info,
+            loss_scaling=loss_scaling,
+            validate_using_ema=config.validate_using_ema,
+        )
 
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
         if epoch not in inference_epochs:
@@ -154,6 +219,7 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
         validation_callback=validation_callback,
         end_of_batch_callback=end_of_batch_ops,
         inference_callback=inference_callback,
+        validate_stepper=validate_stepper,
     )
 
 

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -16,12 +16,19 @@ from fme.core.ema import EMATracker
 from fme.core.generics.data import GriddedDataABC
 from fme.core.generics.lr_tuning import ValidateStepper
 from fme.core.generics.train_stepper import TrainStepperABC
-from fme.core.generics.trainer import AggregatorBuilderABC, Trainer, inference_one_epoch
+from fme.core.generics.trainer import (
+    AggregatorBuilderABC,
+    InferenceCallback,
+    Trainer,
+    inference_one_epoch,
+)
 from fme.core.generics.validation import run_validation, run_validation_loop
 from fme.coupled.aggregator import OneStepAggregator, TrainAggregator
+from fme.coupled.data_loading.gridded_data import InferenceGriddedData
 from fme.coupled.dataset_info import CoupledDatasetInfo
-from fme.coupled.stepper import CoupledTrainOutput
+from fme.coupled.stepper import CoupledTrainOutput, CoupledTrainStepper
 from fme.coupled.train.train_config import (
+    InlineInferenceConfig,
     InlineValidationConfig,
     TrainBuilders,
     TrainConfig,
@@ -84,6 +91,9 @@ def get_validate_stepper_callback(
     loss_scaling: CoupledTensorMapping,
     validate_using_ema: bool,
 ) -> ValidateStepper:
+    # LR tuning passes trial stepper/EMA instances distinct from the Trainer's
+    # own stepper, so this callback manages its own EMA via run_validation_loop
+    # rather than relying on the Trainer's validation_context().
     def validate_stepper(stepper: TrainStepperABC, ema: EMATracker) -> float:
         weighted_loss = 0.0
         for entry_config, data, name in validation_entries:
@@ -109,6 +119,63 @@ def get_validate_stepper_callback(
         return weighted_loss
 
     return validate_stepper
+
+
+def get_inference_callback(
+    inference_entries: Sequence[
+        tuple[InlineInferenceConfig, InferenceGriddedData, str]
+    ],
+    inference_epochs: Sequence[int],
+    inference_epoch_sets: Sequence[set[int]],
+    stepper: CoupledTrainStepper,
+    dataset_info: CoupledDatasetInfo,
+    output_dir: str,
+    save_per_epoch_diagnostics: bool,
+) -> InferenceCallback:
+    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
+        if epoch not in inference_epochs:
+            return {}, None
+        all_logs: dict[str, Any] = {}
+        weighted_error = 0.0
+        has_error = False
+        for i, (entry_config, data, name) in enumerate(inference_entries):
+            if epoch not in inference_epoch_sets[i]:
+                continue
+            batch = next(iter(data.loader))
+            initial_times = batch.ocean_data.time.isel(time=0)
+            n_timesteps_ocean = (
+                entry_config.n_coupled_steps + stepper.ocean.n_ic_timesteps
+            )
+            n_timesteps_atmosphere = (
+                entry_config.n_coupled_steps * stepper.n_inner_steps
+                + stepper.atmosphere.n_ic_timesteps
+            )
+            aggregator = entry_config.aggregator.build(
+                dataset_info=dataset_info,
+                n_timesteps_ocean=n_timesteps_ocean,
+                n_timesteps_atmosphere=n_timesteps_atmosphere,
+                initial_time=initial_times,
+                ocean_normalize=stepper.ocean.normalizer.normalize,
+                atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
+                save_diagnostics=save_per_epoch_diagnostics,
+                output_dir=os.path.join(output_dir, name),
+            )
+            logs = inference_one_epoch(
+                stepper=stepper,
+                validation_context=contextlib.nullcontext,
+                dataset=data,
+                aggregator=aggregator,
+                label=name,
+                epoch=epoch,
+            )
+            all_logs.update(logs)
+            error = logs.get(f"{name}/time_mean_norm/rmse/channel_mean")
+            if error is not None:
+                weighted_error += entry_config.weight * error
+                has_error = True
+        return all_logs, weighted_error if has_error else None
+
+    return inference_callback
 
 
 def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
@@ -165,49 +232,15 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> Trainer:
             validate_using_ema=config.validate_using_ema,
         )
 
-    def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
-        if epoch not in inference_epochs:
-            return {}, None
-        all_logs: dict[str, Any] = {}
-        weighted_error = 0.0
-        has_error = False
-        for i, (entry_config, data, name) in enumerate(inference_entries):
-            if epoch not in inference_epoch_sets[i]:
-                continue
-            batch = next(iter(data.loader))
-            initial_times = batch.ocean_data.time.isel(time=0)
-            n_timesteps_ocean = (
-                entry_config.n_coupled_steps + stepper.ocean.n_ic_timesteps
-            )
-            n_timesteps_atmosphere = (
-                entry_config.n_coupled_steps * stepper.n_inner_steps
-                + stepper.atmosphere.n_ic_timesteps
-            )
-            aggregator = entry_config.aggregator.build(
-                dataset_info=dataset_info,
-                n_timesteps_ocean=n_timesteps_ocean,
-                n_timesteps_atmosphere=n_timesteps_atmosphere,
-                initial_time=initial_times,
-                ocean_normalize=stepper.ocean.normalizer.normalize,
-                atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
-                save_diagnostics=config.save_per_epoch_diagnostics,
-                output_dir=os.path.join(config.output_dir, name),
-            )
-            logs = inference_one_epoch(
-                stepper=stepper,
-                validation_context=contextlib.nullcontext,
-                dataset=data,
-                aggregator=aggregator,
-                label=name,
-                epoch=epoch,
-            )
-            all_logs.update(logs)
-            error = logs.get(f"{name}/time_mean_norm/rmse/channel_mean")
-            if error is not None:
-                weighted_error += entry_config.weight * error
-                has_error = True
-
-        return all_logs, weighted_error if has_error else None
+    inference_callback = get_inference_callback(
+        inference_entries=inference_entries,
+        inference_epochs=inference_epochs,
+        inference_epoch_sets=inference_epoch_sets,
+        stepper=stepper,
+        dataset_info=dataset_info,
+        output_dir=config.output_dir,
+        save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
+    )
 
     return Trainer(
         train_data=train_data,
@@ -240,14 +273,6 @@ class CoupledAggregatorBuilder(
 
     def get_train_aggregator(self) -> TrainAggregator:
         return TrainAggregator()
-
-    def get_validation_aggregator(self) -> OneStepAggregator:
-        return OneStepAggregator(
-            dataset_info=self.dataset_info,
-            save_diagnostics=self.save_per_epoch_diagnostics,
-            output_dir=os.path.join(self.output_dir, "val"),
-            loss_scaling=self.loss_scaling,
-        )
 
 
 def run_train(builders: TrainBuilders, config: TrainConfig):

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -247,13 +247,13 @@ class TrainConfig:
     def __post_init__(self):
         if not self.validation_list:
             raise ValueError("At least one validation entry is required.")
-        resolved_val_names = self.validation_names
-        if len(resolved_val_names) != len(set(resolved_val_names)):
-            raise ValueError(f"Duplicate validation names: {resolved_val_names}")
-        resolved_inf_names = self.inference_names
-        if len(resolved_inf_names) != len(set(resolved_inf_names)):
-            raise ValueError(f"Duplicate inference names: {resolved_inf_names}")
-        reserved_overlap = set(resolved_inf_names) & self._RESERVED_NAMES
+        resolved_validation_names = self.validation_names
+        if len(resolved_validation_names) != len(set(resolved_validation_names)):
+            raise ValueError(f"Duplicate validation names: {resolved_validation_names}")
+        resolved_inference_names = self.inference_names
+        if len(resolved_inference_names) != len(set(resolved_inference_names)):
+            raise ValueError(f"Duplicate inference names: {resolved_inference_names}")
+        reserved_overlap = set(resolved_inference_names) & self._RESERVED_NAMES
         if reserved_overlap:
             raise ValueError(
                 f"Inference names {sorted(reserved_overlap)} collide with "

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -70,6 +70,31 @@ def _validate_loss_n_steps(
 
 
 @dataclasses.dataclass
+class InlineValidationConfig:
+    """
+    Parameters:
+        loader: configuration for the data loader used during validation
+        name: name used as wandb log prefix and output subdirectory. If None,
+            defaults to "val" when there is a single validation config
+            and "val_{i}" when there are multiple. Note: adding a second
+            unnamed config will rename the first from "val" to
+            "val_0", changing its wandb keys and output directory.
+        weight: weight for this validation's loss in the combined checkpoint
+            selection metric. Must be non-negative.
+    """
+
+    loader: CoupledDataLoaderConfig
+    name: str | None = None
+    weight: float = 1.0
+
+    def __post_init__(self):
+        if self.weight < 0:
+            raise ValueError(
+                f"InlineValidationConfig weight must be non-negative, got {self.weight}"
+            )
+
+
+@dataclasses.dataclass
 class InlineInferenceConfig:
     """
     Parameters:
@@ -130,7 +155,10 @@ class TrainConfig:
 
     Attributes:
         train_loader: Configuration for the coupled training data loader.
-        validation_loader: Configuration for the coupled validation data loader.
+        validation: Configuration(s) for inline validation runs. Accepts a single
+            InlineValidationConfig or a list of them. The weighted sum of each
+            run's loss is used for checkpoint selection. Each entry can specify
+            a name (used as wandb log prefix) and weight.
         stepper: Configuration for the coupled stepper.
         optimization: Configuration for the optimization.
         logging: Configuration for logging.
@@ -185,7 +213,7 @@ class TrainConfig:
     """
 
     train_loader: CoupledDataLoaderConfig
-    validation_loader: CoupledDataLoaderConfig
+    validation: InlineValidationConfig | list[InlineValidationConfig]
     stepper: CoupledStepperConfig
     stepper_training: CoupledTrainStepperConfig
     optimization: OptimizationConfig
@@ -217,10 +245,13 @@ class TrainConfig:
     _RESERVED_NAMES = {"train", "val"}
 
     def __post_init__(self):
-        resolved_names = self.inference_names
-        if len(resolved_names) != len(set(resolved_names)):
-            raise ValueError(f"Duplicate inference names: {resolved_names}")
-        reserved_overlap = set(resolved_names) & self._RESERVED_NAMES
+        resolved_val_names = self.validation_names
+        if len(resolved_val_names) != len(set(resolved_val_names)):
+            raise ValueError(f"Duplicate validation names: {resolved_val_names}")
+        resolved_inf_names = self.inference_names
+        if len(resolved_inf_names) != len(set(resolved_inf_names)):
+            raise ValueError(f"Duplicate inference names: {resolved_inf_names}")
+        reserved_overlap = set(resolved_inf_names) & self._RESERVED_NAMES
         if reserved_overlap:
             raise ValueError(
                 f"Inference names {sorted(reserved_overlap)} collide with "
@@ -260,6 +291,25 @@ class TrainConfig:
     @property
     def train_evaluation_batches(self) -> int:
         return self.train_evaluation_samples // self.train_loader.batch_size
+
+    @property
+    def validation_list(self) -> list[InlineValidationConfig]:
+        if isinstance(self.validation, InlineValidationConfig):
+            return [self.validation]
+        return self.validation
+
+    @property
+    def validation_names(self) -> list[str]:
+        validation = self.validation_list
+        names = []
+        for i, entry in enumerate(validation):
+            if entry.name is not None:
+                names.append(entry.name)
+            elif len(validation) == 1:
+                names.append("val")
+            else:
+                names.append(f"val_{i}")
+        return names
 
     @property
     def inference_list(self) -> list[InlineInferenceConfig]:
@@ -312,13 +362,20 @@ class TrainBuilders:
             train=True,
         )
 
-    def get_validation_data(self) -> GriddedData:
+    def get_validation_data(
+        self,
+    ) -> list[tuple[InlineValidationConfig, GriddedData, str]]:
         data_requirements = self._get_train_window_data_requirements()
-        return get_gridded_data(
-            self.config.validation_loader,
-            requirements=data_requirements,
-            train=False,
-        )
+        names = self.config.validation_names
+        entries: list[tuple[InlineValidationConfig, GriddedData, str]] = []
+        for entry, name in zip(self.config.validation_list, names):
+            data = get_gridded_data(
+                entry.loader,
+                requirements=data_requirements,
+                train=False,
+            )
+            entries.append((entry, data, name))
+        return entries
 
     def get_inference_data(
         self,

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -245,6 +245,8 @@ class TrainConfig:
     _RESERVED_NAMES = {"train", "val"}
 
     def __post_init__(self):
+        if not self.validation_list:
+            raise ValueError("At least one validation entry is required.")
         resolved_val_names = self.validation_names
         if len(resolved_val_names) != len(set(resolved_val_names)):
             raise ValueError(f"Duplicate validation names: {resolved_val_names}")


### PR DESCRIPTION
Refactors validation in both ACE and coupled training to support multiple weighted validation configs, mirroring the existing `InlineInferenceConfig` pattern. Each validation entry can have its own data loader, aggregator, epoch schedule, name, and weight. The weighted sum of validation losses drives checkpoint selection and LR scheduling.

Changes:
- `fme.ace.train.train_config.InlineValidationConfig`: new dataclass with `loader`, `aggregator`, `epochs`, `name`, `weight`
- `fme.ace.train.train_config.TrainConfig`: replace `validation_loader`/`validation_aggregator` with `validation: InlineValidationConfig | list[InlineValidationConfig]`; add `validation_list`, `validation_names`, `get_validation_epoch_sets()`, `get_validation_epochs()`
- `fme.ace.train.train.build_trainer`: validation callback iterates over entries, returns weighted loss
- `fme.coupled.train.train_config.InlineValidationConfig`: coupled equivalent with `loader`, `epochs`, `name`, `weight`
- `fme.coupled.train.train_config.TrainConfig`: same refactor as ACE — `validation_loader` → `validation`
- `fme.coupled.train.train.build_trainer`: coupled validation callback iterates over entries
- All baseline YAML configs updated (`validation_loader:` → `validation:\n- loader:`)

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated