### PR TITLE
Fix time_mean variable filter incorrectly affecting channel_mean RMSE

### DIFF
--- a/fme/ace/aggregator/inference/test_time_mean.py
+++ b/fme/ace/aggregator/inference/test_time_mean.py
@@ -147,6 +147,139 @@ def test_bias_values():
     )
 
 
+def test_log_variables_does_not_affect_channel_mean():
+    torch.manual_seed(0)
+    area_weights = torch.ones(1, 1).to(get_device())
+    target_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()),
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 3,
+    }
+    gen_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()) * 2.0,
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 5,
+    }
+    batch = InferenceBatchData(
+        prediction=gen_data_norm,
+        prediction_norm=gen_data_norm,
+        target=target_data_norm,
+        target_norm=target_data_norm,
+        time=make_dummy_time(2, 3),
+        i_time_start=0,
+    )
+    agg = TimeMeanEvaluatorAggregator(
+        LatLonOperations(area_weights),
+        horizontal_dims=["lat", "lon"],
+        target="norm",
+        log_variables=frozenset(["a"]),
+    )
+    agg.record_batch(batch)
+    logs = agg.get_logs(label="time_mean_norm")
+    assert logs["time_mean_norm/rmse/a"] == 1.0
+    assert "time_mean_norm/rmse/b" not in logs
+    assert logs["time_mean_norm/rmse/channel_mean"] == 1.5
+
+
+def test_empty_log_variables_still_computes_channel_mean():
+    torch.manual_seed(0)
+    area_weights = torch.ones(1, 1).to(get_device())
+    agg = TimeMeanEvaluatorAggregator(
+        LatLonOperations(area_weights),
+        horizontal_dims=["lat", "lon"],
+        target="norm",
+        log_variables=frozenset(),
+    )
+    target_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()),
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 3,
+    }
+    gen_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()) * 2.0,
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 5,
+    }
+    agg.record_batch(
+        InferenceBatchData(
+            prediction=gen_data_norm,
+            prediction_norm=gen_data_norm,
+            target=target_data_norm,
+            target_norm=target_data_norm,
+            time=make_dummy_time(2, 3),
+            i_time_start=0,
+        )
+    )
+    logs = agg.get_logs(label="time_mean_norm")
+    assert "time_mean_norm/rmse/a" not in logs
+    assert "time_mean_norm/rmse/b" not in logs
+    assert logs["time_mean_norm/rmse/channel_mean"] == 1.5
+
+
+def test_log_variables_with_channel_mean_names():
+    torch.manual_seed(0)
+    area_weights = torch.ones(1, 1).to(get_device())
+    agg = TimeMeanEvaluatorAggregator(
+        LatLonOperations(area_weights),
+        horizontal_dims=["lat", "lon"],
+        target="norm",
+        channel_mean_names=["a"],
+        log_variables=frozenset(["b"]),
+    )
+    target_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()),
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 3,
+    }
+    gen_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()) * 2.0,
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 5,
+    }
+    agg.record_batch(
+        InferenceBatchData(
+            prediction=gen_data_norm,
+            prediction_norm=gen_data_norm,
+            target=target_data_norm,
+            target_norm=target_data_norm,
+            time=make_dummy_time(2, 3),
+            i_time_start=0,
+        )
+    )
+    logs = agg.get_logs(label="time_mean_norm")
+    assert "time_mean_norm/rmse/a" not in logs
+    assert logs["time_mean_norm/rmse/b"] == 2.0
+    assert logs["time_mean_norm/rmse/channel_mean"] == 1.0
+
+
+def test_log_variables_filters_dataset():
+    torch.manual_seed(0)
+    area_weights = torch.ones(1, 1).to(get_device())
+    agg = TimeMeanEvaluatorAggregator(
+        LatLonOperations(area_weights),
+        horizontal_dims=["lat", "lon"],
+        target="denorm",
+        log_variables=frozenset(["a"]),
+    )
+    target_data = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()),
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 3,
+    }
+    gen_data = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()) * 2.0,
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 5,
+    }
+    agg.record_batch(
+        InferenceBatchData(
+            prediction=gen_data,
+            prediction_norm=gen_data,
+            target=target_data,
+            target_norm=target_data,
+            time=make_dummy_time(2, 3),
+            i_time_start=0,
+        )
+    )
+    ds = agg.get_dataset()
+    assert "bias_map-a" in ds
+    assert "gen_map-a" in ds
+    assert "bias_map-b" not in ds
+    assert "gen_map-b" not in ds
+
+
 def test_aggregator_mean_values():
     area_weights = torch.ones(1, 1).to(get_device())
     agg = TimeMeanAggregator(LatLonOperations(area_weights))

--- a/fme/ace/aggregator/inference/time_mean.py
+++ b/fme/ace/aggregator/inference/time_mean.py
@@ -13,7 +13,7 @@ from fme.core.typing_ import TensorDict, TensorMapping
 from fme.core.wandb import Image
 
 from ..plotting import plot_paneled_data
-from .build_context import MetricBuildContext, maybe_filter
+from .build_context import MetricBuildContext
 from .data import InferenceBatchData, MetricBuildResult, SubAggregator
 
 
@@ -71,6 +71,7 @@ class TimeMeanAggregator:
         target: Literal["norm", "denorm"] = "denorm",
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         reference_means: xr.Dataset | None = None,
+        log_variables: frozenset[str] | None = None,
     ):
         """
         Args:
@@ -81,6 +82,9 @@ class TimeMeanAggregator:
                 used in generating logged image captions.
             reference_means: Dataset containing reference time-mean values
                 for bias computation.
+            log_variables: If provided, only include per-variable entries in
+                get_logs and get_dataset for these variables. All variables
+                are still recorded and available via get_data.
         """
         self._ops = gridded_operations
         self._target = target
@@ -94,6 +98,7 @@ class TimeMeanAggregator:
         self._n_samples: int | None = None
         self._reference_means = reference_means
         self._reference_validated = False
+        self._log_variables = log_variables
 
     @staticmethod
     def _add_or_initialize_time_mean(
@@ -164,6 +169,8 @@ class TimeMeanAggregator:
         data = self.get_data()
         gen_map_key = "gen_map"
         for name, pred in data.items():
+            if self._log_variables is not None and name not in self._log_variables:
+                continue
             if target_maps is not None and name in target_maps:
                 gen_map_caption_key = "gen_target_map"
                 data_panels = [[pred.cpu().numpy()], [target_maps[name].cpu().numpy()]]
@@ -215,6 +222,8 @@ class TimeMeanAggregator:
         dims = ("lat", "lon")
         data = {}
         for name, pred in self.get_data().items():
+            if self._log_variables is not None and name not in self._log_variables:
+                continue
             if name in self._variable_metadata:
                 long_name = self._variable_metadata[name].long_name
                 units = self._variable_metadata[name].units
@@ -253,6 +262,7 @@ class TimeMeanEvaluatorAggregator:
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         reference_means: xr.Dataset | None = None,
         channel_mean_names: Sequence[str] | None = None,
+        log_variables: frozenset[str] | None = None,
     ):
         """
         Args:
@@ -266,6 +276,9 @@ class TimeMeanEvaluatorAggregator:
                 for bias computation.
             channel_mean_names: Names of variables whose RMSE will be averaged. If
                 not provided, all available variables will be used.
+            log_variables: If provided, only include per-variable entries in
+                get_logs and get_dataset for these variables. All variables
+                are still recorded so that channel_mean is computed correctly.
         """
         self._ops = ops
         self._horizontal_dims = horizontal_dims
@@ -275,6 +288,7 @@ class TimeMeanEvaluatorAggregator:
             self._variable_metadata: Mapping[str, VariableMetadata] = {}
         else:
             self._variable_metadata = variable_metadata
+        self._log_variables = log_variables
         # Dictionaries of tensors of shape [n_lat, n_lon] represnting time means
         self._target_agg = TimeMeanAggregator(
             gridded_operations=ops, target=target, variable_metadata=variable_metadata
@@ -284,6 +298,7 @@ class TimeMeanEvaluatorAggregator:
             target=target,
             variable_metadata=variable_metadata,
             reference_means=reference_means,
+            log_variables=log_variables,
         )
         self._channel_mean_names = channel_mean_names
 
@@ -328,21 +343,23 @@ class TimeMeanEvaluatorAggregator:
         bias_map_key = "bias_map"
         rmse_all_channels = {}
         for pred in preds:
-            bias_image = plot_paneled_data(
-                [[pred.bias().cpu().numpy()]],
-                diverging=True,
-                caption=self._get_caption(bias_map_key, pred.name),
-            )
-            plt.close("all")
             rmse_all_channels[pred.name] = pred.rmse()
-            logs.update({f"rmse/{pred.name}": rmse_all_channels[pred.name]})
-            if self._target == "denorm":
-                logs.update(
-                    {
-                        f"{bias_map_key}/{pred.name}": bias_image,
-                        f"bias/{pred.name}": pred.weighted_mean_bias(),
-                    }
+            should_log = self._log_variables is None or pred.name in self._log_variables
+            if should_log:
+                bias_image = plot_paneled_data(
+                    [[pred.bias().cpu().numpy()]],
+                    diverging=True,
+                    caption=self._get_caption(bias_map_key, pred.name),
                 )
+                plt.close("all")
+                logs.update({f"rmse/{pred.name}": rmse_all_channels[pred.name]})
+                if self._target == "denorm":
+                    logs.update(
+                        {
+                            f"{bias_map_key}/{pred.name}": bias_image,
+                            f"bias/{pred.name}": pred.weighted_mean_bias(),
+                        }
+                    )
         if self._target == "norm":
             metric_name = "rmse/channel_mean"
             if self._channel_mean_names is None:
@@ -370,6 +387,8 @@ class TimeMeanEvaluatorAggregator:
         data = {}
         preds = self._get_target_gen_pairs()
         for pred in preds:
+            if self._log_variables is not None and pred.name not in self._log_variables:
+                continue
             if pred.name in self._variable_metadata:
                 long_name = self._variable_metadata[pred.name].long_name
                 units = self._variable_metadata[pred.name].units
@@ -431,5 +450,8 @@ class TimeMeanMetricConfig:
             channel_mean_names=(
                 (self.channel_mean_names or ctx.channel_mean_names) if is_norm else None
             ),
+            log_variables=(
+                frozenset(self.variables) if self.variables is not None else None
+            ),
         )
-        return MetricBuildResult(aggregator=maybe_filter(agg, self.variables))
+        return MetricBuildResult(aggregator=agg)

--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -3,6 +3,7 @@ import dataclasses
 import pytest
 
 from fme.ace.aggregator.inference.main import InferenceEvaluatorAggregatorConfig
+from fme.ace.aggregator.inference.time_mean import TimeMeanMetricConfig
 from fme.ace.data_loading.config import DataLoaderConfig
 from fme.ace.data_loading.inference import (
     InferenceDataLoaderConfig,
@@ -25,7 +26,10 @@ from fme.core.typing_ import Slice
 
 
 def _make_inference_config(
-    name: str | None = None, weight: float = 1.0, epochs: Slice | None = None
+    name: str | None = None,
+    weight: float = 1.0,
+    epochs: Slice | None = None,
+    aggregator: InferenceEvaluatorAggregatorConfig | None = None,
 ) -> InlineInferenceConfig:
     return InlineInferenceConfig(
         loader=InferenceDataLoaderConfig(
@@ -36,7 +40,7 @@ def _make_inference_config(
         ),
         n_forward_steps=1,
         forward_steps_in_memory=1,
-        aggregator=InferenceEvaluatorAggregatorConfig(),
+        aggregator=aggregator or InferenceEvaluatorAggregatorConfig(),
         epochs=epochs if epochs is not None else Slice(),
         name=name,
         weight=weight,
@@ -154,6 +158,22 @@ def test_zero_weight_accepted():
 def test_default_weight_is_one():
     config = _make_inference_config()
     assert config.weight == 1.0
+
+
+def test_disabled_time_mean_norm_with_positive_weight_raises():
+    agg = InferenceEvaluatorAggregatorConfig(
+        time_mean_norm=TimeMeanMetricConfig(target="norm", enabled=False),
+    )
+    with pytest.raises(ValueError, match="time_mean_norm must be enabled"):
+        _make_inference_config(weight=1.0, aggregator=agg)
+
+
+def test_disabled_time_mean_norm_with_zero_weight_accepted():
+    agg = InferenceEvaluatorAggregatorConfig(
+        time_mean_norm=TimeMeanMetricConfig(target="norm", enabled=False),
+    )
+    config = _make_inference_config(weight=0.0, aggregator=agg)
+    assert config.weight == 0.0
 
 
 def test_get_inference_epoch_sets_empty(tmp_path):

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -77,6 +77,16 @@ class InlineInferenceConfig:
             raise ValueError(
                 f"InlineInferenceConfig weight must be non-negative, got {self.weight}"
             )
+        if (
+            self.weight > 0
+            and isinstance(self.aggregator, InferenceEvaluatorAggregatorConfig)
+            and not self.aggregator.time_mean_norm.enabled
+        ):
+            raise ValueError(
+                "time_mean_norm must be enabled when weight > 0, because "
+                "checkpoint selection requires the time_mean_norm/rmse/channel_mean "
+                "metric."
+            )
         dist = Distributed.get_instance()
         if self.loader.start_indices.n_initial_conditions % dist.world_size != 0:
             raise ValueError(


### PR DESCRIPTION
The `variables` config on `TimeMeanMetricConfig` was using `VariableFilterAdapter` to strip variables from input data before the aggregator saw them, which caused the `channel_mean` RMSE (used for checkpoint selection) to be computed over only the filtered subset instead of all `channel_mean_names`. Additionally, disabling `time_mean_norm` on a weighted inference entry would only fail at runtime rather than at config validation.

Changes:
- `TimeMeanAggregator`, `TimeMeanEvaluatorAggregator`: add `log_variables` parameter that controls which per-variable metrics are reported in `get_logs` and `get_dataset`, while always computing RMSE for all variables so that `channel_mean` is correct
- `TimeMeanMetricConfig.build`: pass `variables` as `log_variables` to the aggregator instead of wrapping with `VariableFilterAdapter`
- `InlineInferenceConfig.__post_init__`: reject configs where `time_mean_norm.enabled` is `False` but `weight > 0`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated