### PR TITLE
Rename masking to spatial masking

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -96,13 +96,13 @@ from fme.core.dataset.xarray import OverwriteConfig, XarrayDataConfig
 from fme.core.generics.lr_tuning import LRTuningConfig
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.loss import StepLossConfig
-from fme.core.masking import StaticMaskingConfig
 from fme.core.normalizer import NormalizationConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
 from fme.core.optimization import CheckpointConfig
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
 from fme.core.scheduler import SchedulerConfig, SequentialSchedulerConfig
+from fme.core.spatial_masking import StaticSpatialMaskingConfig
 from fme.core.step import (
     MultiCallStepConfig,
     SeparateRadiationStepConfig,

--- a/fme/ace/aggregator/inference/test_annual.py
+++ b/fme/ace/aggregator/inference/test_annual.py
@@ -113,9 +113,11 @@ def test_paired_annual_aggregator_with_nans(tmpdir):
     mask = np.ones((n_lat, n_lon))
     mask[1, 1] = 0
     monthly_ds["a"] = monthly_ds["a"].where(mask > 0)
-    mask_provider = SpatialMaskProvider({"mask_a": torch.tensor(mask)}).to(get_device())
+    spatial_mask_provider = SpatialMaskProvider({"mask_a": torch.tensor(mask)}).to(
+        get_device()
+    )
     agg = PairedGlobalMeanAnnualAggregator(
-        ops=LatLonOperations(area_weights, mask_provider),
+        ops=LatLonOperations(area_weights, spatial_mask_provider),
         timestep=TIMESTEP,
         monthly_reference_data=monthly_ds,
     )
@@ -294,10 +296,10 @@ def test_annual_aggregator_with_nans():
     data["a"][:, :, 1, 1] = float("nan")
     masks = {"mask_a": torch.ones_like(data["a"][0, 0])}
     masks["mask_a"][1, 1] = 0
-    mask_provider = SpatialMaskProvider(masks).to(get_device())
+    spatial_mask_provider = SpatialMaskProvider(masks).to(get_device())
 
     agg = GlobalMeanAnnualAggregator(
-        ops=LatLonOperations(area_weights, mask_provider), timestep=TIMESTEP
+        ops=LatLonOperations(area_weights, spatial_mask_provider), timestep=TIMESTEP
     )
     time = xr.DataArray(
         [

--- a/fme/ace/aggregator/inference/test_annual.py
+++ b/fme/ace/aggregator/inference/test_annual.py
@@ -18,7 +18,7 @@ from fme.ace.testing import DimSizes, MonthlyReferenceData
 from fme.core.coordinates import DimSize
 from fme.core.device import get_device
 from fme.core.gridded_ops import LatLonOperations
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.testing import mock_distributed
 
 TIMESTEP = datetime.timedelta(hours=6)
@@ -113,7 +113,7 @@ def test_paired_annual_aggregator_with_nans(tmpdir):
     mask = np.ones((n_lat, n_lon))
     mask[1, 1] = 0
     monthly_ds["a"] = monthly_ds["a"].where(mask > 0)
-    mask_provider = MaskProvider({"mask_a": torch.tensor(mask)}).to(get_device())
+    mask_provider = SpatialMaskProvider({"mask_a": torch.tensor(mask)}).to(get_device())
     agg = PairedGlobalMeanAnnualAggregator(
         ops=LatLonOperations(area_weights, mask_provider),
         timestep=TIMESTEP,
@@ -294,7 +294,7 @@ def test_annual_aggregator_with_nans():
     data["a"][:, :, 1, 1] = float("nan")
     masks = {"mask_a": torch.ones_like(data["a"][0, 0])}
     masks["mask_a"][1, 1] = 0
-    mask_provider = MaskProvider(masks).to(get_device())
+    mask_provider = SpatialMaskProvider(masks).to(get_device())
 
     agg = GlobalMeanAnnualAggregator(
         ops=LatLonOperations(area_weights, mask_provider), timestep=TIMESTEP

--- a/fme/ace/aggregator/inference/test_seasonal.py
+++ b/fme/ace/aggregator/inference/test_seasonal.py
@@ -70,9 +70,9 @@ def test_seasonal_aggregator_with_nans():
     area_weights = torch.ones(n_lat, n_lon).to(fme.get_device())
     mask = torch.ones((n_lat, n_lon))
     mask[1, 1] = 0
-    mask_provider = SpatialMaskProvider({"mask_a": mask}).to(get_device())
+    spatial_mask_provider = SpatialMaskProvider({"mask_a": mask}).to(get_device())
     agg = SeasonalAggregator(
-        LatLonOperations(area_weights, mask_provider),
+        LatLonOperations(area_weights, spatial_mask_provider),
     )
     target_data = {
         "a": torch.randn(n_sample, n_time, n_lat, n_lon, device=get_device())

--- a/fme/ace/aggregator/inference/test_seasonal.py
+++ b/fme/ace/aggregator/inference/test_seasonal.py
@@ -10,7 +10,7 @@ from fme.ace.aggregator.inference.data import InferenceBatchData
 from fme.ace.aggregator.inference.seasonal import SeasonalAggregator
 from fme.core.device import get_device
 from fme.core.gridded_ops import LatLonOperations
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 
 
 def get_zero_time(shape, dims):
@@ -70,7 +70,7 @@ def test_seasonal_aggregator_with_nans():
     area_weights = torch.ones(n_lat, n_lon).to(fme.get_device())
     mask = torch.ones((n_lat, n_lon))
     mask[1, 1] = 0
-    mask_provider = MaskProvider({"mask_a": mask}).to(get_device())
+    mask_provider = SpatialMaskProvider({"mask_a": mask}).to(get_device())
     agg = SeasonalAggregator(
         LatLonOperations(area_weights, mask_provider),
     )

--- a/fme/ace/data_loading/gridded_data.py
+++ b/fme/ace/data_loading/gridded_data.py
@@ -88,7 +88,7 @@ class GriddedData(GriddedDataABC[BatchData]):
         return DatasetInfo(
             horizontal_coordinates=self._global_properties.horizontal_coordinates,
             vertical_coordinate=self._global_properties.vertical_coordinate,
-            mask_provider=self._global_properties.mask_provider,
+            spatial_mask_provider=self._global_properties.spatial_mask_provider,
             timestep=self._timestep,
             variable_metadata=self._global_properties.variable_metadata,
             all_labels=self._global_properties.all_labels,
@@ -206,7 +206,7 @@ class InferenceGriddedData(InferenceDataABC[PrognosticState, BatchData]):
         return DatasetInfo(
             horizontal_coordinates=self._global_properties.horizontal_coordinates,
             vertical_coordinate=self._global_properties.vertical_coordinate,
-            mask_provider=self._global_properties.mask_provider,
+            spatial_mask_provider=self._global_properties.spatial_mask_provider,
             timestep=self.timestep,
             all_labels=self._global_properties.all_labels,
         )

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -1214,7 +1214,7 @@ def test_localize_properties():
     mask_tensor = torch.arange(n_lat * n_lon, dtype=torch.float32).reshape(
         1, n_lat, n_lon
     )
-    mask_provider = SpatialMaskProvider(masks={"mask_test": mask_tensor})
+    spatial_mask_provider = SpatialMaskProvider(masks={"mask_test": mask_tensor})
     timestep = datetime.timedelta(hours=6)
     metadata = {"temp": VariableMetadata(units="K", long_name="Temperature")}
     vertical = NullVerticalCoordinate()
@@ -1222,7 +1222,7 @@ def test_localize_properties():
         variable_metadata=metadata,
         vertical_coordinate=vertical,
         horizontal_coordinates=coords,
-        spatial_mask_provider=mask_provider,
+        spatial_mask_provider=spatial_mask_provider,
         timestep=timestep,
         is_remote=False,
         all_labels=None,
@@ -1279,12 +1279,12 @@ def _global_properties():
     metadata = {"temp": VariableMetadata(units="K", long_name="Temperature")}
     vertical = NullVerticalCoordinate()
     mask = torch.ones(n_lat, n_lon)
-    mask_provider = SpatialMaskProvider(masks={"mask_land": mask})
+    spatial_mask_provider = SpatialMaskProvider(masks={"mask_land": mask})
     return DatasetProperties(
         variable_metadata=metadata,
         vertical_coordinate=vertical,
         horizontal_coordinates=coords,
-        spatial_mask_provider=mask_provider,
+        spatial_mask_provider=spatial_mask_provider,
         timestep=timestep,
         is_remote=False,
         all_labels=None,
@@ -1305,7 +1305,7 @@ def _assert_dataset_info_uses_global_properties(dataset_info, props):
     # vertical_coordinate type must match
     assert type(dataset_info.vertical_coordinate) is type(props.vertical_coordinate)
 
-    # mask_provider must have the same keys as the global (non-localized) one
+    # spatial_mask_provider must have the same keys as the global (non-localized) one
     info_masks = dataset_info.spatial_mask_provider.masks
     prop_masks = props.spatial_mask_provider.masks
     assert set(info_masks.keys()) == set(prop_masks.keys())

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -44,7 +44,7 @@ from fme.core.dataset.schedule import IntMilestone, IntSchedule
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.device import using_gpu
 from fme.core.distributed.distributed import Distributed
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.testing.regression import validate_tensor_dict
 from fme.core.typing_ import Slice
 
@@ -1214,7 +1214,7 @@ def test_localize_properties():
     mask_tensor = torch.arange(n_lat * n_lon, dtype=torch.float32).reshape(
         1, n_lat, n_lon
     )
-    mask_provider = MaskProvider(masks={"mask_test": mask_tensor})
+    mask_provider = SpatialMaskProvider(masks={"mask_test": mask_tensor})
     timestep = datetime.timedelta(hours=6)
     metadata = {"temp": VariableMetadata(units="K", long_name="Temperature")}
     vertical = NullVerticalCoordinate()
@@ -1222,7 +1222,7 @@ def test_localize_properties():
         variable_metadata=metadata,
         vertical_coordinate=vertical,
         horizontal_coordinates=coords,
-        mask_provider=mask_provider,
+        spatial_mask_provider=mask_provider,
         timestep=timestep,
         is_remote=False,
         all_labels=None,
@@ -1251,8 +1251,8 @@ def test_localize_properties():
         assert combined_lon == lon.tolist(), "lon coverage incomplete or has gaps"
 
     # Gather local masks to root and verify they tile to the global mask.
-    assert isinstance(local.mask_provider, MaskProvider)
-    local_mask = local.mask_provider.masks["mask_test"]
+    assert isinstance(local.spatial_mask_provider, SpatialMaskProvider)
+    local_mask = local.spatial_mask_provider.masks["mask_test"]
     h_slice, w_slice = dist.get_local_slices((n_lat, n_lon))
     all_slices = dist.gather_object((h_slice, w_slice))
     all_masks = dist.gather_object(local_mask.tolist())
@@ -1279,12 +1279,12 @@ def _global_properties():
     metadata = {"temp": VariableMetadata(units="K", long_name="Temperature")}
     vertical = NullVerticalCoordinate()
     mask = torch.ones(n_lat, n_lon)
-    mask_provider = MaskProvider(masks={"mask_land": mask})
+    mask_provider = SpatialMaskProvider(masks={"mask_land": mask})
     return DatasetProperties(
         variable_metadata=metadata,
         vertical_coordinate=vertical,
         horizontal_coordinates=coords,
-        mask_provider=mask_provider,
+        spatial_mask_provider=mask_provider,
         timestep=timestep,
         is_remote=False,
         all_labels=None,
@@ -1306,8 +1306,8 @@ def _assert_dataset_info_uses_global_properties(dataset_info, props):
     assert type(dataset_info.vertical_coordinate) is type(props.vertical_coordinate)
 
     # mask_provider must have the same keys as the global (non-localized) one
-    info_masks = dataset_info.mask_provider.masks
-    prop_masks = props.mask_provider.masks
+    info_masks = dataset_info.spatial_mask_provider.masks
+    prop_masks = props.spatial_mask_provider.masks
     assert set(info_masks.keys()) == set(prop_masks.keys())
     for key in prop_masks:
         assert info_masks[key].shape == prop_masks[key].shape

--- a/fme/ace/models/graphcast/main.py
+++ b/fme/ace/models/graphcast/main.py
@@ -135,7 +135,7 @@ class GraphCast(torch.nn.Module):
     def get_coordinates_and_mask(self):
         if any(x is None for x in (self.lat, self.lon, self.mask)):
             if self.is_ocean:
-                mask_provider = self.dataset_info.mask_provider
+                mask_provider = self.dataset_info.spatial_mask_provider
                 mask = mask_provider.get_mask_tensor_for("mask_2d")
                 if mask is not None:
                     self.mask = mask.cpu().numpy().astype(bool)

--- a/fme/ace/models/graphcast/main.py
+++ b/fme/ace/models/graphcast/main.py
@@ -135,8 +135,8 @@ class GraphCast(torch.nn.Module):
     def get_coordinates_and_mask(self):
         if any(x is None for x in (self.lat, self.lon, self.mask)):
             if self.is_ocean:
-                mask_provider = self.dataset_info.spatial_mask_provider
-                mask = mask_provider.get_mask_tensor_for("mask_2d")
+                spatial_mask_provider = self.dataset_info.spatial_mask_provider
+                mask = spatial_mask_provider.get_mask_tensor_for("mask_2d")
                 if mask is not None:
                     self.mask = mask.cpu().numpy().astype(bool)
                 else:

--- a/fme/ace/models/graphcast/test_graphcast.py
+++ b/fme/ace/models/graphcast/test_graphcast.py
@@ -30,14 +30,14 @@ def dummy_datasetinfo(height: int, width: int) -> DatasetInfo:
     mock_horizontal_coords.coords = {"lat": lat, "lon": lon}
     mock_horizontal_coords.meshgrid = (latT, lonT)
 
-    mask_provider = SpatialMaskProvider(
+    spatial_mask_provider = SpatialMaskProvider(
         masks={"mask_2d": torch.ones(height, width, dtype=torch.bool)}
     )
 
     # Create DatasetInfo with mocked components
     dataset_info = DatasetInfo(
         horizontal_coordinates=mock_horizontal_coords,
-        spatial_mask_provider=mask_provider,
+        spatial_mask_provider=spatial_mask_provider,
     )
 
     return dataset_info

--- a/fme/ace/models/graphcast/test_graphcast.py
+++ b/fme/ace/models/graphcast/test_graphcast.py
@@ -13,7 +13,7 @@ DIR = os.path.abspath(os.path.dirname(__file__))
 from fme.ace.models.graphcast import GRAPHCAST_AVAIL
 from fme.ace.models.graphcast.main import GraphCast
 from fme.core.dataset_info import DatasetInfo
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 
 
 def dummy_datasetinfo(height: int, width: int) -> DatasetInfo:
@@ -30,14 +30,14 @@ def dummy_datasetinfo(height: int, width: int) -> DatasetInfo:
     mock_horizontal_coords.coords = {"lat": lat, "lon": lon}
     mock_horizontal_coords.meshgrid = (latT, lonT)
 
-    mask_provider = MaskProvider(
+    mask_provider = SpatialMaskProvider(
         masks={"mask_2d": torch.ones(height, width, dtype=torch.bool)}
     )
 
     # Create DatasetInfo with mocked components
     dataset_info = DatasetInfo(
         horizontal_coordinates=mock_horizontal_coords,
-        mask_provider=mask_provider,
+        spatial_mask_provider=mask_provider,
     )
 
     return dataset_info

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -43,7 +43,6 @@ from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
 from fme.core.labels import BatchLabels
 from fme.core.loss import StepLoss, StepLossConfig
-from fme.core.masking import NullMasking, StaticMaskingConfig
 from fme.core.normalizer import (
     NetworkAndLossNormalizationConfig,
     NormalizationConfig,
@@ -52,6 +51,7 @@ from fme.core.normalizer import (
 from fme.core.ocean import OceanConfig
 from fme.core.optimization import NullOptimization
 from fme.core.registry import CorrectorSelector, ModuleSelector
+from fme.core.spatial_masking import NullSpatialMasking, StaticSpatialMaskingConfig
 from fme.core.step.args import StepArgs
 from fme.core.step.multi_call import (
     MultiCallConfig,
@@ -511,7 +511,7 @@ class StepperConfig:
     """
 
     step: StepSelector
-    input_masking: StaticMaskingConfig | None = None
+    input_masking: StaticSpatialMaskingConfig | None = None
     derived_forcings: DerivedForcingsConfig = dataclasses.field(
         default_factory=lambda: DerivedForcingsConfig()
     )
@@ -591,14 +591,16 @@ class StepperConfig:
                 dataset_info.timestep
             )
         if self.input_masking is None:
-            input_masking = NullMasking()
+            input_masking = NullSpatialMasking()
         else:
             input_masking = self.input_masking.build(
-                mask=dataset_info.mask_provider,
+                mask=dataset_info.spatial_mask_provider,
                 means=step.normalizer.means,
             )
         try:
-            output_process_func = dataset_info.mask_provider.build_output_masker()
+            output_process_func = (
+                dataset_info.spatial_mask_provider.build_output_spatial_masker()
+            )
         except MissingDatasetInfo:
             output_process_func = NullPostProcessFn()
         return Stepper(

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -66,8 +66,6 @@ from fme.core.dataset_info import DatasetInfo, MissingDatasetInfo
 from fme.core.device import get_device
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.loss import StepLossConfig
-from fme.core.mask_provider import MaskProvider
-from fme.core.masking import StaticMaskingConfig
 from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
 from fme.core.ocean import OceanConfig
 from fme.core.optimization import (
@@ -78,6 +76,8 @@ from fme.core.optimization import (
 )
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
+from fme.core.spatial_mask_provider import SpatialMaskProvider
+from fme.core.spatial_masking import StaticSpatialMaskingConfig
 from fme.core.step import SingleModuleStepConfig, StepSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.multi_call import MultiCallConfig
@@ -129,7 +129,7 @@ def get_data(names: Iterable[str], n_samples, n_time, epoch: int = 0) -> Spheric
 
 def get_dataset_info(
     img_shape=(5, 5),
-    mask_provider=None,
+    spatial_mask_provider=None,
     vertical_coordinate=None,
     horizontal_coordinate=None,
 ) -> DatasetInfo:
@@ -146,7 +146,7 @@ def get_dataset_info(
         horizontal_coordinates=horizontal_coordinate,
         vertical_coordinate=vertical_coordinate,
         timestep=TIMESTEP,
-        mask_provider=mask_provider,
+        spatial_mask_provider=spatial_mask_provider,
     )
 
 
@@ -1982,7 +1982,9 @@ def test_get_serialized_stepper_vertical_coordinate():
     assert isinstance(vertical_coordinate, VerticalCoordinate)
 
 
-def _get_stepper_with_input_masking(dataset_info_has_mask_provider: bool = True):
+def _get_stepper_with_input_masking(
+    dataset_info_has_spatial_mask_provider: bool = True,
+):
     # basic StepperConfig with input_masking configured
     config = StepperConfig(
         step=StepSelector(
@@ -2003,12 +2005,14 @@ def _get_stepper_with_input_masking(dataset_info_has_mask_provider: bool = True)
                 )
             ),
         ),
-        input_masking=StaticMaskingConfig(mask_value=0, fill_value=0.0),
+        input_masking=StaticSpatialMaskingConfig(mask_value=0, fill_value=0.0),
     )
-    mask_provider: MaskProvider | None = None
-    if dataset_info_has_mask_provider:
-        mask_provider = MaskProvider()
-    return config.get_stepper(get_dataset_info(mask_provider=mask_provider))
+    spatial_mask_provider: SpatialMaskProvider | None = None
+    if dataset_info_has_spatial_mask_provider:
+        spatial_mask_provider = SpatialMaskProvider()
+    return config.get_stepper(
+        get_dataset_info(spatial_mask_provider=spatial_mask_provider)
+    )
 
 
 def test_get_stepper_with_input_masking():
@@ -2016,14 +2020,16 @@ def test_get_stepper_with_input_masking():
     # configured when the vertical coordinate is a mask_provider
 
     # no error raised
-    _ = _get_stepper_with_input_masking(dataset_info_has_mask_provider=True)
+    _ = _get_stepper_with_input_masking(dataset_info_has_spatial_mask_provider=True)
 
 
 def test_get_stepper_with_input_masking_raises():
     # no get_mask_tensor_for method on vertical coordinate raises error when
     # input_masking provided in config
-    with pytest.raises(MissingDatasetInfo, match="mask_provider"):
-        _ = _get_stepper_with_input_masking(dataset_info_has_mask_provider=False)
+    with pytest.raises(MissingDatasetInfo, match="spatial_mask_provider"):
+        _ = _get_stepper_with_input_masking(
+            dataset_info_has_spatial_mask_provider=False
+        )
 
 
 @pytest.mark.parametrize("n_ensemble", [1, 3])

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -2017,7 +2017,7 @@ def _get_stepper_with_input_masking(
 
 def test_get_stepper_with_input_masking():
     # check that no error is raised when building a stepper with input_masking
-    # configured when the vertical coordinate is a mask_provider
+    # configured when the vertical coordinate is a spatial_mask_provider
 
     # no error raised
     _ = _get_stepper_with_input_masking(dataset_info_has_spatial_mask_provider=True)

--- a/fme/core/coordinates.py
+++ b/fme/core/coordinates.py
@@ -15,8 +15,12 @@ from fme.core.derived_variables import compute_derived_quantities
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.gridded_ops import GriddedOperations, HEALPixOperations, LatLonOperations
-from fme.core.mask_provider import MaskProvider, MaskProviderABC, NullMaskProvider
 from fme.core.ocean_derived_variables import compute_ocean_derived_quantities
+from fme.core.spatial_mask_provider import (
+    NullSpatialMaskProvider,
+    SpatialMaskProvider,
+    SpatialMaskProviderABC,
+)
 from fme.core.typing_ import TensorDict, TensorMapping
 from fme.core.winds import lon_lat_to_xyz
 
@@ -567,7 +571,7 @@ class HorizontalCoordinates(abc.ABC):
 
     @abc.abstractmethod
     def get_gridded_operations(
-        self, mask_provider: MaskProviderABC = NullMaskProvider
+        self, spatial_mask_provider: SpatialMaskProviderABC = NullSpatialMaskProvider
     ) -> GriddedOperations:
         pass
 
@@ -678,9 +682,9 @@ class LatLonCoordinates(HorizontalCoordinates):
             return "legendre-gauss"
 
     def get_gridded_operations(
-        self, mask_provider: MaskProviderABC = NullMaskProvider
+        self, spatial_mask_provider: SpatialMaskProviderABC = NullSpatialMaskProvider
     ) -> LatLonOperations:
-        return LatLonOperations(self.area_weights, mask_provider)
+        return LatLonOperations(self.area_weights, spatial_mask_provider)
 
     @property
     def meshgrid(self) -> tuple[torch.Tensor, torch.Tensor]:
@@ -812,22 +816,23 @@ class HEALPixCoordinates(HorizontalCoordinates):
         return None
 
     def get_gridded_operations(
-        self, mask_provider: MaskProviderABC = NullMaskProvider
+        self, spatial_mask_provider: SpatialMaskProviderABC = NullSpatialMaskProvider
     ) -> HEALPixOperations:
         # this code is necessary because when no masks are in a given dataset, we return
-        # an empty MaskProvider instead of the NullMaskProvider.
-        if mask_provider == NullMaskProvider:
+        # an empty SpatialMaskProvider instead of the NullSpatialMaskProvider.
+        if spatial_mask_provider == NullSpatialMaskProvider:
             null_mask = True
-        elif isinstance(mask_provider, MaskProvider):
-            null_mask = len(mask_provider.masks) == 0
+        elif isinstance(spatial_mask_provider, SpatialMaskProvider):
+            null_mask = len(spatial_mask_provider.masks) == 0
         else:
             raise TypeError(
-                f"Don't know how to handle given mask_provider: {mask_provider}"
+                "Don't know how to handle given spatial_mask_provider: "
+                f"{spatial_mask_provider}"
             )
         if not (null_mask):
             raise NotImplementedError(
                 "HEALPixCoordinates does not support a mask provider. "
-                "Use NullMaskProvider when getting gridded operations "
+                "Use NullSpatialMaskProvider when getting gridded operations "
                 "for HEALPixCoordinates."
             )
         return HEALPixOperations(self.nside)

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -14,8 +14,8 @@ from fme.core.corrector.ocean import (
     _compute_ocean_net_surface_energy_flux,
 )
 from fme.core.gridded_ops import LatLonOperations
-from fme.core.mask_provider import MaskProvider
 from fme.core.ocean_data import OceanData
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.typing_ import TensorMapping
 
 DEVICE = get_device()
@@ -325,7 +325,7 @@ def test_ocean_heat_content_correction(hfds_type):
         "mask_1": mask[:, :, :, 1],
         "mask_2d": mask[:, :, :, 0],
     }
-    mask_provider = MaskProvider(masks)
+    mask_provider = SpatialMaskProvider(masks)
     ops = LatLonOperations(torch.ones(size=[3, 3]), mask_provider)
 
     idepth = torch.tensor([2.5, 10, 20])

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -325,8 +325,8 @@ def test_ocean_heat_content_correction(hfds_type):
         "mask_1": mask[:, :, :, 1],
         "mask_2d": mask[:, :, :, 0],
     }
-    mask_provider = SpatialMaskProvider(masks)
-    ops = LatLonOperations(torch.ones(size=[3, 3]), mask_provider)
+    spatial_mask_provider = SpatialMaskProvider(masks)
+    ops = LatLonOperations(torch.ones(size=[3, 3]), spatial_mask_provider)
 
     idepth = torch.tensor([2.5, 10, 20])
     depth_coordinate = DepthCoordinate(idepth, mask)

--- a/fme/core/dataset/dummy.py
+++ b/fme/core/dataset/dummy.py
@@ -9,7 +9,7 @@ from fme.core.dataset.dataset import DatasetABC, DatasetItem
 from fme.core.dataset.properties import DatasetProperties
 from fme.core.dataset.schedule import IntSchedule
 from fme.core.dataset.xarray import _get_timestep
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 
 
 class DummyDataset(DatasetABC):
@@ -86,7 +86,7 @@ class DummyDataset(DatasetABC):
             variable_metadata={},
             vertical_coordinate=NullVerticalCoordinate(),
             horizontal_coordinates=self._horizontal_coordinates,
-            mask_provider=MaskProvider(),
+            spatial_mask_provider=SpatialMaskProvider(),
             timestep=self.timestep,
             is_remote=False,
             all_labels=self._labels,

--- a/fme/core/dataset/properties.py
+++ b/fme/core/dataset/properties.py
@@ -4,7 +4,7 @@ import warnings
 from fme.core.coordinates import HorizontalCoordinates, VerticalCoordinate
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.device import get_device
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 
 
 class DatasetProperties:
@@ -13,7 +13,7 @@ class DatasetProperties:
         variable_metadata: dict[str, VariableMetadata],
         vertical_coordinate: VerticalCoordinate,
         horizontal_coordinates: HorizontalCoordinates,
-        mask_provider: MaskProvider,
+        spatial_mask_provider: SpatialMaskProvider,
         timestep: datetime.timedelta | None,
         is_remote: bool,
         all_labels: set[str] | None,
@@ -21,7 +21,7 @@ class DatasetProperties:
         self.variable_metadata = variable_metadata
         self.vertical_coordinate = vertical_coordinate
         self.horizontal_coordinates = horizontal_coordinates
-        self.mask_provider = mask_provider
+        self.spatial_mask_provider = spatial_mask_provider
         self.timestep = timestep
         self.is_remote = is_remote
         self.all_labels = all_labels
@@ -32,7 +32,7 @@ class DatasetProperties:
             self.variable_metadata,
             self.vertical_coordinate.to(device),
             self.horizontal_coordinates.to(device),
-            self.mask_provider.to(device),
+            self.spatial_mask_provider.to(device),
             self.timestep,
             self.is_remote,
             self.all_labels,
@@ -46,7 +46,7 @@ class DatasetProperties:
             self.variable_metadata,
             self.vertical_coordinate,
             self.horizontal_coordinates.localize(),
-            self.mask_provider.localize(),
+            self.spatial_mask_provider.localize(),
             self.timestep,
             self.is_remote,
             self.all_labels,
@@ -62,7 +62,7 @@ class DatasetProperties:
                 raise ValueError("Inconsistent vertical coordinates between datasets")
             if self.horizontal_coordinates != other.horizontal_coordinates:
                 raise ValueError("Inconsistent horizontal coordinates between datasets")
-            if self.mask_provider != other.mask_provider:
+            if self.spatial_mask_provider != other.spatial_mask_provider:
                 raise ValueError("Inconsistent mask providers between datasets")
         except ValueError as e:
             if strict:
@@ -89,7 +89,7 @@ class DatasetProperties:
     def update_merged_dataset(self, other: "DatasetProperties"):
         if isinstance(self.variable_metadata, dict):
             self.variable_metadata.update(other.variable_metadata)
-        self.mask_provider.update(other.mask_provider)
+        self.spatial_mask_provider.update(other.spatial_mask_provider)
         self.is_remote = self.is_remote or other.is_remote
         if self.timestep != other.timestep:
             raise ValueError("Inconsistent timesteps between datasets")
@@ -97,15 +97,15 @@ class DatasetProperties:
             raise ValueError("Inconsistent horizontal coordinates between datasets")
         self._update_labels(other)
 
-    def update_mask_provider(self, mask_provider: MaskProvider):
-        self.mask_provider.update(mask_provider)
+    def update_spatial_mask_provider(self, spatial_mask_provider: SpatialMaskProvider):
+        self.spatial_mask_provider.update(spatial_mask_provider)
 
     def copy(self) -> "DatasetProperties":
         return DatasetProperties(
             self.variable_metadata,
             self.vertical_coordinate,
             self.horizontal_coordinates,
-            self.mask_provider,
+            self.spatial_mask_provider,
             self.timestep,
             self.is_remote,
             self.all_labels,

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -39,7 +39,7 @@ from fme.core.dataset.xarray import (
     _repeat_and_increment_time,
     get_xarray_dataset,
 )
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.typing_ import Slice
 
 from .utils import as_broadcasted_tensor
@@ -1226,7 +1226,7 @@ def test_dataset_properties_update_masks(mock_monthly_netcdfs):
     config = XarrayDataConfig(data_path=mock_data.tmpdir)
     dataset = xarray_dataset_constructor(config, mock_data.var_names.all_names, 2)
     data_properties = dataset.properties
-    assert not data_properties.mask_provider.masks
-    existing_mask = MaskProvider(masks={"mask_0": torch.ones(4, 8)})
-    data_properties.update_mask_provider(existing_mask)
-    assert "mask_0" in dataset.properties.mask_provider.masks
+    assert not data_properties.spatial_mask_provider.masks
+    existing_mask = SpatialMaskProvider(masks={"mask_0": torch.ones(4, 8)})
+    data_properties.update_spatial_mask_provider(existing_mask)
+    assert "mask_0" in dataset.properties.spatial_mask_provider.masks

--- a/fme/core/dataset/testing.py
+++ b/fme/core/dataset/testing.py
@@ -7,7 +7,7 @@ import xarray as xr
 from fme.core.coordinates import LatLonCoordinates, NullVerticalCoordinate
 from fme.core.dataset.dataset import DatasetABC, DatasetItem
 from fme.core.dataset.properties import DatasetProperties
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.typing_ import TensorMapping
 
 
@@ -45,7 +45,7 @@ class MockDataset(DatasetABC):
                 horizontal_coordinates=LatLonCoordinates(
                     lon=torch.arange(0, 1), lat=torch.arange(0, 1)
                 ),
-                mask_provider=MaskProvider(),
+                spatial_mask_provider=SpatialMaskProvider(),
                 timestep=None,
                 is_remote=False,
                 all_labels=self.labels,

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -31,7 +31,7 @@ from fme.core.dataset.properties import DatasetProperties
 from fme.core.dataset.schedule import IntSchedule
 from fme.core.dataset.time import RepeatedInterval, TimeSlice
 from fme.core.dataset.utils import FillNaNsConfig
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.stacker import Stacker
 from fme.core.typing_ import Slice, TensorDict
 
@@ -333,12 +333,14 @@ def get_raw_paths(path, file_pattern):
     return raw_paths
 
 
-def _get_mask_provider(ds: xr.Dataset, dtype: torch.dtype | None) -> MaskProvider:
+def _get_spatial_mask_provider(
+    ds: xr.Dataset, dtype: torch.dtype | None
+) -> SpatialMaskProvider:
     """Get mask provider from a dataset.
 
     If the dataset contains time-invariant variables that start with the string
-    "mask_" then these variables will be used to instantiate a MaskProvider
-    object. Otherwise, an empty MaskProvider is returned.
+    "mask_" then these variables will be used to instantiate a SpatialMaskProvider
+    object. Otherwise, an empty SpatialMaskProvider is returned.
 
     Args:
         ds: Dataset to get vertical coordinates from.
@@ -354,7 +356,7 @@ def _get_mask_provider(ds: xr.Dataset, dtype: torch.dtype | None) -> MaskProvide
     for name in masks:
         if "time" in ds[name].dims:
             raise ValueError("Masks must be time-independent.")
-    mask_provider = MaskProvider(masks)
+    mask_provider = SpatialMaskProvider(masks)
     logging.info(f"Initialized {mask_provider}.")
     return mask_provider
 
@@ -568,7 +570,7 @@ class XarrayDataset(DatasetABC):
             engine=self.engine,
             chunks=None,
         )
-        self._mask_provider = _get_mask_provider(first_dataset, self.dtype)
+        self._mask_provider = _get_spatial_mask_provider(first_dataset, self.dtype)
         (
             self._horizontal_coordinates,
             self._static_derived_data,

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -356,9 +356,9 @@ def _get_spatial_mask_provider(
     for name in masks:
         if "time" in ds[name].dims:
             raise ValueError("Masks must be time-independent.")
-    mask_provider = SpatialMaskProvider(masks)
-    logging.info(f"Initialized {mask_provider}.")
-    return mask_provider
+    spatial_mask_provider = SpatialMaskProvider(masks)
+    logging.info(f"Initialized {spatial_mask_provider}.")
+    return spatial_mask_provider
 
 
 @dataclasses.dataclass
@@ -570,7 +570,9 @@ class XarrayDataset(DatasetABC):
             engine=self.engine,
             chunks=None,
         )
-        self._mask_provider = _get_spatial_mask_provider(first_dataset, self.dtype)
+        self._spatial_mask_provider = _get_spatial_mask_provider(
+            first_dataset, self.dtype
+        )
         (
             self._horizontal_coordinates,
             self._static_derived_data,
@@ -682,7 +684,7 @@ class XarrayDataset(DatasetABC):
             self._variable_metadata,
             self._vertical_coordinate,
             self._horizontal_coordinates,
-            self._mask_provider,
+            self._spatial_mask_provider,
             self.timestep,
             self._is_remote,
             self._labels,

--- a/fme/core/dataset_info.py
+++ b/fme/core/dataset_info.py
@@ -14,8 +14,12 @@ from fme.core.coordinates import (
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.dataset.utils import decode_timestep, encode_timestep
 from fme.core.gridded_ops import GriddedOperations
-from fme.core.mask_provider import MaskProvider, MaskProviderABC, NullMaskProvider
 from fme.core.ocean_data import HasOceanDepthIntegral
+from fme.core.spatial_mask_provider import (
+    NullSpatialMaskProvider,
+    SpatialMaskProvider,
+    SpatialMaskProviderABC,
+)
 
 
 class MissingDatasetInfo(ValueError):
@@ -46,7 +50,7 @@ class DatasetInfo:
         self,
         horizontal_coordinates: HorizontalCoordinates | None = None,
         vertical_coordinate: VerticalCoordinate | None = None,
-        mask_provider: MaskProvider | None = None,
+        spatial_mask_provider: SpatialMaskProvider | None = None,
         timestep: datetime.timedelta | None = None,
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         gridded_operations: GriddedOperations | None = None,
@@ -55,7 +59,7 @@ class DatasetInfo:
     ):
         self._horizontal_coordinates = horizontal_coordinates
         self._vertical_coordinate = vertical_coordinate
-        self._mask_provider = mask_provider
+        self._mask_provider = spatial_mask_provider
         self._timestep = timestep
         self._variable_metadata = variable_metadata
         if all_labels is None:
@@ -93,7 +97,7 @@ class DatasetInfo:
             f"horizontal_coordinates={self._horizontal_coordinates}, "
             f"vertical_coordinate={self._vertical_coordinate}, "
             f"timestep={self._timestep}), "
-            f"mask_provider={self._mask_provider}, "
+            f"spatial_mask_provider={self._mask_provider}, "
             f"variable_metadata={self._variable_metadata}, "
             f"all_labels={self._all_labels})"
         )
@@ -125,7 +129,7 @@ class DatasetInfo:
             try:
                 self._mask_provider.assert_compatible_with(other._mask_provider)
             except AssertionError as e:
-                issues.append(f"mask_provider is not compatible: {e}")
+                issues.append(f"spatial_mask_provider is not compatible: {e}")
         if self._timestep is not None:
             if self._timestep != other._timestep:
                 issues.append(
@@ -166,10 +170,12 @@ class DatasetInfo:
         if self._horizontal_coordinates is None:
             raise MissingDatasetInfo("horizontal_coordinates")
         if self._mask_provider is None:
-            mp: MaskProviderABC = NullMaskProvider
+            mp: SpatialMaskProviderABC = NullSpatialMaskProvider
         else:
             mp = self._mask_provider
-        return self._horizontal_coordinates.get_gridded_operations(mask_provider=mp)
+        return self._horizontal_coordinates.get_gridded_operations(
+            spatial_mask_provider=mp
+        )
 
     @property
     def horizontal_coordinates(self) -> HorizontalCoordinates:
@@ -206,9 +212,9 @@ class DatasetInfo:
         )
 
     @property
-    def mask_provider(self) -> MaskProvider:
+    def spatial_mask_provider(self) -> SpatialMaskProvider:
         if self._mask_provider is None:
-            raise MissingDatasetInfo("mask_provider")
+            raise MissingDatasetInfo("spatial_mask_provider")
         return self._mask_provider
 
     @property
@@ -232,7 +238,7 @@ class DatasetInfo:
         return DatasetInfo(
             horizontal_coordinates=self._horizontal_coordinates,
             vertical_coordinate=self._vertical_coordinate,
-            mask_provider=self._mask_provider,
+            spatial_mask_provider=self._mask_provider,
             timestep=self._timestep,
             variable_metadata=new_metadata,
             gridded_operations=self._gridded_operations,
@@ -311,7 +317,7 @@ class DatasetInfo:
         else:
             vertical_coordinate = None
         if state.get("mask_provider") is not None:
-            mask_provider = MaskProvider.from_state(state["mask_provider"])
+            mask_provider = SpatialMaskProvider.from_state(state["mask_provider"])
         else:
             mask_provider = None
         if state.get("timestep") is not None:
@@ -322,7 +328,7 @@ class DatasetInfo:
         return cls(
             horizontal_coordinates=horizontal_coordinates,
             vertical_coordinate=vertical_coordinate,
-            mask_provider=mask_provider,
+            spatial_mask_provider=mask_provider,
             timestep=timestep,
             variable_metadata=variable_metadata,
             gridded_operations=gridded_ops,

--- a/fme/core/dataset_info.py
+++ b/fme/core/dataset_info.py
@@ -59,7 +59,7 @@ class DatasetInfo:
     ):
         self._horizontal_coordinates = horizontal_coordinates
         self._vertical_coordinate = vertical_coordinate
-        self._mask_provider = spatial_mask_provider
+        self._spatial_mask_provider = spatial_mask_provider
         self._timestep = timestep
         self._variable_metadata = variable_metadata
         if all_labels is None:
@@ -86,7 +86,7 @@ class DatasetInfo:
             and self._gridded_operations == other._gridded_operations
             and self._horizontal_coordinates == other._horizontal_coordinates
             and self._vertical_coordinate == other._vertical_coordinate
-            and self._mask_provider == other._mask_provider
+            and self._spatial_mask_provider == other._spatial_mask_provider
             and self._timestep == other._timestep
             and self._variable_metadata == other._variable_metadata
         )
@@ -97,7 +97,7 @@ class DatasetInfo:
             f"horizontal_coordinates={self._horizontal_coordinates}, "
             f"vertical_coordinate={self._vertical_coordinate}, "
             f"timestep={self._timestep}), "
-            f"spatial_mask_provider={self._mask_provider}, "
+            f"spatial_mask_provider={self._spatial_mask_provider}, "
             f"variable_metadata={self._variable_metadata}, "
             f"all_labels={self._all_labels})"
         )
@@ -125,9 +125,14 @@ class DatasetInfo:
                     f"vertical_coordinate is not compatible, "
                     f"{self._vertical_coordinate} != {other._vertical_coordinate}"
                 )
-        if self._mask_provider is not None and other._mask_provider is not None:
+        if (
+            self._spatial_mask_provider is not None
+            and other._spatial_mask_provider is not None
+        ):
             try:
-                self._mask_provider.assert_compatible_with(other._mask_provider)
+                self._spatial_mask_provider.assert_compatible_with(
+                    other._spatial_mask_provider
+                )
             except AssertionError as e:
                 issues.append(f"spatial_mask_provider is not compatible: {e}")
         if self._timestep is not None:
@@ -169,10 +174,10 @@ class DatasetInfo:
             return self._gridded_operations
         if self._horizontal_coordinates is None:
             raise MissingDatasetInfo("horizontal_coordinates")
-        if self._mask_provider is None:
+        if self._spatial_mask_provider is None:
             mp: SpatialMaskProviderABC = NullSpatialMaskProvider
         else:
-            mp = self._mask_provider
+            mp = self._spatial_mask_provider
         return self._horizontal_coordinates.get_gridded_operations(
             spatial_mask_provider=mp
         )
@@ -213,9 +218,9 @@ class DatasetInfo:
 
     @property
     def spatial_mask_provider(self) -> SpatialMaskProvider:
-        if self._mask_provider is None:
+        if self._spatial_mask_provider is None:
             raise MissingDatasetInfo("spatial_mask_provider")
-        return self._mask_provider
+        return self._spatial_mask_provider
 
     @property
     def timestep(self) -> datetime.timedelta:
@@ -238,7 +243,7 @@ class DatasetInfo:
         return DatasetInfo(
             horizontal_coordinates=self._horizontal_coordinates,
             vertical_coordinate=self._vertical_coordinate,
-            spatial_mask_provider=self._mask_provider,
+            spatial_mask_provider=self._spatial_mask_provider,
             timestep=self._timestep,
             variable_metadata=new_metadata,
             gridded_operations=self._gridded_operations,
@@ -263,10 +268,10 @@ class DatasetInfo:
             vertical_coordinate = None
         else:
             vertical_coordinate = self._vertical_coordinate.as_dict()
-        if self._mask_provider is None:
-            mask_provider = None
+        if self._spatial_mask_provider is None:
+            spatial_mask_provider = None
         else:
-            mask_provider = self._mask_provider.get_state()
+            spatial_mask_provider = self._spatial_mask_provider.get_state()
         if self._timestep is None:
             timestep = None
         else:
@@ -274,7 +279,7 @@ class DatasetInfo:
         return {
             "horizontal_coordinates": horizontal_coordinates,
             "vertical_coordinate": vertical_coordinate,
-            "mask_provider": mask_provider,
+            "mask_provider": spatial_mask_provider,
             "timestep": timestep,
             "variable_metadata": self._variable_metadata,
             "gridded_operations": gridded_operations,
@@ -317,9 +322,11 @@ class DatasetInfo:
         else:
             vertical_coordinate = None
         if state.get("mask_provider") is not None:
-            mask_provider = SpatialMaskProvider.from_state(state["mask_provider"])
+            spatial_mask_provider = SpatialMaskProvider.from_state(
+                state["mask_provider"]
+            )
         else:
-            mask_provider = None
+            spatial_mask_provider = None
         if state.get("timestep") is not None:
             timestep = decode_timestep(state["timestep"])
         else:
@@ -328,7 +335,7 @@ class DatasetInfo:
         return cls(
             horizontal_coordinates=horizontal_coordinates,
             vertical_coordinate=vertical_coordinate,
-            spatial_mask_provider=mask_provider,
+            spatial_mask_provider=spatial_mask_provider,
             timestep=timestep,
             variable_metadata=variable_metadata,
             gridded_operations=gridded_ops,

--- a/fme/core/gridded_ops.py
+++ b/fme/core/gridded_ops.py
@@ -11,7 +11,10 @@ from fme.core.cuhpx.sht import iSHT as CuHpxiSHT
 from fme.core.device import get_device
 from fme.core.distributed.distributed import Distributed
 from fme.core.hpx.reorder import get_reordering_xy_to_ring
-from fme.core.mask_provider import MaskProviderABC, NullMaskProvider
+from fme.core.spatial_mask_provider import (
+    NullSpatialMaskProvider,
+    SpatialMaskProviderABC,
+)
 from fme.core.tensors import assert_dict_allclose
 from fme.core.typing_ import TensorDict, TensorMapping
 
@@ -265,14 +268,14 @@ def get_all_subclasses(cls: type[T]) -> list[type[T]]:
     return all_subclasses
 
 
-def _mask_area_weights(
+def _spatial_mask_area_weights(
     area_weights: torch.Tensor,
-    mask_provider: MaskProviderABC,
+    spatial_mask_provider: SpatialMaskProviderABC,
     name: str | None,
 ) -> torch.Tensor:
     if name is None:
         return area_weights
-    mask = mask_provider.get_mask_tensor_for(name)
+    mask = spatial_mask_provider.get_mask_tensor_for(name)
     if mask is None:
         return area_weights
     return area_weights * mask
@@ -284,7 +287,7 @@ class LatLonOperations(GriddedOperations):
     def __init__(
         self,
         area_weights: torch.Tensor,
-        mask_provider: MaskProviderABC = NullMaskProvider,
+        spatial_mask_provider: SpatialMaskProviderABC = NullSpatialMaskProvider,
         grid: str = "legendre-gauss",
     ):
         self._validate_area_weights(area_weights)
@@ -295,8 +298,8 @@ class LatLonOperations(GriddedOperations):
         local_weights = self._cpu_area_global[..., h_slice, w_slice]
         self._device_area = local_weights.to(get_device(), copy=True)
         self._cpu_area = local_weights.to("cpu", copy=True)
-        self._device_mask_provider = mask_provider.to(get_device())
-        self._cpu_mask_provider = mask_provider.to("cpu")
+        self._device_mask_provider = spatial_mask_provider.to(get_device())
+        self._cpu_mask_provider = spatial_mask_provider.to("cpu")
         self._grid = grid
 
     def _validate_area_weights(self, area_weights: torch.Tensor) -> None:
@@ -319,11 +322,13 @@ class LatLonOperations(GriddedOperations):
     ):
         if data.device == torch.device("cpu"):
             area_weights = self._cpu_area
-            mask_provider = self._cpu_mask_provider
+            spatial_mask_provider = self._cpu_mask_provider
         else:
             area_weights = self._device_area
-            mask_provider = self._device_mask_provider
-        area_weights = _mask_area_weights(area_weights, mask_provider, name)
+            spatial_mask_provider = self._device_mask_provider
+        area_weights = _spatial_mask_area_weights(
+            area_weights, spatial_mask_provider, name
+        )
         if regional_weights is None:
             return area_weights
         if regional_weights.device.type != data.device.type:

--- a/fme/core/prescriber.py
+++ b/fme/core/prescriber.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from fme.core.masking import replace_on_mask
+from fme.core.spatial_masking import replace_on_mask
 from fme.core.typing_ import TensorDict, TensorMapping
 
 

--- a/fme/core/spatial_mask_provider.py
+++ b/fme/core/spatial_mask_provider.py
@@ -8,14 +8,14 @@ import torch
 
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
-from fme.core.masking import NullMasking, StaticMasking
+from fme.core.spatial_masking import NullSpatialMasking, StaticSpatialMasking
 from fme.core.typing_ import TensorDict, TensorMapping
 
 LEVEL_PATTERN = re.compile(r"_(\d+)$")
 
 
-class MaskProviderABC(abc.ABC):
-    SelfType = TypeVar("SelfType", bound="MaskProviderABC")
+class SpatialMaskProviderABC(abc.ABC):
+    SelfType = TypeVar("SelfType", bound="SpatialMaskProviderABC")
 
     @abc.abstractmethod
     def get_mask_tensor_for(self, name: str) -> torch.Tensor | None: ...
@@ -27,7 +27,7 @@ class MaskProviderABC(abc.ABC):
     def update(self: SelfType, other: SelfType) -> None: ...
 
     @abc.abstractmethod
-    def build_output_masker(self) -> Callable[[TensorMapping], TensorDict]: ...
+    def build_output_spatial_masker(self) -> Callable[[TensorMapping], TensorDict]: ...
 
     @abc.abstractmethod
     def localize(self: SelfType) -> SelfType:
@@ -38,49 +38,49 @@ class MaskProviderABC(abc.ABC):
     def get_state(self) -> dict[str, Any]: ...
 
 
-class _NullMaskProvider(MaskProviderABC):
+class _NullSpatialMaskProvider(SpatialMaskProviderABC):
     def get_mask_tensor_for(self, name: str) -> torch.Tensor | None:
         return None
 
-    def to(self, device: str) -> "_NullMaskProvider":
+    def to(self, device: str) -> "_NullSpatialMaskProvider":
         return self
 
-    def localize(self) -> "_NullMaskProvider":
+    def localize(self) -> "_NullSpatialMaskProvider":
         return self
 
-    def update(self, other: MaskProviderABC) -> None:
-        if not isinstance(other, _NullMaskProvider):
+    def update(self, other: SpatialMaskProviderABC) -> None:
+        if not isinstance(other, _NullSpatialMaskProvider):
             raise ValueError(
-                f"Attempted to update NullMaskProvider with non-null {other}"
+                f"Attempted to update NullSpatialMaskProvider with non-null {other}"
             )
 
-    def build_output_masker(self) -> Callable[[TensorMapping], TensorDict]:
-        return NullMasking()
+    def build_output_spatial_masker(self) -> Callable[[TensorMapping], TensorDict]:
+        return NullSpatialMasking()
 
     def get_state(self) -> dict[str, Any]:
         return {"masks": {}}
 
 
-NullMaskProvider = _NullMaskProvider()
+NullSpatialMaskProvider = _NullSpatialMaskProvider()
 
 
-class MaskProvider(MaskProviderABC):
+class SpatialMaskProvider(SpatialMaskProviderABC):
     """
     Stores and returns 2D mask tensors.
 
     Masks are special time-invariant data variables with names that start with
-    the string "mask_". There are three types of masks that MaskProvider knows
-    how to use, in order from highest to lowest priority:
+    the string "mask_". There are three types of masks that SpatialMaskProvider
+    knows how to use, in order from highest to lowest priority:
 
     1. Variable-specific masks, e.g. "mask_sst" and "mask_thetao_1".
     2. Level-specific masks, e.g. "mask_0" and "mask_1".
     3. A catch-all 2D mask named "mask_2d".
 
-    For example, when matching the variable "theta_1", MaskProvider will first
+    For example, when matching the variable "theta_1", SpatialMaskProvider will first
     check if it has a mask called "mask_theta_1". If not, then it will check for
     a mask called "mask_1", returning None if this is also not found.
 
-    Another example: when matching the variable "sst", MaskProvider checks for
+    Another example: when matching the variable "sst", SpatialMaskProvider checks for
     "mask_sst" and then "mask_2d", returning None if neither are found.
 
     Args:
@@ -97,18 +97,18 @@ class MaskProvider(MaskProviderABC):
         for key in self._masks:
             if not key.startswith("mask_"):
                 raise ValueError(
-                    "The 'mask' TensorDict passed to MaskProvider init has "
+                    "The 'mask' TensorDict passed to SpatialMaskProvider init has "
                     f"non-mask tensors, including {key}. Expected all keys "
                     "to start with the string 'mask_'."
                 )
 
-    def build_output_masker(self) -> Callable[[TensorMapping], TensorDict]:
+    def build_output_spatial_masker(self) -> Callable[[TensorMapping], TensorDict]:
         """
-        Returns a StaticMasking object that fills in NaNs outside of mask
+        Returns a StaticSpatialMasking object that fills in NaNs outside of mask
         valid points, i.e. where the mask value is 0.
 
         """
-        return StaticMasking(
+        return StaticSpatialMasking(
             mask_value=0,
             fill_value=float("nan"),
             mask=self,
@@ -132,26 +132,26 @@ class MaskProvider(MaskProviderABC):
         # 2D mask or None
         return self.masks.get("mask_2d", None)
 
-    def to(self, device: str) -> "MaskProvider":
-        return MaskProvider(
+    def to(self, device: str) -> "SpatialMaskProvider":
+        return SpatialMaskProvider(
             {name: tensor.to(device) for name, tensor in self.masks.items()},
         )
 
-    def localize(self) -> "MaskProvider":
+    def localize(self) -> "SpatialMaskProvider":
         if not self._masks:
             return self
-        return MaskProvider(
+        return SpatialMaskProvider(
             {
                 k: v[Distributed.get_instance().get_local_slices(v.shape)].contiguous()
                 for k, v in self._masks.items()
             },
         )
 
-    def update(self, other: "MaskProvider") -> None:
-        """Update the MaskProvider's masks with masks from another MaskProvider.
+    def update(self, other: "SpatialMaskProvider") -> None:
+        """Update masks with masks from another SpatialMaskProvider.
 
         Raises a ValueError if there are overlapping mask names between the two
-        MaskProviders.
+        SpatialMaskProviders.
         """
         self_keys = set(self.masks.keys())
         other_keys = set(other.masks.keys())
@@ -168,7 +168,7 @@ class MaskProvider(MaskProviderABC):
             self._masks.update(other.masks)
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, MaskProvider):
+        if not isinstance(other, SpatialMaskProvider):
             return False
         if not self.masks.keys() == other.masks.keys():
             return False
@@ -181,14 +181,16 @@ class MaskProvider(MaskProviderABC):
 
     def __repr__(self) -> str:
         return (
-            "MaskProvider(\n    masks=[\n        "
+            "SpatialMaskProvider(\n    masks=[\n        "
             + ",\n        ".join(sorted(list(self.masks.keys())))
             + ",\n    ]\n)"
         )
 
     def assert_compatible_with(self, other) -> None:
-        if not isinstance(other, MaskProvider):
-            raise AssertionError(f"expected MaskProvider, got {type(other).__name__}")
+        if not isinstance(other, SpatialMaskProvider):
+            raise AssertionError(
+                f"expected SpatialMaskProvider, got {type(other).__name__}"
+            )
         missing_keys = self.masks.keys() - other.masks.keys()
         if missing_keys:
             raise AssertionError(f"mask keys {missing_keys} not found in other")
@@ -202,7 +204,7 @@ class MaskProvider(MaskProviderABC):
         return {"masks": self.masks}
 
     @classmethod
-    def from_state(cls, state: dict[str, Any]) -> "MaskProvider":
+    def from_state(cls, state: dict[str, Any]) -> "SpatialMaskProvider":
         device = get_device()
         masks = {k: v.to(device, copy=True) for k, v in state["masks"].items()}
         return cls(masks=masks)

--- a/fme/core/spatial_masking.py
+++ b/fme/core/spatial_masking.py
@@ -32,20 +32,20 @@ def replace_on_mask(
 
 
 @runtime_checkable
-class HasGetMaskTensorFor(Protocol):
-    def build_output_masker(self) -> Callable[[TensorMapping], TensorDict]: ...
+class HasGetSpatialMask(Protocol):
+    def build_output_spatial_masker(self) -> Callable[[TensorMapping], TensorDict]: ...
 
     def get_mask_tensor_for(self, name: str) -> torch.Tensor | None:
         """Get the mask for a specific variable name."""
         ...
 
-    def to(self, device: str) -> "HasGetMaskTensorFor": ...
+    def to(self, device: str) -> "HasGetSpatialMask": ...
 
 
 @dataclasses.dataclass
-class StaticMaskingConfig:
+class StaticSpatialMaskingConfig:
     """
-    Replace static masked regions with a fill value.
+    Replace static spatially masked regions with a fill value.
 
     Parameters:
         mask_value: Value of the mask variable in masked regions. Either 0 or 1.
@@ -67,13 +67,13 @@ class StaticMaskingConfig:
                 f"mask_value must be either 0 or 1, but got {self.mask_value}"
             )
 
-    def build(self, mask: HasGetMaskTensorFor, means: TensorMapping | None = None):
+    def build(self, mask: HasGetSpatialMask, means: TensorMapping | None = None):
         """
-        Build StaticMasking.
+        Build StaticSpatialMasking.
 
         """
         if isinstance(self.fill_value, float):
-            return StaticMasking(
+            return StaticSpatialMasking(
                 mask_value=self.mask_value,
                 fill_value=collections.defaultdict(
                     lambda: torch.as_tensor(self.fill_value)
@@ -86,7 +86,7 @@ class StaticMaskingConfig:
                 "fill_values mapping required by build unless configured "
                 "fill_value is a float."
             )
-        return StaticMasking(
+        return StaticSpatialMasking(
             mask_value=self.mask_value,
             fill_value=means,
             mask=mask,
@@ -94,12 +94,12 @@ class StaticMaskingConfig:
         )
 
 
-class StaticMasking:
+class StaticSpatialMasking:
     def __init__(
         self,
         mask_value: int,
         fill_value: float | TensorMapping,
-        mask: HasGetMaskTensorFor,
+        mask: HasGetSpatialMask,
         exclude_names_and_prefixes: list[str] | None = None,
     ):
         if isinstance(fill_value, float):
@@ -150,7 +150,7 @@ class StaticMasking:
                 fill_value = self._fill_mapping[name]
             except KeyError as err:
                 raise KeyError(
-                    "StaticMasking was initialized with a fill_value mapping "
+                    "StaticSpatialMasking was initialized with a fill_value mapping "
                     f"but the mapping is missing key '{name}'."
                 ) from err
             fill = torch.full_like(tensor, fill_value)
@@ -165,6 +165,6 @@ class StaticMasking:
         return data_
 
 
-class NullMasking:
+class NullSpatialMasking:
     def __call__(self, data: TensorMapping) -> TensorDict:
         return dict(data)

--- a/fme/core/test_coordinates.py
+++ b/fme/core/test_coordinates.py
@@ -13,7 +13,7 @@ from fme.core.coordinates import (
     dz_from_idepth,
 )
 from fme.core.device import get_device
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 
 try:
     from earth2grid import healpix as e2ghpx
@@ -216,8 +216,8 @@ def test_masked_lat_lon_ops_from_coords():
     lon = torch.tensor([0.0])
     mask = torch.tensor([[1], [0], [1]])
     coords = LatLonCoordinates(lat=lat, lon=lon)
-    mask_provider = MaskProvider(masks={"mask_0": mask})
-    gridded_ops = coords.get_gridded_operations(mask_provider=mask_provider)
+    mask_provider = SpatialMaskProvider(masks={"mask_0": mask})
+    gridded_ops = coords.get_gridded_operations(spatial_mask_provider=mask_provider)
     input_ = torch.tensor([[1.0], [-10.0], [3.0]])
     result = gridded_ops.area_weighted_mean(input_, name="T_0")
     torch.testing.assert_close(result, torch.tensor(2.0))
@@ -228,11 +228,11 @@ def test_healpix_ops_raises_value_error_with_mask():
     height = torch.arange(16)
     width = torch.arange(16)
     healpix_coords = HEALPixCoordinates(face=face, height=height, width=width)
-    mask_provider = MaskProvider(masks={"mask_0": torch.tensor([1, 0, 1])})
+    mask_provider = SpatialMaskProvider(masks={"mask_0": torch.tensor([1, 0, 1])})
 
     expected_msg = "HEALPixCoordinates does not support a mask"
     with pytest.raises(NotImplementedError, match=expected_msg):
-        healpix_coords.get_gridded_operations(mask_provider=mask_provider)
+        healpix_coords.get_gridded_operations(spatial_mask_provider=mask_provider)
 
 
 @pytest.mark.parametrize(

--- a/fme/core/test_coordinates.py
+++ b/fme/core/test_coordinates.py
@@ -216,8 +216,10 @@ def test_masked_lat_lon_ops_from_coords():
     lon = torch.tensor([0.0])
     mask = torch.tensor([[1], [0], [1]])
     coords = LatLonCoordinates(lat=lat, lon=lon)
-    mask_provider = SpatialMaskProvider(masks={"mask_0": mask})
-    gridded_ops = coords.get_gridded_operations(spatial_mask_provider=mask_provider)
+    spatial_mask_provider = SpatialMaskProvider(masks={"mask_0": mask})
+    gridded_ops = coords.get_gridded_operations(
+        spatial_mask_provider=spatial_mask_provider
+    )
     input_ = torch.tensor([[1.0], [-10.0], [3.0]])
     result = gridded_ops.area_weighted_mean(input_, name="T_0")
     torch.testing.assert_close(result, torch.tensor(2.0))
@@ -228,11 +230,15 @@ def test_healpix_ops_raises_value_error_with_mask():
     height = torch.arange(16)
     width = torch.arange(16)
     healpix_coords = HEALPixCoordinates(face=face, height=height, width=width)
-    mask_provider = SpatialMaskProvider(masks={"mask_0": torch.tensor([1, 0, 1])})
+    spatial_mask_provider = SpatialMaskProvider(
+        masks={"mask_0": torch.tensor([1, 0, 1])}
+    )
 
     expected_msg = "HEALPixCoordinates does not support a mask"
     with pytest.raises(NotImplementedError, match=expected_msg):
-        healpix_coords.get_gridded_operations(spatial_mask_provider=mask_provider)
+        healpix_coords.get_gridded_operations(
+            spatial_mask_provider=spatial_mask_provider
+        )
 
 
 @pytest.mark.parametrize(

--- a/fme/core/test_dataset_info.py
+++ b/fme/core/test_dataset_info.py
@@ -20,8 +20,8 @@ from fme.core.dataset_info import (
 )
 from fme.core.device import get_device
 from fme.core.gridded_ops import LatLonOperations
-from fme.core.mask_provider import MaskProvider
 from fme.core.metrics import spherical_area_weights
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 
 
 @pytest.mark.parametrize(
@@ -51,12 +51,12 @@ from fme.core.metrics import spherical_area_weights
                     lat=torch.arange(-4, 4, device=get_device()),
                     lon=torch.arange(16, device=get_device()),
                 ),
-                mask_provider=MaskProvider(
+                spatial_mask_provider=SpatialMaskProvider(
                     masks={"mask_0": torch.ones(10, 10, device=get_device())}
                 ),
                 timestep=datetime.timedelta(hours=1),
             ),
-            id="mask_provider",
+            id="spatial_mask_provider",
         ),
         pytest.param(
             DatasetInfo(
@@ -164,19 +164,25 @@ def test_dataset_info_round_trip(dataset_info: DatasetInfo):
         ),
         pytest.param(
             DatasetInfo(
-                mask_provider=MaskProvider(masks={"mask_0": torch.ones(10, 10)})
+                spatial_mask_provider=SpatialMaskProvider(
+                    masks={"mask_0": torch.ones(10, 10)}
+                )
             ),
             DatasetInfo(
-                mask_provider=MaskProvider(masks={"mask_0": torch.ones(10, 10)})
+                spatial_mask_provider=SpatialMaskProvider(
+                    masks={"mask_0": torch.ones(10, 10)}
+                )
             ),
             id="mask_provider_equal",
         ),
         pytest.param(
             DatasetInfo(
-                mask_provider=MaskProvider(masks={"mask_0": torch.ones(10, 10)})
+                spatial_mask_provider=SpatialMaskProvider(
+                    masks={"mask_0": torch.ones(10, 10)}
+                )
             ),
             DatasetInfo(
-                mask_provider=MaskProvider(
+                spatial_mask_provider=SpatialMaskProvider(
                     masks={
                         "mask_0": torch.ones(10, 10),
                         "mask_1": torch.ones(10, 10),
@@ -186,13 +192,13 @@ def test_dataset_info_round_trip(dataset_info: DatasetInfo):
             id="mask_provider_subset",
         ),
         pytest.param(
-            DatasetInfo(mask_provider=MaskProvider()),
+            DatasetInfo(spatial_mask_provider=SpatialMaskProvider()),
             DatasetInfo(),
             id="mask_provider_missing_from_second",
         ),
         pytest.param(
             DatasetInfo(),
-            DatasetInfo(mask_provider=MaskProvider()),
+            DatasetInfo(spatial_mask_provider=SpatialMaskProvider()),
             id="mask_provider_missing_from_first",
         ),
         pytest.param(
@@ -253,17 +259,21 @@ def test_assert_compatible_with_compatible_dataset_info(a: DatasetInfo, b: Datas
         ),
         pytest.param(
             DatasetInfo(
-                mask_provider=MaskProvider(masks={"mask_0": torch.ones(10, 10)})
+                spatial_mask_provider=SpatialMaskProvider(
+                    masks={"mask_0": torch.ones(10, 10)}
+                )
             ),
             DatasetInfo(
-                mask_provider=MaskProvider(masks={"mask_0": torch.zeros(10, 10)})
+                spatial_mask_provider=SpatialMaskProvider(
+                    masks={"mask_0": torch.zeros(10, 10)}
+                )
             ),
-            ["mask_provider"],
+            ["spatial_mask_provider"],
             id="mask_provider_masks_differ",
         ),
         pytest.param(
             DatasetInfo(
-                mask_provider=MaskProvider(
+                spatial_mask_provider=SpatialMaskProvider(
                     masks={
                         "mask_0": torch.ones(10, 10),
                         "mask_1": torch.ones(10, 10),
@@ -271,9 +281,11 @@ def test_assert_compatible_with_compatible_dataset_info(a: DatasetInfo, b: Datas
                 )
             ),
             DatasetInfo(
-                mask_provider=MaskProvider(masks={"mask_0": torch.zeros(10, 10)})
+                spatial_mask_provider=SpatialMaskProvider(
+                    masks={"mask_0": torch.zeros(10, 10)}
+                )
             ),
-            ["mask_provider"],
+            ["spatial_mask_provider"],
             id="mask_provider_not_subset",
         ),
         pytest.param(
@@ -404,16 +416,16 @@ def test_masked_gridded_ops():
     lon = torch.arange(4)
     lat = torch.arange(2)
     coords = LatLonCoordinates(lat=lat, lon=lon)
-    mask_provider = MaskProvider(masks={"mask_0": torch.ones(10, 10)})
+    mask_provider = SpatialMaskProvider(masks={"mask_0": torch.ones(10, 10)})
     dataset_info = DatasetInfo(
         horizontal_coordinates=coords,
-        mask_provider=mask_provider,
+        spatial_mask_provider=mask_provider,
     )
     assert dataset_info.horizontal_coordinates == coords
-    assert dataset_info.mask_provider == mask_provider
+    assert dataset_info.spatial_mask_provider == mask_provider
     expected_gridded_ops = LatLonOperations(
         area_weights=spherical_area_weights(lat, len(lon)),
-        mask_provider=mask_provider,
+        spatial_mask_provider=mask_provider,
     )
     assert dataset_info.gridded_operations == expected_gridded_ops
 

--- a/fme/core/test_dataset_info.py
+++ b/fme/core/test_dataset_info.py
@@ -173,7 +173,7 @@ def test_dataset_info_round_trip(dataset_info: DatasetInfo):
                     masks={"mask_0": torch.ones(10, 10)}
                 )
             ),
-            id="mask_provider_equal",
+            id="spatial_mask_provider_equal",
         ),
         pytest.param(
             DatasetInfo(
@@ -189,17 +189,17 @@ def test_dataset_info_round_trip(dataset_info: DatasetInfo):
                     }
                 )
             ),
-            id="mask_provider_subset",
+            id="spatial_mask_provider_subset",
         ),
         pytest.param(
             DatasetInfo(spatial_mask_provider=SpatialMaskProvider()),
             DatasetInfo(),
-            id="mask_provider_missing_from_second",
+            id="spatial_mask_provider_missing_from_second",
         ),
         pytest.param(
             DatasetInfo(),
             DatasetInfo(spatial_mask_provider=SpatialMaskProvider()),
-            id="mask_provider_missing_from_first",
+            id="spatial_mask_provider_missing_from_first",
         ),
         pytest.param(
             DatasetInfo(),
@@ -269,7 +269,7 @@ def test_assert_compatible_with_compatible_dataset_info(a: DatasetInfo, b: Datas
                 )
             ),
             ["spatial_mask_provider"],
-            id="mask_provider_masks_differ",
+            id="spatial_mask_provider_masks_differ",
         ),
         pytest.param(
             DatasetInfo(
@@ -286,7 +286,7 @@ def test_assert_compatible_with_compatible_dataset_info(a: DatasetInfo, b: Datas
                 )
             ),
             ["spatial_mask_provider"],
-            id="mask_provider_not_subset",
+            id="spatial_mask_provider_not_subset",
         ),
         pytest.param(
             DatasetInfo(timestep=datetime.timedelta(hours=1)),
@@ -416,16 +416,16 @@ def test_masked_gridded_ops():
     lon = torch.arange(4)
     lat = torch.arange(2)
     coords = LatLonCoordinates(lat=lat, lon=lon)
-    mask_provider = SpatialMaskProvider(masks={"mask_0": torch.ones(10, 10)})
+    spatial_mask_provider = SpatialMaskProvider(masks={"mask_0": torch.ones(10, 10)})
     dataset_info = DatasetInfo(
         horizontal_coordinates=coords,
-        spatial_mask_provider=mask_provider,
+        spatial_mask_provider=spatial_mask_provider,
     )
     assert dataset_info.horizontal_coordinates == coords
-    assert dataset_info.spatial_mask_provider == mask_provider
+    assert dataset_info.spatial_mask_provider == spatial_mask_provider
     expected_gridded_ops = LatLonOperations(
         area_weights=spherical_area_weights(lat, len(lon)),
-        spatial_mask_provider=mask_provider,
+        spatial_mask_provider=spatial_mask_provider,
     )
     assert dataset_info.gridded_operations == expected_gridded_ops
 

--- a/fme/core/test_spatial_mask_provider.py
+++ b/fme/core/test_spatial_mask_provider.py
@@ -2,12 +2,12 @@ import pytest
 import torch
 
 from fme.core.device import get_device
-from fme.core.mask_provider import MaskProvider, NullMaskProvider
+from fme.core.spatial_mask_provider import NullSpatialMaskProvider, SpatialMaskProvider
 
 
 def test_mask_provider_init_error():
     with pytest.raises(ValueError, match="var_1"):
-        _ = MaskProvider(
+        _ = SpatialMaskProvider(
             masks={
                 "mask_0": torch.rand(2, 2),
                 "var_1": torch.rand(2, 2),
@@ -20,7 +20,7 @@ def test_mask_provider_get_mask_tensor_for():
     mask_1 = torch.rand(2, 2)
     mask_temp_1 = torch.rand(2, 2)
     mask_2d = torch.rand(2, 2)
-    provider = MaskProvider(
+    provider = SpatialMaskProvider(
         masks={
             "mask_0": mask_0,
             "mask_1": mask_1,
@@ -41,7 +41,7 @@ def test_mask_provider_get_mask_tensor_for():
 def test_mask_provider_get_mask_tensor_for_no_3d():
     mask_temp_1 = torch.rand(2, 2)
     mask_2d = torch.rand(2, 2)
-    provider = MaskProvider(
+    provider = SpatialMaskProvider(
         masks={
             "mask_temp_1": mask_temp_1,
             "mask_2d": mask_2d,
@@ -58,7 +58,7 @@ def test_mask_provider_get_mask_tensor_for_no_3d():
 def test_mask_provider_get_mask_tensor_for_var_specific_only():
     mask_temp_1 = torch.rand(2, 2)
     mask_var = torch.rand(2, 2)
-    provider = MaskProvider(
+    provider = SpatialMaskProvider(
         masks={
             "mask_temp_1": mask_temp_1,
             "mask_var": mask_var,
@@ -74,7 +74,7 @@ def test_mask_provider_get_mask_tensor_for_var_specific_only():
 
 
 def test_mask_provider_empty_init():
-    provider = MaskProvider()
+    provider = SpatialMaskProvider()
     assert provider.get_mask_tensor_for("temp_0") is None
     assert provider.get_mask_tensor_for("var") is None
 
@@ -82,7 +82,7 @@ def test_mask_provider_empty_init():
 def test_mask_provider_to_device():
     # test moving masks to a different device
     masks = {"mask_temp": torch.tensor([1, 0], dtype=torch.float32)}
-    provider = MaskProvider(masks=masks)
+    provider = SpatialMaskProvider(masks=masks)
     # using 'meta' device for testing without needing specific hardware
     provider_meta = provider.to("meta")
     assert provider_meta.masks["mask_temp"].device == torch.device("meta")
@@ -94,8 +94,8 @@ def test_mask_provider_update_success():
     # test updating masks from another provider with non-overlapping keys
     masks1 = {"mask_temp": torch.tensor([1, 0])}
     masks2 = {"mask_humidity": torch.tensor([0, 1])}
-    provider1 = MaskProvider(masks=masks1)
-    provider2 = MaskProvider(masks=masks2)
+    provider1 = SpatialMaskProvider(masks=masks1)
+    provider2 = SpatialMaskProvider(masks=masks2)
 
     provider1.update(provider2)
 
@@ -116,8 +116,8 @@ def test_mask_provider_update_uses_first_overlapped_keys():
         "mask_humidity": torch.tensor([0, 1]),
         "mask_common": torch.tensor([1, 1]),
     }
-    provider1 = MaskProvider(masks=masks1.copy())
-    provider2 = MaskProvider(masks=masks2.copy())
+    provider1 = SpatialMaskProvider(masks=masks1.copy())
+    provider2 = SpatialMaskProvider(masks=masks2.copy())
     provider1.update(provider2)
     assert torch.equal(
         provider1.masks["mask_common"],
@@ -162,8 +162,8 @@ def test_mask_provider_update_uses_first_overlapped_keys():
     ],
 )
 def test_mask_provider_eq(masks1, masks2, expected_equal: bool):
-    provider1 = MaskProvider(masks=masks1)
-    provider2 = MaskProvider(masks=masks2)
+    provider1 = SpatialMaskProvider(masks=masks1)
+    provider2 = SpatialMaskProvider(masks=masks2)
     if expected_equal:
         assert provider1 == provider2
     else:
@@ -171,14 +171,14 @@ def test_mask_provider_eq(masks1, masks2, expected_equal: bool):
 
 
 @pytest.mark.parametrize(
-    "mask_provider",
+    "spatial_mask_provider",
     [
-        pytest.param(MaskProvider(), id="empty"),
+        pytest.param(SpatialMaskProvider(), id="empty"),
         pytest.param(
-            MaskProvider(masks={"mask_0": torch.ones(10, 10)}), id="single_mask"
+            SpatialMaskProvider(masks={"mask_0": torch.ones(10, 10)}), id="single_mask"
         ),
         pytest.param(
-            MaskProvider(
+            SpatialMaskProvider(
                 masks={
                     "mask_0": torch.ones(10, 10),
                     "mask_temp": torch.zeros(10, 10),
@@ -188,11 +188,11 @@ def test_mask_provider_eq(masks1, masks2, expected_equal: bool):
         ),
     ],
 )
-def test_mask_provider_round_trip(mask_provider: MaskProvider):
-    state = mask_provider.get_state()
-    reloaded_provider = MaskProvider.from_state(state)
+def test_mask_provider_round_trip(spatial_mask_provider: SpatialMaskProvider):
+    state = spatial_mask_provider.get_state()
+    reloaded_provider = SpatialMaskProvider.from_state(state)
     device = get_device()
-    assert mask_provider.to(str(device)) == reloaded_provider
+    assert spatial_mask_provider.to(str(device)) == reloaded_provider
 
 
 @pytest.mark.parametrize(
@@ -221,8 +221,8 @@ def test_mask_provider_round_trip(mask_provider: MaskProvider):
     ],
 )
 def test_mask_provider_assert_compatible_with_compatible(masks1, masks2):
-    provider1 = MaskProvider(masks=masks1)
-    provider2 = MaskProvider(masks=masks2)
+    provider1 = SpatialMaskProvider(masks=masks1)
+    provider2 = SpatialMaskProvider(masks=masks2)
     provider1.assert_compatible_with(provider2)
 
 
@@ -250,27 +250,27 @@ def test_mask_provider_assert_compatible_with_compatible(masks1, masks2):
     ],
 )
 def test_mask_provider_assert_compatible_with_incompatible(masks1, masks2, match):
-    provider1 = MaskProvider(masks=masks1)
-    provider2 = MaskProvider(masks=masks2)
+    provider1 = SpatialMaskProvider(masks=masks1)
+    provider2 = SpatialMaskProvider(masks=masks2)
     with pytest.raises(AssertionError, match=match):
         provider1.assert_compatible_with(provider2)
 
 
 def test_mask_provider_assert_compatible_with_non_mask_provider():
-    provider = MaskProvider(masks={"mask_temp": torch.tensor([1.0, 0.0])})
-    with pytest.raises(AssertionError, match="expected MaskProvider"):
+    provider = SpatialMaskProvider(masks={"mask_temp": torch.tensor([1.0, 0.0])})
+    with pytest.raises(AssertionError, match="expected SpatialMaskProvider"):
         provider.assert_compatible_with("not a mask provider")
 
 
 def test_null_mask_provider_update_err():
-    mask_provider = MaskProvider(masks={"mask_2d": torch.rand(2, 2)})
+    mask_provider = SpatialMaskProvider(masks={"mask_2d": torch.rand(2, 2)})
     with pytest.raises(ValueError, match="mask_2d"):
-        NullMaskProvider.update(mask_provider)
+        NullSpatialMaskProvider.update(mask_provider)
 
 
 def test_from_state_places_tensors_on_device():
     state = {"masks": {"mask_2d": torch.tensor([[1.0, 0.0], [0.0, 1.0]], device="cpu")}}
-    provider = MaskProvider.from_state(state)
+    provider = SpatialMaskProvider.from_state(state)
     device = get_device()
     for tensor in provider.masks.values():
         assert tensor.device == device
@@ -279,6 +279,6 @@ def test_from_state_places_tensors_on_device():
 def test_from_state_decouples_memory():
     masks = {"mask_2d": torch.tensor([[1.0, 0.0], [0.0, 1.0]], device="cpu")}
     state = {"masks": masks}
-    provider = MaskProvider.from_state(state)
+    provider = SpatialMaskProvider.from_state(state)
     masks["mask_2d"].fill_(999.0)
     assert provider.masks["mask_2d"].max().item() == 1.0

--- a/fme/core/test_spatial_masking.py
+++ b/fme/core/test_spatial_masking.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 import fme
-from fme.core.masking import StaticMasking, StaticMaskingConfig
+from fme.core.spatial_masking import StaticSpatialMasking, StaticSpatialMaskingConfig
 
 DEVICE = fme.get_device()
 
@@ -34,7 +34,7 @@ class _Mask:
             # 2D variable
             return self.mask_2d
 
-    def build_output_masker(self):
+    def build_output_spatial_masker(self):
         raise NotImplementedError
 
     def to(self, device: str) -> "_Mask":
@@ -42,7 +42,7 @@ class _Mask:
 
 
 def test_masking_config():
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=1,
         fill_value=0.0,
     )
@@ -51,12 +51,12 @@ def test_masking_config():
     _ = config.build(_Mask(mask_2d=torch.ones(1, 1), mask_3d=torch.ones(1, 1, 1)))
 
     with pytest.raises(ValueError, match="mask_value must be either 0 or 1"):
-        _ = StaticMaskingConfig(
+        _ = StaticSpatialMaskingConfig(
             mask_value=3,
             fill_value=0.0,
         )
 
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=1,
         fill_value="mean",
     )
@@ -89,7 +89,7 @@ _DATA = {
     ],
 )
 def test_masking(exclude):
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=0.0,
         exclude_names_and_prefixes=exclude,
@@ -116,7 +116,7 @@ def test_masking(exclude):
     ],
 )
 def test_masking_exclusion(exclude):
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=float("nan"),
         exclude_names_and_prefixes=[exclude],
@@ -138,7 +138,7 @@ def test_masking_exclusion(exclude):
 
 
 def test_masking_with_means():
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value="mean",
     )
@@ -159,7 +159,7 @@ def test_masking_with_means():
 
 
 def test_masking_no_3d_masking():
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=0.0,
         exclude_names_and_prefixes=["specific_total_water"],
@@ -174,7 +174,7 @@ def test_masking_no_3d_masking():
 
 
 def test_masking_no_surface_masking():
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=0.0,
         exclude_names_and_prefixes=["PRESsfc"],
@@ -189,7 +189,7 @@ def test_masking_no_surface_masking():
 
 
 def test_masking_missing_2d_mask():
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=0.0,
         exclude_names_and_prefixes=["specific_total_water"],
@@ -200,7 +200,7 @@ def test_masking_missing_2d_mask():
 
 
 def test_masking_missing_3d_mask():
-    config = StaticMaskingConfig(
+    config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=0.0,
     )
@@ -213,7 +213,7 @@ def test_masking_missing_3d_mask():
 
 
 def test_static_masking_error_on_missing_mean():
-    mask = StaticMasking(
+    mask = StaticSpatialMasking(
         mask_value=0,
         fill_value={
             "specific_total_water_0": torch.tensor(2.0, device=DEVICE),
@@ -226,7 +226,7 @@ def test_static_masking_error_on_missing_mean():
 
 
 def test_static_masking_mask_ignored_name():
-    mask = StaticMasking(
+    mask = StaticSpatialMasking(
         mask_value=0,
         fill_value=float("nan"),
         mask=_Mask(_MASK_2D, _MASK_3D),

--- a/fme/coupled/data_loading/gridded_data.py
+++ b/fme/coupled/data_loading/gridded_data.py
@@ -82,14 +82,14 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
             ocean=DatasetInfo(
                 horizontal_coordinates=self._ocean.horizontal_coordinates,
                 vertical_coordinate=self._ocean.vertical_coordinate,
-                mask_provider=self._ocean.mask_provider,
+                spatial_mask_provider=self._ocean.spatial_mask_provider,
                 timestep=self._ocean.timestep,
                 variable_metadata=self._properties.variable_metadata,
             ),
             atmosphere=DatasetInfo(
                 horizontal_coordinates=self._atmosphere.horizontal_coordinates,
                 vertical_coordinate=self._atmosphere.vertical_coordinate,
-                mask_provider=self._atmosphere.mask_provider,
+                spatial_mask_provider=self._atmosphere.spatial_mask_provider,
                 timestep=self._atmosphere.timestep,
                 variable_metadata=self._properties.variable_metadata,
             ),
@@ -211,13 +211,13 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
         ocean = DatasetInfo(
             horizontal_coordinates=self._properties.ocean.horizontal_coordinates,
             vertical_coordinate=self._properties.ocean.vertical_coordinate,
-            mask_provider=self._properties.ocean.mask_provider,
+            spatial_mask_provider=self._properties.ocean.spatial_mask_provider,
             timestep=self.ocean_timestep,
         )
         atmosphere = DatasetInfo(
             horizontal_coordinates=self._properties.atmosphere.horizontal_coordinates,
             vertical_coordinate=self._properties.atmosphere.vertical_coordinate,
-            mask_provider=self._properties.atmosphere.mask_provider,
+            spatial_mask_provider=self._properties.atmosphere.spatial_mask_provider,
             timestep=self.atmosphere_timestep,
         )
         return CoupledDatasetInfo(ocean=ocean, atmosphere=atmosphere)

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -145,14 +145,17 @@ class InferenceDataset(torch.utils.data.Dataset):
     ) -> DatasetProperties:
         if dataset_info is None:
             return ocean_properties
-        ocean_mask_is_empty = not ocean_properties.mask_provider.masks
+        ocean_mask_is_empty = not ocean_properties.spatial_mask_provider.masks
         identical_masks = (
-            len(ocean_properties.mask_provider.masks) > 0
-            and len(dataset_info.ocean.mask_provider.masks) > 0
-            and ocean_properties.mask_provider == dataset_info.ocean.mask_provider
+            len(ocean_properties.spatial_mask_provider.masks) > 0
+            and len(dataset_info.ocean.spatial_mask_provider.masks) > 0
+            and ocean_properties.spatial_mask_provider
+            == dataset_info.ocean.spatial_mask_provider
         )
         if ocean_mask_is_empty or identical_masks:
-            ocean_properties.update_mask_provider(dataset_info.ocean.mask_provider)
+            ocean_properties.update_spatial_mask_provider(
+                dataset_info.ocean.spatial_mask_provider
+            )
         else:
             logging.warning(
                 "Not updating ocean mask provider from dataset info in the checkpoint"
@@ -241,7 +244,7 @@ def _make_dummy_ocean_forcing(
         variable_metadata=dict(dataset_info.ocean.variable_metadata),
         vertical_coordinate=dataset_info.ocean.vertical_coordinate,
         horizontal_coordinates=dataset_info.ocean.horizontal_coordinates,
-        mask_provider=dataset_info.ocean.mask_provider,
+        spatial_mask_provider=dataset_info.ocean.spatial_mask_provider,
         timestep=dataset_info.ocean.timestep,
         is_remote=False,
         all_labels=set(),

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -25,11 +25,11 @@ from fme.core.coordinates import (
 from fme.core.dataset.merged import MergeNoConcatDatasetConfig
 from fme.core.dataset.xarray import (
     XarrayDataConfig,
-    _get_mask_provider,
+    _get_spatial_mask_provider,
     _get_vertical_coordinate,
     get_horizontal_coordinates,
 )
-from fme.core.mask_provider import MaskProvider
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.typing_ import Slice
 from fme.coupled.data_loading.batch_data import CoupledBatchData, CoupledPrognosticState
 from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
@@ -144,8 +144,8 @@ class MockComponentData:
         return pd.Timedelta(self.timedelta).to_pytimedelta()
 
     @property
-    def mask_provider(self) -> MaskProvider:
-        return _get_mask_provider(self.ds, dtype=None)
+    def spatial_mask_provider(self) -> SpatialMaskProvider:
+        return _get_spatial_mask_provider(self.ds, dtype=None)
 
     @property
     def vcoord(self) -> VerticalCoordinate:

--- a/fme/coupled/dataset_info.py
+++ b/fme/coupled/dataset_info.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal
 
 from fme.core.dataset_info import DatasetInfo, MissingDatasetInfo
-from fme.core.masking import HasGetMaskTensorFor
+from fme.core.spatial_masking import HasGetSpatialMask
 from fme.coupled.data_loading.data_typing import CoupledHorizontalCoordinates
 
 
@@ -22,11 +22,11 @@ class CoupledDatasetInfo:
         self.atmosphere = atmosphere
 
     @property
-    def ocean_mask_provider(self) -> HasGetMaskTensorFor:
+    def ocean_spatial_mask_provider(self) -> HasGetSpatialMask:
         try:
-            return self.ocean.mask_provider
+            return self.ocean.spatial_mask_provider
         except MissingDatasetInfo as err:
-            raise MissingCoupledDatasetInfo("ocean_mask_provider") from err
+            raise MissingCoupledDatasetInfo("ocean_spatial_mask_provider") from err
 
     def __eq__(self, other):
         if not isinstance(other, CoupledDatasetInfo):

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -290,8 +290,8 @@ def _create_dataset_info_for_stepper(
         hcoord=mock_data.hcoord,
         ocean_timestep=mock_data.ocean.timestep,
         atmos_timestep=mock_data.atmosphere.timestep,
-        ocean_mask_provider=mock_data.ocean.mask_provider,
-        atmos_mask_provider=mock_data.atmosphere.mask_provider,
+        ocean_spatial_mask_provider=mock_data.ocean.spatial_mask_provider,
+        atmos_spatial_mask_provider=mock_data.atmosphere.spatial_mask_provider,
     ).dataset_info
     return dataset_info, mock_data
 

--- a/fme/coupled/inference/test_inference.py
+++ b/fme/coupled/inference/test_inference.py
@@ -67,8 +67,8 @@ def _setup(
         hcoord=mock_data.hcoord,
         ocean_timestep=mock_data.ocean.timestep,
         atmos_timestep=mock_data.atmosphere.timestep,
-        ocean_mask_provider=mock_data.ocean.mask_provider,
-        atmos_mask_provider=mock_data.atmosphere.mask_provider,
+        ocean_spatial_mask_provider=mock_data.ocean.spatial_mask_provider,
+        atmos_spatial_mask_provider=mock_data.atmosphere.spatial_mask_provider,
     ).dataset_info
     checkpoint_path = save_coupled_stepper(
         tmp_path,

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -783,7 +783,7 @@ class CoupledStepper:
         self.atmosphere = atmosphere
         self._config = config
         self._dataset_info = dataset_info
-        self._ocean_mask_provider = dataset_info.ocean_mask_provider
+        self._ocean_spatial_mask_provider = dataset_info.ocean_spatial_mask_provider
 
         _: PredictFunction[  # for type checking
             CoupledPrognosticState,
@@ -920,7 +920,7 @@ class CoupledStepper:
             )
         for name, tensor in forcings_from_ocean.items():
             # set ocean invalid points to 0 based on the ocean masking
-            mask = self._ocean_mask_provider.get_mask_tensor_for(name)
+            mask = self._ocean_spatial_mask_provider.get_mask_tensor_for(name)
             if mask is not None:
                 mask = mask.expand(tensor.shape)
                 forcings_from_ocean[name] = tensor.where(mask != 0, 0)

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -23,12 +23,12 @@ from fme.core.coordinates import (
 )
 from fme.core.dataset_info import DatasetInfo
 from fme.core.loss import StepLossConfig
-from fme.core.mask_provider import MaskProvider
 from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
 from fme.core.optimization import NullOptimization
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
+from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.step.single_module import SingleModuleStepConfig
 from fme.core.step.step import StepSelector
 from fme.coupled.dataset_info import CoupledDatasetInfo
@@ -119,11 +119,11 @@ class CoupledDatasetInfoBuilder:
     hcoord: CoupledHorizontalCoordinates | None = None
     ocean_timestep: datetime.timedelta = OCEAN_TIMESTEP
     atmos_timestep: datetime.timedelta = ATMOS_TIMESTEP
-    ocean_mask_provider: MaskProvider = dataclasses.field(
-        default_factory=lambda: MaskProvider()
+    ocean_spatial_mask_provider: SpatialMaskProvider = dataclasses.field(
+        default_factory=lambda: SpatialMaskProvider()
     )
-    atmos_mask_provider: MaskProvider = dataclasses.field(
-        default_factory=lambda: MaskProvider()
+    atmos_spatial_mask_provider: SpatialMaskProvider = dataclasses.field(
+        default_factory=lambda: SpatialMaskProvider()
     )
 
     def __post_init__(self):
@@ -142,13 +142,13 @@ class CoupledDatasetInfoBuilder:
             ocean=DatasetInfo(
                 horizontal_coordinates=self.hcoord.ocean,
                 vertical_coordinate=self.vcoord.ocean,
-                mask_provider=self.ocean_mask_provider,
+                spatial_mask_provider=self.ocean_spatial_mask_provider,
                 timestep=self.ocean_timestep,
             ),
             atmosphere=DatasetInfo(
                 horizontal_coordinates=self.hcoord.atmosphere,
                 vertical_coordinate=self.vcoord.atmosphere,
-                mask_provider=self.atmos_mask_provider,
+                spatial_mask_provider=self.atmos_spatial_mask_provider,
                 timestep=self.atmos_timestep,
             ),
         )
@@ -1197,7 +1197,7 @@ def test__get_atmosphere_forcings(
     sst_mask[0, 0] = 0
     dataset_info = CoupledDatasetInfoBuilder(
         vcoord=vertical_coord,
-        ocean_mask_provider=MaskProvider({"mask_2d": sst_mask}),
+        ocean_spatial_mask_provider=SpatialMaskProvider({"mask_2d": sst_mask}),
     ).dataset_info
     coupler = config.get_stepper(dataset_info)
     shape_ocean = (1, 1, N_LAT, N_LON)


### PR DESCRIPTION
Renames the masking infrastructure to explicitly indicate "spatial" masking, in preparation for adding channel masking support.

Changes:
- `fme.core.masking` → `fme.core.spatial_masking`: `StaticMaskingConfig` → `StaticSpatialMaskingConfig`, `StaticMasking` → `StaticSpatialMasking`, `NullMasking` → `NullSpatialMasking`, `HasGetMaskTensorFor` → `HasGetSpatialMask`
- `fme.core.mask_provider` → `fme.core.spatial_mask_provider`: `MaskProviderABC` → `SpatialMaskProviderABC`, `MaskProvider` → `SpatialMaskProvider`, `NullMaskProvider` → `NullSpatialMaskProvider`, `build_output_masker` → `build_output_spatial_masker`
- `fme.core.dataset.properties.DatasetProperties`, `fme.core.dataset_info.DatasetInfo`: `mask_provider` field/property → `spatial_mask_provider`
- `fme.core.gridded_ops`: `_mask_area_weights` → `_spatial_mask_area_weights`, `LatLonOperations` param renamed
- `fme.core.coordinates.HorizontalCoordinates.get_gridded_operations`: `mask_provider` param → `spatial_mask_provider`
- `fme.core.dataset.xarray._get_mask_provider` → `_get_spatial_mask_provider`
- `fme.coupled.dataset_info.CoupledDatasetInfo.ocean_mask_provider` → `ocean_spatial_mask_provider`
- Serialization dict keys (`"mask_provider"`) and YAML config key (`input_masking`) preserved for backwards compatibility
- All imports and references updated across `fme/ace`, `fme/core`, and `fme/coupled`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated