### PR TITLE
Log IPO aggregator by default

### DIFF
--- a/fme/ace/aggregator/inference/ipo/__init__.py
+++ b/fme/ace/aggregator/inference/ipo/__init__.py
@@ -1,1 +1,5 @@
-from .ipo_index import IpoIndexMetricConfig, PairedIPOIndexAggregator
+from .ipo_index import (
+    IPOIndexAggregator,
+    IpoIndexMetricConfig,
+    PairedIPOIndexAggregator,
+)

--- a/fme/ace/aggregator/inference/ipo/__init__.py
+++ b/fme/ace/aggregator/inference/ipo/__init__.py
@@ -1,5 +1,5 @@
 from .ipo_index import (
     IPOIndexAggregator,
-    IpoIndexMetricConfig,
+    IPOIndexMetricConfig,
     PairedIPOIndexAggregator,
 )

--- a/fme/ace/aggregator/inference/ipo/ipo_index.py
+++ b/fme/ace/aggregator/inference/ipo/ipo_index.py
@@ -208,6 +208,118 @@ class _IPORegionalAccumulator:
         return xr.concat(index_data_arrays, dim="sample")
 
 
+class IPOIndexAggregator:
+    """Single-data (no target) aggregator for IPO Tripolar Index.
+
+    Computes the TPI (Henley et al. 2017) from model SST output and reports:
+    - Filtered TPI time series plot
+    - Power spectrum of unfiltered monthly TPI
+    - Scalar std of the filtered TPI
+    """
+
+    def __init__(
+        self,
+        lat: torch.Tensor,
+        lon: torch.Tensor,
+        cutoff_period_yrs: float = 13.0,
+        sst_names: list[str] | None = None,
+    ):
+        regions = {
+            name: LatLonRegion(
+                lat=lat,
+                lon=lon,
+                lat_bounds=spec["lat_bounds"],
+                lon_bounds=spec["lon_bounds"],
+            )
+            for name, spec in TPI_REGIONS.items()
+        }
+        self._sst_names = sst_names if sst_names is not None else DEFAULT_SST_NAMES
+        self._accumulator = _IPORegionalAccumulator(regions, sst_names=self._sst_names)
+        self._cutoff_period_yrs = cutoff_period_yrs
+
+    def record_batch(self, data: InferenceBatchData) -> None:
+        self._accumulator.record_batch(data)
+
+    def get_logs(self, label: str) -> dict[str, Any]:
+        tpi_indices = self._accumulator.get_tpi_indices()
+        logs: dict[str, Any] = {}
+
+        for sst_name in self._sst_names:
+            if sst_name not in tpi_indices:
+                continue
+            tpi_da = tpi_indices[sst_name]
+            if tpi_da.sizes["time"] < 2:
+                continue
+
+            filtered = self._apply_filter_to_samples(tpi_da)
+            if filtered is not None:
+                logs[f"{sst_name}_ipo_tpi_filtered"] = self._plot_filtered_tpi(filtered)
+                logs[f"{sst_name}_ipo_tpi_std"] = _compute_sample_mean_std(filtered)
+                logs[f"{sst_name}_ipo_tpi_power_spectrum"] = self._plot_power_spectrum(
+                    tpi_da
+                )
+
+        if len(label) > 0:
+            label = label + "/"
+        return {f"{label}{k}": v for k, v in logs.items()}
+
+    def get_dataset(self) -> xr.Dataset:
+        return self._accumulator.get_tpi_indices()
+
+    def _apply_filter_to_samples(self, tpi_da: xr.DataArray) -> xr.DataArray | None:
+        """Apply low-pass filter to each sample, trimming edge transients.
+
+        Trims one cutoff period from each end to remove filtfilt edge artifacts.
+        Returns None if the series is too short.
+        """
+        trim = int(self._cutoff_period_yrs * 12)
+        min_length = MIN_YEARS_FOR_FILTERED_TPI * 12
+        filtered_samples = []
+        for sample in range(tpi_da.sizes["sample"]):
+            sample_data = tpi_da.isel(sample=sample).dropna("time")
+            if sample_data.sizes["time"] < min_length:
+                return None
+            filtered_values = low_pass_filter(
+                sample_data.values, cutoff_period_yrs=self._cutoff_period_yrs
+            )
+            trimmed = xr.DataArray(
+                filtered_values[trim:-trim],
+                coords={"time": sample_data.time[trim:-trim]},
+                dims=sample_data.dims,
+            )
+            filtered_samples.append(trimmed)
+        return xr.concat(filtered_samples, dim="sample")
+
+    def _plot_filtered_tpi(self, prediction: xr.DataArray) -> plt.Figure:
+        fig, ax = plt.subplots(1, 1)
+        pred_plottable = prediction.assign_coords(
+            {"time": convert_cftime_to_datetime_coord(prediction.time)}
+        )
+        plot_mean_and_samples(
+            ax,
+            pred_plottable,
+            "predicted ensemble mean",
+            time_series_dim="time",
+        )
+        ax.set_title("IPO TPI (13-yr low-pass filtered)")
+        ax.set_ylabel("K")
+        ax.legend()
+        fig.tight_layout()
+        return fig
+
+    def _plot_power_spectrum(self, prediction_tpi: xr.DataArray) -> plt.Figure:
+        pred_freq, pred_power = _calculate_sample_average_power_spectrum(prediction_tpi)
+        fig, ax = plt.subplots(1, 1)
+        ax.plot(pred_freq, pred_power, label="predicted ensemble mean")
+        ax.set_title("Power Spectrum of IPO TPI (unfiltered)")
+        ax.set_xlabel("Frequency [cycles/year]")
+        ax.set_ylabel("Power [K**2]")
+        ax.set(xscale="log", yscale="log")
+        ax.legend()
+        fig.tight_layout()
+        return fig
+
+
 class PairedIPOIndexAggregator:
     """Paired (target, prediction) aggregator for IPO Tripolar Index.
 

--- a/fme/ace/aggregator/inference/ipo/ipo_index.py
+++ b/fme/ace/aggregator/inference/ipo/ipo_index.py
@@ -483,7 +483,7 @@ class PairedIPOIndexAggregator:
 
 
 @dataclasses.dataclass
-class IpoIndexMetricConfig:
+class IPOIndexMetricConfig:
     type: Literal["ipo_index"] = "ipo_index"
     name: str = "ipo_index"
 

--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -34,7 +34,7 @@ from .histogram import HistogramMetricConfig
 from .ipo.ipo_index import (
     MIN_YEARS_FOR_FILTERED_TPI,
     IPOIndexAggregator,
-    IpoIndexMetricConfig,
+    IPOIndexMetricConfig,
 )
 from .reduced import MeanMetricConfig, SingleTargetMeanAggregator
 from .seasonal import SeasonalMetricConfig
@@ -64,7 +64,7 @@ MetricConfig = (
     | EnsoIndexMetricConfig
     | EnsoCoefficientMetricConfig
     | EnsembleMetricConfig
-    | IpoIndexMetricConfig
+    | IPOIndexMetricConfig
 )
 
 
@@ -144,7 +144,7 @@ class InferenceEvaluatorAggregatorConfig:
         if ctx.n_timesteps * ctx.timestep > APPROXIMATELY_EIGHTY_YEARS and isinstance(
             ctx.horizontal_coordinates, LatLonCoordinates
         ):
-            metrics.append(IpoIndexMetricConfig())
+            metrics.append(IPOIndexMetricConfig())
 
         return metrics
 
@@ -352,7 +352,7 @@ class LegacyFlagInferenceEvaluatorAggregatorConfig:
             and n_timesteps * timestep > APPROXIMATELY_EIGHTY_YEARS
             and isinstance(horizontal_coordinates, LatLonCoordinates)
         ):
-            metrics.append(IpoIndexMetricConfig())
+            metrics.append(IPOIndexMetricConfig())
         return InferenceEvaluatorAggregatorConfig(
             metrics=metrics,
             monthly_reference_data=self.monthly_reference_data,

--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -31,7 +31,11 @@ from .enso import RegionalIndexAggregator
 from .enso.dynamic_index import EnsoIndexMetricConfig
 from .enso.enso_coefficient import EnsoCoefficientMetricConfig
 from .histogram import HistogramMetricConfig
-from .ipo.ipo_index import MIN_YEARS_FOR_FILTERED_TPI, IpoIndexMetricConfig
+from .ipo.ipo_index import (
+    MIN_YEARS_FOR_FILTERED_TPI,
+    IPOIndexAggregator,
+    IpoIndexMetricConfig,
+)
 from .reduced import MeanMetricConfig, SingleTargetMeanAggregator
 from .seasonal import SeasonalMetricConfig
 from .spectrum import PowerSpectrumMetricConfig, SphericalPowerSpectrumAggregator
@@ -136,6 +140,11 @@ class InferenceEvaluatorAggregatorConfig:
 
         if ctx.n_timesteps * ctx.timestep > SLIGHTLY_LESS_THAN_FIVE_YEARS:
             metrics.append(EnsoCoefficientMetricConfig())
+
+        if ctx.n_timesteps * ctx.timestep > APPROXIMATELY_EIGHTY_YEARS and isinstance(
+            ctx.horizontal_coordinates, LatLonCoordinates
+        ):
+            metrics.append(IpoIndexMetricConfig())
 
         return metrics
 
@@ -670,6 +679,14 @@ class InferenceAggregatorConfig:
             aggregators["enso_index"] = RegionalIndexAggregator(
                 regional_weights=nino34_region.regional_weights,
                 regional_mean=gridded_operations.regional_area_weighted_mean,
+            )
+        if (
+            isinstance(horizontal_coordinates, LatLonCoordinates)
+            and n_timesteps * dataset_info.timestep > APPROXIMATELY_EIGHTY_YEARS
+        ):
+            aggregators["ipo_index"] = IPOIndexAggregator(
+                lat=horizontal_coordinates.lat,
+                lon=horizontal_coordinates.lon,
             )
 
         return InferenceAggregator(

--- a/fme/ace/aggregator/inference/test_evaluator.py
+++ b/fme/ace/aggregator/inference/test_evaluator.py
@@ -22,6 +22,8 @@ from fme.ace.aggregator.inference import (
     VideoMetricConfig,
     ZonalMeanMetricConfig,
 )
+from fme.ace.aggregator.inference.build_context import MetricBuildContext
+from fme.ace.aggregator.inference.ipo.ipo_index import IpoIndexMetricConfig
 from fme.ace.data_loading.batch_data import BatchData, PairedData
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -419,6 +421,35 @@ class TestAggregatorConfigMetrics:
                 MeanMetricConfig(target="norm", name="mean_custom"),
             ]
         )
+
+    @pytest.mark.parametrize(
+        "n_timesteps, timestep_days, expect_ipo",
+        [
+            (10 * 365, 1, False),  # 10 years, below threshold
+            (90 * 365, 1, True),  # 90 years, above threshold
+        ],
+    )
+    def test_default_metrics_includes_ipo_for_long_runs(
+        self, n_timesteps, timestep_days, expect_ipo
+    ):
+        ds_info = get_ds_info(nx=8, ny=4)
+        ctx = MetricBuildContext(
+            ops=ds_info.gridded_operations,
+            horizontal_coordinates=ds_info.horizontal_coordinates,
+            n_timesteps=n_timesteps,
+            n_ic_steps=1,
+            timestep=datetime.timedelta(days=timestep_days),
+            variable_metadata=None,
+            channel_mean_names=None,
+            monthly_reference_data=None,
+            time_mean_reference_data=None,
+            initial_time=get_zero_time(shape=[1, 0], dims=["sample", "time"]),
+        )
+        metrics = InferenceEvaluatorAggregatorConfig._default_metrics(
+            ctx, n_ensemble_per_ic=1
+        )
+        has_ipo = any(isinstance(m, IpoIndexMetricConfig) for m in metrics)
+        assert has_ipo is expect_ipo
 
     def test_default_metrics_build(self):
         n_sample, n_time = 10, 22

--- a/fme/ace/aggregator/inference/test_evaluator.py
+++ b/fme/ace/aggregator/inference/test_evaluator.py
@@ -23,7 +23,7 @@ from fme.ace.aggregator.inference import (
     ZonalMeanMetricConfig,
 )
 from fme.ace.aggregator.inference.build_context import MetricBuildContext
-from fme.ace.aggregator.inference.ipo.ipo_index import IpoIndexMetricConfig
+from fme.ace.aggregator.inference.ipo.ipo_index import IPOIndexMetricConfig
 from fme.ace.data_loading.batch_data import BatchData, PairedData
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
@@ -448,7 +448,7 @@ class TestAggregatorConfigMetrics:
         metrics = InferenceEvaluatorAggregatorConfig._default_metrics(
             ctx, n_ensemble_per_ic=1
         )
-        has_ipo = any(isinstance(m, IpoIndexMetricConfig) for m in metrics)
+        has_ipo = any(isinstance(m, IPOIndexMetricConfig) for m in metrics)
         assert has_ipo is expect_ipo
 
     def test_default_metrics_build(self):

--- a/fme/ace/aggregator/inference/test_inference.py
+++ b/fme/ace/aggregator/inference/test_inference.py
@@ -6,7 +6,10 @@ import torch
 import xarray as xr
 
 from fme.ace.aggregator.inference import InferenceAggregatorConfig
+from fme.ace.aggregator.inference.ipo.ipo_index import IPOIndexAggregator
 from fme.ace.data_loading.batch_data import PairedData
+from fme.core.coordinates import LatLonCoordinates
+from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
 
 from .test_evaluator import get_ds_info
@@ -139,6 +142,29 @@ def test_flush_diagnostics(tmpdir):
     ]
     for file in expected_files:
         assert (tmpdir / f"{file}_diagnostics.nc").exists()
+
+
+@pytest.mark.parametrize(
+    "n_timesteps, timestep_days, expect_ipo",
+    [
+        (10 * 12, 30, False),  # 10 years, below threshold
+        (90 * 12, 30, True),  # 90 years, above threshold
+    ],
+)
+def test_ipo_aggregator_registered_for_long_runs(
+    n_timesteps, timestep_days, expect_ipo
+):
+    ds_info = DatasetInfo(
+        horizontal_coordinates=LatLonCoordinates(
+            lon=torch.arange(8), lat=torch.arange(4)
+        ),
+        timestep=datetime.timedelta(days=timestep_days),
+    )
+    agg = InferenceAggregatorConfig().build(
+        ds_info, n_timesteps, save_diagnostics=False
+    )
+    has_ipo = any(isinstance(a, IPOIndexAggregator) for a in agg._aggregators.values())
+    assert has_ipo is expect_ipo
 
 
 def test_agg_raises_without_output_dir():

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -15,7 +15,7 @@ from fme.ace.aggregator.inference.main import (
     EnsoCoefficientMetricConfig,
     EnsoIndexMetricConfig,
     HistogramMetricConfig,
-    IpoIndexMetricConfig,
+    IPOIndexMetricConfig,
     MeanMetricConfig,
     PowerSpectrumMetricConfig,
     SeasonalMetricConfig,
@@ -291,7 +291,7 @@ class InferenceEvaluatorAggregatorConfig:
         if n_timesteps * timestep > SLIGHTLY_LESS_THAN_FIVE_YEARS:
             metrics.append(EnsoCoefficientMetricConfig())
         if include_nino34 and n_timesteps * timestep > APPROXIMATELY_EIGHTY_YEARS:
-            metrics.append(IpoIndexMetricConfig())
+            metrics.append(IPOIndexMetricConfig())
         return metrics
 
     def build(


### PR DESCRIPTION
Changes:
- Added `IPOIndexMetricConfig` to `InferenceEvaluatorAggregatorConfig._default_metrics` for runs > 80 years
- Wired `IPOIndexAggregator` into `InferenceAggregatorConfig.build`
- Added new single-target `IPOIndexAggregator` class 

- [x] Tests added

Resolves #1164 
