### PR TITLE
Install HPX reorder arrays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ find = {}
 
 [tool.setuptools.package-data]
 "fme.core.cuhpx" = ["data/*.npy", "data/*.fits"]
+"fme.core.hpx" = ["data/*.npy"]
 
 [tool.uv]
 cache-keys = [


### PR DESCRIPTION
HEALPix reordering arrays aren't included when installing the repository. This PR fixes this by adding them to the `pyproject.toml`.
