### PR TITLE
Revert back to torch>=2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "tensorly",
     "tensorly-torch",
     "torch-harmonics==0.8.0",
-    "torch>=2.8.0",
+    "torch>=2.4.0",
     "wandb[media]>=0.19.0",
     "xarray",
     "zarr>=3",


### PR DESCRIPTION
Since we don't actually use any new features that would require torch>2.4, we revert back to torch>=2.4.