### PR TITLE
Version bump to 2026.5.1

### DIFF
--- a/fme/__init__.py
+++ b/fme/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2026.4.0"
+__version__ = "2026.5.0"
 
 
 from . import ace, coupled

--- a/fme/__init__.py
+++ b/fme/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2026.5.0"
+__version__ = "2026.5.1"
 
 
 from . import ace, coupled


### PR DESCRIPTION
Version bump to 2026.5.1.

Note that this PR intentionally doesn't correspond with the [tagged commit of 2026.5.1](https://github.com/ai2cm/ace/commit/12b9103f2decdc524ccb8e3d7a4b25debddedf91) that was released to PyPI, as that commit didn't happen on main. This is just here to keep things from being out of date and to remind us to do this for future releases.