### PR TITLE
Add `IpoIndexMetricConfig` to coupled inference aggregator

### DIFF
--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -8,12 +8,14 @@ import torch
 import xarray as xr
 
 from fme.ace.aggregator.inference.main import (
+    APPROXIMATELY_EIGHTY_YEARS,
     APPROXIMATELY_TWO_YEARS,
     SLIGHTLY_LESS_THAN_FIVE_YEARS,
     AnnualMetricConfig,
     EnsoCoefficientMetricConfig,
     EnsoIndexMetricConfig,
     HistogramMetricConfig,
+    IpoIndexMetricConfig,
     MeanMetricConfig,
     PowerSpectrumMetricConfig,
     SeasonalMetricConfig,
@@ -288,6 +290,8 @@ class InferenceEvaluatorAggregatorConfig:
                 metrics.append(EnsoIndexMetricConfig())
         if n_timesteps * timestep > SLIGHTLY_LESS_THAN_FIVE_YEARS:
             metrics.append(EnsoCoefficientMetricConfig())
+        if include_nino34 and n_timesteps * timestep > APPROXIMATELY_EIGHTY_YEARS:
+            metrics.append(IpoIndexMetricConfig())
         return metrics
 
     def build(


### PR DESCRIPTION
Enables IPO aggregator for coupled inference.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated