### PR TITLE
Fix `_get_variable_metadata` silently dropping variables

### DIFF
--- a/fme/ace/aggregator/inference/annual.py
+++ b/fme/ace/aggregator/inference/annual.py
@@ -91,8 +91,8 @@ class PairedGlobalMeanAnnualAggregator:
                 continue
 
             if name in self.variable_metadata:
-                long_name = self.variable_metadata[name].long_name
-                units = self.variable_metadata[name].units
+                long_name = self.variable_metadata[name].display_long_name(name)
+                units = self.variable_metadata[name].display_units("unknown units")
             else:
                 long_name = name
                 units = "unknown units"
@@ -235,8 +235,8 @@ class GlobalMeanAnnualAggregator:
                 continue
 
             if name in self.variable_metadata:
-                long_name = self.variable_metadata[name].long_name
-                units = self.variable_metadata[name].units
+                long_name = self.variable_metadata[name].display_long_name(name)
+                units = self.variable_metadata[name].display_units("unknown units")
             else:
                 long_name = name
                 units = "unknown units"

--- a/fme/ace/aggregator/inference/enso/enso_coefficient.py
+++ b/fme/ace/aggregator/inference/enso/enso_coefficient.py
@@ -252,8 +252,10 @@ class EnsoCoefficientEvaluatorAggregator:
         images, metrics = {}, {}
         for name in gen_coefficients.keys():
             if name in self._variable_metadata:
-                caption_name = self._variable_metadata[name].long_name
-                caption_units = self._variable_metadata[name].units
+                caption_name = self._variable_metadata[name].display_long_name(name)
+                caption_units = self._variable_metadata[name].display_units(
+                    "unknown units"
+                )
             else:
                 caption_name = name
                 caption_units = "unknown units"
@@ -328,8 +330,8 @@ class EnsoCoefficientEvaluatorAggregator:
 
     def _get_var_attrs(self, name: str) -> dict[str, str]:
         if name in self._variable_metadata:
-            attrs_name = self._variable_metadata[name].long_name
-            attrs_units = self._variable_metadata[name].units
+            attrs_name = self._variable_metadata[name].display_long_name(name)
+            attrs_units = self._variable_metadata[name].display_units("unknown units")
         else:
             attrs_name = name
             attrs_units = "unknown units"

--- a/fme/ace/aggregator/inference/reduced.py
+++ b/fme/ace/aggregator/inference/reduced.py
@@ -319,7 +319,7 @@ class MeanAggregator:
                 datum.var_name, VariableMetadata("unknown_units", datum.var_name)
             )
             data_vars[datum.get_xarray_key()] = xr.DataArray(
-                datum.data, dims=["forecast_step"], attrs=metadata._asdict()
+                datum.data, dims=["forecast_step"], attrs=metadata.as_attrs()
             )
 
         if len(data_vars.values()) > 0:
@@ -503,7 +503,7 @@ class SingleTargetMeanAggregator:
                 datum.var_name, VariableMetadata("unknown_units", datum.var_name)
             )
             data_vars[datum.get_xarray_key()] = xr.DataArray(
-                datum.data, dims=["forecast_step"], attrs=metadata._asdict()
+                datum.data, dims=["forecast_step"], attrs=metadata.as_attrs()
             )
 
         n_forecast_steps = len(next(iter(data_vars.values())))

--- a/fme/ace/aggregator/inference/seasonal.py
+++ b/fme/ace/aggregator/inference/seasonal.py
@@ -98,8 +98,8 @@ class SeasonalAggregator:
                 continue
 
             if self._variable_metadata is not None and name in self._variable_metadata:
-                long_name = self._variable_metadata[name].long_name
-                units = self._variable_metadata[name].units
+                long_name = self._variable_metadata[name].display_long_name(name)
+                units = self._variable_metadata[name].display_units()
                 caption_name = f"{long_name} ({units})"
             else:
                 caption_name = name

--- a/fme/ace/aggregator/inference/spectrum.py
+++ b/fme/ace/aggregator/inference/spectrum.py
@@ -93,9 +93,9 @@ class SphericalPowerSpectrumAggregator:
             spectrum_np = spectrum.cpu().numpy()
             wavenumber = np.arange(len(spectrum_np))
             metadata = self._variable_metadata.get(name)
-            if metadata is not None:
+            if metadata is not None and metadata.long_name is not None:
                 long_name = f"spherical power spectrum of {metadata.long_name}"
-                units = f"({metadata.units})^2"
+                units = f"({metadata.units or 'unknown_units'})^2"
             else:
                 long_name = f"spherical power spectrum of {name}"
                 units = "unknown_units"

--- a/fme/ace/aggregator/inference/time_mean.py
+++ b/fme/ace/aggregator/inference/time_mean.py
@@ -211,8 +211,8 @@ class TimeMeanAggregator:
 
     def _get_caption(self, key: str, name: str) -> str:
         if name in self._variable_metadata:
-            caption_name = self._variable_metadata[name].long_name
-            units = self._variable_metadata[name].units
+            caption_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = self._image_captions[key].format(name=caption_name, units=units)
@@ -225,12 +225,12 @@ class TimeMeanAggregator:
             if self._log_variables is not None and name not in self._log_variables:
                 continue
             if name in self._variable_metadata:
-                long_name = self._variable_metadata[name].long_name
-                units = self._variable_metadata[name].units
+                long_name = self._variable_metadata[name].display_long_name(name)
+                units = self._variable_metadata[name].display_units()
             else:
                 long_name = name
                 units = "unknown_units"
-            gen_metadata = VariableMetadata(long_name=long_name, units=units)._asdict()
+            gen_metadata = VariableMetadata(long_name=long_name, units=units).as_attrs()
             data.update(
                 {
                     f"gen_map-{name}": xr.DataArray(
@@ -385,8 +385,8 @@ class TimeMeanEvaluatorAggregator:
 
     def _get_caption(self, key: str, name: str) -> str:
         if name in self._variable_metadata:
-            caption_name = self._variable_metadata[name].long_name
-            units = self._variable_metadata[name].units
+            caption_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = self._image_captions[key].format(name=caption_name, units=units)
@@ -399,15 +399,17 @@ class TimeMeanEvaluatorAggregator:
             if self._log_variables is not None and pred.name not in self._log_variables:
                 continue
             if pred.name in self._variable_metadata:
-                long_name = self._variable_metadata[pred.name].long_name
-                units = self._variable_metadata[pred.name].units
+                long_name = self._variable_metadata[pred.name].display_long_name(
+                    pred.name
+                )
+                units = self._variable_metadata[pred.name].display_units()
             else:
                 long_name = pred.name
                 units = "unknown_units"
-            gen_metadata = VariableMetadata(long_name=long_name, units=units)._asdict()
+            gen_metadata = VariableMetadata(long_name=long_name, units=units).as_attrs()
             bias_metadata = self._variable_metadata.get(
                 pred.name, VariableMetadata(long_name=long_name, units=units)
-            )._asdict()
+            ).as_attrs()
             data.update(
                 {
                     f"bias_map-{pred.name}": xr.DataArray(

--- a/fme/ace/aggregator/inference/video.py
+++ b/fme/ace/aggregator/inference/video.py
@@ -373,22 +373,21 @@ class VideoAggregator:
         def get_units(name: str) -> str | None:
             if name in self._variable_metadata:
                 return self._variable_metadata[name].units
-            else:
-                return None
+            return None
 
         def get_long_name(name: str) -> str | None:
             if name in self._variable_metadata:
                 return self._variable_metadata[name].long_name
-            else:
-                return None
+            return None
 
         for name in gen_data:
+            long_name = get_long_name(name) or name
             video_data[name] = _MaybePairedVideoData(
                 caption=self._get_caption(name),
                 gen=gen_data[name],
                 target=target_data[name],
                 units=get_units(name),
-                long_name=f"ensemble mean of {get_long_name(name)}",
+                long_name=f"ensemble mean of {long_name}",
             )
             if self._enable_extended_videos:
                 video_data[f"bias/{name}"] = _MaybePairedVideoData(
@@ -477,8 +476,8 @@ class VideoAggregator:
             "Autoregressive (left) prediction and (right) target for {name} [{units}]"
         )
         if name in self._variable_metadata:
-            caption_name = self._variable_metadata[name].long_name
-            units = self._variable_metadata[name].units
+            caption_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units("unknown units")
         else:
             caption_name, units = name, "unknown units"
         return caption.format(name=caption_name, units=units)

--- a/fme/ace/aggregator/inference/zonal_mean.py
+++ b/fme/ace/aggregator/inference/zonal_mean.py
@@ -279,7 +279,7 @@ class ZonalMeanAggregator:
     def get_dataset(self) -> xr.Dataset:
         data = {
             k.replace("/", "-"): xr.DataArray(
-                v.datum, dims=("forecast_step", "lat"), attrs=v.metadata._asdict()
+                v.datum, dims=("forecast_step", "lat"), attrs=v.metadata.as_attrs()
             )
             for k, v in self._get_data().items()
         }
@@ -289,8 +289,8 @@ class ZonalMeanAggregator:
 
     def _get_caption(self, key: str, varname: str) -> str:
         if varname in self._variable_metadata:
-            caption_name = self._variable_metadata[varname].long_name
-            units = self._variable_metadata[varname].units
+            caption_name = self._variable_metadata[varname].display_long_name(varname)
+            units = self._variable_metadata[varname].display_units()
         else:
             caption_name, units = varname, "unknown_units"
         caption = self._captions[key].format(name=caption_name, units=units)

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -256,8 +256,8 @@ class _EnsembleAggregator:
 
     def _get_caption(self, name: str) -> str:
         if self._metadata is not None and name in self._metadata:
-            caption_name = self._metadata[name].long_name
-            units = self._metadata[name].units
+            caption_name = self._metadata[name].display_long_name(name)
+            units = self._metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = f"{caption_name} ({units})"

--- a/fme/ace/aggregator/one_step/map.py
+++ b/fme/ace/aggregator/one_step/map.py
@@ -128,8 +128,8 @@ class MapAggregator:
 
     def _get_caption(self, key: str, name: str) -> str:
         if name in self._metadata:
-            caption_name = self._metadata[name].long_name
-            units = self._metadata[name].units
+            caption_name = self._metadata[name].display_long_name(name)
+            units = self._metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = self._captions[key].format(name=caption_name, units=units)
@@ -140,8 +140,8 @@ class MapAggregator:
         ds = xr.Dataset()
         for name in gen:
             if name in self._metadata:
-                long_name = self._metadata[name].long_name
-                units = self._metadata[name].units
+                long_name = self._metadata[name].display_long_name(name)
+                units = self._metadata[name].display_units()
             else:
                 long_name = name
                 units = "unknown_units"

--- a/fme/ace/aggregator/one_step/snapshot.py
+++ b/fme/ace/aggregator/one_step/snapshot.py
@@ -120,8 +120,8 @@ class SnapshotAggregator:
 
     def _get_caption(self, key: str, name: str) -> str:
         if name in self._metadata:
-            caption_name = self._metadata[name].long_name
-            units = self._metadata[name].units
+            caption_name = self._metadata[name].display_long_name(name)
+            units = self._metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = self._captions[key].format(name=caption_name, units=units)
@@ -132,8 +132,8 @@ class SnapshotAggregator:
         ds = xr.Dataset()
         for name in gen:
             if name in self._metadata:
-                long_name = self._metadata[name].long_name
-                units = self._metadata[name].units
+                long_name = self._metadata[name].display_long_name(name)
+                units = self._metadata[name].display_units()
             else:
                 long_name = name
                 units = "unknown_units"

--- a/fme/ace/data_loading/test_metadata.py
+++ b/fme/ace/data_loading/test_metadata.py
@@ -108,7 +108,8 @@ def test_metadata(tmp_path, variable_metadata, n_ensemble_members):
     data = get_gridded_data(config=config, train=True, requirements=requirements)
     target_metadata = {
         name: variable_metadata[name]
-        for name in variable_metadata
         if variable_metadata[name] is not None
+        else VariableMetadata(units="", long_name="")
+        for name in variable_metadata
     }
     assert data.variable_metadata == target_metadata  # type: ignore

--- a/fme/ace/data_loading/test_metadata.py
+++ b/fme/ace/data_loading/test_metadata.py
@@ -39,12 +39,10 @@ def _save_netcdf(
         if len(dim_sizes) > 0:
             data = data.astype(np.float32)
         item_metadata = variable_metadata[name]
-        attrs: dict[str, str] = {}
         if item_metadata is not None:
-            if item_metadata.units is not None:
-                attrs["units"] = item_metadata.units
-            if item_metadata.long_name is not None:
-                attrs["long_name"] = item_metadata.long_name
+            attrs = item_metadata.as_attrs()
+        else:
+            attrs = {}
         data_vars[name] = xr.DataArray(data, dims=list(dim_sizes), attrs=attrs)
     coords = {
         dim_name: xr.DataArray(

--- a/fme/ace/data_loading/test_metadata.py
+++ b/fme/ace/data_loading/test_metadata.py
@@ -39,13 +39,12 @@ def _save_netcdf(
         if len(dim_sizes) > 0:
             data = data.astype(np.float32)
         item_metadata = variable_metadata[name]
-        if item_metadata is None:
-            attrs = {}
-        else:
-            attrs = {
-                "units": item_metadata.units,
-                "long_name": item_metadata.long_name,
-            }
+        attrs: dict[str, str] = {}
+        if item_metadata is not None:
+            if item_metadata.units is not None:
+                attrs["units"] = item_metadata.units
+            if item_metadata.long_name is not None:
+                attrs["long_name"] = item_metadata.long_name
         data_vars[name] = xr.DataArray(data, dims=list(dim_sizes), attrs=attrs)
     coords = {
         dim_name: xr.DataArray(
@@ -74,6 +73,14 @@ def _save_netcdf(
         pytest.param(
             {"bar": VariableMetadata("km", "bar_long_name")},
             id="one_var_metadata",
+        ),
+        pytest.param(
+            {"bar": VariableMetadata("km", None)},
+            id="one_var_units_only",
+        ),
+        pytest.param(
+            {"bar": VariableMetadata(None, "bar_long_name")},
+            id="one_var_long_name_only",
         ),
         pytest.param(
             {"foo": VariableMetadata("m", "foo_long_name"), "bar": None},
@@ -109,7 +116,7 @@ def test_metadata(tmp_path, variable_metadata, n_ensemble_members):
     target_metadata = {
         name: variable_metadata[name]
         if variable_metadata[name] is not None
-        else VariableMetadata(units="", long_name="")
+        else VariableMetadata()
         for name in variable_metadata
     }
     assert data.variable_metadata == target_metadata  # type: ignore

--- a/fme/ace/inference/data_writer/main.py
+++ b/fme/ace/inference/data_writer/main.py
@@ -300,10 +300,7 @@ def _write(
         array = maybe_squeeze(data.data[name]).detach().cpu().numpy()
         data_arrays[name] = xr.DataArray(array, dims=dims_to_write)
         if name in variable_metadata:
-            data_arrays[name].attrs = {
-                "long_name": variable_metadata[name].long_name,
-                "units": variable_metadata[name].units,
-            }
+            data_arrays[name].attrs = variable_metadata[name].as_attrs()
     data_arrays["time"] = time_array
     ds = xr.Dataset(data_arrays, coords=coords)
     ds.attrs.update(dataset_metadata.as_flat_str_dict())

--- a/fme/ace/inference/data_writer/monthly.py
+++ b/fme/ace/inference/data_writer/monthly.py
@@ -290,12 +290,10 @@ class MonthlyDataWriter:
                     fill_value=np.nan,
                 )
                 if variable_name in self.variable_metadata:
-                    self.dataset.variables[
-                        variable_name
-                    ].units = self.variable_metadata[variable_name].units
-                    self.dataset.variables[
-                        variable_name
-                    ].long_name = self.variable_metadata[variable_name].long_name
+                    for attr, val in (
+                        self.variable_metadata[variable_name].as_attrs().items()
+                    ):
+                        setattr(self.dataset.variables[variable_name], attr, val)
                 self.dataset.variables[variable_name].coordinates = " ".join(
                     [INIT_TIME, VALID_TIME, COUNTS]
                 )

--- a/fme/ace/inference/data_writer/raw.py
+++ b/fme/ace/inference/data_writer/raw.py
@@ -214,12 +214,10 @@ class RawDataWriter:
                     fill_value=np.nan,
                 )
                 if variable_name in self.variable_metadata:
-                    self.dataset.variables[
-                        variable_name
-                    ].units = self.variable_metadata[variable_name].units
-                    self.dataset.variables[
-                        variable_name
-                    ].long_name = self.variable_metadata[variable_name].long_name
+                    for attr, val in (
+                        self.variable_metadata[variable_name].as_attrs().items()
+                    ):
+                        setattr(self.dataset.variables[variable_name], attr, val)
                 self.dataset.variables[variable_name].coordinates = " ".join(
                     [INIT_TIME, VALID_TIME]
                 )

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import NamedTuple
 
 import cftime
 import numpy as np
@@ -21,6 +20,7 @@ from fme.ace.inference.data_writer.main import (
 from fme.ace.inference.data_writer.raw import get_batch_lead_time_microseconds
 from fme.ace.inference.data_writer.time_coarsen import TimeCoarsenConfig
 from fme.ace.inference.data_writer.zarr import ZarrWriterConfig
+from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.device import get_device
 from fme.core.labels import BatchLabels
 from fme.core.typing_ import TensorMapping
@@ -94,10 +94,6 @@ def get_paired_data(
 
 
 class TestDataWriter:
-    class VariableMetadata(NamedTuple):
-        units: str
-        long_name: str
-
     @pytest.fixture(params=["julian", "proleptic_gregorian", "noleap"])
     def calendar(self, request):
         """
@@ -140,8 +136,8 @@ class TestDataWriter:
     @pytest.fixture
     def sample_metadata(self):
         return {
-            "temp": self.VariableMetadata(units="K", long_name="Temperature"),
-            "humidity": self.VariableMetadata(units="%", long_name="Relative Humidity"),
+            "temp": VariableMetadata(units="K", long_name="Temperature"),
+            "humidity": VariableMetadata(units="%", long_name="Relative Humidity"),
         }
 
     @pytest.fixture

--- a/fme/ace/inference/data_writer/zarr.py
+++ b/fme/ace/inference/data_writer/zarr.py
@@ -27,15 +27,7 @@ def _variable_metadata_to_dict(
 ) -> dict[str, dict[str, str]] | None:
     if variable_metadata is None:
         return None
-    result = {}
-    for var, metadata in variable_metadata.items():
-        attrs: dict[str, str] = {}
-        if metadata.units is not None:
-            attrs["units"] = metadata.units
-        if metadata.long_name is not None:
-            attrs["long_name"] = metadata.long_name
-        result[var] = attrs
-    return result
+    return {var: metadata.as_attrs() for var, metadata in variable_metadata.items()}
 
 
 def _get_encoded_lead_times(

--- a/fme/ace/inference/data_writer/zarr.py
+++ b/fme/ace/inference/data_writer/zarr.py
@@ -27,10 +27,15 @@ def _variable_metadata_to_dict(
 ) -> dict[str, dict[str, str]] | None:
     if variable_metadata is None:
         return None
-    return {
-        var: {"units": metadata.units, "long_name": metadata.long_name}
-        for var, metadata in variable_metadata.items()
-    }
+    result = {}
+    for var, metadata in variable_metadata.items():
+        attrs: dict[str, str] = {}
+        if metadata.units is not None:
+            attrs["units"] = metadata.units
+        if metadata.long_name is not None:
+            attrs["long_name"] = metadata.long_name
+        result[var] = attrs
+    return result
 
 
 def _get_encoded_lead_times(

--- a/fme/core/dataset/data_typing.py
+++ b/fme/core/dataset/data_typing.py
@@ -17,3 +17,9 @@ class VariableMetadata(NamedTuple):
         if self.long_name is not None:
             result["long_name"] = self.long_name
         return result
+
+    def display_long_name(self, fallback: str) -> str:
+        return self.long_name if self.long_name is not None else fallback
+
+    def display_units(self, fallback: str = "unknown_units") -> str:
+        return self.units if self.units is not None else fallback

--- a/fme/core/dataset/data_typing.py
+++ b/fme/core/dataset/data_typing.py
@@ -1,3 +1,6 @@
-from collections import namedtuple
+from typing import NamedTuple
 
-VariableMetadata = namedtuple("VariableMetadata", ["units", "long_name"])
+
+class VariableMetadata(NamedTuple):
+    units: str | None = None
+    long_name: str | None = None

--- a/fme/core/dataset/data_typing.py
+++ b/fme/core/dataset/data_typing.py
@@ -1,6 +1,19 @@
+from collections.abc import Mapping
 from typing import NamedTuple
 
 
 class VariableMetadata(NamedTuple):
     units: str | None = None
     long_name: str | None = None
+
+    @classmethod
+    def from_attrs(cls, attrs: Mapping[str, str]) -> "VariableMetadata":
+        return cls(units=attrs.get("units"), long_name=attrs.get("long_name"))
+
+    def as_attrs(self) -> dict[str, str]:
+        result: dict[str, str] = {}
+        if self.units is not None:
+            result["units"] = self.units
+        if self.long_name is not None:
+            result["long_name"] = self.long_name
+        return result

--- a/fme/core/dataset/test_data_typing.py
+++ b/fme/core/dataset/test_data_typing.py
@@ -1,0 +1,42 @@
+from fme.core.dataset.data_typing import VariableMetadata
+
+
+def test_from_attrs_both():
+    m = VariableMetadata.from_attrs({"units": "K", "long_name": "Temperature"})
+    assert m.units == "K"
+    assert m.long_name == "Temperature"
+
+
+def test_from_attrs_partial():
+    m = VariableMetadata.from_attrs({"units": "K"})
+    assert m.units == "K"
+    assert m.long_name is None
+
+
+def test_from_attrs_empty():
+    m = VariableMetadata.from_attrs({})
+    assert m.units is None
+    assert m.long_name is None
+
+
+def test_as_attrs_filters_none():
+    assert VariableMetadata().as_attrs() == {}
+    assert VariableMetadata(units="K").as_attrs() == {"units": "K"}
+    assert VariableMetadata(long_name="T").as_attrs() == {"long_name": "T"}
+    assert VariableMetadata("K", "T").as_attrs() == {"units": "K", "long_name": "T"}
+
+
+def test_display_long_name():
+    assert VariableMetadata().display_long_name("fallback") == "fallback"
+    assert (
+        VariableMetadata(long_name="Temperature").display_long_name("x")
+        == "Temperature"
+    )
+    assert VariableMetadata(long_name="").display_long_name("x") == ""
+
+
+def test_display_units():
+    assert VariableMetadata().display_units() == "unknown_units"
+    assert VariableMetadata().display_units("custom") == "custom"
+    assert VariableMetadata(units="K").display_units() == "K"
+    assert VariableMetadata(units="").display_units() == ""

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -1230,3 +1230,12 @@ def test_dataset_properties_update_masks(mock_monthly_netcdfs):
     existing_mask = MaskProvider(masks={"mask_0": torch.ones(4, 8)})
     data_properties.update_mask_provider(existing_mask)
     assert "mask_0" in dataset.properties.mask_provider.masks
+
+
+def test_variable_metadata_includes_all_names(mock_monthly_netcdfs):
+    mock_data: MockData = mock_monthly_netcdfs
+    config = XarrayDataConfig(data_path=mock_data.tmpdir)
+    names = mock_data.var_names.all_names
+    dataset = xarray_dataset_constructor(config, names, 2)
+    metadata_keys = set(dataset.properties.variable_metadata.keys())
+    assert metadata_keys == set(names)

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -703,6 +703,8 @@ class XarrayDataset(DatasetABC):
                     units=ds[name].units,
                     long_name=ds[name].long_name,
                 )
+            else:
+                result[name] = VariableMetadata(units="", long_name="")
         self._variable_metadata = result
 
     def _get_files_stats(

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -716,13 +716,11 @@ class XarrayDataset(DatasetABC):
         for name in self._names:
             if name in StaticDerivedData.names:
                 result[name] = StaticDerivedData.metadata[name]
-            elif hasattr(ds[name], "units") and hasattr(ds[name], "long_name"):
-                result[name] = VariableMetadata(
-                    units=ds[name].units,
-                    long_name=ds[name].long_name,
-                )
             else:
-                result[name] = VariableMetadata(units="", long_name="")
+                result[name] = VariableMetadata(
+                    units=getattr(ds[name], "units", None),
+                    long_name=getattr(ds[name], "long_name", None),
+                )
         self._variable_metadata = result
 
     def _get_files_stats(

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -717,10 +717,7 @@ class XarrayDataset(DatasetABC):
             if name in StaticDerivedData.names:
                 result[name] = StaticDerivedData.metadata[name]
             else:
-                result[name] = VariableMetadata(
-                    units=getattr(ds[name], "units", None),
-                    long_name=getattr(ds[name], "long_name", None),
-                )
+                result[name] = VariableMetadata.from_attrs(ds[name].attrs)
         self._variable_metadata = result
 
     def _get_files_stats(

--- a/fme/downscaling/aggregators/main.py
+++ b/fme/downscaling/aggregators/main.py
@@ -771,8 +771,8 @@ class MeanMapAggregator:
 
     def _get_caption(self, key: str, name: str, vmin: float, vmax: float) -> str:
         if name in self._variable_metadata:
-            caption_name = self._variable_metadata[name].long_name
-            units = self._variable_metadata[name].units
+            caption_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = self._captions[key].format(name=caption_name, units=units)

--- a/fme/downscaling/aggregators/no_target.py
+++ b/fme/downscaling/aggregators/no_target.py
@@ -146,12 +146,12 @@ def _plot_timeseries(
         plt.plot(times, coarse_data, color="black", label="coarse", linestyle="-.")
     plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
     plt.xlabel("time")
+    caption_name, units = fine_data.name, "unknown_units"
     if variable_metadata is not None:
-        if fine_data.name in variable_metadata:
-            caption_name = variable_metadata[fine_data.name].long_name
-            units = variable_metadata[fine_data.name].units
-    else:
-        caption_name, units = fine_data.name, "unknown_units"
+        if variable_metadata.long_name is not None:
+            caption_name = variable_metadata.long_name
+        if variable_metadata.units is not None:
+            units = variable_metadata.units
     plt.ylabel(f"{caption_name} [{units}]")
     plt.legend()
 
@@ -317,7 +317,7 @@ class _MapAggregator:
 
     def _get_caption(self, key: str, name: str, vmin: float, vmax: float) -> str:
         _caption = (
-            "{name}  mean full field; (left) generated and " "(right) coarse [{units}]"
+            "{name}  mean full field; (left) generated and (right) coarse [{units}]"
         )
 
         if name in self._variable_metadata:

--- a/fme/downscaling/aggregators/no_target.py
+++ b/fme/downscaling/aggregators/no_target.py
@@ -321,8 +321,8 @@ class _MapAggregator:
         )
 
         if name in self._variable_metadata:
-            caption_name = self._variable_metadata[name].long_name
-            units = self._variable_metadata[name].units
+            caption_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units()
         else:
             caption_name, units = name, "unknown_units"
         caption = _caption.format(name=caption_name, units=units)


### PR DESCRIPTION
`XarrayDataset._get_variable_metadata` silently omits variables that lack `units` or `long_name` attributes, causing `variable_metadata` to under-report the loaded variable set.

Changes:
- `VariableMetadata` now supports null `units` and/or `long_name`. Added helper methods `from_attrs()` (class method), `as_attrs()`, `display_name()` and `display_units()`.
- `fme.core.dataset.xarray.XarrayDataset._get_variable_metadata`: use null `VariableMetadata` attrs for variables without `units`/`long_name` attrs
- The `_variable_metadata_to_dict` util used by `ZarrWriterAdapter` and `SeparateICZarrWriterAdapter` filters out `None` values for `VariableMetadata`, preserving existing behavior.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #1183 