### PR TITLE
Add optional mask to LossOutput for per-sample variable masking

### DIFF
--- a/fme/ace/aggregator/test_train.py
+++ b/fme/ace/aggregator/test_train.py
@@ -7,6 +7,7 @@ from fme.ace.aggregator.train import TrainAggregator, TrainAggregatorConfig
 from fme.ace.stepper.single_module import TrainOutput
 from fme.core.device import get_device
 from fme.core.gridded_ops import LatLonOperations
+from fme.core.loss import ChannelLossInfo
 from fme.core.typing_ import EnsembleTensorDict
 
 
@@ -109,7 +110,9 @@ def test_aggregator_logs_per_channel_loss():
             gen_data=gen_data,
             time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
             normalize=lambda x: x,
-            per_channel_losses={"a": torch.tensor(0.5, device=device)},
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(0.5, device=device), count=4)
+            },
         ),
     )
     agg.record_batch(
@@ -119,12 +122,65 @@ def test_aggregator_logs_per_channel_loss():
             gen_data=gen_data,
             time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
             normalize=lambda x: x,
-            per_channel_losses={"a": torch.tensor(1.0, device=device)},
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(1.0, device=device), count=4)
+            },
         ),
     )
     logs = agg.get_logs(label="train")
     assert logs["train/mean/loss"] == 1.5
     assert logs["train/mean/loss/a"] == 0.75
+
+
+def test_aggregator_per_channel_loss_weighted_by_count():
+    """When batches have different counts, the mean is weighted correctly."""
+    batch_size = 4
+    n_ensemble = 1
+    n_time = 2
+    nx, ny = 2, 2
+    device = get_device()
+    gridded_operations = LatLonOperations(
+        area_weights=torch.ones(nx, ny, device=device)
+    )
+    config = TrainAggregatorConfig(
+        spherical_power_spectrum=False, weighted_rmse=False, per_channel_loss=True
+    )
+    agg = TrainAggregator(config=config, operations=gridded_operations)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    # Batch 1: loss=1.0 from 2 active samples
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(1.0, device=device), count=2),
+            },
+        ),
+    )
+    # Batch 2: loss=3.0 from 6 active samples
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(3.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(3.0, device=device), count=6),
+            },
+        ),
+    )
+    logs = agg.get_logs(label="train")
+    # weighted mean: (1.0*2 + 3.0*6) / (2+6) = 20/8 = 2.5
+    assert logs["train/mean/loss/a"] == pytest.approx(2.5)
 
 
 def test_aggregator_per_channel_loss_disabled():
@@ -156,7 +212,9 @@ def test_aggregator_per_channel_loss_disabled():
             gen_data=gen_data,
             time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
             normalize=lambda x: x,
-            per_channel_losses={"a": torch.tensor(0.5, device=device)},
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(0.5, device=device), count=4)
+            },
         ),
     )
     logs = agg.get_logs(label="train")

--- a/fme/ace/aggregator/train.py
+++ b/fme/ace/aggregator/train.py
@@ -76,7 +76,8 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
     def __init__(self, config: TrainAggregatorConfig, operations: GriddedOperations):
         self._n_loss_batches = 0
         self._loss = torch.tensor(0.0, device=get_device())
-        self._per_channel_loss: dict[str, torch.Tensor] = {}
+        self._per_channel_weighted_sum: dict[str, torch.Tensor] = {}
+        self._per_channel_count: dict[str, int] = {}
         self._per_channel_loss_enabled = config.per_channel_loss
         self._paired_aggregators: dict[str, Aggregator] = {}
         if config.spherical_power_spectrum:
@@ -106,12 +107,15 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
         self._loss += batch.metrics["loss"]
         self._n_loss_batches += 1
         if self._per_channel_loss_enabled and batch.per_channel_losses is not None:
-            for var_name, value in batch.per_channel_losses.items():
-                acc = self._per_channel_loss.get(
+            for var_name, info in batch.per_channel_losses.items():
+                ws = self._per_channel_weighted_sum.get(
                     var_name,
-                    torch.tensor(0.0, device=get_device(), dtype=value.dtype),
+                    torch.tensor(0.0, device=get_device(), dtype=info.loss.dtype),
                 )
-                self._per_channel_loss[var_name] = acc + value
+                self._per_channel_weighted_sum[var_name] = ws + info.loss * info.count
+                self._per_channel_count[var_name] = (
+                    self._per_channel_count.get(var_name, 0) + info.count
+                )
 
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
@@ -140,9 +144,14 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
             dist.reduce_mean(self._loss / self._n_loss_batches).cpu().numpy()
         )
         if self._n_loss_batches > 0 and self._per_channel_loss_enabled:
-            for var_name, acc in self._per_channel_loss.items():
+            for var_name in self._per_channel_weighted_sum:
+                count = self._per_channel_count[var_name]
+                if count > 0:
+                    mean = self._per_channel_weighted_sum[var_name] / count
+                else:
+                    mean = self._per_channel_weighted_sum[var_name]
                 logs[f"{label}/mean/loss/{var_name}"] = float(
-                    dist.reduce_mean(acc / self._n_loss_batches).cpu().numpy()
+                    dist.reduce_mean(mean).cpu().numpy()
                 )
         return logs
 

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -42,7 +42,7 @@ from fme.core.generics.inference import PredictFunction
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
 from fme.core.labels import BatchLabels
-from fme.core.loss import StepLoss, StepLossConfig
+from fme.core.loss import ChannelLossInfo, StepLoss, StepLossConfig
 from fme.core.masking import NullMasking, StaticMaskingConfig
 from fme.core.normalizer import (
     NetworkAndLossNormalizationConfig,
@@ -345,7 +345,7 @@ class TrainOutput(TrainOutputABC):
     derive_func: Callable[[TensorMapping, TensorMapping], TensorDict] = lambda x, _: (
         dict(x)
     )
-    per_channel_losses: dict[str, torch.Tensor] | None = None
+    per_channel_losses: dict[str, ChannelLossInfo] | None = None
 
     def __post_init__(self):
         for v in self.target_data.values():
@@ -1605,7 +1605,7 @@ class TrainStepper(
         target_data: BatchData,
         optimization: OptimizationABC,
         metrics: dict[str, float],
-    ) -> tuple[list[EnsembleTensorDict], dict[str, torch.Tensor] | None]:
+    ) -> tuple[list[EnsembleTensorDict], dict[str, ChannelLossInfo] | None]:
         input_data = data.get_start(self._prognostic_names, self.n_ic_timesteps)
         # output from self.predict_paired does not include initial condition
         n_forward_steps = data.time.shape[1] - self.n_ic_timesteps
@@ -1643,7 +1643,8 @@ class TrainStepper(
                     "data requirements are retrieved, so this is a bug."
                 )
             n_forward_steps = stochastic_n_forward_steps
-        per_channel_sum: dict[str, torch.Tensor] | None = None
+        weighted_sums: dict[str, torch.Tensor] | None = None
+        total_counts: dict[str, int] | None = None
         for step in range(n_forward_steps):
             optimize_step = (
                 step == n_forward_steps - 1 or not self._config.optimize_last_step_only
@@ -1668,14 +1669,28 @@ class TrainStepper(
                 step_total_loss = step_loss.total()
                 metrics[f"loss_step_{step}"] = step_total_loss.detach()
                 per_ch = step_loss.get_channel_losses()
-                if per_channel_sum is None:
-                    per_channel_sum = {k: v.detach().clone() for k, v in per_ch.items()}
+                if weighted_sums is None:
+                    weighted_sums = {
+                        k: v.loss.detach() * v.count for k, v in per_ch.items()
+                    }
+                    total_counts = {k: v.count for k, v in per_ch.items()}
                 else:
-                    for k in per_channel_sum:
-                        per_channel_sum[k] = per_channel_sum[k] + per_ch[k].detach()
+                    assert total_counts is not None
+                    for k, v in per_ch.items():
+                        weighted_sums[k] = weighted_sums[k] + v.loss.detach() * v.count
+                        total_counts[k] = total_counts[k] + v.count
             if optimize_step:
                 optimization.accumulate_loss(step_total_loss)
-        return output_list, per_channel_sum
+        per_channel_losses: dict[str, ChannelLossInfo] | None = None
+        if weighted_sums is not None and total_counts is not None:
+            per_channel_losses = {
+                k: ChannelLossInfo(
+                    loss=weighted_sums[k] / max(total_counts[k], 1),
+                    count=total_counts[k],
+                )
+                for k in weighted_sums
+            }
+        return output_list, per_channel_losses
 
     def update_training_history(self, training_job: TrainingJob) -> None:
         """

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -351,6 +351,29 @@ def test_train_on_batch_per_channel_losses_contain_all_out_names():
         assert info.count > 0
 
 
+def test_train_on_batch_per_channel_losses_include_zero_weighted_channels():
+    """Channels with weight=0 are still reported in per_channel_losses.
+
+    The step is expected to compute and return all out channels regardless
+    of whether they meaningfully contribute to the optimized loss, so that
+    aggregator keys remain stable across batches and forward steps.
+    """
+    torch.manual_seed(0)
+    n_steps = 2
+    data_with_ic = get_data(["a", "b", "c"], n_samples=4, n_time=n_steps + 1).data
+    config = _get_stepper_config(["a", "b", "c"], ["a", "b", "c"])
+    stepper = _get_train_stepper(
+        config,
+        loss=StepLossConfig(type="MSE", weights={"b": 0.0}),
+    )
+    stepped = stepper.train_on_batch(data=data_with_ic, optimization=NullOptimization())
+    assert stepped.per_channel_losses is not None
+    assert set(stepped.per_channel_losses.keys()) == {"a", "b", "c"}
+    for info in stepped.per_channel_losses.values():
+        assert info.count > 0
+    assert stepped.per_channel_losses["b"].loss.item() == 0.0
+
+
 def test_train_on_batch_crps_loss():
     torch.manual_seed(0)
 

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -338,6 +338,19 @@ def test_train_on_batch_addition_series():
     )
 
 
+def test_train_on_batch_per_channel_losses_contain_all_out_names():
+    torch.manual_seed(0)
+    n_steps = 3
+    data_with_ic = get_data(["a", "b", "c"], n_samples=4, n_time=n_steps + 1).data
+    config = _get_stepper_config(["a", "b", "c"], ["a", "b", "c"])
+    stepper = _get_train_stepper(config, loss=StepLossConfig(type="MSE"))
+    stepped = stepper.train_on_batch(data=data_with_ic, optimization=NullOptimization())
+    assert stepped.per_channel_losses is not None
+    assert set(stepped.per_channel_losses.keys()) == {"a", "b", "c"}
+    for info in stepped.per_channel_losses.values():
+        assert info.count > 0
+
+
 def test_train_on_batch_crps_loss():
     torch.manual_seed(0)
 

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -15,6 +15,14 @@ from fme.core.packer import Packer
 from fme.core.typing_ import TensorMapping
 
 
+@dataclasses.dataclass
+class ChannelLossInfo:
+    """Per-channel loss value and the number of batch samples that contributed."""
+
+    loss: torch.Tensor
+    count: int
+
+
 class LossComponent(abc.ABC):
     """A pre-weighted loss tensor that knows how to reduce itself to ``(B, C)``.
 
@@ -75,6 +83,7 @@ class LossOutput:
         self._channel_names = channel_names
         self._mask = mask
         self._per_channel: torch.Tensor | None = None
+        self._counts: list[int] | None = None
 
     def _get_per_channel(self) -> torch.Tensor:
         """Return a ``(C,)`` tensor of per-channel losses, computed once.
@@ -82,24 +91,25 @@ class LossOutput:
         When a mask is present (shape ``(B, C)``), each channel's loss
         is averaged only over the batch samples where that channel is
         present, so masked-out variables never dilute the result.
+
+        Also caches ``_counts`` — the number of active batch samples
+        per channel — for use in :meth:`get_channel_losses`.
         """
         if self._per_channel is None:
             bc = sum(c.reduce_to_channel() for c in self._losses)
             assert isinstance(bc, torch.Tensor)
             if bc.ndim == 0:
                 self._per_channel = bc.expand(len(self._channel_names))
+                self._counts = [1] * len(self._channel_names)
             elif self._mask is not None:
                 masked_sum = (bc * self._mask).sum(dim=0)
-                counts = self._mask.sum(dim=0).clamp(min=1)
-                self._per_channel = masked_sum / counts
+                raw_counts = self._mask.sum(dim=0)
+                self._per_channel = masked_sum / raw_counts.clamp(min=1)
+                self._counts = [int(c.item()) for c in raw_counts]
             else:
                 self._per_channel = bc.mean(dim=0)
+                self._counts = [bc.shape[0]] * len(self._channel_names)
         return self._per_channel
-
-    def _n_active_channels(self) -> int:
-        if self._mask is not None:
-            return int((self._mask.sum(dim=0) > 0).sum().item())
-        return len(self._channel_names)
 
     def total(self) -> torch.Tensor:
         """Scalar loss — the optimisation target."""
@@ -110,11 +120,27 @@ class LossOutput:
                 return pc[active].mean()
         return pc.mean()
 
-    def get_channel_losses(self) -> dict[str, torch.Tensor]:
-        """Per-channel scalar losses that sum to ``total()``."""
+    def get_channel_losses(self) -> dict[str, ChannelLossInfo]:
+        """Per-channel mean losses with active-sample counts.
+
+        Each :class:`ChannelLossInfo` carries the mean loss for that
+        channel (averaged over active samples only) and the number of
+        batch samples that contributed.  Downstream aggregators should
+        use the counts to compute properly weighted means across
+        batches.
+        """
         pc = self._get_per_channel()
-        n = self._n_active_channels()
-        return dict(zip(self._channel_names, (pc / n).unbind(0)))
+        assert self._counts is not None
+        if pc.ndim == 0:
+            return {
+                name: ChannelLossInfo(loss=pc, count=self._counts[i])
+                for i, name in enumerate(self._channel_names)
+            }
+        n = min(pc.shape[0], len(self._channel_names))
+        return {
+            self._channel_names[i]: ChannelLossInfo(loss=pc[i], count=self._counts[i])
+            for i in range(n)
+        }
 
     def scale(self, weight: float) -> "LossOutput":
         """Return a new ``LossOutput`` with every component scaled."""
@@ -123,33 +149,6 @@ class LossOutput:
             self._channel_names,
             mask=self._mask,
         )
-
-
-def _build_channel_mask(
-    data_mask: TensorMapping,
-    names: list[str],
-    device: torch.device,
-    batch_size: int,
-) -> torch.Tensor:
-    """Build a ``(B, C)`` float mask from per-variable boolean masks.
-
-    Args:
-        data_mask: Per-variable boolean masks of shape ``[batch]``.
-        names: Channel names in packing order.
-        device: Device for the output tensor.
-        batch_size: Size of the batch dimension.
-
-    Returns:
-        Float tensor of shape ``(batch_size, len(names))`` with 1.0
-        for present entries and 0.0 for absent ones.
-    """
-    masks = []
-    for name in names:
-        if name in data_mask:
-            masks.append(data_mask[name].to(device=device, dtype=torch.float))
-        else:
-            masks.append(torch.ones(batch_size, device=device, dtype=torch.float))
-    return torch.stack(masks, dim=1)
 
 
 class _MSELoss(torch.nn.Module):
@@ -265,12 +264,17 @@ class WeightedMappingLoss:
 
         mask = None
         if data_mask is not None:
-            mask = _build_channel_mask(
-                data_mask,
-                list(self.packer.names),
-                predict_tensors.device,
-                predict_tensors.shape[0],
-            )
+            batch_size = predict_tensors.shape[0]
+            device = predict_tensors.device
+            filled: dict[str, torch.Tensor] = {}
+            for name in self.packer.names:
+                if name in data_mask:
+                    filled[name] = data_mask[name].to(device=device, dtype=torch.float)
+                else:
+                    filled[name] = torch.ones(
+                        batch_size, device=device, dtype=torch.float
+                    )
+            mask = self.packer.pack(filled, axis=1)
 
         return LossOutput(
             losses=losses,

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -91,25 +91,34 @@ class LossOutput:
         When a mask is present (shape ``(B, C)``), each channel's loss
         is averaged only over the batch samples where that channel is
         present, so masked-out variables never dilute the result.
-
-        Also caches ``_counts`` — the number of active batch samples
-        per channel — for use in :meth:`get_channel_losses`.
         """
         if self._per_channel is None:
             bc = sum(c.reduce_to_channel() for c in self._losses)
             assert isinstance(bc, torch.Tensor)
             if bc.ndim == 0:
                 self._per_channel = bc.expand(len(self._channel_names))
-                self._counts = [1] * len(self._channel_names)
             elif self._mask is not None:
                 masked_sum = (bc * self._mask).sum(dim=0)
-                raw_counts = self._mask.sum(dim=0)
-                self._per_channel = masked_sum / raw_counts.clamp(min=1)
-                self._counts = [int(c.item()) for c in raw_counts]
+                self._per_channel = masked_sum / self._mask.sum(dim=0).clamp(min=1)
             else:
                 self._per_channel = bc.mean(dim=0)
-                self._counts = [bc.shape[0]] * len(self._channel_names)
         return self._per_channel
+
+    def _get_counts(self) -> list[int]:
+        """Return per-channel active-sample counts, computed once.
+
+        With a mask, counts may include 0 for channels masked out in
+        every sample.  Without a mask every sample is active.
+        """
+        if self._counts is None:
+            if self._mask is not None:
+                self._counts = [int(c.item()) for c in self._mask.sum(dim=0)]
+            else:
+                bc = sum(c.reduce_to_channel() for c in self._losses)
+                assert isinstance(bc, torch.Tensor)
+                batch_size = 1 if bc.ndim == 0 else bc.shape[0]
+                self._counts = [batch_size] * len(self._channel_names)
+        return self._counts
 
     def total(self) -> torch.Tensor:
         """Scalar loss — the optimisation target."""
@@ -130,15 +139,15 @@ class LossOutput:
         batches.
         """
         pc = self._get_per_channel()
-        assert self._counts is not None
+        counts = self._get_counts()
         if pc.ndim == 0:
             return {
-                name: ChannelLossInfo(loss=pc, count=self._counts[i])
+                name: ChannelLossInfo(loss=pc, count=counts[i])
                 for i, name in enumerate(self._channel_names)
             }
         n = min(pc.shape[0], len(self._channel_names))
         return {
-            self._channel_names[i]: ChannelLossInfo(loss=pc[i], count=self._counts[i])
+            self._channel_names[i]: ChannelLossInfo(loss=pc[i], count=counts[i])
             for i in range(n)
         }
 

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -109,7 +109,13 @@ class LossOutput:
         return self._per_channel, self._counts
 
     def total(self) -> torch.Tensor:
-        """Scalar loss — the optimisation target."""
+        """Scalar loss used as the optimization target.
+
+        This is the mean of the per-channel losses across channels (over
+        active channels only when a mask is present), not a sum. Adding
+        or removing channels therefore does not change the scale of the
+        returned value.
+        """
         pc, _ = self._reduce()
         if self._mask is not None:
             active = self._mask.sum(dim=0) > 0

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -251,20 +251,28 @@ class WeightedMappingLoss:
         cdim = (
             input_ndim + self.channel_dim if self.channel_dim < 0 else self.channel_dim
         )
-        elementwise_cls = StandardLoss if cdim <= 1 else EnsembleComponentLoss
+
+        def _wrap_elementwise(t: torch.Tensor) -> StandardLoss:
+            # Element-wise loss tensors have the same shape as the input;
+            # the channel position depends on the data layout (ensemble,
+            # tile, etc.).  Reduce non-(batch, channel) dims here so the
+            # downstream component carries a canonical ``(B, C)`` tensor.
+            dims = tuple(i for i in range(t.ndim) if i not in (0, cdim))
+            reduced = t.mean(dim=dims) if dims else t
+            return StandardLoss(reduced)
+
         if isinstance(result, list):
             # Inner losses that return raw element-wise tensors (e.g. MSE,
             # L1) wrap themselves in StandardLoss but don't know the input
-            # channel layout.  When the input is ensemble-shaped, re-wrap
-            # so the component reduces around the channel dim correctly.
+            # channel layout, so reduce around the actual channel dim here.
             losses = [
-                elementwise_cls(c.loss)
+                _wrap_elementwise(c.loss)
                 if c.loss.ndim == input_ndim and type(c) is StandardLoss
                 else c
                 for c in result
             ]
         else:
-            losses = [elementwise_cls(result)]
+            losses = [_wrap_elementwise(result)]
 
         mask = None
         if data_mask is not None:

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -247,16 +247,24 @@ class WeightedMappingLoss:
             target_tensors = torch.where(nan_mask, 0.0, target_tensors)
 
         result = self.loss(predict_tensors, target_tensors)
+        input_ndim = predict_tensors.ndim
+        cdim = (
+            input_ndim + self.channel_dim if self.channel_dim < 0 else self.channel_dim
+        )
+        elementwise_cls = StandardLoss if cdim <= 1 else EnsembleComponentLoss
         if isinstance(result, list):
-            losses = result
+            # Inner losses that return raw element-wise tensors (e.g. MSE,
+            # L1) wrap themselves in StandardLoss but don't know the input
+            # channel layout.  When the input is ensemble-shaped, re-wrap
+            # so the component reduces around the channel dim correctly.
+            losses = [
+                elementwise_cls(c.loss)
+                if c.loss.ndim == input_ndim and type(c) is StandardLoss
+                else c
+                for c in result
+            ]
         else:
-            cdim = (
-                predict_tensors.ndim + self.channel_dim
-                if self.channel_dim < 0
-                else self.channel_dim
-            )
-            component_cls = StandardLoss if cdim <= 1 else EnsembleComponentLoss
-            losses = [component_cls(result)]
+            losses = [elementwise_cls(result)]
 
         mask = None
         if data_mask is not None:

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -85,8 +85,8 @@ class LossOutput:
         self._per_channel: torch.Tensor | None = None
         self._counts: list[int] | None = None
 
-    def _get_per_channel(self) -> torch.Tensor:
-        """Return a ``(C,)`` tensor of per-channel losses, computed once.
+    def _reduce(self) -> tuple[torch.Tensor, list[int]]:
+        """Return ``(per_channel, counts)`` tensors, computed once.
 
         When a mask is present (shape ``(B, C)``), each channel's loss
         is averaged only over the batch samples where that channel is
@@ -97,32 +97,20 @@ class LossOutput:
             assert isinstance(bc, torch.Tensor)
             if bc.ndim == 0:
                 self._per_channel = bc.expand(len(self._channel_names))
+                self._counts = [1] * len(self._channel_names)
             elif self._mask is not None:
                 masked_sum = (bc * self._mask).sum(dim=0)
                 self._per_channel = masked_sum / self._mask.sum(dim=0).clamp(min=1)
-            else:
-                self._per_channel = bc.mean(dim=0)
-        return self._per_channel
-
-    def _get_counts(self) -> list[int]:
-        """Return per-channel active-sample counts, computed once.
-
-        With a mask, counts may include 0 for channels masked out in
-        every sample.  Without a mask every sample is active.
-        """
-        if self._counts is None:
-            if self._mask is not None:
                 self._counts = [int(c.item()) for c in self._mask.sum(dim=0)]
             else:
-                bc = sum(c.reduce_to_channel() for c in self._losses)
-                assert isinstance(bc, torch.Tensor)
-                batch_size = 1 if bc.ndim == 0 else bc.shape[0]
-                self._counts = [batch_size] * len(self._channel_names)
-        return self._counts
+                self._per_channel = bc.mean(dim=0)
+                self._counts = [bc.shape[0]] * len(self._channel_names)
+        assert self._per_channel is not None and self._counts is not None
+        return self._per_channel, self._counts
 
     def total(self) -> torch.Tensor:
         """Scalar loss — the optimisation target."""
-        pc = self._get_per_channel()
+        pc, _ = self._reduce()
         if self._mask is not None:
             active = self._mask.sum(dim=0) > 0
             if active.any():
@@ -138,17 +126,16 @@ class LossOutput:
         use the counts to compute properly weighted means across
         batches.
         """
-        pc = self._get_per_channel()
-        counts = self._get_counts()
-        if pc.ndim == 0:
-            return {
-                name: ChannelLossInfo(loss=pc, count=counts[i])
-                for i, name in enumerate(self._channel_names)
-            }
-        n = min(pc.shape[0], len(self._channel_names))
+        pc, counts = self._reduce()
+        n_channels = len(self._channel_names)
+        if pc.ndim > 0 and pc.shape[0] != n_channels:
+            raise RuntimeError(
+                f"Per-channel loss has {pc.shape[0]} elements but "
+                f"{n_channels} channel names were provided."
+            )
         return {
-            self._channel_names[i]: ChannelLossInfo(loss=pc[i], count=counts[i])
-            for i in range(n)
+            name: ChannelLossInfo(loss=pc[i], count=counts[i])
+            for i, name in enumerate(self._channel_names)
         }
 
     def scale(self, weight: float) -> "LossOutput":

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -25,6 +25,12 @@ class LossComponent(abc.ABC):
     """
 
     def __init__(self, loss: torch.Tensor):
+        """
+        Args:
+            loss: The loss tensor.  Can be a scalar (``ndim == 0``),
+                a partially-reduced tensor like ``(B, C)``, or a
+                full element-wise tensor like ``(B, C, lat, lon)``.
+        """
         self.loss = loss
 
     @abc.abstractmethod
@@ -63,30 +69,51 @@ class LossOutput:
         self,
         losses: list[LossComponent],
         channel_names: list[str],
+        mask: torch.Tensor | None = None,
     ):
         self._losses = losses
         self._channel_names = channel_names
+        self._mask = mask
         self._per_channel: torch.Tensor | None = None
 
     def _get_per_channel(self) -> torch.Tensor:
-        """Return a ``(C,)`` tensor of batch-mean losses, computed once."""
+        """Return a ``(C,)`` tensor of per-channel losses, computed once.
+
+        When a mask is present (shape ``(B, C)``), each channel's loss
+        is averaged only over the batch samples where that channel is
+        present, so masked-out variables never dilute the result.
+        """
         if self._per_channel is None:
             bc = sum(c.reduce_to_channel() for c in self._losses)
             assert isinstance(bc, torch.Tensor)
             if bc.ndim == 0:
                 self._per_channel = bc.expand(len(self._channel_names))
+            elif self._mask is not None:
+                masked_sum = (bc * self._mask).sum(dim=0)
+                counts = self._mask.sum(dim=0).clamp(min=1)
+                self._per_channel = masked_sum / counts
             else:
                 self._per_channel = bc.mean(dim=0)
         return self._per_channel
 
+    def _n_active_channels(self) -> int:
+        if self._mask is not None:
+            return int((self._mask.sum(dim=0) > 0).sum().item())
+        return len(self._channel_names)
+
     def total(self) -> torch.Tensor:
         """Scalar loss — the optimisation target."""
-        return self._get_per_channel().mean()
+        pc = self._get_per_channel()
+        if self._mask is not None:
+            active = self._mask.sum(dim=0) > 0
+            if active.any():
+                return pc[active].mean()
+        return pc.mean()
 
     def get_channel_losses(self) -> dict[str, torch.Tensor]:
         """Per-channel scalar losses that sum to ``total()``."""
         pc = self._get_per_channel()
-        n = len(self._channel_names)
+        n = self._n_active_channels()
         return dict(zip(self._channel_names, (pc / n).unbind(0)))
 
     def scale(self, weight: float) -> "LossOutput":
@@ -94,7 +121,35 @@ class LossOutput:
         return LossOutput(
             [type(c)(c.loss * weight) for c in self._losses],
             self._channel_names,
+            mask=self._mask,
         )
+
+
+def _build_channel_mask(
+    data_mask: TensorMapping,
+    names: list[str],
+    device: torch.device,
+    batch_size: int,
+) -> torch.Tensor:
+    """Build a ``(B, C)`` float mask from per-variable boolean masks.
+
+    Args:
+        data_mask: Per-variable boolean masks of shape ``[batch]``.
+        names: Channel names in packing order.
+        device: Device for the output tensor.
+        batch_size: Size of the batch dimension.
+
+    Returns:
+        Float tensor of shape ``(batch_size, len(names))`` with 1.0
+        for present entries and 0.0 for absent ones.
+    """
+    masks = []
+    for name in names:
+        if name in data_mask:
+            masks.append(data_mask[name].to(device=device, dtype=torch.float))
+        else:
+            masks.append(torch.ones(batch_size, device=device, dtype=torch.float))
+    return torch.stack(masks, dim=1)
 
 
 class _MSELoss(torch.nn.Module):
@@ -171,11 +226,16 @@ class WeightedMappingLoss:
         self,
         predict_dict: TensorMapping,
         target_dict: TensorMapping,
+        data_mask: TensorMapping | None = None,
     ) -> LossOutput:
         """
         Args:
             predict_dict: The predicted data.
             target_dict: The target data.
+            data_mask: Optional per-variable boolean masks of shape
+                ``[batch]`` indicating which samples have each variable
+                present. Used to exclude masked channels from the loss
+                average.
 
         Returns:
             A ``LossOutput`` wrapping pre-weighted loss component tensors.
@@ -202,9 +262,20 @@ class WeightedMappingLoss:
             )
             component_cls = StandardLoss if cdim <= 1 else EnsembleComponentLoss
             losses = [component_cls(result)]
+
+        mask = None
+        if data_mask is not None:
+            mask = _build_channel_mask(
+                data_mask,
+                list(self.packer.names),
+                predict_tensors.device,
+                predict_tensors.shape[0],
+            )
+
         return LossOutput(
             losses=losses,
             channel_names=list(self.packer.names),
+            mask=mask,
         )
 
     def get_normalizer_state(self) -> dict[str, float]:
@@ -665,18 +736,23 @@ class StepLoss(torch.nn.Module):
         predict_dict: TensorMapping,
         target_dict: TensorMapping,
         step: int,
+        data_mask: TensorMapping | None = None,
     ) -> LossOutput:
         """
         Args:
             predict_dict: The predicted data.
             target_dict: The target data.
             step: The step number, indexed from 0 for the first step.
+            data_mask: Optional per-variable boolean masks forwarded to
+                the underlying :class:`WeightedMappingLoss`.
 
         Returns:
             A ``LossOutput`` wrapping the step-weighted loss tensor.
         """
         step_weight = (1.0 + self.sqrt_loss_decay_constant * step) ** (-0.5)
-        return self.loss(predict_dict, target_dict).scale(step_weight)
+        return self.loss(predict_dict, target_dict, data_mask=data_mask).scale(
+            step_weight
+        )
 
 
 @dataclasses.dataclass

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -19,7 +19,6 @@ from fme.core.loss import (
     StepLossConfig,
     VariableWeightingLoss,
     WeightedMappingLoss,
-    _build_channel_mask,
     _construct_weight_tensor,
 )
 from fme.core.normalizer import StandardNormalizer
@@ -220,7 +219,8 @@ def test_WeightedMappingLoss(mean, scale):
     torch.testing.assert_close(result.total(), expected_scalar)
     channel_losses = result.get_channel_losses()
     assert set(channel_losses.keys()) == set(out_names)
-    torch.testing.assert_close(sum(channel_losses.values()), expected_scalar)
+    channel_mean = torch.stack([v.loss for v in channel_losses.values()]).mean()
+    torch.testing.assert_close(channel_mean, expected_scalar)
 
 
 def test_VariableWeightingLoss():
@@ -309,7 +309,8 @@ def test_StepLossConfig_weights():
     torch.testing.assert_close(result.total(), expected)
     channel_losses = result.get_channel_losses()
     assert set(channel_losses.keys()) == set(out_names)
-    torch.testing.assert_close(sum(channel_losses.values()), expected)
+    channel_mean = torch.stack([v.loss for v in channel_losses.values()]).mean()
+    torch.testing.assert_close(channel_mean, expected)
 
 
 @pytest.mark.parametrize("sqrt_loss_step_decay_constant", [0.0, 0.1, 1.0])
@@ -477,18 +478,13 @@ def test_finite_difference_crps_rejects_zero_levels():
         FiniteDifferenceCRPSLoss(alpha=1.0, levels=0)
 
 
-def test_build_channel_mask():
+def test_packer_builds_channel_mask():
     data_mask = {
-        "a": torch.tensor([True, True, False]),
-        "b": torch.tensor([True, False, True]),
+        "a": torch.tensor([1.0, 1.0, 0.0]),
+        "b": torch.tensor([1.0, 0.0, 1.0]),
     }
-    names = ["a", "b"]
-    mask = _build_channel_mask(
-        data_mask,
-        names,
-        device=torch.device("cpu"),
-        batch_size=3,
-    )
+    packer = Packer(["a", "b"])
+    mask = packer.pack(data_mask, axis=1)
     assert mask.shape == (3, 2)
     expected = torch.tensor(
         [
@@ -500,18 +496,14 @@ def test_build_channel_mask():
     torch.testing.assert_close(mask, expected)
 
 
-def test_build_channel_mask_missing_name_defaults_to_present():
-    data_mask = {
-        "a": torch.tensor([True, False]),
-        "c": torch.tensor([False, True]),
+def test_packer_mask_missing_name_defaults_to_present():
+    packer = Packer(["a", "b", "c"])
+    filled = {
+        "a": torch.tensor([1.0, 0.0]),
+        "b": torch.ones(2),
+        "c": torch.tensor([0.0, 1.0]),
     }
-    names = ["a", "b", "c"]
-    mask = _build_channel_mask(
-        data_mask,
-        names,
-        device=torch.device("cpu"),
-        batch_size=2,
-    )
+    mask = packer.pack(filled, axis=1)
     expected = torch.tensor(
         [
             [1.0, 1.0, 0.0],
@@ -544,7 +536,7 @@ def test_loss_output_total_without_mask_unchanged():
     torch.testing.assert_close(output.total(), torch.tensor(2.5))
 
 
-def test_loss_output_channel_losses_sum_to_total_with_mask():
+def test_loss_output_channel_losses_with_mask():
     torch.manual_seed(42)
     loss = torch.randn(4, 3, 5, 5).abs()
     mask = torch.tensor(
@@ -561,9 +553,13 @@ def test_loss_output_channel_losses_sum_to_total_with_mask():
         mask=mask,
     )
     channel_losses = output.get_channel_losses()
+    active_losses = [v.loss for v in channel_losses.values() if v.count > 0]
     torch.testing.assert_close(
-        sum(channel_losses.values()), output.total(), atol=1e-5, rtol=1e-5
+        torch.stack(active_losses).mean(), output.total(), atol=1e-5, rtol=1e-5
     )
+    assert channel_losses["a"].count == 3
+    assert channel_losses["b"].count == 3
+    assert channel_losses["c"].count == 4
 
 
 def test_weighted_mapping_loss_with_data_mask():
@@ -685,12 +681,12 @@ def test_per_channel_losses_are_distinct_area_weighted_mse():
     y = {n: torch.zeros(4, 8, 16, device=get_device()) for n in out_names}
     output = loss(x, y, step=0)
     channel_losses = output.get_channel_losses()
-    assert channel_losses["var_a"] != channel_losses["var_b"]
-    assert channel_losses["var_a"] < channel_losses["var_b"]
+    assert channel_losses["var_a"].loss != channel_losses["var_b"].loss
+    assert channel_losses["var_a"].loss < channel_losses["var_b"].loss
 
 
-def test_per_channel_losses_sum_to_total():
-    """sum(get_channel_losses().values()) must equal total()."""
+def test_per_channel_losses_average_to_total():
+    """mean(info.loss for all channels) must equal total() when no mask."""
     torch.manual_seed(0)
     area = torch.ones(8, 16, device=get_device())
     out_names = ["a", "b", "c"]
@@ -708,8 +704,10 @@ def test_per_channel_losses_sum_to_total():
     y = {n: torch.randn(4, 8, 16, device=get_device()) for n in out_names}
     output = loss(x, y, step=0)
     total = output.total()
-    channel_sum = sum(output.get_channel_losses().values())
-    torch.testing.assert_close(channel_sum, total)
+    channel_mean = torch.stack(
+        [info.loss for info in output.get_channel_losses().values()]
+    ).mean()
+    torch.testing.assert_close(channel_mean, total)
 
 
 def test_per_channel_losses_are_distinct_mse():
@@ -732,8 +730,8 @@ def test_per_channel_losses_are_distinct_mse():
     y = {n: torch.zeros(4, 8, 16, device=get_device()) for n in out_names}
     output = loss(x, y, step=0)
     channel_losses = output.get_channel_losses()
-    assert channel_losses["var_a"] != channel_losses["var_b"]
-    assert channel_losses["var_a"] < channel_losses["var_b"]
+    assert channel_losses["var_a"].loss != channel_losses["var_b"].loss
+    assert channel_losses["var_a"].loss < channel_losses["var_b"].loss
 
 
 def test_energy_score_preweighting_preserves_total(very_fast_only: bool):
@@ -787,8 +785,9 @@ class TestLossOutputScale:
         scaled_channels = loss.scale(3.0).get_channel_losses()
         for name in original_channels:
             torch.testing.assert_close(
-                scaled_channels[name], original_channels[name] * 3.0
+                scaled_channels[name].loss, original_channels[name].loss * 3.0
             )
+            assert scaled_channels[name].count == original_channels[name].count
 
     def test_channel_names_preserved(self):
         names = ["x", "y", "z"]
@@ -798,6 +797,18 @@ class TestLossOutputScale:
         )
         scaled = loss.scale(2.0)
         assert list(scaled.get_channel_losses().keys()) == names
+
+    def test_scale_preserves_counts(self):
+        mask = torch.tensor([[1.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
+        loss = LossOutput(
+            losses=[StandardLoss(torch.randn(3, 2, 4, 4).abs())],
+            channel_names=["a", "b"],
+            mask=mask,
+        )
+        original = loss.get_channel_losses()
+        scaled = loss.scale(2.0).get_channel_losses()
+        assert original["a"].count == scaled["a"].count == 2
+        assert original["b"].count == scaled["b"].count == 2
 
     def test_preserves_component_subclass_types(self):
         components = [
@@ -819,7 +830,7 @@ class TestLossOutputScale:
         scaled_channels = scaled.get_channel_losses()
         for name in original_channels:
             torch.testing.assert_close(
-                scaled_channels[name], original_channels[name] * 0.5
+                scaled_channels[name].loss, original_channels[name].loss * 0.5
             )
 
     def test_scale_by_zero(self):

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -500,7 +500,7 @@ def test_packer_mask_missing_name_defaults_to_present():
     packer = Packer(["a", "b", "c"])
     filled = {
         "a": torch.tensor([1.0, 0.0]),
-        "b": torch.ones(2),
+        "b": torch.tensor([1.0, 1.0]),
         "c": torch.tensor([0.0, 1.0]),
     }
     mask = packer.pack(filled, axis=1)
@@ -616,13 +616,18 @@ def test_step_loss_forwards_data_mask():
         channel_dim=-3,
         normalizer=normalizer,
     )
-    x_mapping = {name: torch.ones(4, 5, 5).to(get_device()) for name in out_names}
+    x_mapping = {
+        "var_0": torch.ones(4, 5, 5).to(get_device()),
+        "var_1": torch.full((4, 5, 5), 2.0).to(get_device()),
+    }
     y_mapping = {name: torch.zeros(4, 5, 5).to(get_device()) for name in out_names}
     data_mask = {
         "var_0": torch.tensor([True, True, True, True]),
         "var_1": torch.tensor([False, False, False, False]),
     }
     result = step_loss(x_mapping, y_mapping, step=0, data_mask=data_mask)
+    # var_0: MSE=1.0 (4 samples). var_1: MSE=4.0 but all masked out → no contribution.
+    # Without the mask the total would be mean(1.0, 4.0) = 2.5.
     torch.testing.assert_close(result.total(), torch.tensor(1.0, device=get_device()))
 
 

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -19,6 +19,7 @@ from fme.core.loss import (
     StepLossConfig,
     VariableWeightingLoss,
     WeightedMappingLoss,
+    _build_channel_mask,
     _construct_weight_tensor,
 )
 from fme.core.normalizer import StandardNormalizer
@@ -476,6 +477,190 @@ def test_finite_difference_crps_rejects_zero_levels():
         FiniteDifferenceCRPSLoss(alpha=1.0, levels=0)
 
 
+def test_build_channel_mask():
+    data_mask = {
+        "a": torch.tensor([True, True, False]),
+        "b": torch.tensor([True, False, True]),
+    }
+    names = ["a", "b"]
+    mask = _build_channel_mask(
+        data_mask,
+        names,
+        device=torch.device("cpu"),
+        batch_size=3,
+    )
+    assert mask.shape == (3, 2)
+    expected = torch.tensor(
+        [
+            [1.0, 1.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+        ]
+    )
+    torch.testing.assert_close(mask, expected)
+
+
+def test_build_channel_mask_missing_name_defaults_to_present():
+    data_mask = {
+        "a": torch.tensor([True, False]),
+        "c": torch.tensor([False, True]),
+    }
+    names = ["a", "b", "c"]
+    mask = _build_channel_mask(
+        data_mask,
+        names,
+        device=torch.device("cpu"),
+        batch_size=2,
+    )
+    expected = torch.tensor(
+        [
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0],
+        ]
+    )
+    torch.testing.assert_close(mask, expected)
+
+
+def test_loss_output_total_with_mask():
+    loss = torch.tensor(
+        [
+            [[1.0], [2.0]],
+            [[3.0], [4.0]],
+            [[5.0], [6.0]],
+        ]
+    ).unsqueeze(-1)
+    mask = torch.tensor([[1.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
+    output = LossOutput(
+        losses=[StandardLoss(loss)], channel_names=["a", "b"], mask=mask
+    )
+    # ch_a: mean(1,3)=2.0; ch_b: mean(2,6)=4.0
+    expected = (2.0 + 4.0) / 2.0
+    torch.testing.assert_close(output.total(), torch.tensor(expected))
+
+
+def test_loss_output_total_without_mask_unchanged():
+    loss = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    output = LossOutput(losses=[StandardLoss(loss)], channel_names=["a", "b"])
+    torch.testing.assert_close(output.total(), torch.tensor(2.5))
+
+
+def test_loss_output_channel_losses_sum_to_total_with_mask():
+    torch.manual_seed(42)
+    loss = torch.randn(4, 3, 5, 5).abs()
+    mask = torch.tensor(
+        [
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ]
+    )
+    output = LossOutput(
+        losses=[StandardLoss(loss)],
+        channel_names=["a", "b", "c"],
+        mask=mask,
+    )
+    channel_losses = output.get_channel_losses()
+    torch.testing.assert_close(
+        sum(channel_losses.values()), output.total(), atol=1e-5, rtol=1e-5
+    )
+
+
+def test_weighted_mapping_loss_with_data_mask():
+    out_names = ["var_0", "var_1"]
+    normalizer = StandardNormalizer(
+        means={name: torch.as_tensor(0.0) for name in out_names},
+        stds={name: torch.as_tensor(1.0) for name in out_names},
+    )
+    loss = torch.nn.MSELoss(reduction="none")
+    mapping_loss = WeightedMappingLoss(
+        loss,
+        weights={},
+        out_names=out_names,
+        normalizer=normalizer,
+    )
+    x_val = torch.ones(4, 5, 5).to(get_device())
+    y_val = torch.zeros(4, 5, 5).to(get_device())
+    x_mapping = {"var_0": x_val, "var_1": x_val * 2}
+    y_mapping = {"var_0": y_val, "var_1": y_val}
+    result_no_mask = mapping_loss(x_mapping, y_mapping)
+    expected_no_mask = (1.0 + 4.0) / 2.0
+    torch.testing.assert_close(
+        result_no_mask.total(), torch.tensor(expected_no_mask, device=get_device())
+    )
+
+    data_mask = {
+        "var_0": torch.tensor([True, True, True, True]),
+        "var_1": torch.tensor([True, True, False, False]),
+    }
+    result_masked = mapping_loss(x_mapping, y_mapping, data_mask=data_mask)
+    # var_0: MSE=1.0 for all 4 samples, mean=1.0
+    # var_1: MSE=4.0, but only 2 of 4 unmasked, mean=4.0
+    # total: mean(1.0, 4.0) = 2.5
+    torch.testing.assert_close(
+        result_masked.total(),
+        torch.tensor(2.5, device=get_device()),
+        atol=1e-5,
+        rtol=1e-5,
+    )
+
+
+def test_step_loss_forwards_data_mask():
+    out_names = ["var_0", "var_1"]
+    normalizer = StandardNormalizer(
+        means={name: torch.as_tensor(0.0) for name in out_names},
+        stds={name: torch.as_tensor(1.0) for name in out_names},
+    )
+    area = torch.ones(1, 1)
+    gridded_operations: GriddedOperations = LatLonOperations(area)
+    config = StepLossConfig(type="MSE")
+    step_loss = config.build(
+        gridded_operations,
+        out_names=out_names,
+        channel_dim=-3,
+        normalizer=normalizer,
+    )
+    x_mapping = {name: torch.ones(4, 5, 5).to(get_device()) for name in out_names}
+    y_mapping = {name: torch.zeros(4, 5, 5).to(get_device()) for name in out_names}
+    data_mask = {
+        "var_0": torch.tensor([True, True, True, True]),
+        "var_1": torch.tensor([False, False, False, False]),
+    }
+    result = step_loss(x_mapping, y_mapping, step=0, data_mask=data_mask)
+    torch.testing.assert_close(result.total(), torch.tensor(1.0, device=get_device()))
+
+
+def test_weighted_mapping_loss_with_ensemble_and_data_mask():
+    out_names = ["a", "b"]
+    normalizer = StandardNormalizer(
+        means={name: torch.as_tensor(0.0) for name in out_names},
+        stds={name: torch.as_tensor(1.0) for name in out_names},
+    )
+    loss = torch.nn.MSELoss(reduction="none")
+    mapping_loss = WeightedMappingLoss(
+        loss, weights={}, out_names=out_names, normalizer=normalizer
+    )
+    n_batch, n_ens, h, w = 3, 2, 4, 4
+    x = {
+        "a": torch.ones(n_batch, n_ens, h, w).to(get_device()),
+        "b": torch.ones(n_batch, n_ens, h, w).to(get_device()) * 2,
+    }
+    y = {name: torch.zeros(n_batch, n_ens, h, w).to(get_device()) for name in out_names}
+    data_mask = {
+        "a": torch.tensor([True, True, False]),
+        "b": torch.tensor([True, False, False]),
+    }
+    result = mapping_loss(x, y, data_mask=data_mask)
+    assert result._mask is not None
+    assert result._mask.shape == (n_batch, len(out_names))
+    # a: MSE=1.0 for 2 unmasked samples, per-channel mean=1.0
+    # b: MSE=4.0 for 1 unmasked sample, per-channel mean=4.0
+    # total: mean(1.0, 4.0) = 2.5
+    torch.testing.assert_close(
+        result.total(), torch.tensor(2.5, device=get_device()), atol=1e-5, rtol=1e-5
+    )
+
+
 def test_per_channel_losses_are_distinct_area_weighted_mse():
     """Per-channel losses should differ when inputs differ per channel.
 
@@ -576,6 +761,12 @@ def test_ensemble_component_loss_reduce_to_channel():
     assert result.shape == (4, 5)
     expected = tensor.mean(dim=(1, 3, 4))
     torch.testing.assert_close(result, expected)
+
+
+def test_ensemble_component_loss_reduce_to_channel_scalar():
+    tensor = torch.tensor(5.0, device=get_device())
+    result = EnsembleComponentLoss(tensor).reduce_to_channel()
+    torch.testing.assert_close(result, tensor)
 
 
 class TestLossOutputScale:


### PR DESCRIPTION
Adds an optional `(B, C)` float mask to `LossOutput` so that when heterogeneous data sources provide different variable sets per sample, masked-out channels don't dilute the loss average. Per-channel losses are averaged only over samples where that channel is present, and fully-absent channels are excluded from the scalar `total()`.

Changes:
- `fme.core.loss.LossOutput`: accepts optional `mask` parameter; `_reduce()`, `total()`, `get_channel_losses()`, and `scale()` all respect the mask
- `fme.core.loss.ChannelLossInfo`: new dataclass pairing a per-channel loss with its active-sample count, returned by `get_channel_losses()`
- `fme.core.loss.WeightedMappingLoss.__call__` and `fme.core.loss.StepLoss.forward`: accept and forward `data_mask: TensorMapping | None`, using `Packer` to build the `(B, C)` channel mask
- `fme.ace.stepper.single_module.TrainStepper._accumulate_loss`: tracks weighted sums and counts across steps
- `fme.ace.aggregator.train.TrainAggregator`: uses count-weighted averaging instead of simple batch-count division

Note: `data_mask` is plumbed through `WeightedMappingLoss` and `StepLoss` but is not yet passed from the stepper's training loop — this PR provides the infrastructure, and a follow-up will wire the mask from the data loader.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated