### PR TITLE
Run all forward steps during evaluation with per-step metrics

### DIFF
--- a/fme/ace/aggregator/loss_metrics.py
+++ b/fme/ace/aggregator/loss_metrics.py
@@ -1,0 +1,58 @@
+import torch
+
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+
+
+class PerStepLossAggregator:
+    """Accumulates per-step loss metrics across batches and produces means."""
+
+    def __init__(self):
+        self._sums: dict[str, torch.Tensor] = {}
+        self._counts: dict[str, int] = {}
+
+    def record(self, metrics: dict[str, torch.Tensor]) -> None:
+        for key, value in metrics.items():
+            if key not in self._sums:
+                self._sums[key] = value.detach().clone()
+                self._counts[key] = 1
+            else:
+                self._sums[key] = self._sums[key] + value.detach()
+                self._counts[key] += 1
+
+    def get_logs(self, label: str) -> dict[str, float]:
+        dist = Distributed.get_instance()
+        logs: dict[str, float] = {}
+        for key in sorted(self._sums.keys()):
+            count = self._counts[key]
+            logs[f"{label}/mean/{key}"] = float(
+                dist.reduce_mean(self._sums[key] / count).cpu().numpy()
+            )
+        return logs
+
+
+class PerChannelLossAggregator:
+    """Accumulates per-channel (per-variable) loss values across batches."""
+
+    def __init__(self):
+        self._sums: dict[str, torch.Tensor] = {}
+        self._n_batches = 0
+
+    def record(self, per_channel_losses: dict[str, torch.Tensor]) -> None:
+        self._n_batches += 1
+        for var_name, value in per_channel_losses.items():
+            acc = self._sums.get(
+                var_name,
+                torch.tensor(0.0, device=get_device(), dtype=value.dtype),
+            )
+            self._sums[var_name] = acc + value
+
+    def get_logs(self, label: str) -> dict[str, float]:
+        dist = Distributed.get_instance()
+        logs: dict[str, float] = {}
+        if self._n_batches > 0:
+            for var_name, acc in self._sums.items():
+                logs[f"{label}/mean/loss/{var_name}"] = float(
+                    dist.reduce_mean(acc / self._n_batches).cpu().numpy()
+                )
+        return logs

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 import torch
 
+from fme.ace.aggregator.loss_metrics import PerStepLossAggregator
 from fme.ace.aggregator.one_step.deterministic import (
     DeterministicTrainOutput,
     OneStepDeterministicAggregator,
@@ -10,8 +11,6 @@ from fme.ace.aggregator.one_step.deterministic import (
 from fme.ace.aggregator.one_step.ensemble import get_one_step_ensemble_aggregator
 from fme.ace.stepper import TrainOutput
 from fme.core.dataset_info import DatasetInfo
-from fme.core.device import get_device
-from fme.core.distributed import Distributed
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.tensors import fold_ensemble_dim, fold_sized_ensemble_dim
 from fme.core.typing_ import TensorMapping
@@ -62,25 +61,19 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
             metadata=dataset_info.variable_metadata,
         )
         self._ensemble_recorded = False
-        self._per_step_loss_sums: dict[str, torch.Tensor] = {}
-        self._per_step_loss_counts: dict[str, int] = {}
+        self._per_step_losses = PerStepLossAggregator()
 
     @torch.no_grad()
     def record_batch(
         self,
         batch: TrainOutput,
     ):
-        for key, value in batch.metrics.items():
-            if key.startswith("loss_step_") or key.startswith("loss/"):
-                if key not in self._per_step_loss_sums:
-                    self._per_step_loss_sums[key] = torch.tensor(
-                        0.0, device=get_device()
-                    )
-                    self._per_step_loss_counts[key] = 0
-                self._per_step_loss_sums[key] = (
-                    self._per_step_loss_sums[key] + value.detach()
-                )
-                self._per_step_loss_counts[key] += 1
+        step_metrics = {
+            k: v
+            for k, v in batch.metrics.items()
+            if k.startswith("loss_step_") or k.startswith("loss/")
+        }
+        self._per_step_losses.record(step_metrics)
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
         self._deterministic_aggregator.record_batch(
@@ -108,12 +101,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
             label: Label to prepend to all log keys.
         """
         deterministic_logs = self._deterministic_aggregator.get_logs(label)
-        dist = Distributed.get_instance()
-        for key in sorted(self._per_step_loss_sums.keys()):
-            count = self._per_step_loss_counts[key]
-            deterministic_logs[f"{label}/mean/{key}"] = float(
-                dist.reduce_mean(self._per_step_loss_sums[key] / count).cpu().numpy()
-            )
+        deterministic_logs.update(self._per_step_losses.get_logs(label))
         if self._ensemble_recorded:
             stochastic_logs = self._ensemble_aggregator.get_logs(label)
             if len(set(deterministic_logs.keys()) & set(stochastic_logs.keys())) > 0:

--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -10,6 +10,8 @@ from fme.ace.aggregator.one_step.deterministic import (
 from fme.ace.aggregator.one_step.ensemble import get_one_step_ensemble_aggregator
 from fme.ace.stepper import TrainOutput
 from fme.core.dataset_info import DatasetInfo
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
 from fme.core.generics.aggregator import AggregatorABC
 from fme.core.tensors import fold_ensemble_dim, fold_sized_ensemble_dim
 from fme.core.typing_ import TensorMapping
@@ -60,12 +62,25 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
             metadata=dataset_info.variable_metadata,
         )
         self._ensemble_recorded = False
+        self._per_step_loss_sums: dict[str, torch.Tensor] = {}
+        self._per_step_loss_counts: dict[str, int] = {}
 
     @torch.no_grad()
     def record_batch(
         self,
         batch: TrainOutput,
     ):
+        for key, value in batch.metrics.items():
+            if key.startswith("loss_step_") or key.startswith("loss/"):
+                if key not in self._per_step_loss_sums:
+                    self._per_step_loss_sums[key] = torch.tensor(
+                        0.0, device=get_device()
+                    )
+                    self._per_step_loss_counts[key] = 0
+                self._per_step_loss_sums[key] = (
+                    self._per_step_loss_sums[key] + value.detach()
+                )
+                self._per_step_loss_counts[key] += 1
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
         self._deterministic_aggregator.record_batch(
@@ -93,6 +108,12 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
             label: Label to prepend to all log keys.
         """
         deterministic_logs = self._deterministic_aggregator.get_logs(label)
+        dist = Distributed.get_instance()
+        for key in sorted(self._per_step_loss_sums.keys()):
+            count = self._per_step_loss_counts[key]
+            deterministic_logs[f"{label}/mean/{key}"] = float(
+                dist.reduce_mean(self._per_step_loss_sums[key] / count).cpu().numpy()
+            )
         if self._ensemble_recorded:
             stochastic_logs = self._ensemble_aggregator.get_logs(label)
             if len(set(deterministic_logs.keys()) & set(stochastic_logs.keys())) > 0:

--- a/fme/ace/aggregator/train.py
+++ b/fme/ace/aggregator/train.py
@@ -76,6 +76,8 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
     def __init__(self, config: TrainAggregatorConfig, operations: GriddedOperations):
         self._n_loss_batches = 0
         self._loss = torch.tensor(0.0, device=get_device())
+        self._per_step_loss_sums: dict[str, torch.Tensor] = {}
+        self._per_step_loss_counts: dict[str, int] = {}
         self._per_channel_loss: dict[str, torch.Tensor] = {}
         self._per_channel_loss_enabled = config.per_channel_loss
         self._paired_aggregators: dict[str, Aggregator] = {}
@@ -105,6 +107,16 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
     def record_batch(self, batch: TrainOutput):
         self._loss += batch.metrics["loss"]
         self._n_loss_batches += 1
+        for key, value in batch.metrics.items():
+            if key.startswith("loss_step_"):
+                if key not in self._per_step_loss_sums:
+                    self._per_step_loss_sums[key] = value.detach().clone()
+                    self._per_step_loss_counts[key] = 1
+                else:
+                    self._per_step_loss_sums[key] = (
+                        self._per_step_loss_sums[key] + value.detach()
+                    )
+                    self._per_step_loss_counts[key] += 1
         if self._per_channel_loss_enabled and batch.per_channel_losses is not None:
             for var_name, value in batch.per_channel_losses.items():
                 acc = self._per_channel_loss.get(
@@ -139,6 +151,11 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
         logs[f"{label}/mean/loss"] = float(
             dist.reduce_mean(self._loss / self._n_loss_batches).cpu().numpy()
         )
+        for key in sorted(self._per_step_loss_sums.keys()):
+            count = self._per_step_loss_counts[key]
+            logs[f"{label}/mean/{key}"] = float(
+                dist.reduce_mean(self._per_step_loss_sums[key] / count).cpu().numpy()
+            )
         if self._n_loss_batches > 0 and self._per_channel_loss_enabled:
             for var_name, acc in self._per_channel_loss.items():
                 logs[f"{label}/mean/loss/{var_name}"] = float(

--- a/fme/ace/aggregator/train.py
+++ b/fme/ace/aggregator/train.py
@@ -6,6 +6,10 @@ import torch
 
 from fme.ace.aggregator.inference.data import InferenceBatchData, make_dummy_time
 from fme.ace.aggregator.inference.spectrum import PairedSphericalPowerSpectrumAggregator
+from fme.ace.aggregator.loss_metrics import (
+    PerChannelLossAggregator,
+    PerStepLossAggregator,
+)
 from fme.ace.aggregator.one_step.reduced import MeanAggregator
 from fme.ace.stepper import TrainOutput
 from fme.core.device import get_device
@@ -76,10 +80,10 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
     def __init__(self, config: TrainAggregatorConfig, operations: GriddedOperations):
         self._n_loss_batches = 0
         self._loss = torch.tensor(0.0, device=get_device())
-        self._per_step_loss_sums: dict[str, torch.Tensor] = {}
-        self._per_step_loss_counts: dict[str, int] = {}
-        self._per_channel_loss: dict[str, torch.Tensor] = {}
-        self._per_channel_loss_enabled = config.per_channel_loss
+        self._per_step_losses = PerStepLossAggregator()
+        self._per_channel_losses: PerChannelLossAggregator | None = (
+            PerChannelLossAggregator() if config.per_channel_loss else None
+        )
         self._paired_aggregators: dict[str, Aggregator] = {}
         if config.spherical_power_spectrum:
             try:
@@ -107,23 +111,15 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
     def record_batch(self, batch: TrainOutput):
         self._loss += batch.metrics["loss"]
         self._n_loss_batches += 1
-        for key, value in batch.metrics.items():
-            if key.startswith("loss_step_"):
-                if key not in self._per_step_loss_sums:
-                    self._per_step_loss_sums[key] = value.detach().clone()
-                    self._per_step_loss_counts[key] = 1
-                else:
-                    self._per_step_loss_sums[key] = (
-                        self._per_step_loss_sums[key] + value.detach()
-                    )
-                    self._per_step_loss_counts[key] += 1
-        if self._per_channel_loss_enabled and batch.per_channel_losses is not None:
-            for var_name, value in batch.per_channel_losses.items():
-                acc = self._per_channel_loss.get(
-                    var_name,
-                    torch.tensor(0.0, device=get_device(), dtype=value.dtype),
-                )
-                self._per_channel_loss[var_name] = acc + value
+        step_metrics = {
+            k: v for k, v in batch.metrics.items() if k.startswith("loss_step_")
+        }
+        self._per_step_losses.record(step_metrics)
+        if (
+            self._per_channel_losses is not None
+            and batch.per_channel_losses is not None
+        ):
+            self._per_channel_losses.record(batch.per_channel_losses)
 
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
@@ -151,16 +147,9 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
         logs[f"{label}/mean/loss"] = float(
             dist.reduce_mean(self._loss / self._n_loss_batches).cpu().numpy()
         )
-        for key in sorted(self._per_step_loss_sums.keys()):
-            count = self._per_step_loss_counts[key]
-            logs[f"{label}/mean/{key}"] = float(
-                dist.reduce_mean(self._per_step_loss_sums[key] / count).cpu().numpy()
-            )
-        if self._n_loss_batches > 0 and self._per_channel_loss_enabled:
-            for var_name, acc in self._per_channel_loss.items():
-                logs[f"{label}/mean/loss/{var_name}"] = float(
-                    dist.reduce_mean(acc / self._n_loss_batches).cpu().numpy()
-                )
+        logs.update(self._per_step_losses.get_logs(label))
+        if self._per_channel_losses is not None:
+            logs.update(self._per_channel_losses.get_logs(label))
         return logs
 
     @torch.no_grad()

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1534,6 +1534,7 @@ class TrainStepper(
         data: BatchData,
         optimization: OptimizationABC,
         compute_derived_variables: bool = False,
+        evaluate_all_steps: bool = False,
     ) -> TrainOutput:
         """
         Train the model on a batch of data with one or more forward steps.
@@ -1550,6 +1551,9 @@ class TrainStepper(
                 Use `NullOptimization` to disable training.
             compute_derived_variables: Whether to compute derived variables for the
                 prediction and target data.
+            evaluate_all_steps: When True, run all available forward steps and
+                compute per-step metrics for each, but only count steps within
+                the stochastically-sampled range toward the accumulated loss.
 
         Returns:
             The loss metrics, the generated data, the normalized generated data,
@@ -1570,6 +1574,7 @@ class TrainStepper(
             target_data,
             optimization,
             metrics,
+            evaluate_all_steps=evaluate_all_steps,
         )
 
         regularizer_loss = self._stepper.get_regularizer_loss()
@@ -1605,6 +1610,7 @@ class TrainStepper(
         target_data: BatchData,
         optimization: OptimizationABC,
         metrics: dict[str, float],
+        evaluate_all_steps: bool = False,
     ) -> tuple[list[EnsembleTensorDict], dict[str, torch.Tensor] | None]:
         input_data = data.get_start(self._prognostic_names, self.n_ic_timesteps)
         # output from self.predict_paired does not include initial condition
@@ -1627,6 +1633,7 @@ class TrainStepper(
         )
         output_list: list[EnsembleTensorDict] = []
         output_iterator = iter(output_generator)
+        n_loss_steps = n_forward_steps
         sampler = (
             self._n_forward_steps_sampler
             if self._is_training
@@ -1642,11 +1649,14 @@ class TrainStepper(
                     "This is supposed to be ensured by the StepperConfig when train "
                     "data requirements are retrieved, so this is a bug."
                 )
-            n_forward_steps = stochastic_n_forward_steps
+            n_loss_steps = stochastic_n_forward_steps
+            if not evaluate_all_steps:
+                n_forward_steps = stochastic_n_forward_steps
         per_channel_sum: dict[str, torch.Tensor] | None = None
         for step in range(n_forward_steps):
-            optimize_step = (
-                step == n_forward_steps - 1 or not self._config.optimize_last_step_only
+            counts_toward_loss = step < n_loss_steps
+            optimize_step = counts_toward_loss and (
+                step == n_loss_steps - 1 or not self._config.optimize_last_step_only
             )
             if optimize_step:
                 context = contextlib.nullcontext()
@@ -1667,12 +1677,15 @@ class TrainStepper(
                 step_loss = self._loss_obj(gen_step, target_step, step=step)
                 step_total_loss = step_loss.total()
                 metrics[f"loss_step_{step}"] = step_total_loss.detach()
-                per_ch = step_loss.get_channel_losses()
-                if per_channel_sum is None:
-                    per_channel_sum = {k: v.detach().clone() for k, v in per_ch.items()}
-                else:
-                    for k in per_channel_sum:
-                        per_channel_sum[k] = per_channel_sum[k] + per_ch[k].detach()
+                if counts_toward_loss:
+                    per_ch = step_loss.get_channel_losses()
+                    if per_channel_sum is None:
+                        per_channel_sum = {
+                            k: v.detach().clone() for k, v in per_ch.items()
+                        }
+                    else:
+                        for k in per_channel_sum:
+                            per_channel_sum[k] = per_channel_sum[k] + per_ch[k].detach()
             if optimize_step:
                 optimization.accumulate_loss(step_total_loss)
         return output_list, per_channel_sum

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1653,11 +1653,13 @@ class TrainStepper(
             if not evaluate_all_steps:
                 n_forward_steps = stochastic_n_forward_steps
         per_channel_sum: dict[str, torch.Tensor] | None = None
+        last_optimization_window_step = n_loss_steps - 1
         for step in range(n_forward_steps):
-            counts_toward_loss = step < n_loss_steps
-            optimize_step = counts_toward_loss and (
-                step == n_loss_steps - 1 or not self._config.optimize_last_step_only
-            )
+            within_optimization_window = step < n_loss_steps
+            if self._config.optimize_last_step_only:
+                optimize_step = step == last_optimization_window_step
+            else:
+                optimize_step = within_optimization_window
             if optimize_step:
                 context = contextlib.nullcontext()
             else:
@@ -1666,8 +1668,6 @@ class TrainStepper(
                 gen_step = next(output_iterator)
                 gen_step = unfold_ensemble_dim(gen_step, n_ensemble=n_ensemble)
                 output_list.append(gen_step)
-                # Note: here we examine the loss for a single timestep,
-                # not a single model call (which may contain multiple timesteps).
                 target_step = add_ensemble_dim(
                     {
                         k: v.select(self.TIME_DIM, step)
@@ -1677,7 +1677,7 @@ class TrainStepper(
                 step_loss = self._loss_obj(gen_step, target_step, step=step)
                 step_total_loss = step_loss.total()
                 metrics[f"loss_step_{step}"] = step_total_loss.detach()
-                if counts_toward_loss:
+                if optimize_step:
                     per_ch = step_loss.get_channel_losses()
                     if per_channel_sum is None:
                         per_channel_sum = {

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -441,6 +441,45 @@ def test_train_on_batch_optimize_last_step_only(optimize_last_step_only: bool):
         assert all(forward_calls_grad_enabled)
 
 
+def test_per_channel_losses_bounded_by_accumulated_loss():
+    """Per-channel loss total must not exceed optimization accumulated loss."""
+    torch.manual_seed(0)
+
+    n_steps = 4
+    data_with_ic: BatchData = get_data(["a", "b"], n_samples=5, n_time=n_steps + 1).data
+
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": torch.nn.Identity()}
+                    ),
+                    in_names=["a", "b"],
+                    out_names=["a", "b"],
+                    normalization=NetworkAndLossNormalizationConfig(
+                        network=NormalizationConfig(
+                            means=get_scalar_data(["a", "b"], 0.0),
+                            stds=get_scalar_data(["a", "b"], 1.0),
+                        ),
+                    ),
+                )
+            ),
+        ),
+    )
+    stepper = _get_train_stepper(
+        config,
+        optimize_last_step_only=True,
+    )
+    optimization = NullOptimization()
+    stepped = stepper.train_on_batch(data=data_with_ic, optimization=optimization)
+    accumulated_loss = stepped.metrics["loss"]
+    assert stepped.per_channel_losses is not None
+    per_channel_total = sum(stepped.per_channel_losses.values())
+    assert per_channel_total <= accumulated_loss + 1e-6
+
+
 def test_train_on_batch_with_prescribed_ocean():
     torch.manual_seed(0)
 

--- a/fme/core/generics/test_lr_tuning.py
+++ b/fme/core/generics/test_lr_tuning.py
@@ -79,6 +79,7 @@ class _Stepper(TrainStepperABC["None", "_BatchData", "None", "None", "_TrainOutp
         data: "_BatchData",
         optimization: OptimizationABC,
         compute_derived_variables: bool = False,
+        evaluate_all_steps: bool = False,
     ) -> _TrainOutput:
         x = torch.ones(1, 1, device=get_device())
         loss = self._modules[0](x).sum()

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -200,6 +200,7 @@ class TrainStepper(TrainStepperABC[PSType, BDType, FDType, SDType, TrainOutput])
         batch: BDType,
         optimization: OptimizationABC,
         compute_derived_variables: bool = False,
+        evaluate_all_steps: bool = False,
     ) -> TrainOutput:
         optimization.accumulate_loss(torch.tensor(float("inf")))
         optimization.step_weights()

--- a/fme/core/generics/train_stepper.py
+++ b/fme/core/generics/train_stepper.py
@@ -31,6 +31,7 @@ class TrainStepperABC(abc.ABC, Generic[PS, BD, FD, SD, TO]):
         data: BD,
         optimization: OptimizationABC,
         compute_derived_variables: bool = False,
+        evaluate_all_steps: bool = False,
     ) -> TO:
         pass
 

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -575,7 +575,9 @@ class Trainer:
                 stop_batch=self.config.train_evaluation_batches
             ):
                 with GlobalTimer():
-                    stepped = self.stepper.train_on_batch(batch, self._no_optimization)
+                    stepped = self.stepper.train_on_batch(
+                        batch, self._no_optimization, evaluate_all_steps=True
+                    )
                 aggregator.record_batch(stepped)
         if (
             self._should_save_checkpoints()

--- a/fme/core/generics/validation.py
+++ b/fme/core/generics/validation.py
@@ -62,6 +62,7 @@ def run_validation_loop(
                 batch,
                 optimization=no_opt,
                 compute_derived_variables=compute_derived_variables,
+                evaluate_all_steps=True,
             )
             with timer.context("aggregator"):
                 aggregator.record_batch(batch=stepped)

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -59,18 +59,38 @@ class TrainAggregator(AggregatorABC[CoupledTrainOutput]):
     def __init__(self):
         self._n_batches = 0
         self._loss = torch.tensor(0.0, device=get_device())
+        self._per_step_loss_sums: dict[str, torch.Tensor] = {}
+        self._per_step_loss_counts: dict[str, int] = {}
 
     @torch.no_grad()
     def record_batch(self, batch: CoupledTrainOutput):
         self._loss += batch.total_metrics["loss"]
         self._n_batches += 1
+        for component in (batch.ocean, batch.atmosphere):
+            for key, value in component.metrics.items():
+                if key.startswith("loss/"):
+                    if key not in self._per_step_loss_sums:
+                        self._per_step_loss_sums[key] = torch.tensor(
+                            0.0, device=get_device()
+                        )
+                        self._per_step_loss_counts[key] = 0
+                    self._per_step_loss_sums[key] = (
+                        self._per_step_loss_sums[key] + value.detach()
+                    )
+                    self._per_step_loss_counts[key] += 1
 
     @torch.no_grad()
     def get_logs(self, label: str) -> dict[str, torch.Tensor]:
         logs = {f"{label}/mean/loss": self._loss / self._n_batches}
         dist = Distributed.get_instance()
+        for key in sorted(self._per_step_loss_sums.keys()):
+            count = self._per_step_loss_counts[key]
+            logs[f"{label}/mean/{key}"] = float(
+                dist.reduce_mean(self._per_step_loss_sums[key] / count).cpu().numpy()
+            )
         for key in sorted(logs.keys()):
-            logs[key] = float(dist.reduce_mean(logs[key].detach()).cpu().numpy())
+            if isinstance(logs[key], torch.Tensor):
+                logs[key] = float(dist.reduce_mean(logs[key].detach()).cpu().numpy())
         return logs
 
     @torch.no_grad()

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -35,6 +35,7 @@ from fme.ace.aggregator.inference.main import (
     InferenceEvaluatorAggregator as InferenceEvaluatorAggregator_,
 )
 from fme.ace.aggregator.inference.main import MetricConfig as AceMetricConfig
+from fme.ace.aggregator.loss_metrics import PerStepLossAggregator
 from fme.ace.aggregator.one_step.main import OneStepAggregator as OneStepAggregator_
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.device import get_device
@@ -59,38 +60,26 @@ class TrainAggregator(AggregatorABC[CoupledTrainOutput]):
     def __init__(self):
         self._n_batches = 0
         self._loss = torch.tensor(0.0, device=get_device())
-        self._per_step_loss_sums: dict[str, torch.Tensor] = {}
-        self._per_step_loss_counts: dict[str, int] = {}
+        self._per_step_losses = PerStepLossAggregator()
 
     @torch.no_grad()
     def record_batch(self, batch: CoupledTrainOutput):
         self._loss += batch.total_metrics["loss"]
         self._n_batches += 1
         for component in (batch.ocean, batch.atmosphere):
-            for key, value in component.metrics.items():
-                if key.startswith("loss/"):
-                    if key not in self._per_step_loss_sums:
-                        self._per_step_loss_sums[key] = torch.tensor(
-                            0.0, device=get_device()
-                        )
-                        self._per_step_loss_counts[key] = 0
-                    self._per_step_loss_sums[key] = (
-                        self._per_step_loss_sums[key] + value.detach()
-                    )
-                    self._per_step_loss_counts[key] += 1
+            step_metrics = {
+                k: v for k, v in component.metrics.items() if k.startswith("loss/")
+            }
+            self._per_step_losses.record(step_metrics)
 
     @torch.no_grad()
     def get_logs(self, label: str) -> dict[str, torch.Tensor]:
-        logs = {f"{label}/mean/loss": self._loss / self._n_batches}
         dist = Distributed.get_instance()
-        for key in sorted(self._per_step_loss_sums.keys()):
-            count = self._per_step_loss_counts[key]
-            logs[f"{label}/mean/{key}"] = float(
-                dist.reduce_mean(self._per_step_loss_sums[key] / count).cpu().numpy()
-            )
-        for key in sorted(logs.keys()):
-            if isinstance(logs[key], torch.Tensor):
-                logs[key] = float(dist.reduce_mean(logs[key].detach()).cpu().numpy())
+        logs: dict[str, float] = {}
+        logs[f"{label}/mean/loss"] = float(
+            dist.reduce_mean(self._loss / self._n_batches).cpu().numpy()
+        )
+        logs.update(self._per_step_losses.get_logs(label))
         return logs
 
     @torch.no_grad()

--- a/fme/coupled/loss.py
+++ b/fme/coupled/loss.py
@@ -47,6 +47,16 @@ class StepLossABC(abc.ABC):
     def set_eval(self) -> None:
         pass
 
+    def compute_loss(
+        self, prediction: StepPredictionABC, target_data: TensorMapping
+    ) -> torch.Tensor:
+        """Compute the loss for a step unconditionally (ignoring step_is_optimized).
+
+        Used during evaluation to produce per-step metrics for all steps.
+        Returns zero for null/zero-weight losses.
+        """
+        return torch.tensor(0.0, device=get_device())
+
     @abc.abstractmethod
     def n_required_forward_steps(self) -> int:
         """Number of consecutive leading forward steps that must be computed
@@ -247,6 +257,14 @@ class LossContributions(StepLossABC):
             last_optimized_step = min(self._n_steps, self._n_steps_limit) - 1
             return step == last_optimized_step
         return step < self._n_steps
+
+    def compute_loss(
+        self, prediction: StepPredictionABC, target_data: TensorMapping
+    ) -> torch.Tensor:
+        if self._weight == 0.0:
+            return torch.tensor(0.0, device=get_device())
+        loss_output = self._loss(prediction.data, target_data, prediction.step)
+        return self._weight * loss_output.total()
 
     def __call__(
         self, prediction: StepPredictionABC, target_data: TensorMapping

--- a/fme/coupled/loss.py
+++ b/fme/coupled/loss.py
@@ -47,15 +47,15 @@ class StepLossABC(abc.ABC):
     def set_eval(self) -> None:
         pass
 
+    @abc.abstractmethod
     def compute_loss(
         self, prediction: StepPredictionABC, target_data: TensorMapping
     ) -> torch.Tensor:
         """Compute the loss for a step unconditionally (ignoring step_is_optimized).
 
         Used during evaluation to produce per-step metrics for all steps.
-        Returns zero for null/zero-weight losses.
         """
-        return torch.tensor(0.0, device=get_device())
+        ...
 
     @abc.abstractmethod
     def n_required_forward_steps(self) -> int:
@@ -184,6 +184,11 @@ class NullLossContributions(StepLossABC):
 
     def step_is_optimized(self, step: int) -> bool:
         return False
+
+    def compute_loss(
+        self, prediction: StepPredictionABC, target_data: TensorMapping
+    ) -> torch.Tensor:
+        return torch.tensor(0.0, device=get_device())
 
     def __call__(
         self, prediction: StepPredictionABC, target_data: TensorMapping

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -1418,6 +1418,13 @@ class CoupledStepperTrainLoss:
     ) -> bool:
         return self._loss_objs[realm].step_is_optimized(step)
 
+    def compute_loss(
+        self,
+        prediction: ComponentEnsembleStepPrediction,
+        target_data: TensorMapping,
+    ) -> torch.Tensor:
+        return self._loss_objs[prediction.realm].compute_loss(prediction, target_data)
+
     def __call__(
         self,
         prediction: ComponentEnsembleStepPrediction,
@@ -1670,6 +1677,7 @@ class CoupledTrainStepper(
         optimization: OptimizationABC,
         metrics: ComponentStepMetrics,
         output_list: list[ComponentEnsembleStepPrediction],
+        evaluate_all_steps: bool = False,
     ) -> None:
         target_step = {
             k: v.select(time_dim, gen_step.step) for k, v in forward_data.items()
@@ -1680,11 +1688,18 @@ class CoupledTrainStepper(
             step=gen_step.step,
         )
         target_step_ensemble = add_ensemble_dim(target_step)
-        step_loss = self._loss(ensemble_step, target_step_ensemble)
-        if step_loss is not None:
+        if evaluate_all_steps:
+            step_loss = self._loss.compute_loss(ensemble_step, target_step_ensemble)
             label = f"loss/{gen_step.realm}_step_{gen_step.step}"
             metrics.add_metric(label, step_loss.detach(), gen_step.realm)
-            optimization.accumulate_loss(step_loss)
+            if self._loss.step_is_optimized(gen_step.realm, gen_step.step):
+                optimization.accumulate_loss(step_loss)
+        else:
+            step_loss = self._loss(ensemble_step, target_step_ensemble)
+            if step_loss is not None:
+                label = f"loss/{gen_step.realm}_step_{gen_step.step}"
+                metrics.add_metric(label, step_loss.detach(), gen_step.realm)
+                optimization.accumulate_loss(step_loss)
         output_list.append(
             ensemble_step.detach_if_using_gradient_accumulation(
                 optimization
@@ -1698,6 +1713,7 @@ class CoupledTrainStepper(
         atmos_forward_data: BatchData,
         optimization: OptimizationABC,
         metrics: ComponentStepMetrics,
+        evaluate_all_steps: bool = False,
     ) -> list[ComponentEnsembleStepPrediction]:
         n_ensemble = self._config.n_ensemble
         data_ensemble = CoupledBatchData(
@@ -1721,13 +1737,16 @@ class CoupledTrainStepper(
         output_iterator = iter(output_generator)
         output_list: list[ComponentEnsembleStepPrediction] = []
         n_outer_steps_data = data.ocean_data.n_timesteps - self.n_ic_timesteps
-        # Clamp to at least 1 outer step so downstream gen_data is non-empty
-        # in the rare case where stochastic samplers yield n_steps=0 for both
-        # realms; that batch contributes zero loss but a valid TrainOutput.
-        n_outer_steps = min(
-            n_outer_steps_data,
-            max(1, self._loss.n_required_outer_steps(self.n_inner_steps)),
-        )
+        if evaluate_all_steps:
+            n_outer_steps = n_outer_steps_data
+        else:
+            # Clamp to at least 1 outer step so downstream gen_data is non-empty
+            # in the rare case where stochastic samplers yield n_steps=0 for both
+            # realms; that batch contributes zero loss but a valid TrainOutput.
+            n_outer_steps = min(
+                n_outer_steps_data,
+                max(1, self._loss.n_required_outer_steps(self.n_inner_steps)),
+            )
         for i_outer in range(n_outer_steps):
             for i_inner in range(self.n_inner_steps):
                 global_atmos_step = i_outer * self.n_inner_steps + i_inner
@@ -1750,6 +1769,7 @@ class CoupledTrainStepper(
                         optimization=optimization,
                         metrics=metrics,
                         output_list=output_list,
+                        evaluate_all_steps=evaluate_all_steps,
                     )
             optimize = self._loss.step_is_optimized("ocean", i_outer)
             grad_context = contextlib.nullcontext() if optimize else torch.no_grad()
@@ -1764,6 +1784,7 @@ class CoupledTrainStepper(
                     optimization=optimization,
                     metrics=metrics,
                     output_list=output_list,
+                    evaluate_all_steps=evaluate_all_steps,
                 )
 
         return output_list
@@ -1802,7 +1823,12 @@ class CoupledTrainStepper(
         optimization.set_mode(self.modules)
         with optimization.autocast():
             output_list = self._accumulate_loss(
-                data, ocean_forward_data, atmos_forward_data, optimization, metrics
+                data,
+                ocean_forward_data,
+                atmos_forward_data,
+                optimization,
+                metrics,
+                evaluate_all_steps=evaluate_all_steps,
             )
 
         loss = optimization.get_accumulated_loss().detach()

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -1773,6 +1773,7 @@ class CoupledTrainStepper(
         data: CoupledBatchData,
         optimization: OptimizationABC,
         compute_derived_variables: bool = False,
+        evaluate_all_steps: bool = False,
     ) -> CoupledTrainOutput:
         """
         Args:
@@ -1782,6 +1783,9 @@ class CoupledTrainStepper(
                 Use `NullOptimization` to disable training.
             compute_derived_variables: Whether to compute derived variables for the
                 prediction and target atmosphere data.
+            evaluate_all_steps: When True, run all available forward steps and
+                compute per-step metrics for each, but only count steps within
+                the stochastically-sampled range toward the accumulated loss.
 
         """
         atmos_forward_data = self.atmosphere.get_forward_data(

--- a/fme/coupled/test_loss.py
+++ b/fme/coupled/test_loss.py
@@ -92,6 +92,11 @@ class _StepLoss(StepLossABC):
     def n_required_forward_steps(self) -> int:
         return 2
 
+    def compute_loss(
+        self, prediction: StepPredictionABC, target_data: TensorMapping
+    ) -> torch.Tensor:
+        return self._loss_obj(prediction.data, target_data, prediction.step)
+
     def __call__(
         self, prediction: StepPredictionABC, target_data: TensorMapping
     ) -> torch.Tensor:


### PR DESCRIPTION
Stacks on #1170. Closes #1172.

During evaluation, the stepper currently only runs forward steps up to the stochastically-sampled count, so per-step loss metrics (e.g. `loss_step_40`) are only produced for the selected range and may not appear at all for longer lead times. This PR makes evaluation run all available forward steps, producing robust per-step loss metrics at every lead time, while still computing the mean loss from only the stochastically-sampled steps to stay congruent with `batch_loss`.

Changes:
- `fme.core.generics.train_stepper.TrainStepperABC.train_on_batch` — add `evaluate_all_steps` parameter (default False)
- `fme.ace.stepper.single_module.TrainStepper._accumulate_loss` — when `evaluate_all_steps=True`, loop over all data steps but only count sampled steps toward accumulated loss; fix pre-existing bug where per-channel losses accumulated for wrong steps with `optimize_last_step_only`
- `fme.coupled.loss.StepLossABC.compute_loss` — now abstract; `NullLossContributions` and `LossContributions` provide concrete implementations
- `fme.coupled.stepper.CoupledStepperTrainLoss.compute_loss` and `CoupledTrainStepper._accumulate_step_loss`/`_accumulate_loss` — coupled evaluation uses all outer steps and logs metrics for every step
- `fme.ace.aggregator.loss_metrics` — new `PerStepLossAggregator` and `PerChannelLossAggregator` sub-aggregator classes
- `fme.ace.aggregator.train.TrainAggregator` — delegates per-step and per-channel loss accumulation to sub-aggregators
- `fme.ace.aggregator.one_step.main.OneStepAggregator` — delegates per-step losses to sub-aggregator
- `fme.coupled.aggregator.TrainAggregator` — delegates per-step losses to sub-aggregator
- `fme.core.generics.trainer` and `fme.core.generics.validation` — pass `evaluate_all_steps=True` during evaluation

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated