### PR TITLE
Stabilize derived-forcings train test against NaN flake on GPU

### DIFF
--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -51,6 +51,7 @@ from fme.ace.stepper.time_length_probabilities import (
 from fme.ace.testing import (
     DimSizes,
     MonthlyReferenceData,
+    patch_cm4_solar_constant,
     save_nd_netcdf,
     save_scalar_netcdf,
     save_stepper_checkpoint,
@@ -330,7 +331,7 @@ def _get_test_yaml_files(
             use_gradient_accumulation=True,
             enable_automatic_mixed_precision=True,
             optimizer_type="Adam",
-            lr=0.001,
+            lr=0.0001,
             kwargs=dict(weight_decay=0.01),
             scheduler=SchedulerConfig(
                 type="CosineAnnealingLR",
@@ -1042,13 +1043,14 @@ def test_train_and_inference_with_derived_forcings(
         derived_forcings=derived_forcings,
         stats_std_fill_value=1.0,
     )
-    with mock_wandb() as wandb:
-        train_main(
-            yaml_config=train_config,
-        )
-    with mock_wandb() as wandb:
-        wandb.configure(log_to_wandb=True)
-        inference_evaluator_main(yaml_config=inference_config)
+    with patch_cm4_solar_constant(1.0):
+        with mock_wandb() as wandb:
+            train_main(
+                yaml_config=train_config,
+            )
+        with mock_wandb() as wandb:
+            wandb.configure(log_to_wandb=True)
+            inference_evaluator_main(yaml_config=inference_config)
 
 
 def test_train_with_non_local_experiment_dir_error():

--- a/fme/ace/testing/__init__.py
+++ b/fme/ace/testing/__init__.py
@@ -8,4 +8,5 @@ from .fv3gfs_data import (
     save_nd_netcdf,
     save_scalar_netcdf,
 )
+from .insolation import patch_cm4_solar_constant
 from .stepper_checkpoint import save_stepper_checkpoint

--- a/fme/ace/testing/insolation.py
+++ b/fme/ace/testing/insolation.py
@@ -1,0 +1,26 @@
+import contextlib
+import unittest.mock
+
+import torch
+
+from fme.ace.stepper.insolation import CM4Insolation
+
+
+@contextlib.contextmanager
+def patch_cm4_solar_constant(value: float = 1.0):
+    """Temporarily force ``CM4Insolation`` to use a fixed solar constant.
+
+    Useful in tests where the configured solar constant (literal or loaded
+    from disk) produces insolation magnitudes that are inconsistent with the
+    on-disk normalization stats, leading to NaN training losses.
+    """
+    original_call = CM4Insolation.__call__
+
+    def patched_call(self, time, timestep, horizontal_coordinates, solar_constant):
+        replacement = torch.as_tensor(
+            value, dtype=solar_constant.dtype, device=solar_constant.device
+        )
+        return original_call(self, time, timestep, horizontal_coordinates, replacement)
+
+    with unittest.mock.patch.object(CM4Insolation, "__call__", patched_call):
+        yield


### PR DESCRIPTION
The `test_train_and_inference_with_derived_forcings` test occasionally fails on GPU with `ValueError: Loss is NaN-valued during training.` (see issue #1186). The root cause is a scale mismatch between the derived insolation values fed to the model and the on-disk normalization stats for the DSWRFtoa slot: the stats are drawn from random N(0,1) noise that was used to fill the on-disk variable, but the actual values fed at train time are the output of `CM4Insolation`, which span ~0..1400 W/m² for the literal-constant case and signed random magnitudes for the load-from-disk case. With AMP enabled and Adam at lr=1e-3, the resulting out-of-distribution inputs are occasionally large enough to drive gradients to NaN on GPU.

This PR forces the solar constant to 1.0 inside the test via a small context-managed monkey-patch of `CM4Insolation.__call__`, which bounds the derived insolation to roughly [0, 1] and brings it in line with the normalizer's expected scale. It also lowers the test default learning rate from 1e-3 to 1e-4 to better mirror production training settings.

Changes:
- `fme.ace.testing.patch_cm4_solar_constant`: new context manager that temporarily replaces the solar constant passed to `CM4Insolation` with a fixed value (defaults to 1.0), reverting on exit.
- `fme.ace.test_train.test_train_and_inference_with_derived_forcings`: wrap the `train_main` / `inference_evaluator_main` calls in `patch_cm4_solar_constant(1.0)` so the derived insolation matches the synthetic-stats scale.
- `fme.ace.test_train._get_test_yaml_files`: drop the test optimizer learning rate from 1e-3 to 1e-4.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #1186