### PR TITLE
Add typed metric configs for OneStepAggregatorConfig

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -22,6 +22,8 @@ from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
 )
+from fme.ace.aggregator.one_step.ensemble import EnsembleMetricConfig
+from fme.ace.aggregator.one_step.reduced import StepMeanMetricConfig
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.augmentation import AugmentationConfig
 from fme.ace.data_loading.getters import get_forcing_data

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -18,9 +18,16 @@ from fme.ace.aggregator.inference.spectrum import PowerSpectrumMetricConfig
 from fme.ace.aggregator.inference.time_mean import TimeMeanMetricConfig
 from fme.ace.aggregator.inference.video import VideoMetricConfig
 from fme.ace.aggregator.inference.zonal_mean import ZonalMeanMetricConfig
-from fme.ace.aggregator.one_step import OneStepAggregatorConfig
-from fme.ace.aggregator.one_step.ensemble import EnsembleMetricConfig
-from fme.ace.aggregator.one_step.reduced import StepMeanMetricConfig
+from fme.ace.aggregator.one_step import (
+    LegacyFlagOneStepAggregatorConfig,
+    OneStepAggregatorConfig,
+    build_one_step_aggregator,
+)
+from fme.ace.aggregator.one_step.ensemble import OneStepEnsembleMetricConfig
+from fme.ace.aggregator.one_step.map import OneStepMapMetricConfig
+from fme.ace.aggregator.one_step.reduced import OneStepMeanMetricConfig
+from fme.ace.aggregator.one_step.snapshot import OneStepSnapshotMetricConfig
+from fme.ace.aggregator.one_step.spectrum import OneStepSpectrumMetricConfig
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.augmentation import AugmentationConfig
 from fme.ace.data_loading.getters import get_forcing_data

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -21,13 +21,7 @@ from fme.ace.aggregator.inference.zonal_mean import ZonalMeanMetricConfig
 from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
-    build_one_step_aggregator,
 )
-from fme.ace.aggregator.one_step.ensemble import OneStepEnsembleMetricConfig
-from fme.ace.aggregator.one_step.map import OneStepMapMetricConfig
-from fme.ace.aggregator.one_step.reduced import OneStepMeanMetricConfig
-from fme.ace.aggregator.one_step.snapshot import OneStepSnapshotMetricConfig
-from fme.ace.aggregator.one_step.spectrum import OneStepSpectrumMetricConfig
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.augmentation import AugmentationConfig
 from fme.ace.data_loading.getters import get_forcing_data

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -21,9 +21,19 @@ from fme.ace.aggregator.inference.zonal_mean import ZonalMeanMetricConfig
 from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
+    build_one_step_aggregator,
 )
-from fme.ace.aggregator.one_step.ensemble import EnsembleMetricConfig
-from fme.ace.aggregator.one_step.reduced import StepMeanMetricConfig
+from fme.ace.aggregator.one_step.ensemble import (
+    EnsembleMetricConfig,
+    OneStepEnsembleMetricConfig,
+)
+from fme.ace.aggregator.one_step.map import OneStepMapMetricConfig
+from fme.ace.aggregator.one_step.reduced import (
+    OneStepMeanMetricConfig,
+    StepMeanMetricConfig,
+)
+from fme.ace.aggregator.one_step.snapshot import OneStepSnapshotMetricConfig
+from fme.ace.aggregator.one_step.spectrum import OneStepSpectrumMetricConfig
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.augmentation import AugmentationConfig
 from fme.ace.data_loading.getters import get_forcing_data

--- a/fme/ace/aggregator/__init__.py
+++ b/fme/ace/aggregator/__init__.py
@@ -9,5 +9,6 @@ from .one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregator,
     OneStepAggregatorConfig,
+    build_one_step_aggregator,
 )
 from .train import TrainAggregator

--- a/fme/ace/aggregator/__init__.py
+++ b/fme/ace/aggregator/__init__.py
@@ -5,6 +5,10 @@ from .inference import (
     build_inference_evaluator_aggregator,
 )
 from .null import NullAggregator
-from .one_step import OneStepAggregator
-from .one_step.main import OneStepAggregatorConfig
+from .one_step import (
+    LegacyFlagOneStepAggregatorConfig,
+    OneStepAggregator,
+    OneStepAggregatorConfig,
+    build_one_step_aggregator,
+)
 from .train import TrainAggregator

--- a/fme/ace/aggregator/__init__.py
+++ b/fme/ace/aggregator/__init__.py
@@ -9,6 +9,5 @@ from .one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregator,
     OneStepAggregatorConfig,
-    build_one_step_aggregator,
 )
 from .train import TrainAggregator

--- a/fme/ace/aggregator/inference/histogram.py
+++ b/fme/ace/aggregator/inference/histogram.py
@@ -13,7 +13,7 @@ from .data import InferenceBatchData, MetricBuildResult, SubAggregator
 class HistogramMetricConfig:
     variables: list[str] | None = None
     name: str = "histogram"
-    enabled: bool = True
+    enabled: bool = False
     strict: bool = True
 
     def get_name(self) -> str:

--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -228,14 +228,12 @@ class InferenceEvaluatorAggregatorConfig:
     time_mean_norm: TimeMeanMetricConfig = dataclasses.field(
         default_factory=lambda: TimeMeanMetricConfig(target="norm")
     )
-    video: VideoMetricConfig = dataclasses.field(
-        default_factory=lambda: VideoMetricConfig(enabled=False)
-    )
+    video: VideoMetricConfig = dataclasses.field(default_factory=VideoMetricConfig)
     histogram: HistogramMetricConfig = dataclasses.field(
-        default_factory=lambda: HistogramMetricConfig(enabled=False)
+        default_factory=HistogramMetricConfig
     )
     seasonal: SeasonalMetricConfig = dataclasses.field(
-        default_factory=lambda: SeasonalMetricConfig(enabled=False)
+        default_factory=SeasonalMetricConfig
     )
     annual: AnnualMetricConfig = dataclasses.field(default_factory=AnnualMetricConfig)
     enso_index: EnsoIndexMetricConfig = dataclasses.field(

--- a/fme/ace/aggregator/inference/seasonal.py
+++ b/fme/ace/aggregator/inference/seasonal.py
@@ -251,7 +251,7 @@ def _to_dataset(data: TensorMapping, time: xr.DataArray) -> xr.Dataset:
 class SeasonalMetricConfig:
     variables: list[str] | None = None
     name: str = "seasonal"
-    enabled: bool = True
+    enabled: bool = False
     strict: bool = True
 
     def get_name(self) -> str:

--- a/fme/ace/aggregator/inference/video.py
+++ b/fme/ace/aggregator/inference/video.py
@@ -525,7 +525,7 @@ class VideoMetricConfig:
     variables: list[str] | None = None
     name: str = "video"
     enable_extended_videos: bool = False
-    enabled: bool = True
+    enabled: bool = False
     strict: bool = True
 
     def get_name(self) -> str:

--- a/fme/ace/aggregator/one_step/__init__.py
+++ b/fme/ace/aggregator/one_step/__init__.py
@@ -1,1 +1,6 @@
-from .main import OneStepAggregator, OneStepAggregatorConfig  # noqa: F401
+from .main import (  # noqa: F401
+    LegacyFlagOneStepAggregatorConfig,
+    OneStepAggregator,
+    OneStepAggregatorConfig,
+    build_one_step_aggregator,
+)

--- a/fme/ace/aggregator/one_step/__init__.py
+++ b/fme/ace/aggregator/one_step/__init__.py
@@ -1,1 +1,1 @@
-from .main import OneStepAggregator, OneStepAggregatorConfig
+from .main import OneStepAggregator, OneStepAggregatorConfig  # noqa: F401

--- a/fme/ace/aggregator/one_step/__init__.py
+++ b/fme/ace/aggregator/one_step/__init__.py
@@ -2,4 +2,5 @@ from .main import (  # noqa: F401
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregator,
     OneStepAggregatorConfig,
+    build_one_step_aggregator,
 )

--- a/fme/ace/aggregator/one_step/__init__.py
+++ b/fme/ace/aggregator/one_step/__init__.py
@@ -2,5 +2,4 @@ from .main import (  # noqa: F401
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregator,
     OneStepAggregatorConfig,
-    build_one_step_aggregator,
 )

--- a/fme/ace/aggregator/one_step/build_context.py
+++ b/fme/ace/aggregator/one_step/build_context.py
@@ -12,7 +12,7 @@ from fme.core.gridded_ops import GriddedOperations
 from fme.core.typing_ import EnsembleTensorDict, TensorMapping
 
 
-class _Aggregator(Protocol):
+class Aggregator(Protocol):
     def get_logs(self, label: str) -> TensorMapping: ...
 
     def record_batch(
@@ -27,7 +27,7 @@ class _Aggregator(Protocol):
     def get_dataset(self) -> xr.Dataset: ...
 
 
-class _EnsembleAggregator(Protocol):
+class EnsembleAggregator(Protocol):
     def record_batch(
         self,
         target_data: EnsembleTensorDict,
@@ -52,5 +52,5 @@ class OneStepBuildContext:
 
 @dataclasses.dataclass
 class OneStepMetricBuildResult:
-    deterministic: _Aggregator | None = None
-    ensemble: _EnsembleAggregator | None = None
+    deterministic: Aggregator | None = None
+    ensemble: EnsembleAggregator | None = None

--- a/fme/ace/aggregator/one_step/build_context.py
+++ b/fme/ace/aggregator/one_step/build_context.py
@@ -39,7 +39,7 @@ class _EnsembleAggregator(Protocol):
 
 
 class MetricNotSupportedError(Exception):
-    """Raised when a metric cannot be built for the current grid type."""
+    """Raised when a metric cannot be built for the current configuration."""
 
 
 @dataclasses.dataclass

--- a/fme/ace/aggregator/one_step/build_context.py
+++ b/fme/ace/aggregator/one_step/build_context.py
@@ -39,7 +39,7 @@ class _EnsembleAggregator(Protocol):
 
 
 class MetricNotSupportedError(Exception):
-    """Raised when a metric cannot be built for the current configuration."""
+    """Raised when a metric cannot be built for the current grid type."""
 
 
 @dataclasses.dataclass

--- a/fme/ace/aggregator/one_step/build_context.py
+++ b/fme/ace/aggregator/one_step/build_context.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+import xarray as xr
+
+from fme.core.coordinates import HorizontalCoordinates
+from fme.core.dataset.data_typing import VariableMetadata
+from fme.core.gridded_ops import GriddedOperations
+from fme.core.typing_ import EnsembleTensorDict, TensorMapping
+
+
+class _Aggregator(Protocol):
+    def get_logs(self, label: str) -> TensorMapping: ...
+
+    def record_batch(
+        self,
+        loss: float,
+        target_data: TensorMapping,
+        gen_data: TensorMapping,
+        target_data_norm: TensorMapping,
+        gen_data_norm: TensorMapping,
+    ) -> None: ...
+
+    def get_dataset(self) -> xr.Dataset: ...
+
+
+class _EnsembleAggregator(Protocol):
+    def record_batch(
+        self,
+        target_data: EnsembleTensorDict,
+        gen_data: EnsembleTensorDict,
+        i_time_start: int = ...,
+    ) -> None: ...
+
+    def get_logs(self, label: str) -> TensorMapping: ...
+
+
+class MetricNotSupportedError(Exception):
+    """Raised when a metric cannot be built for the current configuration."""
+
+
+@dataclasses.dataclass
+class OneStepBuildContext:
+    ops: GriddedOperations
+    horizontal_coordinates: HorizontalCoordinates
+    variable_metadata: Mapping[str, VariableMetadata] | None
+    channel_mean_names: Sequence[str] | None
+
+
+@dataclasses.dataclass
+class OneStepMetricBuildResult:
+    deterministic: _Aggregator | None = None
+    ensemble: _EnsembleAggregator | None = None

--- a/fme/ace/aggregator/one_step/deterministic.py
+++ b/fme/ace/aggregator/one_step/deterministic.py
@@ -9,7 +9,7 @@ from fme.core.diagnostics import get_reduced_diagnostics, write_reduced_diagnost
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.typing_ import TensorDict, TensorMapping
 
-from .build_context import _Aggregator
+from .build_context import Aggregator
 
 
 @dataclasses.dataclass
@@ -32,7 +32,7 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
 
     def __init__(
         self,
-        aggregators: Mapping[str, _Aggregator],
+        aggregators: Mapping[str, Aggregator],
         coords: Mapping[str, np.ndarray],
         save_diagnostics: bool = True,
         output_dir: str | None = None,

--- a/fme/ace/aggregator/one_step/deterministic.py
+++ b/fme/ace/aggregator/one_step/deterministic.py
@@ -1,22 +1,15 @@
 import dataclasses
 import logging
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping
 from typing import Protocol
 
 import numpy as np
 import torch
 import xarray as xr
 
-from fme.core.dataset_info import DatasetInfo
 from fme.core.diagnostics import get_reduced_diagnostics, write_reduced_diagnostics
-from fme.core.fill import SmoothFloodFill
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.typing_ import TensorDict, TensorMapping
-
-from .map import MapAggregator
-from .reduced import MeanAggregator
-from .snapshot import SnapshotAggregator
-from .spectrum import SpectrumAggregator
 
 
 class _Aggregator(Protocol):
@@ -54,62 +47,18 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
 
     def __init__(
         self,
-        dataset_info: DatasetInfo,
+        aggregators: Mapping[str, _Aggregator],
+        coords: Mapping[str, np.ndarray],
         save_diagnostics: bool = True,
         output_dir: str | None = None,
         loss_scaling: TensorMapping | None = None,
-        log_snapshots: bool = True,
-        log_mean_maps: bool = True,
-        channel_mean_names: Sequence[str] | None = None,
     ):
-        """
-        Args:
-            dataset_info: Dataset coordinates and metadata.
-            save_diagnostics: Whether to save diagnostics.
-            output_dir: Directory to write diagnostics to.
-            variable_metadata: Metadata for each variable.
-            loss_scaling: Dictionary of variables and their scaling factors
-                used in loss computation.
-            log_snapshots: Whether to include snapshots in diagnostics.
-            log_mean_maps: Whether to include mean maps in diagnostics.
-            channel_mean_names: Names of variables whose RMSE will be averaged. If
-                not provided, all available variables will be used.
-        """
         if save_diagnostics and output_dir is None:
             raise ValueError("Output directory must be set to save diagnostics.")
         self._output_dir = output_dir
         self._save_diagnostics = save_diagnostics
-        horizontal_coordinates = dataset_info.horizontal_coordinates
-        self._coords = horizontal_coordinates.coords
-        self._aggregators: dict[str, _Aggregator] = {
-            "mean": MeanAggregator(dataset_info.gridded_operations),
-            "mean_norm": MeanAggregator(
-                dataset_info.gridded_operations,
-                target="norm",
-                channel_mean_names=channel_mean_names,
-                include_bias=False,
-                include_grad_mag_percent_diff=False,
-            ),
-        }
-        try:
-            flood_fill = SmoothFloodFill(num_steps=4)
-            self._aggregators["power_spectrum"] = SpectrumAggregator(
-                dataset_info.gridded_operations,
-                nan_fill_fn=flood_fill,
-            )
-        except NotImplementedError:
-            logging.warning(
-                "Spectrum aggregator not implemented for this grid type, omitting."
-            )
-        if log_snapshots:
-            self._aggregators["snapshot"] = SnapshotAggregator(
-                horizontal_coordinates.dims, dataset_info.variable_metadata
-            )
-        if log_mean_maps:
-            self._aggregators["mean_map"] = MapAggregator(
-                horizontal_coordinates.dims, dataset_info.variable_metadata
-            )
-
+        self._coords = coords
+        self._aggregators = aggregators
         self._loss_scaling = loss_scaling or {}
 
     @torch.no_grad()

--- a/fme/ace/aggregator/one_step/deterministic.py
+++ b/fme/ace/aggregator/one_step/deterministic.py
@@ -86,7 +86,7 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
             logging.info(f"Getting logs for {agg_label} aggregator")
             for k, v in self._aggregators[agg_label].get_logs(label=agg_label).items():
                 logs[f"{label}/{k}"] = v
-        logs.pop(f"{label}/mean_norm/loss", None)  # remove duplicate of mean/loss
+        logs.pop(f"{label}/mean_norm/loss")
         logging.info(f"Inserting loss-scaled MSE componenets into logs")
         logs.update(
             self._get_loss_scaled_mse_components(

--- a/fme/ace/aggregator/one_step/deterministic.py
+++ b/fme/ace/aggregator/one_step/deterministic.py
@@ -38,6 +38,16 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
         output_dir: str | None = None,
         loss_scaling: TensorMapping | None = None,
     ):
+        """
+        Args:
+            aggregators: Named sub-aggregators keyed by metric name. Must
+                include a ``"mean_norm"`` entry.
+            coords: Coordinate arrays for writing diagnostics.
+            save_diagnostics: Whether to save diagnostics.
+            output_dir: Directory to write diagnostics to.
+            loss_scaling: Dictionary of variables and their scaling factors
+                used in loss computation.
+        """
         if save_diagnostics and output_dir is None:
             raise ValueError("Output directory must be set to save diagnostics.")
         if "mean_norm" not in aggregators:

--- a/fme/ace/aggregator/one_step/deterministic.py
+++ b/fme/ace/aggregator/one_step/deterministic.py
@@ -1,30 +1,15 @@
 import dataclasses
 import logging
 from collections.abc import Callable, Mapping
-from typing import Protocol
 
 import numpy as np
 import torch
-import xarray as xr
 
 from fme.core.diagnostics import get_reduced_diagnostics, write_reduced_diagnostics
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.typing_ import TensorDict, TensorMapping
 
-
-class _Aggregator(Protocol):
-    def get_logs(self, label: str) -> TensorMapping: ...
-
-    def record_batch(
-        self,
-        loss: float,
-        target_data: TensorMapping,
-        gen_data: TensorMapping,
-        target_data_norm: TensorMapping,
-        gen_data_norm: TensorMapping,
-    ) -> None: ...
-
-    def get_dataset(self) -> xr.Dataset: ...
+from .build_context import _Aggregator
 
 
 @dataclasses.dataclass
@@ -55,6 +40,12 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
     ):
         if save_diagnostics and output_dir is None:
             raise ValueError("Output directory must be set to save diagnostics.")
+        if "mean_norm" not in aggregators:
+            raise ValueError(
+                "An aggregator named 'mean_norm' is required. "
+                "Include a OneStepMeanMetricConfig with target='norm' "
+                "in your metrics list."
+            )
         self._output_dir = output_dir
         self._save_diagnostics = save_diagnostics
         self._coords = coords
@@ -95,7 +86,7 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
             logging.info(f"Getting logs for {agg_label} aggregator")
             for k, v in self._aggregators[agg_label].get_logs(label=agg_label).items():
                 logs[f"{label}/{k}"] = v
-        logs.pop(f"{label}/mean_norm/loss")  # remove duplicate of mean/loss
+        logs.pop(f"{label}/mean_norm/loss", None)  # remove duplicate of mean/loss
         logging.info(f"Inserting loss-scaled MSE componenets into logs")
         logs.update(
             self._get_loss_scaled_mse_components(

--- a/fme/ace/aggregator/one_step/deterministic.py
+++ b/fme/ace/aggregator/one_step/deterministic.py
@@ -86,7 +86,7 @@ class OneStepDeterministicAggregator(AggregatorABC[DeterministicTrainOutput]):
             logging.info(f"Getting logs for {agg_label} aggregator")
             for k, v in self._aggregators[agg_label].get_logs(label=agg_label).items():
                 logs[f"{label}/{k}"] = v
-        logs.pop(f"{label}/mean_norm/loss")
+        logs.pop(f"{label}/mean_norm/loss", None)
         logging.info(f"Inserting loss-scaled MSE componenets into logs")
         logs.update(
             self._get_loss_scaled_mse_components(

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -371,8 +371,6 @@ class EnsembleMetricConfig:
 class OneStepEnsembleMetricConfig:
     name: str = "ensemble"
     log_mean_maps: bool = True
-    enabled: bool = True
-    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -371,6 +371,8 @@ class EnsembleMetricConfig:
 class OneStepEnsembleMetricConfig:
     name: str = "ensemble"
     log_mean_maps: bool = True
+    enabled: bool = True
+    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -14,6 +14,7 @@ from fme.core.typing_ import EnsembleTensorDict, TensorMapping
 
 from ..inference.build_context import MetricBuildContext, MetricNotSupportedError
 from ..inference.data import MetricBuildResult
+from .build_context import OneStepBuildContext, OneStepMetricBuildResult
 
 
 def get_gen_shape(gen_data: TensorMapping):
@@ -361,6 +362,27 @@ class EnsembleMetricConfig:
                 gridded_operations=ctx.ops,
                 target_time=self.step,
                 log_mean_maps=self.log_mean_maps,
+                metadata=ctx.variable_metadata,
+            )
+        )
+
+
+@dataclasses.dataclass
+class OneStepEnsembleMetricConfig:
+    name: str = "ensemble"
+    log_mean_maps: bool = True
+    enabled: bool = True
+    strict: bool = False
+
+    def get_name(self) -> str:
+        return self.name
+
+    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
+        return OneStepMetricBuildResult(
+            ensemble=get_one_step_ensemble_aggregator(
+                gridded_operations=ctx.ops,
+                log_mean_maps=self.log_mean_maps,
+                target_time=1,
                 metadata=ctx.variable_metadata,
             )
         )

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -1,4 +1,5 @@
 import dataclasses
+import logging
 from collections.abc import Sequence
 
 import torch
@@ -6,13 +7,23 @@ import torch
 from fme.ace.aggregator.one_step.deterministic import (
     DeterministicTrainOutput,
     OneStepDeterministicAggregator,
+    _Aggregator,
 )
-from fme.ace.aggregator.one_step.ensemble import get_one_step_ensemble_aggregator
+from fme.ace.aggregator.one_step.ensemble import (
+    SelectStepEnsembleAggregator,
+    get_one_step_ensemble_aggregator,
+)
 from fme.ace.stepper import TrainOutput
 from fme.core.dataset_info import DatasetInfo
+from fme.core.fill import SmoothFloodFill
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.tensors import fold_ensemble_dim, fold_sized_ensemble_dim
 from fme.core.typing_ import TensorMapping
+
+from .map import MapAggregator
+from .reduced import MeanAggregator
+from .snapshot import SnapshotAggregator
+from .spectrum import SpectrumAggregator
 
 
 class OneStepAggregator(AggregatorABC[TrainOutput]):
@@ -25,40 +36,11 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
 
     def __init__(
         self,
-        dataset_info: DatasetInfo,
-        save_diagnostics: bool = True,
-        output_dir: str | None = None,
-        loss_scaling: TensorMapping | None = None,
-        log_snapshots: bool = True,
-        log_mean_maps: bool = True,
-        channel_mean_names: Sequence[str] | None = None,
+        deterministic_aggregator: OneStepDeterministicAggregator,
+        ensemble_aggregator: SelectStepEnsembleAggregator,
     ):
-        """
-        Args:
-            dataset_info: Dataset coordinates and metadata.
-            save_diagnostics: Whether to save diagnostics.
-            output_dir: Directory to write diagnostics to.
-            loss_scaling: Dictionary of variables and their scaling factors
-                used in loss computation.
-            log_snapshots: Whether to include snapshots in diagnostics.
-            log_mean_maps: Whether to include mean maps in diagnostics.
-            channel_mean_names: Names to include in channel-mean metrics.
-        """
-        self._deterministic_aggregator = OneStepDeterministicAggregator(
-            dataset_info=dataset_info,
-            save_diagnostics=save_diagnostics,
-            output_dir=output_dir,
-            loss_scaling=loss_scaling,
-            log_snapshots=log_snapshots,
-            log_mean_maps=log_mean_maps,
-            channel_mean_names=channel_mean_names,
-        )
-        self._ensemble_aggregator = get_one_step_ensemble_aggregator(
-            gridded_operations=dataset_info.gridded_operations,
-            log_mean_maps=log_mean_maps,
-            target_time=1,
-            metadata=dataset_info.variable_metadata,
-        )
+        self._deterministic_aggregator = deterministic_aggregator
+        self._ensemble_aggregator = ensemble_aggregator
         self._ensemble_recorded = False
 
     @torch.no_grad()
@@ -110,6 +92,44 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         self._deterministic_aggregator.flush_diagnostics(subdir)
 
 
+def _build_default_deterministic_aggregators(
+    dataset_info: DatasetInfo,
+    log_snapshots: bool,
+    log_mean_maps: bool,
+    channel_mean_names: Sequence[str] | None,
+) -> dict[str, _Aggregator]:
+    aggregators: dict[str, _Aggregator] = {
+        "mean": MeanAggregator(dataset_info.gridded_operations),
+        "mean_norm": MeanAggregator(
+            dataset_info.gridded_operations,
+            target="norm",
+            channel_mean_names=channel_mean_names,
+            include_bias=False,
+            include_grad_mag_percent_diff=False,
+        ),
+    }
+    try:
+        flood_fill = SmoothFloodFill(num_steps=4)
+        aggregators["power_spectrum"] = SpectrumAggregator(
+            dataset_info.gridded_operations,
+            nan_fill_fn=flood_fill,
+        )
+    except NotImplementedError:
+        logging.warning(
+            "Spectrum aggregator not implemented for this grid type, omitting."
+        )
+    horizontal_coordinates = dataset_info.horizontal_coordinates
+    if log_snapshots:
+        aggregators["snapshot"] = SnapshotAggregator(
+            horizontal_coordinates.dims, dataset_info.variable_metadata
+        )
+    if log_mean_maps:
+        aggregators["mean_map"] = MapAggregator(
+            horizontal_coordinates.dims, dataset_info.variable_metadata
+        )
+    return aggregators
+
+
 @dataclasses.dataclass
 class OneStepAggregatorConfig:
     """
@@ -131,12 +151,26 @@ class OneStepAggregatorConfig:
         loss_scaling: TensorMapping | None = None,
         channel_mean_names: Sequence[str] | None = None,
     ):
-        return OneStepAggregator(
+        aggregators = _build_default_deterministic_aggregators(
             dataset_info=dataset_info,
-            save_diagnostics=save_diagnostics,
-            output_dir=output_dir,
-            loss_scaling=loss_scaling,
             log_snapshots=self.log_snapshots,
             log_mean_maps=self.log_mean_maps,
             channel_mean_names=channel_mean_names,
+        )
+        deterministic_aggregator = OneStepDeterministicAggregator(
+            aggregators=aggregators,
+            coords=dataset_info.horizontal_coordinates.coords,
+            save_diagnostics=save_diagnostics,
+            output_dir=output_dir,
+            loss_scaling=loss_scaling,
+        )
+        ensemble_aggregator = get_one_step_ensemble_aggregator(
+            gridded_operations=dataset_info.gridded_operations,
+            log_mean_maps=self.log_mean_maps,
+            target_time=1,
+            metadata=dataset_info.variable_metadata,
+        )
+        return OneStepAggregator(
+            deterministic_aggregator=deterministic_aggregator,
+            ensemble_aggregator=ensemble_aggregator,
         )

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -115,52 +115,145 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         self._deterministic_aggregator.flush_diagnostics(subdir)
 
 
-def _default_metrics() -> list[OneStepMetricConfig]:
-    return [
-        OneStepMeanMetricConfig(target="denorm"),
-        OneStepMeanMetricConfig(
-            target="norm",
-            include_bias=False,
-            include_grad_mag_percent_diff=False,
-        ),
-        OneStepSpectrumMetricConfig(),
-        OneStepSnapshotMetricConfig(),
-        OneStepMapMetricConfig(),
-        OneStepEnsembleMetricConfig(),
-    ]
+def _validate_no_duplicate_names(metrics: list[OneStepMetricConfig]) -> None:
+    names = [m.get_name() for m in metrics]
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for n in names:
+        if n in seen:
+            duplicates.add(n)
+        seen.add(n)
+    if duplicates:
+        raise ValueError(
+            f"Duplicate metric names: {sorted(duplicates)}. "
+            "Use the 'name' field to disambiguate."
+        )
+
+
+def build_one_step_aggregator(
+    metrics: list[OneStepMetricConfig],
+    dataset_info: DatasetInfo,
+    save_diagnostics: bool = True,
+    output_dir: str | None = None,
+    loss_scaling: TensorMapping | None = None,
+    channel_mean_names: Sequence[str] | None = None,
+    raise_on_unsupported: bool = True,
+) -> OneStepAggregator:
+    _validate_no_duplicate_names(metrics)
+    ctx = OneStepBuildContext(
+        ops=dataset_info.gridded_operations,
+        horizontal_coordinates=dataset_info.horizontal_coordinates,
+        variable_metadata=dataset_info.variable_metadata,
+        channel_mean_names=channel_mean_names,
+    )
+
+    deterministic_aggregators: dict[str, _Aggregator] = {}
+    ensemble_aggregator: _EnsembleAggregator | None = None
+
+    for metric in metrics:
+        name = metric.get_name()
+        try:
+            result: OneStepMetricBuildResult = metric.build(ctx)
+        except MetricNotSupportedError as e:
+            if raise_on_unsupported or metric.strict:
+                raise
+            logging.warning(
+                f"{name} metric not supported for this configuration, omitting: {e}"
+            )
+            continue
+
+        if result.deterministic is not None:
+            deterministic_aggregators[name] = result.deterministic
+        if result.ensemble is not None:
+            if ensemble_aggregator is not None:
+                raise ValueError("Multiple ensemble metrics are not supported.")
+            ensemble_aggregator = result.ensemble
+
+    if ensemble_aggregator is None:
+        ensemble_aggregator = get_one_step_ensemble_aggregator(
+            gridded_operations=ctx.ops,
+            target_time=1,
+            metadata=ctx.variable_metadata,
+        )
+
+    deterministic = OneStepDeterministicAggregator(
+        aggregators=deterministic_aggregators,
+        coords=dataset_info.horizontal_coordinates.coords,
+        save_diagnostics=save_diagnostics,
+        output_dir=output_dir,
+        loss_scaling=loss_scaling,
+    )
+    return OneStepAggregator(
+        deterministic_aggregator=deterministic,
+        ensemble_aggregator=ensemble_aggregator,
+    )
 
 
 @dataclasses.dataclass
 class OneStepAggregatorConfig:
     """
-    Configuration for the validation OneStepAggregator using typed metric configs.
+    Configuration for the validation OneStepAggregator.
 
-    Metrics can be configured explicitly via the ``metrics`` list, where each
-    entry is a typed metric configuration (e.g. ``OneStepMeanMetricConfig``,
-    ``OneStepSnapshotMetricConfig``).  When ``metrics`` is ``None``, a default
-    set of metrics is used.
+    Each metric is a named field with its own typed configuration and an
+    ``enabled`` flag.  Defaults match the standard metric set.
+
+    Metrics whose runtime requirements are not met (e.g. ``power_spectrum``
+    on a non-spherical grid) are skipped with a warning when ``strict``
+    is ``False`` (the default for built-in metrics).
 
     Parameters:
-        metrics: Explicit list of metric configurations.  When ``None``, a
-            default set is used.
+        mean_denorm: Mean metrics on denormalized data.
+        mean_norm: Mean metrics on normalized data.
+        power_spectrum: Spherical power spectrum metrics.
+        snapshot: Snapshot image metrics.
+        mean_map: Mean map image metrics.
+        ensemble: Ensemble spread metrics.
     """
 
-    metrics: list[OneStepMetricConfig] | None = None
+    mean_denorm: OneStepMeanMetricConfig = dataclasses.field(
+        default_factory=lambda: OneStepMeanMetricConfig(target="denorm")
+    )
+    mean_norm: OneStepMeanMetricConfig = dataclasses.field(
+        default_factory=lambda: OneStepMeanMetricConfig(
+            target="norm",
+            include_bias=False,
+            include_grad_mag_percent_diff=False,
+        )
+    )
+    power_spectrum: OneStepSpectrumMetricConfig = dataclasses.field(
+        default_factory=OneStepSpectrumMetricConfig
+    )
+    snapshot: OneStepSnapshotMetricConfig = dataclasses.field(
+        default_factory=OneStepSnapshotMetricConfig
+    )
+    mean_map: OneStepMapMetricConfig = dataclasses.field(
+        default_factory=OneStepMapMetricConfig
+    )
+    ensemble: OneStepEnsembleMetricConfig = dataclasses.field(
+        default_factory=OneStepEnsembleMetricConfig
+    )
 
     def __post_init__(self):
-        if self.metrics is not None:
-            names = [m.get_name() for m in self.metrics]
-            seen: set[str] = set()
-            duplicates: set[str] = set()
-            for n in names:
-                if n in seen:
-                    duplicates.add(n)
-                seen.add(n)
-            if duplicates:
-                raise ValueError(
-                    f"Duplicate metric names: {sorted(duplicates)}. "
-                    "Use the 'name' field to disambiguate."
-                )
+        if self.mean_denorm.target != "denorm":
+            raise ValueError(
+                f"mean_denorm.target must be 'denorm', "
+                f"got '{self.mean_denorm.target}'"
+            )
+        if self.mean_norm.target != "norm":
+            raise ValueError(
+                f"mean_norm.target must be 'norm', got '{self.mean_norm.target}'"
+            )
+
+    def _get_metrics(self) -> list[OneStepMetricConfig]:
+        all_metrics: list[OneStepMetricConfig] = [
+            self.mean_denorm,
+            self.mean_norm,
+            self.power_spectrum,
+            self.snapshot,
+            self.mean_map,
+            self.ensemble,
+        ]
+        return [m for m in all_metrics if m.enabled]
 
     def build(
         self,
@@ -170,55 +263,14 @@ class OneStepAggregatorConfig:
         loss_scaling: TensorMapping | None = None,
         channel_mean_names: Sequence[str] | None = None,
     ) -> OneStepAggregator:
-        ctx = OneStepBuildContext(
-            ops=dataset_info.gridded_operations,
-            horizontal_coordinates=dataset_info.horizontal_coordinates,
-            variable_metadata=dataset_info.variable_metadata,
-            channel_mean_names=channel_mean_names,
-        )
-
-        metrics = self.metrics if self.metrics is not None else _default_metrics()
-        is_explicit = self.metrics is not None
-
-        deterministic_aggregators: dict[str, _Aggregator] = {}
-        ensemble_aggregator: _EnsembleAggregator | None = None
-
-        for metric in metrics:
-            name = metric.get_name()
-            try:
-                result: OneStepMetricBuildResult = metric.build(ctx)
-            except MetricNotSupportedError:
-                if is_explicit:
-                    raise
-                logging.warning(
-                    f"{name} metric not supported for this grid type, omitting."
-                )
-                continue
-
-            if result.deterministic is not None:
-                deterministic_aggregators[name] = result.deterministic
-            if result.ensemble is not None:
-                if ensemble_aggregator is not None:
-                    raise ValueError("Multiple ensemble metrics are not supported.")
-                ensemble_aggregator = result.ensemble
-
-        if ensemble_aggregator is None:
-            ensemble_aggregator = get_one_step_ensemble_aggregator(
-                gridded_operations=ctx.ops,
-                target_time=1,
-                metadata=ctx.variable_metadata,
-            )
-
-        deterministic = OneStepDeterministicAggregator(
-            aggregators=deterministic_aggregators,
-            coords=dataset_info.horizontal_coordinates.coords,
+        return build_one_step_aggregator(
+            metrics=self._get_metrics(),
+            dataset_info=dataset_info,
             save_diagnostics=save_diagnostics,
             output_dir=output_dir,
             loss_scaling=loss_scaling,
-        )
-        return OneStepAggregator(
-            deterministic_aggregator=deterministic,
-            ensemble_aggregator=ensemble_aggregator,
+            channel_mean_names=channel_mean_names,
+            raise_on_unsupported=False,
         )
 
 
@@ -240,12 +292,12 @@ class LegacyFlagOneStepAggregatorConfig:
     def __post_init__(self):
         warnings.warn(
             "LegacyFlagOneStepAggregatorConfig is deprecated. "
-            "Use OneStepAggregatorConfig with typed metrics instead.",
+            "Use OneStepAggregatorConfig instead.",
             DeprecationWarning,
             stacklevel=2,
         )
 
-    def _to_typed_config(self) -> OneStepAggregatorConfig:
+    def _get_metrics(self) -> list[OneStepMetricConfig]:
         metrics: list[OneStepMetricConfig] = [
             OneStepMeanMetricConfig(target="denorm"),
             OneStepMeanMetricConfig(
@@ -260,7 +312,7 @@ class LegacyFlagOneStepAggregatorConfig:
         if self.log_mean_maps:
             metrics.append(OneStepMapMetricConfig())
         metrics.append(OneStepEnsembleMetricConfig(log_mean_maps=self.log_mean_maps))
-        return OneStepAggregatorConfig(metrics=metrics)
+        return metrics
 
     def build(
         self,
@@ -270,7 +322,8 @@ class LegacyFlagOneStepAggregatorConfig:
         loss_scaling: TensorMapping | None = None,
         channel_mean_names: Sequence[str] | None = None,
     ) -> OneStepAggregator:
-        return self._to_typed_config().build(
+        return build_one_step_aggregator(
+            metrics=self._get_metrics(),
             dataset_info=dataset_info,
             save_diagnostics=save_diagnostics,
             output_dir=output_dir,

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -21,11 +21,11 @@ from fme.core.tensors import fold_ensemble_dim, fold_sized_ensemble_dim
 from fme.core.typing_ import TensorMapping
 
 from .build_context import (
+    Aggregator,
+    EnsembleAggregator,
     MetricNotSupportedError,
     OneStepBuildContext,
     OneStepMetricBuildResult,
-    _Aggregator,
-    _EnsembleAggregator,
 )
 from .map import OneStepMapMetricConfig
 from .reduced import OneStepMeanMetricConfig
@@ -52,7 +52,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
     def __init__(
         self,
         deterministic_aggregator: OneStepDeterministicAggregator,
-        ensemble_aggregator: _EnsembleAggregator,
+        ensemble_aggregator: EnsembleAggregator,
     ):
         self._deterministic_aggregator = deterministic_aggregator
         self._ensemble_aggregator = ensemble_aggregator
@@ -147,8 +147,8 @@ def build_one_step_aggregator(
         channel_mean_names=channel_mean_names,
     )
 
-    deterministic_aggregators: dict[str, _Aggregator] = {}
-    ensemble_aggregator: _EnsembleAggregator | None = None
+    deterministic_aggregators: dict[str, Aggregator] = {}
+    ensemble_aggregator: EnsembleAggregator | None = None
 
     for metric in metrics:
         name = metric.get_name()

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -106,145 +106,52 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         self._deterministic_aggregator.flush_diagnostics(subdir)
 
 
-def _validate_no_duplicate_names(metrics: list[OneStepMetricConfig]) -> None:
-    names = [m.get_name() for m in metrics]
-    seen: set[str] = set()
-    duplicates: set[str] = set()
-    for n in names:
-        if n in seen:
-            duplicates.add(n)
-        seen.add(n)
-    if duplicates:
-        raise ValueError(
-            f"Duplicate metric names: {sorted(duplicates)}. "
-            "Use the 'name' field to disambiguate."
-        )
-
-
-def build_one_step_aggregator(
-    metrics: list[OneStepMetricConfig],
-    dataset_info: DatasetInfo,
-    save_diagnostics: bool = True,
-    output_dir: str | None = None,
-    loss_scaling: TensorMapping | None = None,
-    channel_mean_names: Sequence[str] | None = None,
-    raise_on_unsupported: bool = True,
-) -> OneStepAggregator:
-    _validate_no_duplicate_names(metrics)
-    ctx = OneStepBuildContext(
-        ops=dataset_info.gridded_operations,
-        horizontal_coordinates=dataset_info.horizontal_coordinates,
-        variable_metadata=dataset_info.variable_metadata,
-        channel_mean_names=channel_mean_names,
-    )
-
-    deterministic_aggregators: dict[str, _Aggregator] = {}
-    ensemble_aggregator: _EnsembleAggregator | None = None
-
-    for metric in metrics:
-        name = metric.get_name()
-        try:
-            result: OneStepMetricBuildResult = metric.build(ctx)
-        except MetricNotSupportedError as e:
-            if raise_on_unsupported or metric.strict:
-                raise
-            logging.warning(
-                f"{name} metric not supported for this configuration, omitting: {e}"
-            )
-            continue
-
-        if result.deterministic is not None:
-            deterministic_aggregators[name] = result.deterministic
-        if result.ensemble is not None:
-            if ensemble_aggregator is not None:
-                raise ValueError("Multiple ensemble metrics are not supported.")
-            ensemble_aggregator = result.ensemble
-
-    if ensemble_aggregator is None:
-        ensemble_aggregator = get_one_step_ensemble_aggregator(
-            gridded_operations=ctx.ops,
-            target_time=1,
-            metadata=ctx.variable_metadata,
-        )
-
-    deterministic = OneStepDeterministicAggregator(
-        aggregators=deterministic_aggregators,
-        coords=dataset_info.horizontal_coordinates.coords,
-        save_diagnostics=save_diagnostics,
-        output_dir=output_dir,
-        loss_scaling=loss_scaling,
-    )
-    return OneStepAggregator(
-        deterministic_aggregator=deterministic,
-        ensemble_aggregator=ensemble_aggregator,
-    )
+def _default_metrics() -> list[OneStepMetricConfig]:
+    return [
+        OneStepMeanMetricConfig(target="denorm"),
+        OneStepMeanMetricConfig(
+            target="norm",
+            include_bias=False,
+            include_grad_mag_percent_diff=False,
+        ),
+        OneStepSpectrumMetricConfig(),
+        OneStepSnapshotMetricConfig(),
+        OneStepMapMetricConfig(),
+        OneStepEnsembleMetricConfig(),
+    ]
 
 
 @dataclasses.dataclass
 class OneStepAggregatorConfig:
     """
-    Configuration for the validation OneStepAggregator.
+    Configuration for the validation OneStepAggregator using typed metric configs.
 
-    Each metric is a named field with its own typed configuration and an
-    ``enabled`` flag.  Defaults match the standard metric set.
-
-    Metrics whose runtime requirements are not met (e.g. ``power_spectrum``
-    on a non-spherical grid) are skipped with a warning when ``strict``
-    is ``False`` (the default for built-in metrics).
+    Metrics can be configured explicitly via the ``metrics`` list, where each
+    entry is a typed metric configuration (e.g. ``OneStepMeanMetricConfig``,
+    ``OneStepSnapshotMetricConfig``).  When ``metrics`` is ``None``, a default
+    set of metrics is used.
 
     Parameters:
-        mean_denorm: Mean metrics on denormalized data.
-        mean_norm: Mean metrics on normalized data.
-        power_spectrum: Spherical power spectrum metrics.
-        snapshot: Snapshot image metrics.
-        mean_map: Mean map image metrics.
-        ensemble: Ensemble spread metrics.
+        metrics: Explicit list of metric configurations.  When ``None``, a
+            default set is used.
     """
 
-    mean_denorm: OneStepMeanMetricConfig = dataclasses.field(
-        default_factory=lambda: OneStepMeanMetricConfig(target="denorm")
-    )
-    mean_norm: OneStepMeanMetricConfig = dataclasses.field(
-        default_factory=lambda: OneStepMeanMetricConfig(
-            target="norm",
-            include_bias=False,
-            include_grad_mag_percent_diff=False,
-        )
-    )
-    power_spectrum: OneStepSpectrumMetricConfig = dataclasses.field(
-        default_factory=OneStepSpectrumMetricConfig
-    )
-    snapshot: OneStepSnapshotMetricConfig = dataclasses.field(
-        default_factory=OneStepSnapshotMetricConfig
-    )
-    mean_map: OneStepMapMetricConfig = dataclasses.field(
-        default_factory=OneStepMapMetricConfig
-    )
-    ensemble: OneStepEnsembleMetricConfig = dataclasses.field(
-        default_factory=OneStepEnsembleMetricConfig
-    )
+    metrics: list[OneStepMetricConfig] | None = None
 
     def __post_init__(self):
-        if self.mean_denorm.target != "denorm":
-            raise ValueError(
-                f"mean_denorm.target must be 'denorm', "
-                f"got '{self.mean_denorm.target}'"
-            )
-        if self.mean_norm.target != "norm":
-            raise ValueError(
-                f"mean_norm.target must be 'norm', got '{self.mean_norm.target}'"
-            )
-
-    def _get_metrics(self) -> list[OneStepMetricConfig]:
-        all_metrics: list[OneStepMetricConfig] = [
-            self.mean_denorm,
-            self.mean_norm,
-            self.power_spectrum,
-            self.snapshot,
-            self.mean_map,
-            self.ensemble,
-        ]
-        return [m for m in all_metrics if m.enabled]
+        if self.metrics is not None:
+            names = [m.get_name() for m in self.metrics]
+            seen: set[str] = set()
+            duplicates: set[str] = set()
+            for n in names:
+                if n in seen:
+                    duplicates.add(n)
+                seen.add(n)
+            if duplicates:
+                raise ValueError(
+                    f"Duplicate metric names: {sorted(duplicates)}. "
+                    "Use the 'name' field to disambiguate."
+                )
 
     def build(
         self,
@@ -254,14 +161,55 @@ class OneStepAggregatorConfig:
         loss_scaling: TensorMapping | None = None,
         channel_mean_names: Sequence[str] | None = None,
     ) -> OneStepAggregator:
-        return build_one_step_aggregator(
-            metrics=self._get_metrics(),
-            dataset_info=dataset_info,
+        ctx = OneStepBuildContext(
+            ops=dataset_info.gridded_operations,
+            horizontal_coordinates=dataset_info.horizontal_coordinates,
+            variable_metadata=dataset_info.variable_metadata,
+            channel_mean_names=channel_mean_names,
+        )
+
+        metrics = self.metrics if self.metrics is not None else _default_metrics()
+        is_explicit = self.metrics is not None
+
+        deterministic_aggregators: dict[str, _Aggregator] = {}
+        ensemble_aggregator: _EnsembleAggregator | None = None
+
+        for metric in metrics:
+            name = metric.get_name()
+            try:
+                result: OneStepMetricBuildResult = metric.build(ctx)
+            except MetricNotSupportedError:
+                if is_explicit:
+                    raise
+                logging.warning(
+                    f"{name} metric not supported for this grid type, omitting."
+                )
+                continue
+
+            if result.deterministic is not None:
+                deterministic_aggregators[name] = result.deterministic
+            if result.ensemble is not None:
+                if ensemble_aggregator is not None:
+                    raise ValueError("Multiple ensemble metrics are not supported.")
+                ensemble_aggregator = result.ensemble
+
+        if ensemble_aggregator is None:
+            ensemble_aggregator = get_one_step_ensemble_aggregator(
+                gridded_operations=ctx.ops,
+                target_time=1,
+                metadata=ctx.variable_metadata,
+            )
+
+        deterministic = OneStepDeterministicAggregator(
+            aggregators=deterministic_aggregators,
+            coords=dataset_info.horizontal_coordinates.coords,
             save_diagnostics=save_diagnostics,
             output_dir=output_dir,
             loss_scaling=loss_scaling,
-            channel_mean_names=channel_mean_names,
-            raise_on_unsupported=False,
+        )
+        return OneStepAggregator(
+            deterministic_aggregator=deterministic,
+            ensemble_aggregator=ensemble_aggregator,
         )
 
 
@@ -270,7 +218,7 @@ class LegacyFlagOneStepAggregatorConfig:
     """
     Legacy configuration for the validation OneStepAggregator using boolean flags.
 
-    Deprecated: Use OneStepAggregatorConfig instead.
+    Deprecated: Use OneStepAggregatorConfig with typed metrics instead.
 
     Arguments:
         log_snapshots: Whether to log snapshot images.
@@ -283,12 +231,12 @@ class LegacyFlagOneStepAggregatorConfig:
     def __post_init__(self):
         warnings.warn(
             "LegacyFlagOneStepAggregatorConfig is deprecated. "
-            "Use OneStepAggregatorConfig instead.",
+            "Use OneStepAggregatorConfig with typed metrics instead.",
             DeprecationWarning,
             stacklevel=2,
         )
 
-    def _get_metrics(self) -> list[OneStepMetricConfig]:
+    def _to_typed_config(self) -> OneStepAggregatorConfig:
         metrics: list[OneStepMetricConfig] = [
             OneStepMeanMetricConfig(target="denorm"),
             OneStepMeanMetricConfig(
@@ -303,7 +251,7 @@ class LegacyFlagOneStepAggregatorConfig:
         if self.log_mean_maps:
             metrics.append(OneStepMapMetricConfig())
         metrics.append(OneStepEnsembleMetricConfig(log_mean_maps=self.log_mean_maps))
-        return metrics
+        return OneStepAggregatorConfig(metrics=metrics)
 
     def build(
         self,
@@ -313,8 +261,7 @@ class LegacyFlagOneStepAggregatorConfig:
         loss_scaling: TensorMapping | None = None,
         channel_mean_names: Sequence[str] | None = None,
     ) -> OneStepAggregator:
-        return build_one_step_aggregator(
-            metrics=self._get_metrics(),
+        return self._to_typed_config().build(
             dataset_info=dataset_info,
             save_diagnostics=save_diagnostics,
             output_dir=output_dir,

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -52,7 +52,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
     def __init__(
         self,
         deterministic_aggregator: OneStepDeterministicAggregator,
-        ensemble_aggregator: EnsembleAggregator,
+        ensemble_aggregator: EnsembleAggregator | None = None,
     ):
         self._deterministic_aggregator = deterministic_aggregator
         self._ensemble_aggregator = ensemble_aggregator
@@ -80,7 +80,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
                 normalize=batch.normalize,
             )
         )
-        if n_ensemble > 1:
+        if n_ensemble > 1 and self._ensemble_aggregator is not None:
             self._ensemble_aggregator.record_batch(
                 target_data=batch.target_data,
                 gen_data=batch.gen_data,
@@ -98,7 +98,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         """
         deterministic_logs = self._deterministic_aggregator.get_logs(label)
         deterministic_logs.update(self._per_step_losses.get_logs(label))
-        if self._ensemble_recorded:
+        if self._ensemble_recorded and self._ensemble_aggregator is not None:
             stochastic_logs = self._ensemble_aggregator.get_logs(label)
             if len(set(deterministic_logs.keys()) & set(stochastic_logs.keys())) > 0:
                 raise ValueError(
@@ -138,6 +138,7 @@ def build_one_step_aggregator(
     loss_scaling: TensorMapping | None = None,
     channel_mean_names: Sequence[str] | None = None,
     raise_on_unsupported: bool = True,
+    include_default_ensemble: bool = True,
 ) -> OneStepAggregator:
     _validate_no_duplicate_names(metrics)
     ctx = OneStepBuildContext(
@@ -169,7 +170,7 @@ def build_one_step_aggregator(
                 raise ValueError("Multiple ensemble metrics are not supported.")
             ensemble_aggregator = result.ensemble
 
-    if ensemble_aggregator is None:
+    if ensemble_aggregator is None and include_default_ensemble:
         ensemble_aggregator = get_one_step_ensemble_aggregator(
             gridded_operations=ctx.ops,
             target_time=1,
@@ -234,6 +235,10 @@ class OneStepAggregatorConfig:
     )
 
     def __post_init__(self):
+        if not self.mean_denorm.enabled:
+            raise ValueError("mean_denorm cannot be disabled.")
+        if not self.mean_norm.enabled:
+            raise ValueError("mean_norm cannot be disabled.")
         if self.mean_denorm.target != "denorm":
             raise ValueError(
                 f"mean_denorm.target must be 'denorm', "
@@ -271,6 +276,7 @@ class OneStepAggregatorConfig:
             loss_scaling=loss_scaling,
             channel_mean_names=channel_mean_names,
             raise_on_unsupported=False,
+            include_default_ensemble=self.ensemble.enabled,
         )
 
 
@@ -329,4 +335,5 @@ class LegacyFlagOneStepAggregatorConfig:
             output_dir=output_dir,
             loss_scaling=loss_scaling,
             channel_mean_names=channel_mean_names,
+            raise_on_unsupported=False,
         )

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import warnings
 from collections.abc import Sequence
 
 import torch
@@ -7,23 +8,36 @@ import torch
 from fme.ace.aggregator.one_step.deterministic import (
     DeterministicTrainOutput,
     OneStepDeterministicAggregator,
-    _Aggregator,
 )
 from fme.ace.aggregator.one_step.ensemble import (
-    SelectStepEnsembleAggregator,
+    OneStepEnsembleMetricConfig,
     get_one_step_ensemble_aggregator,
 )
 from fme.ace.stepper import TrainOutput
 from fme.core.dataset_info import DatasetInfo
-from fme.core.fill import SmoothFloodFill
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.tensors import fold_ensemble_dim, fold_sized_ensemble_dim
 from fme.core.typing_ import TensorMapping
 
-from .map import MapAggregator
-from .reduced import MeanAggregator
-from .snapshot import SnapshotAggregator
-from .spectrum import SpectrumAggregator
+from .build_context import (
+    MetricNotSupportedError,
+    OneStepBuildContext,
+    OneStepMetricBuildResult,
+    _Aggregator,
+    _EnsembleAggregator,
+)
+from .map import OneStepMapMetricConfig
+from .reduced import OneStepMeanMetricConfig
+from .snapshot import OneStepSnapshotMetricConfig
+from .spectrum import OneStepSpectrumMetricConfig
+
+OneStepMetricConfig = (
+    OneStepMeanMetricConfig
+    | OneStepSnapshotMetricConfig
+    | OneStepMapMetricConfig
+    | OneStepSpectrumMetricConfig
+    | OneStepEnsembleMetricConfig
+)
 
 
 class OneStepAggregator(AggregatorABC[TrainOutput]):
@@ -37,7 +51,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
     def __init__(
         self,
         deterministic_aggregator: OneStepDeterministicAggregator,
-        ensemble_aggregator: SelectStepEnsembleAggregator,
+        ensemble_aggregator: _EnsembleAggregator,
     ):
         self._deterministic_aggregator = deterministic_aggregator
         self._ensemble_aggregator = ensemble_aggregator
@@ -92,48 +106,171 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         self._deterministic_aggregator.flush_diagnostics(subdir)
 
 
-def _build_default_deterministic_aggregators(
+def _validate_no_duplicate_names(metrics: list[OneStepMetricConfig]) -> None:
+    names = [m.get_name() for m in metrics]
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for n in names:
+        if n in seen:
+            duplicates.add(n)
+        seen.add(n)
+    if duplicates:
+        raise ValueError(
+            f"Duplicate metric names: {sorted(duplicates)}. "
+            "Use the 'name' field to disambiguate."
+        )
+
+
+def build_one_step_aggregator(
+    metrics: list[OneStepMetricConfig],
     dataset_info: DatasetInfo,
-    log_snapshots: bool,
-    log_mean_maps: bool,
-    channel_mean_names: Sequence[str] | None,
-) -> dict[str, _Aggregator]:
-    aggregators: dict[str, _Aggregator] = {
-        "mean": MeanAggregator(dataset_info.gridded_operations),
-        "mean_norm": MeanAggregator(
-            dataset_info.gridded_operations,
-            target="norm",
-            channel_mean_names=channel_mean_names,
-            include_bias=False,
-            include_grad_mag_percent_diff=False,
-        ),
-    }
-    try:
-        flood_fill = SmoothFloodFill(num_steps=4)
-        aggregators["power_spectrum"] = SpectrumAggregator(
-            dataset_info.gridded_operations,
-            nan_fill_fn=flood_fill,
+    save_diagnostics: bool = True,
+    output_dir: str | None = None,
+    loss_scaling: TensorMapping | None = None,
+    channel_mean_names: Sequence[str] | None = None,
+    raise_on_unsupported: bool = True,
+) -> OneStepAggregator:
+    _validate_no_duplicate_names(metrics)
+    ctx = OneStepBuildContext(
+        ops=dataset_info.gridded_operations,
+        horizontal_coordinates=dataset_info.horizontal_coordinates,
+        variable_metadata=dataset_info.variable_metadata,
+        channel_mean_names=channel_mean_names,
+    )
+
+    deterministic_aggregators: dict[str, _Aggregator] = {}
+    ensemble_aggregator: _EnsembleAggregator | None = None
+
+    for metric in metrics:
+        name = metric.get_name()
+        try:
+            result: OneStepMetricBuildResult = metric.build(ctx)
+        except MetricNotSupportedError as e:
+            if raise_on_unsupported or metric.strict:
+                raise
+            logging.warning(
+                f"{name} metric not supported for this configuration, omitting: {e}"
+            )
+            continue
+
+        if result.deterministic is not None:
+            deterministic_aggregators[name] = result.deterministic
+        if result.ensemble is not None:
+            if ensemble_aggregator is not None:
+                raise ValueError("Multiple ensemble metrics are not supported.")
+            ensemble_aggregator = result.ensemble
+
+    if ensemble_aggregator is None:
+        ensemble_aggregator = get_one_step_ensemble_aggregator(
+            gridded_operations=ctx.ops,
+            target_time=1,
+            metadata=ctx.variable_metadata,
         )
-    except NotImplementedError:
-        logging.warning(
-            "Spectrum aggregator not implemented for this grid type, omitting."
-        )
-    horizontal_coordinates = dataset_info.horizontal_coordinates
-    if log_snapshots:
-        aggregators["snapshot"] = SnapshotAggregator(
-            horizontal_coordinates.dims, dataset_info.variable_metadata
-        )
-    if log_mean_maps:
-        aggregators["mean_map"] = MapAggregator(
-            horizontal_coordinates.dims, dataset_info.variable_metadata
-        )
-    return aggregators
+
+    deterministic = OneStepDeterministicAggregator(
+        aggregators=deterministic_aggregators,
+        coords=dataset_info.horizontal_coordinates.coords,
+        save_diagnostics=save_diagnostics,
+        output_dir=output_dir,
+        loss_scaling=loss_scaling,
+    )
+    return OneStepAggregator(
+        deterministic_aggregator=deterministic,
+        ensemble_aggregator=ensemble_aggregator,
+    )
 
 
 @dataclasses.dataclass
 class OneStepAggregatorConfig:
     """
     Configuration for the validation OneStepAggregator.
+
+    Each metric is a named field with its own typed configuration and an
+    ``enabled`` flag.  Defaults match the standard metric set.
+
+    Metrics whose runtime requirements are not met (e.g. ``power_spectrum``
+    on a non-spherical grid) are skipped with a warning when ``strict``
+    is ``False`` (the default for built-in metrics).
+
+    Parameters:
+        mean_denorm: Mean metrics on denormalized data.
+        mean_norm: Mean metrics on normalized data.
+        power_spectrum: Spherical power spectrum metrics.
+        snapshot: Snapshot image metrics.
+        mean_map: Mean map image metrics.
+        ensemble: Ensemble spread metrics.
+    """
+
+    mean_denorm: OneStepMeanMetricConfig = dataclasses.field(
+        default_factory=lambda: OneStepMeanMetricConfig(target="denorm")
+    )
+    mean_norm: OneStepMeanMetricConfig = dataclasses.field(
+        default_factory=lambda: OneStepMeanMetricConfig(
+            target="norm",
+            include_bias=False,
+            include_grad_mag_percent_diff=False,
+        )
+    )
+    power_spectrum: OneStepSpectrumMetricConfig = dataclasses.field(
+        default_factory=OneStepSpectrumMetricConfig
+    )
+    snapshot: OneStepSnapshotMetricConfig = dataclasses.field(
+        default_factory=OneStepSnapshotMetricConfig
+    )
+    mean_map: OneStepMapMetricConfig = dataclasses.field(
+        default_factory=OneStepMapMetricConfig
+    )
+    ensemble: OneStepEnsembleMetricConfig = dataclasses.field(
+        default_factory=OneStepEnsembleMetricConfig
+    )
+
+    def __post_init__(self):
+        if self.mean_denorm.target != "denorm":
+            raise ValueError(
+                f"mean_denorm.target must be 'denorm', "
+                f"got '{self.mean_denorm.target}'"
+            )
+        if self.mean_norm.target != "norm":
+            raise ValueError(
+                f"mean_norm.target must be 'norm', got '{self.mean_norm.target}'"
+            )
+
+    def _get_metrics(self) -> list[OneStepMetricConfig]:
+        all_metrics: list[OneStepMetricConfig] = [
+            self.mean_denorm,
+            self.mean_norm,
+            self.power_spectrum,
+            self.snapshot,
+            self.mean_map,
+            self.ensemble,
+        ]
+        return [m for m in all_metrics if m.enabled]
+
+    def build(
+        self,
+        dataset_info: DatasetInfo,
+        save_diagnostics: bool = True,
+        output_dir: str | None = None,
+        loss_scaling: TensorMapping | None = None,
+        channel_mean_names: Sequence[str] | None = None,
+    ) -> OneStepAggregator:
+        return build_one_step_aggregator(
+            metrics=self._get_metrics(),
+            dataset_info=dataset_info,
+            save_diagnostics=save_diagnostics,
+            output_dir=output_dir,
+            loss_scaling=loss_scaling,
+            channel_mean_names=channel_mean_names,
+            raise_on_unsupported=False,
+        )
+
+
+@dataclasses.dataclass
+class LegacyFlagOneStepAggregatorConfig:
+    """
+    Legacy configuration for the validation OneStepAggregator using boolean flags.
+
+    Deprecated: Use OneStepAggregatorConfig instead.
 
     Arguments:
         log_snapshots: Whether to log snapshot images.
@@ -143,6 +280,31 @@ class OneStepAggregatorConfig:
     log_snapshots: bool = True
     log_mean_maps: bool = True
 
+    def __post_init__(self):
+        warnings.warn(
+            "LegacyFlagOneStepAggregatorConfig is deprecated. "
+            "Use OneStepAggregatorConfig instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    def _get_metrics(self) -> list[OneStepMetricConfig]:
+        metrics: list[OneStepMetricConfig] = [
+            OneStepMeanMetricConfig(target="denorm"),
+            OneStepMeanMetricConfig(
+                target="norm",
+                include_bias=False,
+                include_grad_mag_percent_diff=False,
+            ),
+            OneStepSpectrumMetricConfig(),
+        ]
+        if self.log_snapshots:
+            metrics.append(OneStepSnapshotMetricConfig())
+        if self.log_mean_maps:
+            metrics.append(OneStepMapMetricConfig())
+        metrics.append(OneStepEnsembleMetricConfig(log_mean_maps=self.log_mean_maps))
+        return metrics
+
     def build(
         self,
         dataset_info: DatasetInfo,
@@ -150,27 +312,12 @@ class OneStepAggregatorConfig:
         output_dir: str | None = None,
         loss_scaling: TensorMapping | None = None,
         channel_mean_names: Sequence[str] | None = None,
-    ):
-        aggregators = _build_default_deterministic_aggregators(
+    ) -> OneStepAggregator:
+        return build_one_step_aggregator(
+            metrics=self._get_metrics(),
             dataset_info=dataset_info,
-            log_snapshots=self.log_snapshots,
-            log_mean_maps=self.log_mean_maps,
-            channel_mean_names=channel_mean_names,
-        )
-        deterministic_aggregator = OneStepDeterministicAggregator(
-            aggregators=aggregators,
-            coords=dataset_info.horizontal_coordinates.coords,
             save_diagnostics=save_diagnostics,
             output_dir=output_dir,
             loss_scaling=loss_scaling,
-        )
-        ensemble_aggregator = get_one_step_ensemble_aggregator(
-            gridded_operations=dataset_info.gridded_operations,
-            log_mean_maps=self.log_mean_maps,
-            target_time=1,
-            metadata=dataset_info.variable_metadata,
-        )
-        return OneStepAggregator(
-            deterministic_aggregator=deterministic_aggregator,
-            ensemble_aggregator=ensemble_aggregator,
+            channel_mean_names=channel_mean_names,
         )

--- a/fme/ace/aggregator/one_step/map.py
+++ b/fme/ace/aggregator/one_step/map.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Mapping
 
 import torch
@@ -9,6 +10,7 @@ from fme.core.typing_ import TensorDict, TensorMapping
 from fme.core.wandb import Image
 
 from ..plotting import plot_paneled_data
+from .build_context import OneStepBuildContext, OneStepMetricBuildResult
 
 
 class MapAggregator:
@@ -153,3 +155,20 @@ class MapAggregator:
                 attrs=metadata_attrs,
             )
         return ds
+
+
+@dataclasses.dataclass
+class OneStepMapMetricConfig:
+    name: str = "mean_map"
+    enabled: bool = True
+    strict: bool = False
+
+    def get_name(self) -> str:
+        return self.name
+
+    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
+        agg = MapAggregator(
+            ctx.horizontal_coordinates.dims,
+            ctx.variable_metadata,
+        )
+        return OneStepMetricBuildResult(deterministic=agg)

--- a/fme/ace/aggregator/one_step/map.py
+++ b/fme/ace/aggregator/one_step/map.py
@@ -160,6 +160,8 @@ class MapAggregator:
 @dataclasses.dataclass
 class OneStepMapMetricConfig:
     name: str = "mean_map"
+    enabled: bool = True
+    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/map.py
+++ b/fme/ace/aggregator/one_step/map.py
@@ -160,8 +160,6 @@ class MapAggregator:
 @dataclasses.dataclass
 class OneStepMapMetricConfig:
     name: str = "mean_map"
-    enabled: bool = True
-    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/reduced.py
+++ b/fme/ace/aggregator/one_step/reduced.py
@@ -2,7 +2,6 @@ import dataclasses
 from collections.abc import Sequence
 from typing import Any, Literal
 
-import numpy as np
 import torch
 import xarray as xr
 
@@ -97,7 +96,7 @@ class MeanAggregator:
         gen_data: TensorMapping,
         target_data_norm: TensorMapping | None = None,
         gen_data_norm: TensorMapping | None = None,
-        loss: torch.Tensor = torch.tensor(np.nan),
+        loss: float = float("nan"),
         i_time_start: int = 0,
     ):
         self._loss += loss

--- a/fme/ace/aggregator/one_step/reduced.py
+++ b/fme/ace/aggregator/one_step/reduced.py
@@ -238,13 +238,12 @@ class StepMeanMetricConfig:
 
 @dataclasses.dataclass
 class OneStepMeanMetricConfig:
+    type: Literal["one_step_mean"] = "one_step_mean"
     name: str | None = None
     target: Literal["denorm", "norm"] = "denorm"
     include_bias: bool = True
     include_grad_mag_percent_diff: bool = True
     channel_mean_names: list[str] | None = None
-    enabled: bool = True
-    strict: bool = False
 
     def __post_init__(self):
         if self.name is None:

--- a/fme/ace/aggregator/one_step/reduced.py
+++ b/fme/ace/aggregator/one_step/reduced.py
@@ -17,6 +17,7 @@ from ..inference.build_context import (
     maybe_filter,
 )
 from ..inference.data import InferenceBatchData, MetricBuildResult, SubAggregator
+from .build_context import OneStepBuildContext, OneStepMetricBuildResult
 from .reduced_metrics import AreaWeightedReducedMetric, ReducedMetric
 
 
@@ -233,3 +234,43 @@ class StepMeanMetricConfig:
             )
         )
         return MetricBuildResult(aggregator=maybe_filter(agg, self.variables))
+
+
+@dataclasses.dataclass
+class OneStepMeanMetricConfig:
+    name: str | None = None
+    target: Literal["denorm", "norm"] = "denorm"
+    include_bias: bool = True
+    include_grad_mag_percent_diff: bool = True
+    channel_mean_names: list[str] | None = None
+    enabled: bool = True
+    strict: bool = False
+
+    def __post_init__(self):
+        if self.name is None:
+            self.name = "mean" if self.target == "denorm" else "mean_norm"
+        if self.target == "norm":
+            if self.include_bias:
+                raise ValueError("include_bias is not supported when target='norm'.")
+            if self.include_grad_mag_percent_diff:
+                raise ValueError(
+                    "include_grad_mag_percent_diff is not supported "
+                    "when target='norm'."
+                )
+
+    def get_name(self) -> str:
+        return self.name  # type: ignore[return-value]
+
+    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
+        agg = MeanAggregator(
+            ctx.ops,
+            target=self.target,
+            include_bias=self.include_bias,
+            include_grad_mag_percent_diff=self.include_grad_mag_percent_diff,
+            channel_mean_names=(
+                (self.channel_mean_names or ctx.channel_mean_names)
+                if self.target == "norm"
+                else None
+            ),
+        )
+        return OneStepMetricBuildResult(deterministic=agg)

--- a/fme/ace/aggregator/one_step/reduced.py
+++ b/fme/ace/aggregator/one_step/reduced.py
@@ -238,12 +238,13 @@ class StepMeanMetricConfig:
 
 @dataclasses.dataclass
 class OneStepMeanMetricConfig:
-    type: Literal["one_step_mean"] = "one_step_mean"
     name: str | None = None
     target: Literal["denorm", "norm"] = "denorm"
     include_bias: bool = True
     include_grad_mag_percent_diff: bool = True
     channel_mean_names: list[str] | None = None
+    enabled: bool = True
+    strict: bool = False
 
     def __post_init__(self):
         if self.name is None:

--- a/fme/ace/aggregator/one_step/snapshot.py
+++ b/fme/ace/aggregator/one_step/snapshot.py
@@ -162,6 +162,8 @@ class SnapshotAggregator:
 @dataclasses.dataclass
 class OneStepSnapshotMetricConfig:
     name: str = "snapshot"
+    enabled: bool = True
+    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/snapshot.py
+++ b/fme/ace/aggregator/one_step/snapshot.py
@@ -162,8 +162,6 @@ class SnapshotAggregator:
 @dataclasses.dataclass
 class OneStepSnapshotMetricConfig:
     name: str = "snapshot"
-    enabled: bool = True
-    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/snapshot.py
+++ b/fme/ace/aggregator/one_step/snapshot.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Mapping
 
 import torch
@@ -8,6 +9,7 @@ from fme.core.typing_ import TensorMapping
 from fme.core.wandb import Image
 
 from ..plotting import plot_paneled_data
+from .build_context import OneStepBuildContext, OneStepMetricBuildResult
 
 
 class SnapshotAggregator:
@@ -155,3 +157,20 @@ class SnapshotAggregator:
                 attrs=metadata_attrs,
             )
         return ds
+
+
+@dataclasses.dataclass
+class OneStepSnapshotMetricConfig:
+    name: str = "snapshot"
+    enabled: bool = True
+    strict: bool = False
+
+    def get_name(self) -> str:
+        return self.name
+
+    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
+        agg = SnapshotAggregator(
+            ctx.horizontal_coordinates.dims,
+            ctx.variable_metadata,
+        )
+        return OneStepMetricBuildResult(deterministic=agg)

--- a/fme/ace/aggregator/one_step/spectrum.py
+++ b/fme/ace/aggregator/one_step/spectrum.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -10,8 +11,15 @@ from fme.ace.aggregator.inference.spectrum import (
     PairedSphericalPowerSpectrumAggregator as _InferencePairedSpectrumAgg,
 )
 from fme.core.dataset.data_typing import VariableMetadata
+from fme.core.fill import SmoothFloodFill
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.typing_ import TensorMapping
+
+from .build_context import (
+    MetricNotSupportedError,
+    OneStepBuildContext,
+    OneStepMetricBuildResult,
+)
 
 
 class PairedSphericalPowerSpectrumAggregator:
@@ -103,3 +111,21 @@ class SpectrumAggregator:
 
     def get_dataset(self) -> xr.Dataset:
         return self._wrapped.get_dataset()
+
+
+@dataclasses.dataclass
+class OneStepSpectrumMetricConfig:
+    name: str = "power_spectrum"
+    enabled: bool = True
+    strict: bool = False
+
+    def get_name(self) -> str:
+        return self.name
+
+    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
+        try:
+            flood_fill = SmoothFloodFill(num_steps=4)
+            agg = SpectrumAggregator(ctx.ops, nan_fill_fn=flood_fill)
+        except NotImplementedError as e:
+            raise MetricNotSupportedError(str(e)) from e
+        return OneStepMetricBuildResult(deterministic=agg)

--- a/fme/ace/aggregator/one_step/spectrum.py
+++ b/fme/ace/aggregator/one_step/spectrum.py
@@ -116,6 +116,8 @@ class SpectrumAggregator:
 @dataclasses.dataclass
 class OneStepSpectrumMetricConfig:
     name: str = "power_spectrum"
+    enabled: bool = True
+    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/spectrum.py
+++ b/fme/ace/aggregator/one_step/spectrum.py
@@ -116,8 +116,6 @@ class SpectrumAggregator:
 @dataclasses.dataclass
 class OneStepSpectrumMetricConfig:
     name: str = "power_spectrum"
-    enabled: bool = True
-    strict: bool = False
 
     def get_name(self) -> str:
         return self.name

--- a/fme/ace/aggregator/one_step/spectrum.py
+++ b/fme/ace/aggregator/one_step/spectrum.py
@@ -2,7 +2,6 @@ import dataclasses
 from collections.abc import Callable, Mapping
 from typing import Any
 
-import numpy as np
 import torch
 import xarray as xr
 
@@ -78,7 +77,7 @@ class SpectrumAggregator:
         gen_data: TensorMapping,
         target_data_norm: TensorMapping,
         gen_data_norm: TensorMapping,
-        loss: torch.Tensor = torch.tensor(np.nan),
+        loss: float = float("nan"),
         i_time_start: int = 0,
     ):
         n_timesteps = next(iter(target_data.values())).shape[1]

--- a/fme/ace/aggregator/one_step/test_deterministic.py
+++ b/fme/ace/aggregator/one_step/test_deterministic.py
@@ -17,6 +17,12 @@ def test__get_loss_scaled_mse_components():
     ds_info = DatasetInfo(horizontal_coordinates=lat_lon_coordinates)
     aggregators = {
         "mean": MeanAggregator(ds_info.gridded_operations),
+        "mean_norm": MeanAggregator(
+            ds_info.gridded_operations,
+            target="norm",
+            include_bias=False,
+            include_grad_mag_percent_diff=False,
+        ),
     }
     agg = OneStepDeterministicAggregator(
         aggregators=aggregators,

--- a/fme/ace/aggregator/one_step/test_deterministic.py
+++ b/fme/ace/aggregator/one_step/test_deterministic.py
@@ -1,6 +1,7 @@
 import torch
 
 from fme.ace.aggregator.one_step.deterministic import OneStepDeterministicAggregator
+from fme.ace.aggregator.one_step.reduced import MeanAggregator
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
 
@@ -12,11 +13,14 @@ def test__get_loss_scaled_mse_components():
     }
     nx, ny = 10, 10
     lat_lon_coordinates = LatLonCoordinates(torch.arange(nx), torch.arange(ny))
-    # keep area weights ones for simplicity
     lat_lon_coordinates._area_weights = torch.ones(nx, ny)
     ds_info = DatasetInfo(horizontal_coordinates=lat_lon_coordinates)
+    aggregators = {
+        "mean": MeanAggregator(ds_info.gridded_operations),
+    }
     agg = OneStepDeterministicAggregator(
-        ds_info,
+        aggregators=aggregators,
+        coords=lat_lon_coordinates.coords,
         loss_scaling=loss_scaling,
         save_diagnostics=False,
     )

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -1,5 +1,3 @@
-import dataclasses
-
 import numpy as np
 import pytest
 import torch
@@ -8,29 +6,18 @@ import xarray as xr
 from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
+    build_one_step_aggregator,
 )
-from fme.ace.aggregator.one_step.build_context import (
-    MetricNotSupportedError,
-    OneStepBuildContext,
-    OneStepMetricBuildResult,
+from fme.ace.aggregator.one_step.main import (
+    OneStepMeanMetricConfig,
+    OneStepSnapshotMetricConfig,
+    OneStepSpectrumMetricConfig,
 )
-from fme.ace.aggregator.one_step.main import OneStepMeanMetricConfig
 from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
 from fme.core.typing_ import EnsembleTensorDict
-
-
-@dataclasses.dataclass
-class _UnsupportedMetricConfig:
-    name: str = "unsupported"
-
-    def get_name(self) -> str:
-        return self.name
-
-    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
-        raise MetricNotSupportedError("not supported")
 
 
 def get_ds_info(nx: int, ny: int) -> DatasetInfo:
@@ -157,7 +144,7 @@ def test_agg_raises_without_output_dir():
 
 def test_explicit_metrics_build():
     ds_info = get_ds_info(nx=2, ny=2)
-    config = OneStepAggregatorConfig(
+    agg = build_one_step_aggregator(
         metrics=[
             OneStepMeanMetricConfig(target="denorm"),
             OneStepMeanMetricConfig(
@@ -165,9 +152,10 @@ def test_explicit_metrics_build():
                 include_bias=False,
                 include_grad_mag_percent_diff=False,
             ),
-        ]
+        ],
+        dataset_info=ds_info,
+        save_diagnostics=False,
     )
-    agg = config.build(ds_info, save_diagnostics=False)
     target_data = EnsembleTensorDict(
         {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
     )
@@ -189,12 +177,15 @@ def test_explicit_metrics_build():
 
 
 def test_duplicate_metric_names_rejected():
+    ds_info = get_ds_info(nx=2, ny=2)
     with pytest.raises(ValueError, match="Duplicate metric names"):
-        OneStepAggregatorConfig(
+        build_one_step_aggregator(
             metrics=[
                 OneStepMeanMetricConfig(target="denorm"),
                 OneStepMeanMetricConfig(target="denorm"),
-            ]
+            ],
+            dataset_info=ds_info,
+            save_diagnostics=False,
         )
 
 
@@ -240,95 +231,163 @@ def test_legacy_config_builds_same_log_keys():
     assert set(typed_logs.keys()) == set(legacy_logs.keys())
 
 
-def test_explicit_unsupported_metric_raises():
-    ds_info = get_ds_info(nx=2, ny=2)
-    config = OneStepAggregatorConfig(
-        metrics=[
-            OneStepMeanMetricConfig(target="denorm"),
-            OneStepMeanMetricConfig(
-                target="norm",
-                include_bias=False,
-                include_grad_mag_percent_diff=False,
-            ),
-            _UnsupportedMetricConfig(),  # type: ignore[list-item]
-        ]
-    )
-    with pytest.raises(MetricNotSupportedError):
-        config.build(ds_info, save_diagnostics=False)
-
-
-def test_default_unsupported_metric_skipped_with_warning():
+def test_hierarchical_defaults_build():
+    """Hierarchical config with all defaults builds and includes core metrics."""
     nx, ny = 2, 2
     ds_info = get_ds_info(nx, ny)
-    config_with_unsupported = OneStepAggregatorConfig(metrics=None)
-    import fme.ace.aggregator.one_step.main as main_mod
-
-    original_default = main_mod._default_metrics
-
-    def _patched_defaults():
-        return [*original_default(), _UnsupportedMetricConfig()]
-
-    main_mod._default_metrics = _patched_defaults
-    try:
-        agg = config_with_unsupported.build(ds_info, save_diagnostics=False)
-        batch_size, n_ensemble, n_time = 2, 2, 3
-        agg.record_batch(
-            batch=TrainOutput(
-                metrics={"loss": 1.0},
-                target_data=EnsembleTensorDict(
-                    {
-                        "a": torch.randn(
-                            batch_size, 1, n_time, nx, ny, device=get_device()
-                        )
-                    },
-                ),
-                gen_data=EnsembleTensorDict(
-                    {
-                        "a": torch.randn(
-                            batch_size, n_ensemble, n_time, nx, ny, device=get_device()
-                        )
-                    },
-                ),
-                time=xr.DataArray(
-                    np.zeros((batch_size, n_time)), dims=["sample", "time"]
-                ),
-                normalize=lambda x: x,
-            ),
-        )
-        logs = agg.get_logs(label="test")
-        assert "test/unsupported" not in str(logs.keys())
-    finally:
-        main_mod._default_metrics = original_default
-
-
-def test_fallback_ensemble_aggregator_with_explicit_metrics():
-    ds_info = get_ds_info(nx=2, ny=2)
-    config = OneStepAggregatorConfig(
-        metrics=[
-            OneStepMeanMetricConfig(target="denorm"),
-            OneStepMeanMetricConfig(
-                target="norm",
-                include_bias=False,
-                include_grad_mag_percent_diff=False,
-            ),
-        ]
-    )
-    agg = config.build(ds_info, save_diagnostics=False)
-    batch_size, n_ensemble, n_time, nx, ny = 2, 2, 3, 2, 2
+    agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
     target_data = EnsembleTensorDict(
-        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=get_device())},
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
     )
     gen_data = EnsembleTensorDict(
-        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=get_device())},
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
     )
     agg.record_batch(
         batch=TrainOutput(
             metrics={"loss": 1.0},
             target_data=target_data,
             gen_data=gen_data,
-            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
             normalize=lambda x: x,
         ),
     )
     logs = agg.get_logs(label="test")
-    assert "test/crps/a" in logs
+    for expected in ["mean", "mean_norm", "power_spectrum", "snapshot", "mean_map"]:
+        assert any(expected in k for k in logs), f"Expected {expected} in log keys"
+
+
+def test_hierarchical_enable_disable():
+    """Disabling a default metric removes it; other metrics still present."""
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+    agg = OneStepAggregatorConfig(
+        snapshot=OneStepSnapshotMetricConfig(enabled=False),
+    ).build(ds_info, save_diagnostics=False)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert not any("snapshot" in k for k in logs)
+    assert any("mean" in k for k in logs)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        pytest.param(
+            dict(
+                mean_denorm=OneStepMeanMetricConfig(
+                    target="norm",
+                    include_bias=False,
+                    include_grad_mag_percent_diff=False,
+                )
+            ),
+            "mean_denorm.target must be 'denorm'",
+            id="mean_denorm_wrong_target",
+        ),
+        pytest.param(
+            dict(mean_norm=OneStepMeanMetricConfig(target="denorm")),
+            "mean_norm.target must be 'norm'",
+            id="mean_norm_wrong_target",
+        ),
+    ],
+)
+def test_hierarchical_rejects_mismatched_target(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        OneStepAggregatorConfig(**kwargs)
+
+
+def test_raise_on_unsupported_true_raises(monkeypatch):
+    """Explicit build with raise_on_unsupported=True raises for unsupported metrics."""
+    from fme.ace.aggregator.one_step import spectrum
+    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
+
+    def failing_build(self, ctx):
+        raise MetricNotSupportedError("test: spectrum unsupported")
+
+    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
+
+    ds_info = get_ds_info(nx=2, ny=2)
+    with pytest.raises(MetricNotSupportedError):
+        build_one_step_aggregator(
+            metrics=[OneStepSpectrumMetricConfig()],
+            dataset_info=ds_info,
+            save_diagnostics=False,
+        )
+
+
+def test_raise_on_unsupported_false_skips(monkeypatch):
+    """Explicit build with raise_on_unsupported=False skips unsupported metrics."""
+    from fme.ace.aggregator.one_step import spectrum
+    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
+
+    def failing_build(self, ctx):
+        raise MetricNotSupportedError("test: spectrum unsupported")
+
+    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
+
+    ds_info = get_ds_info(nx=2, ny=2)
+    agg = build_one_step_aggregator(
+        metrics=[
+            OneStepMeanMetricConfig(target="denorm"),
+            OneStepMeanMetricConfig(
+                target="norm",
+                include_bias=False,
+                include_grad_mag_percent_diff=False,
+            ),
+            OneStepSpectrumMetricConfig(),
+        ],
+        dataset_info=ds_info,
+        save_diagnostics=False,
+        raise_on_unsupported=False,
+    )
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert any("mean" in k for k in logs)
+    assert not any("power_spectrum" in k for k in logs)
+
+
+def test_strict_metric_raises_even_when_not_raise_on_unsupported(monkeypatch):
+    """A metric with strict=True raises even when raise_on_unsupported=False."""
+    from fme.ace.aggregator.one_step import spectrum
+    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
+
+    def failing_build(self, ctx):
+        raise MetricNotSupportedError("test: spectrum unsupported")
+
+    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
+
+    ds_info = get_ds_info(nx=2, ny=2)
+    with pytest.raises(MetricNotSupportedError):
+        build_one_step_aggregator(
+            metrics=[OneStepSpectrumMetricConfig(strict=True)],
+            dataset_info=ds_info,
+            save_diagnostics=False,
+            raise_on_unsupported=False,
+        )

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -3,7 +3,16 @@ import pytest
 import torch
 import xarray as xr
 
-from fme.ace.aggregator.one_step import OneStepAggregatorConfig
+from fme.ace.aggregator.one_step import (
+    LegacyFlagOneStepAggregatorConfig,
+    OneStepAggregatorConfig,
+    build_one_step_aggregator,
+)
+from fme.ace.aggregator.one_step.main import (
+    OneStepMeanMetricConfig,
+    OneStepSnapshotMetricConfig,
+    OneStepSpectrumMetricConfig,
+)
 from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -131,3 +140,254 @@ def test_agg_raises_without_output_dir():
         ValueError, match="Output directory must be set to save diagnostics"
     ):
         OneStepAggregatorConfig().build(ds_info, save_diagnostics=True, output_dir=None)
