### PR TITLE
Oversample tropics option in downscaling training

### DIFF
--- a/fme/downscaling/data/__init__.py
+++ b/fme/downscaling/data/__init__.py
@@ -11,7 +11,7 @@ from .datasets import (
     PairedBatchData,
     PairedBatchItem,
     PairedGriddedData,
-    RegionOversamplingConfig,
+    RegionSamplingConfig,
 )
 from .static import StaticInput, StaticInputs, load_coords_from_path, load_static_inputs
 from .utils import (

--- a/fme/downscaling/data/__init__.py
+++ b/fme/downscaling/data/__init__.py
@@ -11,6 +11,7 @@ from .datasets import (
     PairedBatchData,
     PairedBatchItem,
     PairedGriddedData,
+    TropicalOversamplingConfig,
 )
 from .static import StaticInput, StaticInputs, load_coords_from_path, load_static_inputs
 from .utils import (

--- a/fme/downscaling/data/__init__.py
+++ b/fme/downscaling/data/__init__.py
@@ -11,7 +11,7 @@ from .datasets import (
     PairedBatchData,
     PairedBatchItem,
     PairedGriddedData,
-    TropicalOversamplingConfig,
+    RegionOversamplingConfig,
 )
 from .static import StaticInput, StaticInputs, load_coords_from_path, load_static_inputs
 from .utils import (

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -357,7 +357,7 @@ class PairedGriddedData:
         drop_partial_patches: bool = True,
         random_offset: bool = False,
         shuffle: bool = False,
-        tropical_oversampling: "TropicalOversamplingConfig | None" = None,
+        tropical_oversampling: "RegionOversamplingConfig | None" = None,
     ) -> Iterator["PairedBatchData"]:
         patched_generator = patched_batch_gen_from_paired_loader(
             self.loader,
@@ -645,63 +645,63 @@ class ContiguousDistributedSampler(DistributedSampler):
 
 
 @dataclasses.dataclass
-class TropicalOversamplingConfig:
+class RegionOversamplingConfig:
     """
-    Oversample training patches whose center latitude is within
-    +/-lat_threshold degrees of the equator.
+    Oversample training patches whose center falls within a specified
+    lat/lon region.
 
     The total number of patches yielded per batch is unchanged.
     Patches are drawn with replacement from a weighted distribution
-    where tropical patches have relative weight ``multiplier`` and
-    extratropical patches have weight 1. Validation generators
-    should not pass this config so that validation metrics remain
-    comparable across runs.
+    where patches inside the region have relative weight ``multiplier``
+    and patches outside have weight 1. Validation generators should not
+    pass this config so that validation metrics remain comparable across
+    runs.
 
     Parameters:
-        lat_threshold: Half-width of the tropical band in degrees.
-            Patches whose center latitude has absolute value <= this
-            threshold are considered tropical. Must satisfy
-            0 < lat_threshold < 90.
-        multiplier: Relative sampling weight for tropical patches.
-            Must be >= 1. A value of 1 gives uniform sampling
+        lat_interval: Latitude range [start, stop] in degrees defining
+            the oversampled region. If None, all latitudes match.
+        lon_interval: Longitude range [start, stop] in degrees defining
+            the oversampled region. If None, all longitudes match.
+        multiplier: Relative sampling weight for patches inside the
+            region. Must be >= 1. A value of 1 gives uniform sampling
             (no oversampling).
     """
 
-    lat_threshold: float = 30.0
-    multiplier: int = 3
+    lat_interval: ClosedInterval | None = None
+    lon_interval: ClosedInterval | None = None
+    multiplier: float = 1.0
 
     def __post_init__(self):
-        if self.multiplier < 1:
-            raise ValueError(f"multiplier must be >= 1, got {self.multiplier}.")
-        if not (0.0 < self.lat_threshold < 90.0):
-            raise ValueError(
-                "lat_threshold must satisfy 0 < lat_threshold < 90, "
-                f"got {self.lat_threshold}."
-            )
+        if self.multiplier < 0:
+            raise ValueError(f"multiplier must be >= 0, got {self.multiplier}.")
+
+    def get_weight(self, lat: float, lon: float) -> float:
+        lat_match = self.lat_interval is None or lat in self.lat_interval
+        lon_match = self.lon_interval is None or lon in self.lon_interval
+        return self.multiplier if lat_match and lon_match else 1.0
 
 
-def _sample_indices_with_tropical_oversampling(
+def _sample_indices_with_region_oversampling(
     coarse_patches: list[Patch],
     coarse_lats: torch.Tensor,
-    config: TropicalOversamplingConfig,
+    coarse_lons: torch.Tensor,
+    config: RegionOversamplingConfig,
 ) -> list[int]:
     """
     Return a list of ``len(coarse_patches)`` patch indices sampled with
-    replacement from a weighted distribution.  Tropical patches (center
-    latitude within +/-``config.lat_threshold``) receive weight
-    ``config.multiplier``; extratropical patches receive weight 1.
+    replacement from a weighted distribution.  Patches whose center
+    falls within the configured region receive weight
+    ``config.multiplier``; other patches receive weight 1.
 
-    ``coarse_lats`` is a 1-D tensor of the coarse latitude coordinates
-    that each patch's ``input_slice`` indexes into.
+    ``coarse_lats`` and ``coarse_lons`` are 1-D tensors of the coarse
+    latitude and longitude coordinates that each patch's
+    ``input_slice`` indexes into.
     """
     weights: list[float] = []
     for patch in coarse_patches:
-        patch_lats = coarse_lats[patch.input_slice.y]
-        center_lat = float(patch_lats.mean().item())
-        if abs(center_lat) <= config.lat_threshold:
-            weights.append(float(config.multiplier))
-        else:
-            weights.append(1.0)
+        center_lat = float(coarse_lats[patch.input_slice.y].mean().item())
+        center_lon = float(coarse_lons[patch.input_slice.x].mean().item())
+        weights.append(config.get_weight(center_lat, center_lon))
     return random.choices(
         range(len(coarse_patches)), weights=weights, k=len(coarse_patches)
     )
@@ -783,7 +783,7 @@ def patched_batch_gen_from_paired_loader(
     drop_partial_patches: bool = True,
     random_offset: bool = False,
     shuffle: bool = False,
-    tropical_oversampling: TropicalOversamplingConfig | None = None,
+    tropical_oversampling: RegionOversamplingConfig | None = None,
 ) -> Iterator[PairedBatchData]:
     for batch in loader:
         coarse_patches, fine_patches = _get_paired_patches(
@@ -798,8 +798,9 @@ def patched_batch_gen_from_paired_loader(
         if tropical_oversampling is not None:
             assert fine_patches is not None  # downscale_factor was provided
             coarse_lats = batch.coarse.latlon_coordinates.lat[0]
-            indices = _sample_indices_with_tropical_oversampling(
-                coarse_patches, coarse_lats, tropical_oversampling
+            coarse_lons = batch.coarse.latlon_coordinates.lon[0]
+            indices = _sample_indices_with_region_oversampling(
+                coarse_patches, coarse_lats, coarse_lons, tropical_oversampling
             )
             coarse_patches = [coarse_patches[i] for i in indices]
             fine_patches = [fine_patches[i] for i in indices]

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -795,7 +795,9 @@ def patched_batch_gen_from_paired_loader(
         )
         if region_sampling is not None:
             assert fine_patches is not None  # downscale_factor was provided
-            coarse_lats = batch.coarse.latlon_coordinates.lat[0]
+            coarse_lats = batch.coarse.latlon_coordinates.lat[
+                0
+            ]  # dims are [batch, lat, lon]
             coarse_lons = batch.coarse.latlon_coordinates.lon[0]
             indices = _sample_indices_with_region_sampling(
                 coarse_patches, coarse_lats, coarse_lons, region_sampling

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -794,10 +794,10 @@ def patched_batch_gen_from_paired_loader(
             drop_partial_patches=drop_partial_patches,
         )
         if region_sampling is not None:
-            assert fine_patches is not None  # downscale_factor was provided
+            assert fine_patches is not None  # for type checking
             coarse_lats = batch.coarse.latlon_coordinates.lat[
                 0
-            ]  # dims are [batch, lat, lon]
+            ]  # dims are [batch, lat/lon]
             coarse_lons = batch.coarse.latlon_coordinates.lon[0]
             indices = _sample_indices_with_region_sampling(
                 coarse_patches, coarse_lats, coarse_lons, region_sampling

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -357,7 +357,7 @@ class PairedGriddedData:
         drop_partial_patches: bool = True,
         random_offset: bool = False,
         shuffle: bool = False,
-        region_oversampling: "RegionOversamplingConfig | None" = None,
+        region_sampling: "RegionSamplingConfig | None" = None,
     ) -> Iterator["PairedBatchData"]:
         patched_generator = patched_batch_gen_from_paired_loader(
             self.loader,
@@ -368,7 +368,7 @@ class PairedGriddedData:
             drop_partial_patches=drop_partial_patches,
             random_offset=random_offset,
             shuffle=shuffle,
-            region_oversampling=region_oversampling,
+            region_sampling=region_sampling,
         )
         return cast(
             Iterator[PairedBatchData],
@@ -645,53 +645,51 @@ class ContiguousDistributedSampler(DistributedSampler):
 
 
 @dataclasses.dataclass
-class RegionOversamplingConfig:
+class RegionSamplingConfig:
     """
-    Oversample training patches whose center falls within a specified
-    lat/lon region.
+    Configures weighted sampling of training patches whose center falls
+    within the specified lat/lon region.
 
-    The total number of patches yielded per batch is unchanged.
-    Patches are drawn with replacement from a weighted distribution
-    where patches inside the region have relative weight ``multiplier``
-    and patches outside have weight 1. Validation generators should not
-    pass this config so that validation metrics remain comparable across
-    runs.
+    The total number of patches yielded per batch remains the same as
+    without sampling a region. Patches are drawn with replacement from
+    a weighted distribution where patches inside the region have relative
+    weight ``weight`` and patches outside have weight 1.
 
     Parameters:
         lat_interval: Latitude range [start, stop] in degrees defining
             the oversampled region. If None, all latitudes match.
         lon_interval: Longitude range [start, stop] in degrees defining
             the oversampled region. If None, all longitudes match.
-        multiplier: Relative sampling weight for patches inside the
+        weight: Relative sampling weight for patches inside the
             region. Must be > 0. A value of 1 gives uniform sampling
             (no oversampling).
     """
 
     lat_interval: ClosedInterval | None = None
     lon_interval: ClosedInterval | None = None
-    multiplier: float = 1.0
+    weight: float = 1.0
 
     def __post_init__(self):
-        if self.multiplier <= 0:
-            raise ValueError(f"multiplier must be > 0, got {self.multiplier}.")
+        if self.weight <= 0:
+            raise ValueError(f"weight must be > 0, got {self.weight}.")
 
     def get_weight(self, lat: float, lon: float) -> float:
         lat_match = self.lat_interval is None or lat in self.lat_interval
         lon_match = self.lon_interval is None or lon in self.lon_interval
-        return self.multiplier if lat_match and lon_match else 1.0
+        return self.weight if lat_match and lon_match else 1.0
 
 
-def _sample_indices_with_region_oversampling(
+def _sample_indices_with_region_sampling(
     coarse_patches: list[Patch],
     coarse_lats: torch.Tensor,
     coarse_lons: torch.Tensor,
-    config: RegionOversamplingConfig,
+    config: RegionSamplingConfig,
 ) -> list[int]:
     """
     Return a list of ``len(coarse_patches)`` patch indices sampled with
     replacement from a weighted distribution.  Patches whose center
     falls within the configured region receive weight
-    ``config.multiplier``; other patches receive weight 1.
+    ``config.weight``; other patches receive weight 1.
 
     ``coarse_lats`` and ``coarse_lons`` are 1-D tensors of the coarse
     latitude and longitude coordinates that each patch's
@@ -783,7 +781,7 @@ def patched_batch_gen_from_paired_loader(
     drop_partial_patches: bool = True,
     random_offset: bool = False,
     shuffle: bool = False,
-    region_oversampling: RegionOversamplingConfig | None = None,
+    region_sampling: RegionSamplingConfig | None = None,
 ) -> Iterator[PairedBatchData]:
     for batch in loader:
         coarse_patches, fine_patches = _get_paired_patches(
@@ -795,12 +793,12 @@ def patched_batch_gen_from_paired_loader(
             shuffle=shuffle,
             drop_partial_patches=drop_partial_patches,
         )
-        if region_oversampling is not None:
+        if region_sampling is not None:
             assert fine_patches is not None  # downscale_factor was provided
             coarse_lats = batch.coarse.latlon_coordinates.lat[0]
             coarse_lons = batch.coarse.latlon_coordinates.lon[0]
-            indices = _sample_indices_with_region_oversampling(
-                coarse_patches, coarse_lats, coarse_lons, region_oversampling
+            indices = _sample_indices_with_region_sampling(
+                coarse_patches, coarse_lats, coarse_lons, region_sampling
             )
             coarse_patches = [coarse_patches[i] for i in indices]
             fine_patches = [fine_patches[i] for i in indices]

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import math
+import random
 from collections.abc import Iterator, Mapping, Sequence
 from typing import Literal, Self, cast
 
@@ -356,6 +357,7 @@ class PairedGriddedData:
         drop_partial_patches: bool = True,
         random_offset: bool = False,
         shuffle: bool = False,
+        tropical_oversampling: "TropicalOversamplingConfig | None" = None,
     ) -> Iterator["PairedBatchData"]:
         patched_generator = patched_batch_gen_from_paired_loader(
             self.loader,
@@ -366,6 +368,7 @@ class PairedGriddedData:
             drop_partial_patches=drop_partial_patches,
             random_offset=random_offset,
             shuffle=shuffle,
+            tropical_oversampling=tropical_oversampling,
         )
         return cast(
             Iterator[PairedBatchData],
@@ -641,6 +644,69 @@ class ContiguousDistributedSampler(DistributedSampler):
         return iter(indices[start:end])
 
 
+@dataclasses.dataclass
+class TropicalOversamplingConfig:
+    """
+    Oversample training patches whose center latitude is within
+    +/-lat_threshold degrees of the equator.
+
+    The total number of patches yielded per batch is unchanged.
+    Patches are drawn with replacement from a weighted distribution
+    where tropical patches have relative weight ``multiplier`` and
+    extratropical patches have weight 1. Validation generators
+    should not pass this config so that validation metrics remain
+    comparable across runs.
+
+    Parameters:
+        lat_threshold: Half-width of the tropical band in degrees.
+            Patches whose center latitude has absolute value <= this
+            threshold are considered tropical. Must satisfy
+            0 < lat_threshold < 90.
+        multiplier: Relative sampling weight for tropical patches.
+            Must be >= 1. A value of 1 gives uniform sampling
+            (no oversampling).
+    """
+
+    lat_threshold: float = 30.0
+    multiplier: int = 3
+
+    def __post_init__(self):
+        if self.multiplier < 1:
+            raise ValueError(f"multiplier must be >= 1, got {self.multiplier}.")
+        if not (0.0 < self.lat_threshold < 90.0):
+            raise ValueError(
+                "lat_threshold must satisfy 0 < lat_threshold < 90, "
+                f"got {self.lat_threshold}."
+            )
+
+
+def _sample_indices_with_tropical_oversampling(
+    coarse_patches: list[Patch],
+    coarse_lats: torch.Tensor,
+    config: TropicalOversamplingConfig,
+) -> list[int]:
+    """
+    Return a list of ``len(coarse_patches)`` patch indices sampled with
+    replacement from a weighted distribution.  Tropical patches (center
+    latitude within +/-``config.lat_threshold``) receive weight
+    ``config.multiplier``; extratropical patches receive weight 1.
+
+    ``coarse_lats`` is a 1-D tensor of the coarse latitude coordinates
+    that each patch's ``input_slice`` indexes into.
+    """
+    weights: list[float] = []
+    for patch in coarse_patches:
+        patch_lats = coarse_lats[patch.input_slice.y]
+        center_lat = float(patch_lats.mean().item())
+        if abs(center_lat) <= config.lat_threshold:
+            weights.append(float(config.multiplier))
+        else:
+            weights.append(1.0)
+    return random.choices(
+        range(len(coarse_patches)), weights=weights, k=len(coarse_patches)
+    )
+
+
 # downscale_factor=None means fine patches not needed here, but reusing
 # _get_paired_patches in both paired and no-target cases to share the
 # coincident offset logic.
@@ -717,6 +783,7 @@ def patched_batch_gen_from_paired_loader(
     drop_partial_patches: bool = True,
     random_offset: bool = False,
     shuffle: bool = False,
+    tropical_oversampling: TropicalOversamplingConfig | None = None,
 ) -> Iterator[PairedBatchData]:
     for batch in loader:
         coarse_patches, fine_patches = _get_paired_patches(
@@ -728,4 +795,12 @@ def patched_batch_gen_from_paired_loader(
             shuffle=shuffle,
             drop_partial_patches=drop_partial_patches,
         )
+        if tropical_oversampling is not None:
+            assert fine_patches is not None  # downscale_factor was provided
+            coarse_lats = batch.coarse.latlon_coordinates.lat[0]
+            indices = _sample_indices_with_tropical_oversampling(
+                coarse_patches, coarse_lats, tropical_oversampling
+            )
+            coarse_patches = [coarse_patches[i] for i in indices]
+            fine_patches = [fine_patches[i] for i in indices]
         yield from batch.generate_from_patches(coarse_patches, fine_patches)

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -357,7 +357,7 @@ class PairedGriddedData:
         drop_partial_patches: bool = True,
         random_offset: bool = False,
         shuffle: bool = False,
-        tropical_oversampling: "RegionOversamplingConfig | None" = None,
+        region_oversampling: "RegionOversamplingConfig | None" = None,
     ) -> Iterator["PairedBatchData"]:
         patched_generator = patched_batch_gen_from_paired_loader(
             self.loader,
@@ -368,7 +368,7 @@ class PairedGriddedData:
             drop_partial_patches=drop_partial_patches,
             random_offset=random_offset,
             shuffle=shuffle,
-            tropical_oversampling=tropical_oversampling,
+            region_oversampling=region_oversampling,
         )
         return cast(
             Iterator[PairedBatchData],
@@ -663,7 +663,7 @@ class RegionOversamplingConfig:
         lon_interval: Longitude range [start, stop] in degrees defining
             the oversampled region. If None, all longitudes match.
         multiplier: Relative sampling weight for patches inside the
-            region. Must be >= 1. A value of 1 gives uniform sampling
+            region. Must be > 0. A value of 1 gives uniform sampling
             (no oversampling).
     """
 
@@ -672,8 +672,8 @@ class RegionOversamplingConfig:
     multiplier: float = 1.0
 
     def __post_init__(self):
-        if self.multiplier < 0:
-            raise ValueError(f"multiplier must be >= 0, got {self.multiplier}.")
+        if self.multiplier <= 0:
+            raise ValueError(f"multiplier must be > 0, got {self.multiplier}.")
 
     def get_weight(self, lat: float, lon: float) -> float:
         lat_match = self.lat_interval is None or lat in self.lat_interval
@@ -783,7 +783,7 @@ def patched_batch_gen_from_paired_loader(
     drop_partial_patches: bool = True,
     random_offset: bool = False,
     shuffle: bool = False,
-    tropical_oversampling: RegionOversamplingConfig | None = None,
+    region_oversampling: RegionOversamplingConfig | None = None,
 ) -> Iterator[PairedBatchData]:
     for batch in loader:
         coarse_patches, fine_patches = _get_paired_patches(
@@ -795,12 +795,12 @@ def patched_batch_gen_from_paired_loader(
             shuffle=shuffle,
             drop_partial_patches=drop_partial_patches,
         )
-        if tropical_oversampling is not None:
+        if region_oversampling is not None:
             assert fine_patches is not None  # downscale_factor was provided
             coarse_lats = batch.coarse.latlon_coordinates.lat[0]
             coarse_lons = batch.coarse.latlon_coordinates.lon[0]
             indices = _sample_indices_with_region_oversampling(
-                coarse_patches, coarse_lats, coarse_lons, tropical_oversampling
+                coarse_patches, coarse_lats, coarse_lons, region_oversampling
             )
             coarse_patches = [coarse_patches[i] for i in indices]
             fine_patches = [fine_patches[i] for i in indices]

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -15,8 +15,8 @@ from fme.downscaling.data.datasets import (
     LatLonCoordinates,
     PairedBatchData,
     PairedBatchItem,
-    TropicalOversamplingConfig,
-    _sample_indices_with_tropical_oversampling,
+    RegionOversamplingConfig,
+    _sample_indices_with_region_oversampling,
     patched_batch_gen_from_paired_loader,
 )
 from fme.downscaling.data.patching import Patch, _HorizontalSlice
@@ -468,90 +468,91 @@ def test_batch_data_apply_patch_already_patched_raises():
         list(patched.generate_from_patches([patch]))
 
 
-@pytest.mark.parametrize(
-    "lat_threshold, multiplier, match",
-    [
-        pytest.param(30.0, 0, "multiplier", id="multiplier_zero"),
-        pytest.param(30.0, -1, "multiplier", id="multiplier_negative"),
-        pytest.param(0.0, 3, "lat_threshold", id="lat_threshold_zero"),
-        pytest.param(-1.0, 3, "lat_threshold", id="lat_threshold_negative"),
-        pytest.param(90.0, 3, "lat_threshold", id="lat_threshold_90"),
-        pytest.param(120.0, 3, "lat_threshold", id="lat_threshold_too_large"),
-    ],
-)
-def test_tropical_oversampling_config_validation(lat_threshold, multiplier, match):
-    with pytest.raises(ValueError, match=match):
-        TropicalOversamplingConfig(lat_threshold=lat_threshold, multiplier=multiplier)
+def test_region_oversampling_config_error_on_negative():
+    with pytest.raises(ValueError, match="multiplier must be >= 0"):
+        RegionOversamplingConfig(multiplier=-1.0)
 
 
-def _make_lat_patches(slices_y: list[slice]) -> list[Patch]:
-    full = slice(None)
+def _make_patches(
+    slices_y: list[slice], slices_x: list[slice] | None = None
+) -> list[Patch]:
+    if slices_x is None:
+        slices_x = [slice(None)] * len(slices_y)
     return [
         Patch(
-            input_slice=_HorizontalSlice(y=s, x=full),
-            output_slice=_HorizontalSlice(y=full, x=full),
+            input_slice=_HorizontalSlice(y=sy, x=sx),
+            output_slice=_HorizontalSlice(y=slice(None), x=slice(None)),
         )
-        for s in slices_y
+        for sy, sx in zip(slices_y, slices_x)
     ]
 
 
 def test_sample_indices_preserves_length():
     coarse_lats = torch.linspace(-66, 70, 12)
-    patches = _make_lat_patches([slice(0, 4), slice(4, 8), slice(8, 12)])
-    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=3)
-
-    indices = _sample_indices_with_tropical_oversampling(patches, coarse_lats, config)
+    coarse_lons = torch.linspace(0, 360, 8)
+    patches = _make_patches(
+        slices_y=[slice(0, 4), slice(4, 8), slice(8, 12)], slices_x=None
+    )
+    config = RegionOversamplingConfig(
+        lat_interval=ClosedInterval(-30.0, 30.0), multiplier=3
+    )
+    indices = _sample_indices_with_region_oversampling(
+        patches, coarse_lats, coarse_lons, config
+    )
     assert len(indices) == len(patches)
 
 
-def test_sample_indices_multiplier_one_is_uniform():
-    coarse_lats = torch.linspace(-66, 70, 12)
-    patches = _make_lat_patches([slice(0, 4), slice(4, 8), slice(8, 12)])
-    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=1)
-
-    # All weights equal, so over many draws every patch should appear
+def test_sample_indices_region_overrepresented():
+    coarse_lats = torch.linspace(-90, 90, 12)
+    coarse_lons = torch.linspace(0, 360, 8)
+    patches = _make_patches(
+        slices_y=[slice(0, 4), slice(4, 8), slice(8, 12)], slices_x=None
+    )
+    config = RegionOversamplingConfig(
+        lat_interval=ClosedInterval(-30.0, 30.0), multiplier=1000.0
+    )
     counts = [0, 0, 0]
-    n_draws = 3000
+    n_draws = 300
     for _ in range(n_draws):
-        indices = _sample_indices_with_tropical_oversampling(
-            patches, coarse_lats, config
+        indices = _sample_indices_with_region_oversampling(
+            patches, coarse_lats, coarse_lons, config
         )
         for idx in indices:
             counts[idx] += 1
     total = sum(counts)
-    for c in counts:
-        assert abs(c / total - 1 / 3) < 0.05
+    assert counts[1] / total > 0.99
 
 
-def test_sample_indices_tropical_overrepresented():
-    # patch 0 center ~ -47.5 (extratropical), patch 1 center ~ 2.0 (tropical),
-    # patch 2 center ~ 51.5 (extratropical)
-    coarse_lats = torch.linspace(-66, 70, 12)
-    patches = _make_lat_patches([slice(0, 4), slice(4, 8), slice(8, 12)])
-    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=5)
-
-    counts = [0, 0, 0]
-    n_draws = 3000
+def test_sample_indices_lat_and_lon_selection():
+    # 2x2 grid of patches; only the patch at (lat_center ~ 0, lon_center ~ 45)
+    # falls inside both intervals.
+    coarse_lats = torch.linspace(-60, 60, 8)  # 4-point patches span ~60 deg
+    coarse_lons = torch.linspace(0, 180, 8)
+    patches = _make_patches(
+        slices_y=[slice(0, 4), slice(4, 8), slice(0, 4), slice(4, 8)],
+        slices_x=[slice(0, 4), slice(0, 4), slice(4, 8), slice(4, 8)],
+    )
+    # patch centers:
+    #   0: lat ~ -30, lon ~ 38.6
+    #   1: lat ~ 30,  lon ~ 38.6
+    #   2: lat ~ -30, lon ~ 141.4
+    #   3: lat ~ 30,  lon ~ 141.4
+    config = RegionOversamplingConfig(
+        lat_interval=ClosedInterval(-35.0, -25.0),
+        lon_interval=ClosedInterval(30.0, 50.0),
+        multiplier=1000,
+    )
+    counts = [0, 0, 0, 0]
+    n_draws = 300
     for _ in range(n_draws):
-        indices = _sample_indices_with_tropical_oversampling(
-            patches, coarse_lats, config
+        indices = _sample_indices_with_region_oversampling(
+            patches, coarse_lats, coarse_lons, config
         )
         for idx in indices:
             counts[idx] += 1
-    # Expected weights: [1, 5, 1] -> fractions [1/7, 5/7, 1/7]
     total = sum(counts)
-    assert counts[1] / total > 0.6  # ~5/7 ≈ 0.714
-
-
-def test_sample_indices_all_extratropical():
-    coarse_lats = torch.linspace(40.0, 80.0, 8)
-    patches = _make_lat_patches([slice(0, 4), slice(4, 8)])
-    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=5)
-
-    indices = _sample_indices_with_tropical_oversampling(patches, coarse_lats, config)
-    # Length preserved; all weights equal so it's uniform sampling
-    assert len(indices) == 2
-    assert all(i in (0, 1) for i in indices)
+    # Only patch 0 (lat ~ -30, lon ~ 38.6) is inside both intervals
+    assert counts[0] / total > 0.99
 
 
 def _make_paired_batch_for_tropical(
@@ -604,7 +605,9 @@ def test_patched_batch_gen_from_paired_loader_no_oversampling():
 def test_patched_batch_gen_from_paired_loader_with_oversampling_preserves_count():
     n_lat, n_lon = 12, 8
     batch = _make_paired_batch_for_tropical(n_lat=n_lat, n_lon=n_lon)
-    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=3)
+    config = RegionOversamplingConfig(
+        lat_interval=ClosedInterval(-30.0, 30.0), multiplier=3
+    )
 
     yielded = list(
         patched_batch_gen_from_paired_loader(

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -469,7 +469,7 @@ def test_batch_data_apply_patch_already_patched_raises():
 
 
 def test_region_oversampling_config_error_on_negative():
-    with pytest.raises(ValueError, match="multiplier must be >= 0"):
+    with pytest.raises(ValueError, match="multiplier must be > 0"):
         RegionOversamplingConfig(multiplier=-1.0)
 
 

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -13,7 +13,11 @@ from fme.downscaling.data.datasets import (
     FineCoarsePairedDataset,
     HorizontalSubsetDataset,
     LatLonCoordinates,
+    PairedBatchData,
     PairedBatchItem,
+    TropicalOversamplingConfig,
+    _sample_indices_with_tropical_oversampling,
+    patched_batch_gen_from_paired_loader,
 )
 from fme.downscaling.data.patching import Patch, _HorizontalSlice
 from fme.downscaling.data.utils import BatchedLatLonCoordinates, ClosedInterval
@@ -462,3 +466,157 @@ def test_batch_data_apply_patch_already_patched_raises():
     (patched,) = list(batch.generate_from_patches([patch]))
     with pytest.raises(ValueError, match="previously patched"):
         list(patched.generate_from_patches([patch]))
+
+
+@pytest.mark.parametrize(
+    "lat_threshold, multiplier, match",
+    [
+        pytest.param(30.0, 0, "multiplier", id="multiplier_zero"),
+        pytest.param(30.0, -1, "multiplier", id="multiplier_negative"),
+        pytest.param(0.0, 3, "lat_threshold", id="lat_threshold_zero"),
+        pytest.param(-1.0, 3, "lat_threshold", id="lat_threshold_negative"),
+        pytest.param(90.0, 3, "lat_threshold", id="lat_threshold_90"),
+        pytest.param(120.0, 3, "lat_threshold", id="lat_threshold_too_large"),
+    ],
+)
+def test_tropical_oversampling_config_validation(lat_threshold, multiplier, match):
+    with pytest.raises(ValueError, match=match):
+        TropicalOversamplingConfig(lat_threshold=lat_threshold, multiplier=multiplier)
+
+
+def _make_lat_patches(slices_y: list[slice]) -> list[Patch]:
+    full = slice(None)
+    return [
+        Patch(
+            input_slice=_HorizontalSlice(y=s, x=full),
+            output_slice=_HorizontalSlice(y=full, x=full),
+        )
+        for s in slices_y
+    ]
+
+
+def test_sample_indices_preserves_length():
+    coarse_lats = torch.linspace(-66, 70, 12)
+    patches = _make_lat_patches([slice(0, 4), slice(4, 8), slice(8, 12)])
+    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=3)
+
+    indices = _sample_indices_with_tropical_oversampling(patches, coarse_lats, config)
+    assert len(indices) == len(patches)
+
+
+def test_sample_indices_multiplier_one_is_uniform():
+    coarse_lats = torch.linspace(-66, 70, 12)
+    patches = _make_lat_patches([slice(0, 4), slice(4, 8), slice(8, 12)])
+    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=1)
+
+    # All weights equal, so over many draws every patch should appear
+    counts = [0, 0, 0]
+    n_draws = 3000
+    for _ in range(n_draws):
+        indices = _sample_indices_with_tropical_oversampling(
+            patches, coarse_lats, config
+        )
+        for idx in indices:
+            counts[idx] += 1
+    total = sum(counts)
+    for c in counts:
+        assert abs(c / total - 1 / 3) < 0.05
+
+
+def test_sample_indices_tropical_overrepresented():
+    # patch 0 center ~ -47.5 (extratropical), patch 1 center ~ 2.0 (tropical),
+    # patch 2 center ~ 51.5 (extratropical)
+    coarse_lats = torch.linspace(-66, 70, 12)
+    patches = _make_lat_patches([slice(0, 4), slice(4, 8), slice(8, 12)])
+    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=5)
+
+    counts = [0, 0, 0]
+    n_draws = 3000
+    for _ in range(n_draws):
+        indices = _sample_indices_with_tropical_oversampling(
+            patches, coarse_lats, config
+        )
+        for idx in indices:
+            counts[idx] += 1
+    # Expected weights: [1, 5, 1] -> fractions [1/7, 5/7, 1/7]
+    total = sum(counts)
+    assert counts[1] / total > 0.6  # ~5/7 ≈ 0.714
+
+
+def test_sample_indices_all_extratropical():
+    coarse_lats = torch.linspace(40.0, 80.0, 8)
+    patches = _make_lat_patches([slice(0, 4), slice(4, 8)])
+    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=5)
+
+    indices = _sample_indices_with_tropical_oversampling(patches, coarse_lats, config)
+    # Length preserved; all weights equal so it's uniform sampling
+    assert len(indices) == 2
+    assert all(i in (0, 1) for i in indices)
+
+
+def _make_paired_batch_for_tropical(
+    n_lat=12, n_lon=8, batch_size=2, downscale_factor=1
+) -> PairedBatchData:
+    lat_coarse = torch.linspace(-66.0, 70.0, n_lat)
+    lon_coarse = torch.linspace(0.0, 360.0, n_lon)
+    coarse = BatchData(
+        data={"x": torch.zeros(batch_size, n_lat, n_lon)},
+        time=xr.DataArray(list(range(batch_size)), dims=["batch"]),
+        latlon_coordinates=BatchedLatLonCoordinates(
+            lat=lat_coarse.unsqueeze(0).expand(batch_size, -1).clone(),
+            lon=lon_coarse.unsqueeze(0).expand(batch_size, -1).clone(),
+        ),
+    )
+    n_lat_fine = n_lat * downscale_factor
+    n_lon_fine = n_lon * downscale_factor
+    lat_fine = torch.linspace(-66.0, 70.0, n_lat_fine)
+    lon_fine = torch.linspace(0.0, 360.0, n_lon_fine)
+    fine = BatchData(
+        data={"x": torch.zeros(batch_size, n_lat_fine, n_lon_fine)},
+        time=xr.DataArray(list(range(batch_size)), dims=["batch"]),
+        latlon_coordinates=BatchedLatLonCoordinates(
+            lat=lat_fine.unsqueeze(0).expand(batch_size, -1).clone(),
+            lon=lon_fine.unsqueeze(0).expand(batch_size, -1).clone(),
+        ),
+    )
+    return PairedBatchData(fine=fine, coarse=coarse)
+
+
+def test_patched_batch_gen_from_paired_loader_no_oversampling():
+    n_lat, n_lon = 12, 8
+    batch = _make_paired_batch_for_tropical(n_lat=n_lat, n_lon=n_lon)
+
+    yielded = list(
+        patched_batch_gen_from_paired_loader(
+            loader=[batch],
+            coarse_yx_extent=(n_lat, n_lon),
+            coarse_yx_patch_extent=(4, n_lon),
+            downscale_factor=1,
+            random_offset=False,
+            shuffle=False,
+            drop_partial_patches=True,
+        )
+    )
+    # 3 lat slices x 1 lon slice = 3 patches
+    assert len(yielded) == 3
+
+
+def test_patched_batch_gen_from_paired_loader_with_oversampling_preserves_count():
+    n_lat, n_lon = 12, 8
+    batch = _make_paired_batch_for_tropical(n_lat=n_lat, n_lon=n_lon)
+    config = TropicalOversamplingConfig(lat_threshold=30.0, multiplier=3)
+
+    yielded = list(
+        patched_batch_gen_from_paired_loader(
+            loader=[batch],
+            coarse_yx_extent=(n_lat, n_lon),
+            coarse_yx_patch_extent=(4, n_lon),
+            downscale_factor=1,
+            random_offset=False,
+            shuffle=False,
+            drop_partial_patches=True,
+            tropical_oversampling=config,
+        )
+    )
+    # Same number of patches as without oversampling (3)
+    assert len(yielded) == 3

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -618,7 +618,7 @@ def test_patched_batch_gen_from_paired_loader_with_oversampling_preserves_count(
             random_offset=False,
             shuffle=False,
             drop_partial_patches=True,
-            tropical_oversampling=config,
+            region_oversampling=config,
         )
     )
     # Same number of patches as without oversampling (3)

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -15,8 +15,8 @@ from fme.downscaling.data.datasets import (
     LatLonCoordinates,
     PairedBatchData,
     PairedBatchItem,
-    RegionOversamplingConfig,
-    _sample_indices_with_region_oversampling,
+    RegionSamplingConfig,
+    _sample_indices_with_region_sampling,
     patched_batch_gen_from_paired_loader,
 )
 from fme.downscaling.data.patching import Patch, _HorizontalSlice
@@ -468,9 +468,9 @@ def test_batch_data_apply_patch_already_patched_raises():
         list(patched.generate_from_patches([patch]))
 
 
-def test_region_oversampling_config_error_on_negative():
-    with pytest.raises(ValueError, match="multiplier must be > 0"):
-        RegionOversamplingConfig(multiplier=-1.0)
+def test_region_sampling_config_error_on_negative():
+    with pytest.raises(ValueError, match="weight must be > 0"):
+        RegionSamplingConfig(weight=-1.0)
 
 
 def _make_patches(
@@ -493,10 +493,8 @@ def test_sample_indices_preserves_length():
     patches = _make_patches(
         slices_y=[slice(0, 4), slice(4, 8), slice(8, 12)], slices_x=None
     )
-    config = RegionOversamplingConfig(
-        lat_interval=ClosedInterval(-30.0, 30.0), multiplier=3
-    )
-    indices = _sample_indices_with_region_oversampling(
+    config = RegionSamplingConfig(lat_interval=ClosedInterval(-30.0, 30.0), weight=3)
+    indices = _sample_indices_with_region_sampling(
         patches, coarse_lats, coarse_lons, config
     )
     assert len(indices) == len(patches)
@@ -508,13 +506,13 @@ def test_sample_indices_region_overrepresented():
     patches = _make_patches(
         slices_y=[slice(0, 4), slice(4, 8), slice(8, 12)], slices_x=None
     )
-    config = RegionOversamplingConfig(
-        lat_interval=ClosedInterval(-30.0, 30.0), multiplier=1000.0
+    config = RegionSamplingConfig(
+        lat_interval=ClosedInterval(-30.0, 30.0), weight=1000.0
     )
     counts = [0, 0, 0]
     n_draws = 300
     for _ in range(n_draws):
-        indices = _sample_indices_with_region_oversampling(
+        indices = _sample_indices_with_region_sampling(
             patches, coarse_lats, coarse_lons, config
         )
         for idx in indices:
@@ -537,15 +535,15 @@ def test_sample_indices_lat_and_lon_selection():
     #   1: lat ~ 30,  lon ~ 38.6
     #   2: lat ~ -30, lon ~ 141.4
     #   3: lat ~ 30,  lon ~ 141.4
-    config = RegionOversamplingConfig(
+    config = RegionSamplingConfig(
         lat_interval=ClosedInterval(-35.0, -25.0),
         lon_interval=ClosedInterval(30.0, 50.0),
-        multiplier=1000,
+        weight=1000,
     )
     counts = [0, 0, 0, 0]
     n_draws = 300
     for _ in range(n_draws):
-        indices = _sample_indices_with_region_oversampling(
+        indices = _sample_indices_with_region_sampling(
             patches, coarse_lats, coarse_lons, config
         )
         for idx in indices:
@@ -605,9 +603,7 @@ def test_patched_batch_gen_from_paired_loader_no_oversampling():
 def test_patched_batch_gen_from_paired_loader_with_oversampling_preserves_count():
     n_lat, n_lon = 12, 8
     batch = _make_paired_batch_for_tropical(n_lat=n_lat, n_lon=n_lon)
-    config = RegionOversamplingConfig(
-        lat_interval=ClosedInterval(-30.0, 30.0), multiplier=3
-    )
+    config = RegionSamplingConfig(lat_interval=ClosedInterval(-30.0, 30.0), weight=3)
 
     yielded = list(
         patched_batch_gen_from_paired_loader(
@@ -618,7 +614,7 @@ def test_patched_batch_gen_from_paired_loader_with_oversampling_preserves_count(
             random_offset=False,
             shuffle=False,
             drop_partial_patches=True,
-            region_oversampling=config,
+            region_sampling=config,
         )
     )
     # Same number of patches as without oversampling (3)

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -553,7 +553,7 @@ def test_sample_indices_lat_and_lon_selection():
     assert counts[0] / total > 0.99
 
 
-def _make_paired_batch_for_tropical(
+def _make_paired_batch(
     n_lat=12, n_lon=8, batch_size=2, downscale_factor=1
 ) -> PairedBatchData:
     lat_coarse = torch.linspace(-66.0, 70.0, n_lat)
@@ -583,7 +583,7 @@ def _make_paired_batch_for_tropical(
 
 def test_patched_batch_gen_from_paired_loader_no_oversampling():
     n_lat, n_lon = 12, 8
-    batch = _make_paired_batch_for_tropical(n_lat=n_lat, n_lon=n_lon)
+    batch = _make_paired_batch(n_lat=n_lat, n_lon=n_lon)
 
     yielded = list(
         patched_batch_gen_from_paired_loader(
@@ -602,7 +602,7 @@ def test_patched_batch_gen_from_paired_loader_no_oversampling():
 
 def test_patched_batch_gen_from_paired_loader_with_oversampling_preserves_count():
     n_lat, n_lon = 12, 8
-    batch = _make_paired_batch_for_tropical(n_lat=n_lat, n_lon=n_lon)
+    batch = _make_paired_batch(n_lat=n_lat, n_lon=n_lon)
     config = RegionSamplingConfig(lat_interval=ClosedInterval(-30.0, 30.0), weight=3)
 
     yielded = list(

--- a/fme/downscaling/test_train.py
+++ b/fme/downscaling/test_train.py
@@ -65,23 +65,13 @@ def _trainer_config_kwargs(tmp_path):
     )
 
 
-def test_trainer_config_tropical_oversampling_requires_patch_extents(tmp_path):
+def test_trainer_config_region_oversampling_requires_patch_extents(tmp_path):
     base = _trainer_config_kwargs(tmp_path)
-    with pytest.raises(ValueError, match="tropical_oversampling requires"):
+    with pytest.raises(ValueError, match="region_oversampling requires"):
         TrainerConfig(
             **base,
             region_oversampling=RegionOversamplingConfig(),
         )
-
-
-def test_trainer_config_tropical_oversampling_with_patch_extents_ok(tmp_path):
-    base = _trainer_config_kwargs(tmp_path)
-    TrainerConfig(
-        **base,
-        coarse_patch_extent_lat=16,
-        coarse_patch_extent_lon=16,
-        region_oversampling=RegionOversamplingConfig(),
-    )
 
 
 @pytest.fixture

--- a/fme/downscaling/test_train.py
+++ b/fme/downscaling/test_train.py
@@ -13,7 +13,7 @@ import yaml
 
 from fme.core.testing.model import compare_restored_parameters
 from fme.core.testing.wandb import mock_wandb
-from fme.downscaling.data import RegionOversamplingConfig
+from fme.downscaling.data import RegionSamplingConfig
 from fme.downscaling.test_utils import create_test_data_on_disk, data_paths_helper
 from fme.downscaling.train import (
     Trainer,
@@ -65,12 +65,12 @@ def _trainer_config_kwargs(tmp_path):
     )
 
 
-def test_trainer_config_region_oversampling_requires_patch_extents(tmp_path):
+def test_trainer_config_region_sampling_requires_patch_extents(tmp_path):
     base = _trainer_config_kwargs(tmp_path)
-    with pytest.raises(ValueError, match="region_oversampling requires"):
+    with pytest.raises(ValueError, match="region_sampling requires"):
         TrainerConfig(
             **base,
-            region_oversampling=RegionOversamplingConfig(),
+            region_sampling=RegionSamplingConfig(),
         )
 
 

--- a/fme/downscaling/test_train.py
+++ b/fme/downscaling/test_train.py
@@ -13,7 +13,7 @@ import yaml
 
 from fme.core.testing.model import compare_restored_parameters
 from fme.core.testing.wandb import mock_wandb
-from fme.downscaling.data import TropicalOversamplingConfig
+from fme.downscaling.data import RegionOversamplingConfig
 from fme.downscaling.test_utils import create_test_data_on_disk, data_paths_helper
 from fme.downscaling.train import (
     Trainer,
@@ -70,7 +70,7 @@ def test_trainer_config_tropical_oversampling_requires_patch_extents(tmp_path):
     with pytest.raises(ValueError, match="tropical_oversampling requires"):
         TrainerConfig(
             **base,
-            tropical_oversampling=TropicalOversamplingConfig(),
+            region_oversampling=RegionOversamplingConfig(),
         )
 
 
@@ -80,7 +80,7 @@ def test_trainer_config_tropical_oversampling_with_patch_extents_ok(tmp_path):
         **base,
         coarse_patch_extent_lat=16,
         coarse_patch_extent_lon=16,
-        tropical_oversampling=TropicalOversamplingConfig(),
+        region_oversampling=RegionOversamplingConfig(),
     )
 
 

--- a/fme/downscaling/test_train.py
+++ b/fme/downscaling/test_train.py
@@ -13,6 +13,7 @@ import yaml
 
 from fme.core.testing.model import compare_restored_parameters
 from fme.core.testing.wandb import mock_wandb
+from fme.downscaling.data import TropicalOversamplingConfig
 from fme.downscaling.test_utils import create_test_data_on_disk, data_paths_helper
 from fme.downscaling.train import (
     Trainer,
@@ -49,6 +50,38 @@ def test_trainer(tmp_path):
 
     with pytest.raises(RuntimeError):
         trainer.train_one_epoch()
+
+
+def _trainer_config_kwargs(tmp_path):
+    return dict(
+        model=MagicMock(),
+        optimization=MagicMock(),
+        train_data=MagicMock(),
+        validation_data=MagicMock(),
+        max_epochs=1,
+        experiment_dir=str(tmp_path),
+        save_checkpoints=False,
+        logging=MagicMock(),
+    )
+
+
+def test_trainer_config_tropical_oversampling_requires_patch_extents(tmp_path):
+    base = _trainer_config_kwargs(tmp_path)
+    with pytest.raises(ValueError, match="tropical_oversampling requires"):
+        TrainerConfig(
+            **base,
+            tropical_oversampling=TropicalOversamplingConfig(),
+        )
+
+
+def test_trainer_config_tropical_oversampling_with_patch_extents_ok(tmp_path):
+    base = _trainer_config_kwargs(tmp_path)
+    TrainerConfig(
+        **base,
+        coarse_patch_extent_lat=16,
+        coarse_patch_extent_lon=16,
+        tropical_oversampling=TropicalOversamplingConfig(),
+    )
 
 
 @pytest.fixture

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -25,6 +25,7 @@ from fme.downscaling.data import (
     PairedBatchData,
     PairedDataLoaderConfig,
     PairedGriddedData,
+    TropicalOversamplingConfig,
     load_static_inputs,
 )
 from fme.downscaling.models import DiffusionModel, DiffusionModelConfig
@@ -147,7 +148,11 @@ class Trainer:
         )
 
     def _get_batch_generator(
-        self, data: PairedGriddedData, random_offset: bool, shuffle: bool
+        self,
+        data: PairedGriddedData,
+        random_offset: bool,
+        shuffle: bool,
+        tropical_oversampling: TropicalOversamplingConfig | None = None,
     ):
         if self.patch_data:
             batch_generator = data.get_patched_generator(
@@ -156,6 +161,7 @@ class Trainer:
                 drop_partial_patches=True,
                 random_offset=random_offset,
                 shuffle=shuffle,
+                tropical_oversampling=tropical_oversampling,
             )
         else:
             batch_generator = data.get_generator()
@@ -174,7 +180,10 @@ class Trainer:
         batch: PairedBatchData
         wandb = WandB.get_instance()
         train_batch_generator = self._get_batch_generator(
-            self.train_data, random_offset=True, shuffle=True
+            self.train_data,
+            random_offset=True,
+            shuffle=True,
+            tropical_oversampling=self.config.tropical_oversampling,
         )
         outputs = None
         for i, batch in enumerate(train_batch_generator):
@@ -395,6 +404,28 @@ class Trainer:
 
 @dataclasses.dataclass
 class TrainerConfig:
+    """
+    Configuration for the downscaling Trainer.
+
+    Most fields are self-explanatory; the following deserve note:
+
+    Parameters:
+        coarse_patch_extent_lat: If set together with
+            ``coarse_patch_extent_lon``, training and validation iterate
+            over patches of the given coarse extent rather than the full
+            domain.
+        coarse_patch_extent_lon: See ``coarse_patch_extent_lat``.
+        tropical_oversampling: Optional config to oversample patches
+            whose center latitude is within +/-lat_threshold of the
+            equator during training. The total number of patches per
+            batch is unchanged; patches are drawn with replacement
+            from a weighted distribution where tropical patches have
+            higher relative weight. Only applied to the training
+            generator (validation patches are unchanged so metrics
+            stay comparable). Requires ``coarse_patch_extent_lat`` and
+            ``coarse_patch_extent_lon`` to be set.
+    """
+
     model: DiffusionModelConfig
     optimization: OptimizationConfig
     train_data: PairedDataLoaderConfig
@@ -413,6 +444,7 @@ class TrainerConfig:
     coarse_patch_extent_lon: int | None = None
     resume_results_dir: str | None = None
     log_loss_vs_noise: bool = False
+    tropical_oversampling: TropicalOversamplingConfig | None = None
 
     def __post_init__(self):
         if (
@@ -425,6 +457,13 @@ class TrainerConfig:
             raise ValueError(
                 "Either none or both of coarse_patch_extent_lat and "
                 "coarse_patch_extent_lon must be set."
+            )
+        if self.tropical_oversampling is not None and (
+            self.coarse_patch_extent_lat is None or self.coarse_patch_extent_lon is None
+        ):
+            raise ValueError(
+                "tropical_oversampling requires both coarse_patch_extent_lat "
+                "and coarse_patch_extent_lon to be set."
             )
 
     @property

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -25,7 +25,7 @@ from fme.downscaling.data import (
     PairedBatchData,
     PairedDataLoaderConfig,
     PairedGriddedData,
-    RegionOversamplingConfig,
+    RegionSamplingConfig,
     load_static_inputs,
 )
 from fme.downscaling.models import DiffusionModel, DiffusionModelConfig
@@ -152,7 +152,7 @@ class Trainer:
         data: PairedGriddedData,
         random_offset: bool,
         shuffle: bool,
-        region_oversampling: RegionOversamplingConfig | None = None,
+        region_sampling: RegionSamplingConfig | None = None,
     ):
         if self.patch_data:
             batch_generator = data.get_patched_generator(
@@ -161,7 +161,7 @@ class Trainer:
                 drop_partial_patches=True,
                 random_offset=random_offset,
                 shuffle=shuffle,
-                region_oversampling=region_oversampling,
+                region_sampling=region_sampling,
             )
         else:
             batch_generator = data.get_generator()
@@ -183,7 +183,7 @@ class Trainer:
             self.train_data,
             random_offset=True,
             shuffle=True,
-            region_oversampling=self.config.region_oversampling,
+            region_sampling=self.config.region_sampling,
         )
         outputs = None
         for i, batch in enumerate(train_batch_generator):
@@ -415,7 +415,7 @@ class TrainerConfig:
             over patches of the given coarse extent rather than the full
             domain.
         coarse_patch_extent_lon: See ``coarse_patch_extent_lat``.
-        region_oversampling: Optional config to oversample patches
+        region_sampling: Optional config to oversample patches
             whose center falls within a specified lat/lon region
             during training. The total number of patches per batch is
             unchanged; patches are drawn with replacement from a
@@ -444,7 +444,7 @@ class TrainerConfig:
     coarse_patch_extent_lon: int | None = None
     resume_results_dir: str | None = None
     log_loss_vs_noise: bool = False
-    region_oversampling: RegionOversamplingConfig | None = None
+    region_sampling: RegionSamplingConfig | None = None
 
     def __post_init__(self):
         if (
@@ -458,11 +458,11 @@ class TrainerConfig:
                 "Either none or both of coarse_patch_extent_lat and "
                 "coarse_patch_extent_lon must be set."
             )
-        if self.region_oversampling is not None and (
+        if self.region_sampling is not None and (
             self.coarse_patch_extent_lat is None or self.coarse_patch_extent_lon is None
         ):
             raise ValueError(
-                "region_oversampling requires both coarse_patch_extent_lat "
+                "region_sampling requires both coarse_patch_extent_lat "
                 "and coarse_patch_extent_lon to be set."
             )
 

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -152,7 +152,7 @@ class Trainer:
         data: PairedGriddedData,
         random_offset: bool,
         shuffle: bool,
-        tropical_oversampling: RegionOversamplingConfig | None = None,
+        region_oversampling: RegionOversamplingConfig | None = None,
     ):
         if self.patch_data:
             batch_generator = data.get_patched_generator(
@@ -161,7 +161,7 @@ class Trainer:
                 drop_partial_patches=True,
                 random_offset=random_offset,
                 shuffle=shuffle,
-                tropical_oversampling=tropical_oversampling,
+                region_oversampling=region_oversampling,
             )
         else:
             batch_generator = data.get_generator()
@@ -183,7 +183,7 @@ class Trainer:
             self.train_data,
             random_offset=True,
             shuffle=True,
-            tropical_oversampling=self.config.region_oversampling,
+            region_oversampling=self.config.region_oversampling,
         )
         outputs = None
         for i, batch in enumerate(train_batch_generator):
@@ -415,7 +415,7 @@ class TrainerConfig:
             over patches of the given coarse extent rather than the full
             domain.
         coarse_patch_extent_lon: See ``coarse_patch_extent_lat``.
-        tropical_oversampling: Optional config to oversample patches
+        region_oversampling: Optional config to oversample patches
             whose center falls within a specified lat/lon region
             during training. The total number of patches per batch is
             unchanged; patches are drawn with replacement from a
@@ -462,7 +462,7 @@ class TrainerConfig:
             self.coarse_patch_extent_lat is None or self.coarse_patch_extent_lon is None
         ):
             raise ValueError(
-                "tropical_oversampling requires both coarse_patch_extent_lat "
+                "region_oversampling requires both coarse_patch_extent_lat "
                 "and coarse_patch_extent_lon to be set."
             )
 

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -25,7 +25,7 @@ from fme.downscaling.data import (
     PairedBatchData,
     PairedDataLoaderConfig,
     PairedGriddedData,
-    TropicalOversamplingConfig,
+    RegionOversamplingConfig,
     load_static_inputs,
 )
 from fme.downscaling.models import DiffusionModel, DiffusionModelConfig
@@ -152,7 +152,7 @@ class Trainer:
         data: PairedGriddedData,
         random_offset: bool,
         shuffle: bool,
-        tropical_oversampling: TropicalOversamplingConfig | None = None,
+        tropical_oversampling: RegionOversamplingConfig | None = None,
     ):
         if self.patch_data:
             batch_generator = data.get_patched_generator(
@@ -183,7 +183,7 @@ class Trainer:
             self.train_data,
             random_offset=True,
             shuffle=True,
-            tropical_oversampling=self.config.tropical_oversampling,
+            tropical_oversampling=self.config.region_oversampling,
         )
         outputs = None
         for i, batch in enumerate(train_batch_generator):
@@ -416,12 +416,12 @@ class TrainerConfig:
             domain.
         coarse_patch_extent_lon: See ``coarse_patch_extent_lat``.
         tropical_oversampling: Optional config to oversample patches
-            whose center latitude is within +/-lat_threshold of the
-            equator during training. The total number of patches per
-            batch is unchanged; patches are drawn with replacement
-            from a weighted distribution where tropical patches have
-            higher relative weight. Only applied to the training
-            generator (validation patches are unchanged so metrics
+            whose center falls within a specified lat/lon region
+            during training. The total number of patches per batch is
+            unchanged; patches are drawn with replacement from a
+            weighted distribution where region patches have higher
+            relative weight. Only applied to the training generator
+            (validation patches are unchanged so metrics
             stay comparable). Requires ``coarse_patch_extent_lat`` and
             ``coarse_patch_extent_lon`` to be set.
     """
@@ -444,7 +444,7 @@ class TrainerConfig:
     coarse_patch_extent_lon: int | None = None
     resume_results_dir: str | None = None
     log_loss_vs_noise: bool = False
-    tropical_oversampling: TropicalOversamplingConfig | None = None
+    region_oversampling: RegionOversamplingConfig | None = None
 
     def __post_init__(self):
         if (
@@ -458,7 +458,7 @@ class TrainerConfig:
                 "Either none or both of coarse_patch_extent_lat and "
                 "coarse_patch_extent_lon must be set."
             )
-        if self.tropical_oversampling is not None and (
+        if self.region_oversampling is not None and (
             self.coarse_patch_extent_lat is None or self.coarse_patch_extent_lon is None
         ):
             raise ValueError(


### PR DESCRIPTION
This PR adds an optional section `region_sampling: RegionSamplingConfig` to the downscaling training config. The `RegionSamplingConfig` class can be used to specify a lat/lon interval range and weight. When the full training data lat/lon extent is divided into `n_patches`, if this option is configured then patches with coordinate centers within the lat/lon interval will be sampled with weight `weight`. Patches outside the region are sampled with weight=1.0. `n_patches` are sampled with replacement using the assigned weights. If no sampling config is provided, there is no change from previous behavior (return all patches). 

If either `RegionSamplingConfig.lat_interval, lon_interval` are None, all lat or lon coordinates are considered to be contained in the sampling config region.

- [x] Tests added