### PR TITLE
Have doc strings match parameter name in ParameterInitializationConfig

### DIFF
--- a/fme/ace/stepper/parameter_init.py
+++ b/fme/ace/stepper/parameter_init.py
@@ -104,7 +104,7 @@ class ParameterInitializationConfig:
     pre-trained model, only the initial slice of the weights is overwritten.
 
     Parameters:
-        weight_path: path to a Stepper checkpoint
+        weights_path: path to a Stepper checkpoint
             containing weights to load
         parameters: list of ParameterClassification objects, each specifying
             whether parameters are excluded from initialization or frozen.


### PR DESCRIPTION
Small PR to have the doc string name match the `weights_path` variable name in `ParameterInitializationConfig`.
Changes:
- Doc string from `weight_path` to `weights_path` 