+
+
+def test_explicit_metrics_build():
+    ds_info = get_ds_info(nx=2, ny=2)
+    agg = build_one_step_aggregator(
+        metrics=[
+            OneStepMeanMetricConfig(target="denorm"),
+            OneStepMeanMetricConfig(
+                target="norm",
+                include_bias=False,
+                include_grad_mag_percent_diff=False,
+            ),
+        ],
+        dataset_info=ds_info,
+        save_diagnostics=False,
+    )
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert "test/mean/weighted_rmse/a" in logs
+    assert "test/snapshot/image-full-field/a" not in logs
+
+
+def test_duplicate_metric_names_rejected():
+    ds_info = get_ds_info(nx=2, ny=2)
+    with pytest.raises(ValueError, match="Duplicate metric names"):
+        build_one_step_aggregator(
+            metrics=[
+                OneStepMeanMetricConfig(target="denorm"),
+                OneStepMeanMetricConfig(target="denorm"),
+            ],
+            dataset_info=ds_info,
+            save_diagnostics=False,
+        )
+
+
+def test_legacy_config_produces_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        LegacyFlagOneStepAggregatorConfig()
+
+
+def test_legacy_config_builds_same_log_keys():
+    batch_size = 10
+    n_ensemble = 2
+    n_time = 3
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+
+    typed_agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
+
+    with pytest.warns(DeprecationWarning):
+        legacy_agg = LegacyFlagOneStepAggregatorConfig().build(
+            ds_info, save_diagnostics=False
+        )
+
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=get_device())},
+    )
+    batch = TrainOutput(
+        metrics={"loss": 1.0},
+        target_data=target_data,
+        gen_data=gen_data,
+        time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+        normalize=lambda x: x,
+    )
+
+    typed_agg.record_batch(batch=batch)
+    legacy_agg.record_batch(batch=batch)
+
+    typed_logs = typed_agg.get_logs(label="test")
+    legacy_logs = legacy_agg.get_logs(label="test")
+
+    assert set(typed_logs.keys()) == set(legacy_logs.keys())
+
+
+def test_hierarchical_defaults_build():
+    """Hierarchical config with all defaults builds and includes core metrics."""
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+    agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    for expected in ["mean", "mean_norm", "power_spectrum", "snapshot", "mean_map"]:
+        assert any(expected in k for k in logs), f"Expected {expected} in log keys"
+
+
+def test_hierarchical_enable_disable():
+    """Disabling a default metric removes it; other metrics still present."""
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+    agg = OneStepAggregatorConfig(
+        snapshot=OneStepSnapshotMetricConfig(enabled=False),
+    ).build(ds_info, save_diagnostics=False)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert not any("snapshot" in k for k in logs)
+    assert any("mean" in k for k in logs)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        pytest.param(
+            dict(
+                mean_denorm=OneStepMeanMetricConfig(
+                    target="norm",
+                    include_bias=False,
+                    include_grad_mag_percent_diff=False,
+                )
+            ),
+            "mean_denorm.target must be 'denorm'",
+            id="mean_denorm_wrong_target",
+        ),
+        pytest.param(
+            dict(mean_norm=OneStepMeanMetricConfig(target="denorm")),
+            "mean_norm.target must be 'norm'",
+            id="mean_norm_wrong_target",
+        ),
+    ],
+)
+def test_hierarchical_rejects_mismatched_target(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        OneStepAggregatorConfig(**kwargs)
+
+
+def test_raise_on_unsupported_true_raises(monkeypatch):
+    """Explicit build with raise_on_unsupported=True raises for unsupported metrics."""
+    from fme.ace.aggregator.one_step import spectrum
+    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
+
+    def failing_build(self, ctx):
+        raise MetricNotSupportedError("test: spectrum unsupported")
+
+    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
+
+    ds_info = get_ds_info(nx=2, ny=2)
+    with pytest.raises(MetricNotSupportedError):
+        build_one_step_aggregator(
+            metrics=[OneStepSpectrumMetricConfig()],
+            dataset_info=ds_info,
+            save_diagnostics=False,
+        )
+
+
+def test_raise_on_unsupported_false_skips(monkeypatch):
+    """Explicit build with raise_on_unsupported=False skips unsupported metrics."""
+    from fme.ace.aggregator.one_step import spectrum
+    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
+
+    def failing_build(self, ctx):
+        raise MetricNotSupportedError("test: spectrum unsupported")
+
+    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
+
+    ds_info = get_ds_info(nx=2, ny=2)
+    agg = build_one_step_aggregator(
+        metrics=[
+            OneStepMeanMetricConfig(target="denorm"),
+            OneStepMeanMetricConfig(
+                target="norm",
+                include_bias=False,
+                include_grad_mag_percent_diff=False,
+            ),
+            OneStepSpectrumMetricConfig(),
+        ],
+        dataset_info=ds_info,
+        save_diagnostics=False,
+        raise_on_unsupported=False,
+    )
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert any("mean" in k for k in logs)
+    assert not any("power_spectrum" in k for k in logs)
+
+
+def test_strict_metric_raises_even_when_not_raise_on_unsupported(monkeypatch):
+    """A metric with strict=True raises even when raise_on_unsupported=False."""
+    from fme.ace.aggregator.one_step import spectrum
+    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
+
+    def failing_build(self, ctx):
+        raise MetricNotSupportedError("test: spectrum unsupported")
+
+    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
+
+    ds_info = get_ds_info(nx=2, ny=2)
+    with pytest.raises(MetricNotSupportedError):
+        build_one_step_aggregator(
+            metrics=[OneStepSpectrumMetricConfig(strict=True)],
+            dataset_info=ds_info,
+            save_diagnostics=False,
+            raise_on_unsupported=False,
+        )

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import numpy as np
 import pytest
 import torch
@@ -7,12 +9,28 @@ from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
 )
+from fme.ace.aggregator.one_step.build_context import (
+    MetricNotSupportedError,
+    OneStepBuildContext,
+    OneStepMetricBuildResult,
+)
 from fme.ace.aggregator.one_step.main import OneStepMeanMetricConfig
 from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
 from fme.core.typing_ import EnsembleTensorDict
+
+
+@dataclasses.dataclass
+class _UnsupportedMetricConfig:
+    name: str = "unsupported"
+
+    def get_name(self) -> str:
+        return self.name
+
+    def build(self, ctx: OneStepBuildContext) -> OneStepMetricBuildResult:
+        raise MetricNotSupportedError("not supported")
 
 
 def get_ds_info(nx: int, ny: int) -> DatasetInfo:
@@ -220,3 +238,97 @@ def test_legacy_config_builds_same_log_keys():
     legacy_logs = legacy_agg.get_logs(label="test")
 
     assert set(typed_logs.keys()) == set(legacy_logs.keys())
+
+
+def test_explicit_unsupported_metric_raises():
+    ds_info = get_ds_info(nx=2, ny=2)
+    config = OneStepAggregatorConfig(
+        metrics=[
+            OneStepMeanMetricConfig(target="denorm"),
+            OneStepMeanMetricConfig(
+                target="norm",
+                include_bias=False,
+                include_grad_mag_percent_diff=False,
+            ),
+            _UnsupportedMetricConfig(),  # type: ignore[list-item]
+        ]
+    )
+    with pytest.raises(MetricNotSupportedError):
+        config.build(ds_info, save_diagnostics=False)
+
+
+def test_default_unsupported_metric_skipped_with_warning():
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+    config_with_unsupported = OneStepAggregatorConfig(metrics=None)
+    import fme.ace.aggregator.one_step.main as main_mod
+
+    original_default = main_mod._default_metrics
+
+    def _patched_defaults():
+        return [*original_default(), _UnsupportedMetricConfig()]
+
+    main_mod._default_metrics = _patched_defaults
+    try:
+        agg = config_with_unsupported.build(ds_info, save_diagnostics=False)
+        batch_size, n_ensemble, n_time = 2, 2, 3
+        agg.record_batch(
+            batch=TrainOutput(
+                metrics={"loss": 1.0},
+                target_data=EnsembleTensorDict(
+                    {
+                        "a": torch.randn(
+                            batch_size, 1, n_time, nx, ny, device=get_device()
+                        )
+                    },
+                ),
+                gen_data=EnsembleTensorDict(
+                    {
+                        "a": torch.randn(
+                            batch_size, n_ensemble, n_time, nx, ny, device=get_device()
+                        )
+                    },
+                ),
+                time=xr.DataArray(
+                    np.zeros((batch_size, n_time)), dims=["sample", "time"]
+                ),
+                normalize=lambda x: x,
+            ),
+        )
+        logs = agg.get_logs(label="test")
+        assert "test/unsupported" not in str(logs.keys())
+    finally:
+        main_mod._default_metrics = original_default
+
+
+def test_fallback_ensemble_aggregator_with_explicit_metrics():
+    ds_info = get_ds_info(nx=2, ny=2)
+    config = OneStepAggregatorConfig(
+        metrics=[
+            OneStepMeanMetricConfig(target="denorm"),
+            OneStepMeanMetricConfig(
+                target="norm",
+                include_bias=False,
+                include_grad_mag_percent_diff=False,
+            ),
+        ]
+    )
+    agg = config.build(ds_info, save_diagnostics=False)
+    batch_size, n_ensemble, n_time, nx, ny = 2, 2, 3, 2, 2
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert "test/crps/a" in logs

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -6,13 +6,8 @@ import xarray as xr
 from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
-    build_one_step_aggregator,
 )
-from fme.ace.aggregator.one_step.main import (
-    OneStepMeanMetricConfig,
-    OneStepSnapshotMetricConfig,
-    OneStepSpectrumMetricConfig,
-)
+from fme.ace.aggregator.one_step.main import OneStepMeanMetricConfig
 from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -144,7 +139,7 @@ def test_agg_raises_without_output_dir():
 
 def test_explicit_metrics_build():
     ds_info = get_ds_info(nx=2, ny=2)
-    agg = build_one_step_aggregator(
+    config = OneStepAggregatorConfig(
         metrics=[
             OneStepMeanMetricConfig(target="denorm"),
             OneStepMeanMetricConfig(
@@ -152,10 +147,9 @@ def test_explicit_metrics_build():
                 include_bias=False,
                 include_grad_mag_percent_diff=False,
             ),
-        ],
-        dataset_info=ds_info,
-        save_diagnostics=False,
+        ]
     )
+    agg = config.build(ds_info, save_diagnostics=False)
     target_data = EnsembleTensorDict(
         {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
     )
@@ -177,15 +171,12 @@ def test_explicit_metrics_build():
 
 
 def test_duplicate_metric_names_rejected():
-    ds_info = get_ds_info(nx=2, ny=2)
     with pytest.raises(ValueError, match="Duplicate metric names"):
-        build_one_step_aggregator(
+        OneStepAggregatorConfig(
             metrics=[
                 OneStepMeanMetricConfig(target="denorm"),
                 OneStepMeanMetricConfig(target="denorm"),
-            ],
-            dataset_info=ds_info,
-            save_diagnostics=False,
+            ]
         )
 
 
@@ -229,165 +220,3 @@ def test_legacy_config_builds_same_log_keys():
     legacy_logs = legacy_agg.get_logs(label="test")
 
     assert set(typed_logs.keys()) == set(legacy_logs.keys())
-
-
-def test_hierarchical_defaults_build():
-    """Hierarchical config with all defaults builds and includes core metrics."""
-    nx, ny = 2, 2
-    ds_info = get_ds_info(nx, ny)
-    agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
-    target_data = EnsembleTensorDict(
-        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
-    )
-    gen_data = EnsembleTensorDict(
-        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
-    )
-    agg.record_batch(
-        batch=TrainOutput(
-            metrics={"loss": 1.0},
-            target_data=target_data,
-            gen_data=gen_data,
-            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
-            normalize=lambda x: x,
-        ),
-    )
-    logs = agg.get_logs(label="test")
-    for expected in ["mean", "mean_norm", "power_spectrum", "snapshot", "mean_map"]:
-        assert any(expected in k for k in logs), f"Expected {expected} in log keys"
-
-
-def test_hierarchical_enable_disable():
-    """Disabling a default metric removes it; other metrics still present."""
-    nx, ny = 2, 2
-    ds_info = get_ds_info(nx, ny)
-    agg = OneStepAggregatorConfig(
-        snapshot=OneStepSnapshotMetricConfig(enabled=False),
-    ).build(ds_info, save_diagnostics=False)
-    target_data = EnsembleTensorDict(
-        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
-    )
-    gen_data = EnsembleTensorDict(
-        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
-    )
-    agg.record_batch(
-        batch=TrainOutput(
-            metrics={"loss": 1.0},
-            target_data=target_data,
-            gen_data=gen_data,
-            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
-            normalize=lambda x: x,
-        ),
-    )
-    logs = agg.get_logs(label="test")
-    assert not any("snapshot" in k for k in logs)
-    assert any("mean" in k for k in logs)
-
-
-@pytest.mark.parametrize(
-    "kwargs,match",
-    [
-        pytest.param(
-            dict(
-                mean_denorm=OneStepMeanMetricConfig(
-                    target="norm",
-                    include_bias=False,
-                    include_grad_mag_percent_diff=False,
-                )
-            ),
-            "mean_denorm.target must be 'denorm'",
-            id="mean_denorm_wrong_target",
-        ),
-        pytest.param(
-            dict(mean_norm=OneStepMeanMetricConfig(target="denorm")),
-            "mean_norm.target must be 'norm'",
-            id="mean_norm_wrong_target",
-        ),
-    ],
-)
-def test_hierarchical_rejects_mismatched_target(kwargs, match):
-    with pytest.raises(ValueError, match=match):
-        OneStepAggregatorConfig(**kwargs)
-
-
-def test_raise_on_unsupported_true_raises(monkeypatch):
-    """Explicit build with raise_on_unsupported=True raises for unsupported metrics."""
-    from fme.ace.aggregator.one_step import spectrum
-    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
-
-    def failing_build(self, ctx):
-        raise MetricNotSupportedError("test: spectrum unsupported")
-
-    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
-
-    ds_info = get_ds_info(nx=2, ny=2)
-    with pytest.raises(MetricNotSupportedError):
-        build_one_step_aggregator(
-            metrics=[OneStepSpectrumMetricConfig()],
-            dataset_info=ds_info,
-            save_diagnostics=False,
-        )
-
-
-def test_raise_on_unsupported_false_skips(monkeypatch):
-    """Explicit build with raise_on_unsupported=False skips unsupported metrics."""
-    from fme.ace.aggregator.one_step import spectrum
-    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
-
-    def failing_build(self, ctx):
-        raise MetricNotSupportedError("test: spectrum unsupported")
-
-    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
-
-    ds_info = get_ds_info(nx=2, ny=2)
-    agg = build_one_step_aggregator(
-        metrics=[
-            OneStepMeanMetricConfig(target="denorm"),
-            OneStepMeanMetricConfig(
-                target="norm",
-                include_bias=False,
-                include_grad_mag_percent_diff=False,
-            ),
-            OneStepSpectrumMetricConfig(),
-        ],
-        dataset_info=ds_info,
-        save_diagnostics=False,
-        raise_on_unsupported=False,
-    )
-    target_data = EnsembleTensorDict(
-        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
-    )
-    gen_data = EnsembleTensorDict(
-        {"a": torch.randn(2, 1, 3, 2, 2, device=get_device())},
-    )
-    agg.record_batch(
-        batch=TrainOutput(
-            metrics={"loss": 1.0},
-            target_data=target_data,
-            gen_data=gen_data,
-            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
-            normalize=lambda x: x,
-        ),
-    )
-    logs = agg.get_logs(label="test")
-    assert any("mean" in k for k in logs)
-    assert not any("power_spectrum" in k for k in logs)
-
-
-def test_strict_metric_raises_even_when_not_raise_on_unsupported(monkeypatch):
-    """A metric with strict=True raises even when raise_on_unsupported=False."""
-    from fme.ace.aggregator.one_step import spectrum
-    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
-
-    def failing_build(self, ctx):
-        raise MetricNotSupportedError("test: spectrum unsupported")
-
-    monkeypatch.setattr(spectrum.OneStepSpectrumMetricConfig, "build", failing_build)
-
-    ds_info = get_ds_info(nx=2, ny=2)
-    with pytest.raises(MetricNotSupportedError):
-        build_one_step_aggregator(
-            metrics=[OneStepSpectrumMetricConfig(strict=True)],
-            dataset_info=ds_info,
-            save_diagnostics=False,
-            raise_on_unsupported=False,
-        )

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 import xarray as xr
 
-from fme.ace.aggregator.one_step import OneStepAggregator
+from fme.ace.aggregator.one_step import OneStepAggregatorConfig
 from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -23,7 +23,7 @@ def test_labels_exist():
     nx, ny = 2, 2
     loss = 1.0
     ds_info = get_ds_info(nx, ny)
-    agg = OneStepAggregator(ds_info, save_diagnostics=False)
+    agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
     target_data = EnsembleTensorDict(
         {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=get_device())},
     )
@@ -72,7 +72,7 @@ def test_aggregator_raises_on_no_data():
     with multiple batches and no distributed training.
     """
     ds_info = get_ds_info(2, 2)
-    agg = OneStepAggregator(ds_info, save_diagnostics=False)
+    agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
     with pytest.raises(ValueError) as excinfo:
         agg.record_batch(
             batch=TrainOutput(
@@ -93,7 +93,7 @@ def test_aggregator_raises_on_no_data():
 def test_flush_diagnostics(tmpdir, epoch):
     nx, ny, batch_size, n_ensemble, n_time = 3, 3, 10, 2, 3
     ds_info = get_ds_info(nx, ny)
-    agg = OneStepAggregator(ds_info, output_dir=(tmpdir / "val"))
+    agg = OneStepAggregatorConfig().build(ds_info, output_dir=str(tmpdir / "val"))
     target_data = EnsembleTensorDict(
         {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=get_device())}
     )
@@ -130,4 +130,4 @@ def test_agg_raises_without_output_dir():
     with pytest.raises(
         ValueError, match="Output directory must be set to save diagnostics"
     ):
-        OneStepAggregator(ds_info, save_diagnostics=True, output_dir=None)
+        OneStepAggregatorConfig().build(ds_info, save_diagnostics=True, output_dir=None)

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -7,12 +7,15 @@ from fme.ace.aggregator.one_step import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
     build_one_step_aggregator,
+    spectrum,
 )
+from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
 from fme.ace.aggregator.one_step.main import (
     OneStepMeanMetricConfig,
     OneStepSnapshotMetricConfig,
     OneStepSpectrumMetricConfig,
 )
+from fme.ace.aggregator.one_step.map import OneStepMapMetricConfig
 from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -229,6 +232,11 @@ def test_legacy_config_builds_same_log_keys():
     legacy_logs = legacy_agg.get_logs(label="test")
 
     assert set(typed_logs.keys()) == set(legacy_logs.keys())
+    for key in typed_logs:
+        typed_val = typed_logs[key]
+        legacy_val = legacy_logs[key]
+        if isinstance(typed_val, float):
+            assert typed_val == pytest.approx(legacy_val), f"Value mismatch for {key}"
 
 
 def test_hierarchical_defaults_build():
@@ -309,10 +317,122 @@ def test_hierarchical_rejects_mismatched_target(kwargs, match):
         OneStepAggregatorConfig(**kwargs)
 
 
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        pytest.param(
+            dict(
+                mean_denorm=OneStepMeanMetricConfig(target="denorm", enabled=False),
+            ),
+            "mean_denorm cannot be disabled",
+            id="mean_denorm_disabled",
+        ),
+        pytest.param(
+            dict(
+                mean_norm=OneStepMeanMetricConfig(
+                    target="norm",
+                    include_bias=False,
+                    include_grad_mag_percent_diff=False,
+                    enabled=False,
+                ),
+            ),
+            "mean_norm cannot be disabled",
+            id="mean_norm_disabled",
+        ),
+    ],
+)
+def test_hierarchical_rejects_disabled_required_metrics(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        OneStepAggregatorConfig(**kwargs)
+
+
+def test_legacy_disabled_flags_match_typed_config():
+    """Legacy config with log_snapshots=False and log_mean_maps=False produces
+    the same keys as the equivalent OneStepAggregatorConfig."""
+    batch_size = 10
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+
+    typed_agg = OneStepAggregatorConfig(
+        snapshot=OneStepSnapshotMetricConfig(enabled=False),
+        mean_map=OneStepMapMetricConfig(enabled=False),
+    ).build(ds_info, save_diagnostics=False)
+
+    with pytest.warns(DeprecationWarning):
+        legacy_agg = LegacyFlagOneStepAggregatorConfig(
+            log_snapshots=False, log_mean_maps=False
+        ).build(ds_info, save_diagnostics=False)
+
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, 3, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, 3, nx, ny, device=get_device())},
+    )
+    batch = TrainOutput(
+        metrics={"loss": 1.0},
+        target_data=target_data,
+        gen_data=gen_data,
+        time=xr.DataArray(np.zeros((batch_size, 3)), dims=["sample", "time"]),
+        normalize=lambda x: x,
+    )
+
+    typed_agg.record_batch(batch=batch)
+    legacy_agg.record_batch(batch=batch)
+
+    typed_logs = typed_agg.get_logs(label="test")
+    legacy_logs = legacy_agg.get_logs(label="test")
+
+    assert set(typed_logs.keys()) == set(legacy_logs.keys())
+    assert not any("snapshot" in k for k in typed_logs)
+    assert not any("mean_map" in k for k in typed_logs)
+
+
+def test_empty_metrics_list_raises():
+    """An empty metrics list raises because mean_norm is required."""
+    ds_info = get_ds_info(nx=2, ny=2)
+    with pytest.raises(ValueError, match="mean_norm"):
+        build_one_step_aggregator(
+            metrics=[],
+            dataset_info=ds_info,
+            save_diagnostics=False,
+        )
+
+
+def test_disabled_ensemble_produces_no_ensemble_logs():
+    """Disabling the ensemble metric produces no ensemble-related log keys."""
+    from fme.ace.aggregator.one_step.ensemble import OneStepEnsembleMetricConfig
+
+    nx, ny = 2, 2
+    ds_info = get_ds_info(nx, ny)
+    agg = OneStepAggregatorConfig(
+        ensemble=OneStepEnsembleMetricConfig(enabled=False),
+    ).build(ds_info, save_diagnostics=False)
+
+    n_ensemble = 2
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(2, 1, 3, nx, ny, device=get_device())},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(2, n_ensemble, 3, nx, ny, device=get_device())},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": 1.0},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((2, 3)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="test")
+    assert not any("crps" in k for k in logs)
+    assert not any("ssr_bias" in k for k in logs)
+    assert not any("ensemble_mean_rmse" in k for k in logs)
+
+
 def test_raise_on_unsupported_true_raises(monkeypatch):
     """Explicit build with raise_on_unsupported=True raises for unsupported metrics."""
-    from fme.ace.aggregator.one_step import spectrum
-    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
 
     def failing_build(self, ctx):
         raise MetricNotSupportedError("test: spectrum unsupported")
@@ -330,8 +450,6 @@ def test_raise_on_unsupported_true_raises(monkeypatch):
 
 def test_raise_on_unsupported_false_skips(monkeypatch):
     """Explicit build with raise_on_unsupported=False skips unsupported metrics."""
-    from fme.ace.aggregator.one_step import spectrum
-    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
 
     def failing_build(self, ctx):
         raise MetricNotSupportedError("test: spectrum unsupported")
@@ -375,8 +493,6 @@ def test_raise_on_unsupported_false_skips(monkeypatch):
 
 def test_strict_metric_raises_even_when_not_raise_on_unsupported(monkeypatch):
     """A metric with strict=True raises even when raise_on_unsupported=False."""
-    from fme.ace.aggregator.one_step import spectrum
-    from fme.ace.aggregator.one_step.build_context import MetricNotSupportedError
 
     def failing_build(self, ctx):
         raise MetricNotSupportedError("test: spectrum unsupported")

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -11,7 +11,10 @@ import numpy.typing as npt
 import torch
 
 import fme
-from fme.ace.aggregator import OneStepAggregatorConfig
+from fme.ace.aggregator import (
+    LegacyFlagOneStepAggregatorConfig,
+    OneStepAggregatorConfig,
+)
 from fme.ace.aggregator.inference import (
     InferenceEvaluatorAggregatorConfig,
     LegacyFlagInferenceEvaluatorAggregatorConfig,
@@ -121,8 +124,8 @@ class ValidationConfig:
     """
 
     loader: DataLoaderConfig
-    aggregator: OneStepAggregatorConfig = dataclasses.field(
-        default_factory=lambda: OneStepAggregatorConfig()
+    aggregator: OneStepAggregatorConfig | LegacyFlagOneStepAggregatorConfig = (
+        dataclasses.field(default_factory=lambda: OneStepAggregatorConfig())
     )
     stepper_training: TrainStepperConfig = dataclasses.field(
         default_factory=lambda: TrainStepperConfig()
@@ -408,7 +411,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
             train_stepper_config = config.validation.stepper_training
             train_stepper = TrainStepper(stepper=stepper, config=train_stepper_config)
 
-            aggregator = config.validation.aggregator.build(
+            val_aggregator = config.validation.aggregator.build(
                 dataset_info=dataset_info,
                 loss_scaling=train_stepper.effective_loss_scaling,
                 save_diagnostics=True,
@@ -418,7 +421,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
         run_validation(
             train_stepper=train_stepper,
             validation_data=valid_data,
-            aggregator=aggregator,
+            aggregator=val_aggregator,
             label="val",
             log_progress=True,
         )

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -17,7 +17,7 @@ import torch
 import xarray as xr
 
 import fme
-from fme.ace.aggregator import OneStepAggregator
+from fme.ace.aggregator import OneStepAggregatorConfig
 from fme.ace.aggregator.plotting import plot_paneled_data
 from fme.ace.data_loading.batch_data import BatchData, PrognosticState
 from fme.ace.inference.test_evaluator import (
@@ -749,7 +749,7 @@ def test_train_on_batch_one_step_aggregator(n_forward_steps):
     # keep area weights ones for simplicity
     lat_lon_coordinates._area_weights = torch.ones(nx, ny)
     ds_info = DatasetInfo(horizontal_coordinates=lat_lon_coordinates)
-    aggregator = OneStepAggregator(ds_info, save_diagnostics=False)
+    aggregator = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
 
     train_stepper = _get_train_stepper(config)
     stepped = train_stepper.train_on_batch(data, optimization=NullOptimization())

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -15,7 +15,9 @@ import yaml
 
 import fme
 from fme.ace.aggregator.inference.main import InferenceEvaluatorAggregatorConfig
-from fme.ace.aggregator.one_step.main import LegacyFlagOneStepAggregatorConfig
+from fme.ace.aggregator.one_step.main import OneStepAggregatorConfig
+from fme.ace.aggregator.one_step.map import OneStepMapMetricConfig
+from fme.ace.aggregator.one_step.snapshot import OneStepSnapshotMetricConfig
 from fme.ace.data_loading.config import DataLoaderConfig
 from fme.ace.data_loading.inference import (
     InferenceDataLoaderConfig,
@@ -110,9 +112,9 @@ def _make_validation_entries(
             batch_size=2,
             num_data_workers=0,
         ),
-        aggregator=LegacyFlagOneStepAggregatorConfig(
-            log_snapshots=log_validation_maps,
-            log_mean_maps=log_validation_maps,
+        aggregator=OneStepAggregatorConfig(
+            snapshot=OneStepSnapshotMetricConfig(enabled=log_validation_maps),
+            mean_map=OneStepMapMetricConfig(enabled=log_validation_maps),
         ),
     )
     if not multi_validation:

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -15,7 +15,7 @@ import yaml
 
 import fme
 from fme.ace.aggregator.inference.main import InferenceEvaluatorAggregatorConfig
-from fme.ace.aggregator.one_step.main import OneStepAggregatorConfig
+from fme.ace.aggregator.one_step.main import LegacyFlagOneStepAggregatorConfig
 from fme.ace.data_loading.config import DataLoaderConfig
 from fme.ace.data_loading.inference import (
     InferenceDataLoaderConfig,
@@ -382,7 +382,7 @@ def _get_test_yaml_files(
         logging=logging_config,
         experiment_dir=str(results_dir),
         save_per_epoch_diagnostics=save_per_epoch_diagnostics,
-        validation_aggregator=OneStepAggregatorConfig(
+        validation_aggregator=LegacyFlagOneStepAggregatorConfig(
             log_snapshots=log_validation_maps,
             log_mean_maps=log_validation_maps,
         ),

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -60,6 +60,7 @@ import torch
 
 import fme
 from fme.ace.aggregator import (
+    LegacyFlagOneStepAggregatorConfig,
     OneStepAggregator,
     OneStepAggregatorConfig,
     TrainAggregator,
@@ -206,7 +207,9 @@ class AggregatorBuilder(
         loss_scaling: dict[str, torch.Tensor] | None = None,
         channel_mean_names: Sequence[str] | None = None,
         save_per_epoch_diagnostics: bool = False,
-        validation_config: OneStepAggregatorConfig = dataclasses.field(
+        validation_config: (
+            OneStepAggregatorConfig | LegacyFlagOneStepAggregatorConfig
+        ) = dataclasses.field(
             default_factory=lambda: OneStepAggregatorConfig(),
         ),
     ):

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -9,6 +9,7 @@ import torch
 from fme.ace.aggregator import (
     InferenceEvaluatorAggregatorConfig,
     LegacyFlagInferenceEvaluatorAggregatorConfig,
+    LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
 )
 from fme.ace.aggregator.train import TrainAggregatorConfig
@@ -205,9 +206,9 @@ class TrainConfig:
     checkpoint_every_n_batches: int = 1000
     segment_epochs: int | None = None
     save_per_epoch_diagnostics: bool = False
-    validation_aggregator: OneStepAggregatorConfig = dataclasses.field(
-        default_factory=lambda: OneStepAggregatorConfig()
-    )
+    validation_aggregator: (
+        OneStepAggregatorConfig | LegacyFlagOneStepAggregatorConfig
+    ) = dataclasses.field(default_factory=lambda: OneStepAggregatorConfig())
     evaluate_before_training: bool = False
     save_best_inference_epoch_checkpoints: bool = False
     lr_tuning: LRTuningConfig | None = None

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -35,7 +35,7 @@ from fme.ace.aggregator.inference.main import (
     InferenceEvaluatorAggregator as InferenceEvaluatorAggregator_,
 )
 from fme.ace.aggregator.inference.main import MetricConfig as AceMetricConfig
-from fme.ace.aggregator.one_step.main import OneStepAggregator as OneStepAggregator_
+from fme.ace.aggregator.one_step.main import OneStepAggregatorConfig
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
@@ -114,9 +114,10 @@ class OneStepAggregator(AggregatorABC[CoupledTrainOutput]):
         self._loss_ocean = torch.tensor(0.0, device=get_device())
         self._loss_atmos = torch.tensor(0.0, device=get_device())
         self._n_batches = 0
+        config = OneStepAggregatorConfig()
         self._aggregators = {
-            "ocean": OneStepAggregator_(
-                dataset_info.ocean,
+            "ocean": config.build(
+                dataset_info=dataset_info.ocean,
                 save_diagnostics=save_diagnostics,
                 output_dir=(
                     os.path.join(output_dir, "ocean")
@@ -126,8 +127,8 @@ class OneStepAggregator(AggregatorABC[CoupledTrainOutput]):
                 loss_scaling=loss_scaling.ocean,
                 channel_mean_names=ocean_channel_mean_names,
             ),
-            "atmosphere": OneStepAggregator_(
-                dataset_info.atmosphere,
+            "atmosphere": config.build(
+                dataset_info=dataset_info.atmosphere,
                 save_diagnostics=save_diagnostics,
                 output_dir=(
                     os.path.join(output_dir, "atmosphere")


### PR DESCRIPTION
Applies the typed metric config pattern (from the InferenceEvaluatorAggregator refactoring in #1123, #1126) to the validation `OneStepAggregator`. This makes validation metrics explicitly configurable via YAML and extensible without adding new boolean flags.

Changes:
- `fme.ace.aggregator.one_step.deterministic.OneStepDeterministicAggregator`: accept pre-built sub-aggregators via `Mapping[str, Aggregator]` instead of constructing them internally
- `fme.ace.aggregator.one_step.build_context`: new module with `OneStepBuildContext`, `OneStepMetricBuildResult`, `MetricNotSupportedError`
- `fme.ace.aggregator.one_step.reduced.OneStepMeanMetricConfig`, `OneStepSnapshotMetricConfig`, `OneStepMapMetricConfig`, `OneStepSpectrumMetricConfig`, `OneStepEnsembleMetricConfig`: typed metric config classes with `get_name()`/`build()` methods
- `fme.ace.aggregator.one_step.main.OneStepAggregatorConfig`: hierarchical config with named fields (`mean_denorm`, `mean_norm`, `power_spectrum`, `snapshot`, `mean_map`, `ensemble`) with `enabled`/`strict` flags, matching the `InferenceEvaluatorAggregatorConfig` pattern
- `fme.ace.aggregator.one_step.main.LegacyFlagOneStepAggregatorConfig`: preserves old boolean-flag interface with deprecation warning
- `fme.ace.train.train_config.TrainConfig`, `fme.ace.train.train.AggregatorBuilder`: accept `OneStepAggregatorConfig | LegacyFlagOneStepAggregatorConfig`
- `fme.ace.inference.evaluator`: rename scoped `aggregator` variable to `val_aggregator` to fix pre-existing mypy type narrowing issue

**Note on inference metric defaults:** `HistogramMetricConfig`, `VideoMetricConfig`, and `SeasonalMetricConfig` changed their class-level `enabled` default from `True` to `False`. This is a cleanup — `InferenceEvaluatorAggregatorConfig` already overrode these to `enabled=False` via `default_factory` lambdas, so the net behavior of the inference pipeline is unchanged. Code that instantiates these config classes directly (outside of `InferenceEvaluatorAggregatorConfig`) will now get `enabled=False` by default.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated