### PR TITLE
Remove stale tmp ckpt files

### DIFF
--- a/fme/core/cli.py
+++ b/fme/core/cli.py
@@ -1,5 +1,7 @@
 import argparse
 import dataclasses
+import glob
+import logging
 import os
 import shutil
 from collections.abc import Sequence
@@ -12,6 +14,15 @@ from fme.core.distributed import Distributed
 from fme.core.wandb import WANDB_RUN_ID_FILE, WandB
 
 from .config import update_dict_with_dotlist
+
+
+def remove_stale_tmp_checkpoints(directory: str) -> None:
+    """Remove leftover .tmp checkpoint files from a prior interrupted save."""
+    if not os.path.isdir(directory):
+        return
+    for tmp_file in glob.glob(os.path.join(directory, ".*.tmp")):
+        logging.warning(f"Removing stale temporary checkpoint file: {tmp_file}")
+        os.remove(tmp_file)
 
 
 @dataclasses.dataclass
@@ -49,6 +60,8 @@ class ResumeResultsConfig:
         if dist.is_root():
             # recursively copy all files in existing_dir to experiment_dir
             shutil.copytree(self.existing_dir, experiment_dir, dirs_exist_ok=True)
+            for subdir in ("training_checkpoints", "checkpoints"):
+                remove_stale_tmp_checkpoints(os.path.join(experiment_dir, subdir))
             wandb_run_id_path = os.path.join(experiment_dir, WANDB_RUN_ID_FILE)
             if not self.resume_wandb and os.path.exists(wandb_run_id_path):
                 os.remove(wandb_run_id_path)

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -63,6 +63,7 @@ from typing import Any, ClassVar, Generic, Protocol, TypeVar
 import torch
 
 import fme
+from fme.core.cli import remove_stale_tmp_checkpoints
 from fme.core.distributed import Distributed
 from fme.core.ema import EMAConfig, EMATracker
 from fme.core.generics.aggregator import AggregatorABC, InferenceAggregatorABC
@@ -248,6 +249,8 @@ class Trainer:
                 os.makedirs(config.checkpoint_dir)
         self.config = config
         self.paths = CheckpointPaths(config.checkpoint_dir)
+        if dist.is_root():
+            remove_stale_tmp_checkpoints(self.paths.checkpoint_dir)
 
         if dist.is_root() and not self.config.save_checkpoint:
             logging.warning(

--- a/fme/core/test_cli.py
+++ b/fme/core/test_cli.py
@@ -1,6 +1,6 @@
 import os
 
-from .cli import prepare_config, prepare_directory
+from .cli import prepare_config, prepare_directory, remove_stale_tmp_checkpoints
 
 
 def test_prepare_config(tmp_path):
@@ -24,3 +24,35 @@ def test_prepare_directory(tmp_path):
     config_data = {"a": 2}
     prepare_directory(path, config_data)
     assert os.path.exists(path / "config.yaml")
+
+
+def test_remove_stale_tmp_checkpoints_removes_multiple_tmp_files(tmp_path):
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+    tmp1 = ckpt_dir / ".uuid-1.tmp"
+    tmp2 = ckpt_dir / ".uuid-2.tmp"
+    tmp1.write_bytes(b"data1")
+    tmp2.write_bytes(b"data2")
+    valid_ckpt = ckpt_dir / "latest.ckpt"
+    valid_ckpt.write_bytes(b"valid")
+
+    remove_stale_tmp_checkpoints(str(ckpt_dir))
+
+    assert not tmp1.exists()
+    assert not tmp2.exists()
+    assert valid_ckpt.exists()
+
+
+def test_remove_stale_tmp_checkpoints_nonexistent_dir(tmp_path):
+    remove_stale_tmp_checkpoints(str(tmp_path / "does_not_exist"))
+
+
+def test_remove_stale_tmp_checkpoints_no_tmp_files(tmp_path):
+    ckpt_dir = tmp_path / "training_checkpoints"
+    ckpt_dir.mkdir()
+    valid_ckpt = ckpt_dir / "ckpt.tar"
+    valid_ckpt.write_bytes(b"valid checkpoint")
+
+    remove_stale_tmp_checkpoints(str(ckpt_dir))
+
+    assert valid_ckpt.exists()

--- a/fme/core/test_cli.py
+++ b/fme/core/test_cli.py
@@ -42,17 +42,10 @@ def test_remove_stale_tmp_checkpoints_removes_multiple_tmp_files(tmp_path):
     assert not tmp2.exists()
     assert valid_ckpt.exists()
 
-
-def test_remove_stale_tmp_checkpoints_nonexistent_dir(tmp_path):
-    remove_stale_tmp_checkpoints(str(tmp_path / "does_not_exist"))
-
-
-def test_remove_stale_tmp_checkpoints_no_tmp_files(tmp_path):
-    ckpt_dir = tmp_path / "training_checkpoints"
-    ckpt_dir.mkdir()
-    valid_ckpt = ckpt_dir / "ckpt.tar"
-    valid_ckpt.write_bytes(b"valid checkpoint")
-
     remove_stale_tmp_checkpoints(str(ckpt_dir))
 
     assert valid_ckpt.exists()
+
+
+def test_remove_stale_tmp_checkpoints_nonexistent_dir(tmp_path):
+    remove_stale_tmp_checkpoints(str(tmp_path / "does_not_exist"))

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -12,7 +12,7 @@ import dacite
 import torch
 import yaml
 
-from fme.core.cli import prepare_directory
+from fme.core.cli import prepare_directory, remove_stale_tmp_checkpoints
 from fme.core.dicts import to_flat_dict
 from fme.core.distributed import Distributed
 from fme.core.ema import EMAConfig, EMATracker
@@ -117,6 +117,8 @@ class Trainer:
                 self.config.checkpoint_dir
             ):
                 os.makedirs(self.config.checkpoint_dir)
+            if self.config.checkpoint_dir is not None:
+                remove_stale_tmp_checkpoints(self.config.checkpoint_dir)
 
         self.epoch_checkpoint_path: str | None = None
 
@@ -535,6 +537,7 @@ def _resume_from_results_dir_if_not_preempted(experiment_dir, resume_results_dir
                 f"Existing results directory {resume_results_dir} does not exist."
             )
         shutil.copytree(resume_results_dir, experiment_dir, dirs_exist_ok=True)
+        remove_stale_tmp_checkpoints(os.path.join(experiment_dir, "checkpoints"))
 
 
 def main(config_path: str):


### PR DESCRIPTION
When a training job is hard-killed during checkpoint saving, the `.{uuid}.tmp` partial checkpoint files are left behind. On Beaker, these get captured in result datasets and propagated to resumed jobs via `shutil.copytree`, accumulating multi-GB of wasted space across preemptions. This PR removes these stale tmp files.

Changes:
- Added a `remove_stale_tmp_checkpoints` helper and called during trainer startup, after `shutil.copytree` in `ResumeResultsConfig.prepare_directory`, and downscaling training

- [x] Tests added

Resolves #1165 
