### PR TITLE
Add normalizer option to remove global mean surface temperature

### DIFF
--- a/fme/core/normalizer.py
+++ b/fme/core/normalizer.py
@@ -11,6 +11,28 @@ import xarray as xr
 from fme.core.device import move_tensordict_to_device
 from fme.core.typing_ import TensorDict, TensorMapping
 
+# Experimental: when NormalizationConfig.experimental_use_shared_temperature_offset
+# is True, every field named here gets a per-sample additive offset applied
+# before normalization (and removed after denormalization). The offset for a
+# sample is the difference between the surface_temperature normalization mean
+# and the sample's cell-wise mean surface_temperature. Hard-coded for now.
+_TEMPERATURE_FIELD_NAMES = frozenset(
+    [
+        "surface_temperature",
+        "TMP2m",
+        "TMP850",
+        "air_temperature_0",
+        "air_temperature_1",
+        "air_temperature_2",
+        "air_temperature_3",
+        "air_temperature_4",
+        "air_temperature_5",
+        "air_temperature_6",
+        "air_temperature_7",
+    ]
+)
+_SHARED_TEMPERATURE_OFFSET_REFERENCE = "surface_temperature"
+
 
 @dataclasses.dataclass
 class NormalizationConfig:
@@ -31,6 +53,15 @@ class NormalizationConfig:
         fill_nans_on_denormalize: Whether to fill NaNs during denormalization. If
             true, on denormalization NaNs in the normalized input become global means in
             the denormalized output.
+        experimental_use_shared_temperature_offset: If true, the built
+            normalizer computes a per-sample offset from the input
+            surface_temperature (surface_temperature normalization mean minus
+            the sample's cell-wise mean) and adds it to every temperature
+            field on normalize / subtracts it on denormalize. Intended for the
+            network (full-field) normalizer only -- the loss normalizer skips
+            this even if the flag is set, since offsets are unnecessary there.
+            surface_temperature must be in the means. Temperature field names
+            are hard-coded; experimental knob, not a stable feature.
     """
 
     global_means_path: str | pathlib.Path | None = None
@@ -39,6 +70,7 @@ class NormalizationConfig:
     stds: Mapping[str, float] = dataclasses.field(default_factory=dict)
     fill_nans_on_normalize: bool = False
     fill_nans_on_denormalize: bool = False
+    experimental_use_shared_temperature_offset: bool = False
 
     def __post_init__(self):
         using_path = (
@@ -91,6 +123,9 @@ class NormalizationConfig:
                 names=names,
                 fill_nans_on_normalize=self.fill_nans_on_normalize,
                 fill_nans_on_denormalize=self.fill_nans_on_denormalize,
+                use_shared_temperature_offset=(
+                    self.experimental_use_shared_temperature_offset
+                ),
             )
         else:
             means = {k: torch.tensor(self.means[k]) for k in names}
@@ -100,6 +135,9 @@ class NormalizationConfig:
                 stds=stds,
                 fill_nans_on_normalize=self.fill_nans_on_normalize,
                 fill_nans_on_denormalize=self.fill_nans_on_denormalize,
+                use_shared_temperature_offset=(
+                    self.experimental_use_shared_temperature_offset
+                ),
             )
 
 
@@ -114,12 +152,25 @@ class StandardNormalizer:
         stds: TensorDict,
         fill_nans_on_normalize: bool = False,
         fill_nans_on_denormalize: bool = False,
+        use_shared_temperature_offset: bool = False,
     ):
         self.means = move_tensordict_to_device(means)
         self.stds = move_tensordict_to_device(stds)
         self._names = set(means).intersection(stds)
         self._fill_nans_on_normalize = fill_nans_on_normalize
         self._fill_nans_on_denormalize = fill_nans_on_denormalize
+        self._use_shared_temperature_offset = use_shared_temperature_offset
+        # Per-sample offset cached by the last normalize() call so the matching
+        # denormalize() can invert it. None until the first normalize() call.
+        self._cached_temperature_offset: torch.Tensor | None = None
+        if use_shared_temperature_offset and (
+            _SHARED_TEMPERATURE_OFFSET_REFERENCE not in self.means
+        ):
+            raise ValueError(
+                "use_shared_temperature_offset is set but "
+                f"{_SHARED_TEMPERATURE_OFFSET_REFERENCE!r} is not present in "
+                "the normalization means."
+            )
 
     @property
     def fill_nans_on_normalize(self):
@@ -129,8 +180,18 @@ class StandardNormalizer:
     def fill_nans_on_denormalize(self):
         return self._fill_nans_on_denormalize
 
+    @property
+    def use_shared_temperature_offset(self) -> bool:
+        return self._use_shared_temperature_offset
+
     def normalize(self, tensors: TensorMapping) -> TensorDict:
         filtered_tensors = {k: v for k, v in tensors.items() if k in self._names}
+        if self._use_shared_temperature_offset:
+            offset = self._compute_temperature_offset(tensors)
+            self._cached_temperature_offset = offset
+            filtered_tensors = _shift_temperature_fields(
+                filtered_tensors, offset, add=True
+            )
         return _normalize(
             filtered_tensors,
             means=self.means,
@@ -140,12 +201,40 @@ class StandardNormalizer:
 
     def denormalize(self, tensors: TensorMapping) -> TensorDict:
         filtered_tensors = {k: v for k, v in tensors.items() if k in self._names}
-        return _denormalize(
+        denormalized = _denormalize(
             filtered_tensors,
             means=self.means,
             stds=self.stds,
             fill_nans=self._fill_nans_on_denormalize,
         )
+        if self._use_shared_temperature_offset:
+            if self._cached_temperature_offset is None:
+                raise RuntimeError(
+                    "denormalize() was called before normalize() on a "
+                    "StandardNormalizer with use_shared_temperature_offset "
+                    "enabled; the offset is computed during normalize()."
+                )
+            denormalized = _shift_temperature_fields(
+                denormalized, self._cached_temperature_offset, add=False
+            )
+        return denormalized
+
+    def _compute_temperature_offset(self, tensors: TensorMapping) -> torch.Tensor:
+        ref_name = _SHARED_TEMPERATURE_OFFSET_REFERENCE
+        if ref_name not in tensors:
+            raise ValueError(
+                "use_shared_temperature_offset is set but "
+                f"{ref_name!r} is not in the input tensors to normalize()."
+            )
+        ref = tensors[ref_name]
+        if ref.ndim < 2:
+            raise ValueError(
+                f"{ref_name!r} must have a sample dim and at least one "
+                f"non-sample dim to compute a per-sample offset; got shape "
+                f"{tuple(ref.shape)}."
+            )
+        sample_mean = ref.mean(dim=tuple(range(1, ref.ndim)))
+        return self.means[ref_name] - sample_mean
 
     def get_state(self):
         """
@@ -156,6 +245,7 @@ class StandardNormalizer:
             "stds": {k: float(v.cpu().numpy().item()) for k, v in self.stds.items()},
             "fill_nans_on_normalize": self._fill_nans_on_normalize,
             "fill_nans_on_denormalize": self._fill_nans_on_denormalize,
+            "use_shared_temperature_offset": self._use_shared_temperature_offset,
         }
 
     @classmethod
@@ -172,6 +262,9 @@ class StandardNormalizer:
             stds=stds,
             fill_nans_on_normalize=state.get("fill_nans_on_normalize", False),
             fill_nans_on_denormalize=state.get("fill_nans_on_denormalize", False),
+            use_shared_temperature_offset=state.get(
+                "use_shared_temperature_offset", False
+            ),
         )
 
     def get_normalization_config(self) -> NormalizationConfig:
@@ -180,6 +273,9 @@ class StandardNormalizer:
             stds={k: float(v.cpu().numpy().item()) for k, v in self.stds.items()},
             fill_nans_on_normalize=self.fill_nans_on_normalize,
             fill_nans_on_denormalize=self.fill_nans_on_denormalize,
+            experimental_use_shared_temperature_offset=(
+                self._use_shared_temperature_offset
+            ),
         )
 
 
@@ -262,6 +358,43 @@ def load_dict_from_netcdf(
     return result
 
 
+def _shift_temperature_fields(
+    tensors: TensorDict,
+    offset: torch.Tensor,
+    add: bool,
+) -> TensorDict:
+    """Add (or subtract) a per-sample offset to every temperature field.
+
+    ``offset`` has shape ``[batch]``; it is broadcast over the non-sample
+    dimensions of each temperature tensor.
+    """
+    result = dict(tensors)
+    for name in _TEMPERATURE_FIELD_NAMES:
+        if name not in result:
+            continue
+        t = result[name]
+        broadcast = offset.view(offset.shape[0], *(1,) * (t.ndim - 1))
+        result[name] = t + broadcast if add else t - broadcast
+    return result
+
+
+def _disable_shared_temperature_offset(
+    normalizer: StandardNormalizer,
+) -> StandardNormalizer:
+    """Return a copy of ``normalizer`` with the shared-temperature-offset
+    behavior turned off, or ``normalizer`` itself if it's already off.
+    """
+    if not normalizer.use_shared_temperature_offset:
+        return normalizer
+    return StandardNormalizer(
+        means=normalizer.means,
+        stds=normalizer.stds,
+        fill_nans_on_normalize=normalizer.fill_nans_on_normalize,
+        fill_nans_on_denormalize=normalizer.fill_nans_on_denormalize,
+        use_shared_temperature_offset=False,
+    )
+
+
 def _combine_normalizers(
     base_normalizer: StandardNormalizer,
     override_normalizer: StandardNormalizer,
@@ -317,14 +450,20 @@ class NetworkAndLossNormalizationConfig:
         residual_scaled_names: list[str],
     ) -> StandardNormalizer:
         if self.loss is not None:
-            return self.loss.build(names=names)
+            built = self.loss.build(names=names)
         elif self.residual is not None:
-            return _combine_normalizers(
+            built = _combine_normalizers(
                 base_normalizer=self.network.build(names=names),
                 override_normalizer=self.residual.build(names=residual_scaled_names),
             )
         else:
-            return self.network.build(names=names)
+            built = self.network.build(names=names)
+        # The shared-temperature-offset flag is only meaningful for the
+        # network normalizer (paired normalize/denormalize). Strip it from
+        # the loss normalizer: there's no denormalize on the loss path, and
+        # offsets computed independently from target vs prediction inputs
+        # would not cancel cleanly.
+        return _disable_shared_temperature_offset(built)
 
     def load(self):
         self.network.load()

--- a/fme/core/normalizer.py
+++ b/fme/core/normalizer.py
@@ -11,11 +11,11 @@ import xarray as xr
 from fme.core.device import move_tensordict_to_device
 from fme.core.typing_ import TensorDict, TensorMapping
 
-# Experimental: when NormalizationConfig.experimental_use_shared_temperature_offset
-# is True, every field named here gets a per-sample additive offset applied
-# before normalization (and removed after denormalization). The offset for a
-# sample is the difference between the surface_temperature normalization mean
-# and the sample's cell-wise mean surface_temperature. Hard-coded for now.
+# When NormalizationConfig.remove_global_mean_surface_temperature is True,
+# every field named here gets a per-sample additive offset applied before
+# normalization (and removed after denormalization). The offset for a sample
+# is the difference between the surface_temperature normalization mean and
+# the sample's cell-wise mean surface_temperature. Hard-coded for now.
 _TEMPERATURE_FIELD_NAMES = frozenset(
     [
         "surface_temperature",
@@ -31,7 +31,7 @@ _TEMPERATURE_FIELD_NAMES = frozenset(
         "air_temperature_7",
     ]
 )
-_SHARED_TEMPERATURE_OFFSET_REFERENCE = "surface_temperature"
+_GLOBAL_MEAN_SURFACE_TEMPERATURE_REFERENCE = "surface_temperature"
 
 
 @dataclasses.dataclass
@@ -53,15 +53,15 @@ class NormalizationConfig:
         fill_nans_on_denormalize: Whether to fill NaNs during denormalization. If
             true, on denormalization NaNs in the normalized input become global means in
             the denormalized output.
-        experimental_use_shared_temperature_offset: If true, the built
-            normalizer computes a per-sample offset from the input
-            surface_temperature (surface_temperature normalization mean minus
-            the sample's cell-wise mean) and adds it to every temperature
-            field on normalize / subtracts it on denormalize. Intended for the
-            network (full-field) normalizer only -- the loss normalizer skips
-            this even if the flag is set, since offsets are unnecessary there.
+        remove_global_mean_surface_temperature: If true, the built normalizer
+            computes a per-sample offset from the input surface_temperature
+            (surface_temperature normalization mean minus the sample's
+            cell-wise mean) and adds it to every temperature field on
+            normalize / subtracts it on denormalize. Intended for the network
+            (full-field) normalizer only -- the loss normalizer skips this
+            even if the flag is set, since offsets are unnecessary there.
             surface_temperature must be in the means. Temperature field names
-            are hard-coded; experimental knob, not a stable feature.
+            are hard-coded.
     """
 
     global_means_path: str | pathlib.Path | None = None
@@ -70,7 +70,7 @@ class NormalizationConfig:
     stds: Mapping[str, float] = dataclasses.field(default_factory=dict)
     fill_nans_on_normalize: bool = False
     fill_nans_on_denormalize: bool = False
-    experimental_use_shared_temperature_offset: bool = False
+    remove_global_mean_surface_temperature: bool = False
 
     def __post_init__(self):
         using_path = (
@@ -123,8 +123,8 @@ class NormalizationConfig:
                 names=names,
                 fill_nans_on_normalize=self.fill_nans_on_normalize,
                 fill_nans_on_denormalize=self.fill_nans_on_denormalize,
-                use_shared_temperature_offset=(
-                    self.experimental_use_shared_temperature_offset
+                remove_global_mean_surface_temperature=(
+                    self.remove_global_mean_surface_temperature
                 ),
             )
         else:
@@ -135,8 +135,8 @@ class NormalizationConfig:
                 stds=stds,
                 fill_nans_on_normalize=self.fill_nans_on_normalize,
                 fill_nans_on_denormalize=self.fill_nans_on_denormalize,
-                use_shared_temperature_offset=(
-                    self.experimental_use_shared_temperature_offset
+                remove_global_mean_surface_temperature=(
+                    self.remove_global_mean_surface_temperature
                 ),
             )
 
@@ -152,23 +152,25 @@ class StandardNormalizer:
         stds: TensorDict,
         fill_nans_on_normalize: bool = False,
         fill_nans_on_denormalize: bool = False,
-        use_shared_temperature_offset: bool = False,
+        remove_global_mean_surface_temperature: bool = False,
     ):
         self.means = move_tensordict_to_device(means)
         self.stds = move_tensordict_to_device(stds)
         self._names = set(means).intersection(stds)
         self._fill_nans_on_normalize = fill_nans_on_normalize
         self._fill_nans_on_denormalize = fill_nans_on_denormalize
-        self._use_shared_temperature_offset = use_shared_temperature_offset
+        self._remove_global_mean_surface_temperature = (
+            remove_global_mean_surface_temperature
+        )
         # Per-sample offset cached by the last normalize() call so the matching
         # denormalize() can invert it. None until the first normalize() call.
         self._cached_temperature_offset: torch.Tensor | None = None
-        if use_shared_temperature_offset and (
-            _SHARED_TEMPERATURE_OFFSET_REFERENCE not in self.means
+        if remove_global_mean_surface_temperature and (
+            _GLOBAL_MEAN_SURFACE_TEMPERATURE_REFERENCE not in self.means
         ):
             raise ValueError(
-                "use_shared_temperature_offset is set but "
-                f"{_SHARED_TEMPERATURE_OFFSET_REFERENCE!r} is not present in "
+                "remove_global_mean_surface_temperature is set but "
+                f"{_GLOBAL_MEAN_SURFACE_TEMPERATURE_REFERENCE!r} is not present in "
                 "the normalization means."
             )
 
@@ -181,12 +183,12 @@ class StandardNormalizer:
         return self._fill_nans_on_denormalize
 
     @property
-    def use_shared_temperature_offset(self) -> bool:
-        return self._use_shared_temperature_offset
+    def remove_global_mean_surface_temperature(self) -> bool:
+        return self._remove_global_mean_surface_temperature
 
     def normalize(self, tensors: TensorMapping) -> TensorDict:
         filtered_tensors = {k: v for k, v in tensors.items() if k in self._names}
-        if self._use_shared_temperature_offset:
+        if self._remove_global_mean_surface_temperature:
             offset = self._compute_temperature_offset(tensors)
             self._cached_temperature_offset = offset
             filtered_tensors = _shift_temperature_fields(
@@ -207,11 +209,11 @@ class StandardNormalizer:
             stds=self.stds,
             fill_nans=self._fill_nans_on_denormalize,
         )
-        if self._use_shared_temperature_offset:
+        if self._remove_global_mean_surface_temperature:
             if self._cached_temperature_offset is None:
                 raise RuntimeError(
                     "denormalize() was called before normalize() on a "
-                    "StandardNormalizer with use_shared_temperature_offset "
+                    "StandardNormalizer with remove_global_mean_surface_temperature "
                     "enabled; the offset is computed during normalize()."
                 )
             denormalized = _shift_temperature_fields(
@@ -220,10 +222,10 @@ class StandardNormalizer:
         return denormalized
 
     def _compute_temperature_offset(self, tensors: TensorMapping) -> torch.Tensor:
-        ref_name = _SHARED_TEMPERATURE_OFFSET_REFERENCE
+        ref_name = _GLOBAL_MEAN_SURFACE_TEMPERATURE_REFERENCE
         if ref_name not in tensors:
             raise ValueError(
-                "use_shared_temperature_offset is set but "
+                "remove_global_mean_surface_temperature is set but "
                 f"{ref_name!r} is not in the input tensors to normalize()."
             )
         ref = tensors[ref_name]
@@ -245,7 +247,9 @@ class StandardNormalizer:
             "stds": {k: float(v.cpu().numpy().item()) for k, v in self.stds.items()},
             "fill_nans_on_normalize": self._fill_nans_on_normalize,
             "fill_nans_on_denormalize": self._fill_nans_on_denormalize,
-            "use_shared_temperature_offset": self._use_shared_temperature_offset,
+            "remove_global_mean_surface_temperature": (
+                self._remove_global_mean_surface_temperature
+            ),
         }
 
     @classmethod
@@ -262,8 +266,9 @@ class StandardNormalizer:
             stds=stds,
             fill_nans_on_normalize=state.get("fill_nans_on_normalize", False),
             fill_nans_on_denormalize=state.get("fill_nans_on_denormalize", False),
-            use_shared_temperature_offset=state.get(
-                "use_shared_temperature_offset", False
+            remove_global_mean_surface_temperature=state.get(
+                "remove_global_mean_surface_temperature",
+                state.get("use_shared_temperature_offset", False),
             ),
         )
 
@@ -273,8 +278,8 @@ class StandardNormalizer:
             stds={k: float(v.cpu().numpy().item()) for k, v in self.stds.items()},
             fill_nans_on_normalize=self.fill_nans_on_normalize,
             fill_nans_on_denormalize=self.fill_nans_on_denormalize,
-            experimental_use_shared_temperature_offset=(
-                self._use_shared_temperature_offset
+            remove_global_mean_surface_temperature=(
+                self._remove_global_mean_surface_temperature
             ),
         )
 
@@ -378,20 +383,20 @@ def _shift_temperature_fields(
     return result
 
 
-def _disable_shared_temperature_offset(
+def _disable_global_mean_surface_temperature_removal(
     normalizer: StandardNormalizer,
 ) -> StandardNormalizer:
-    """Return a copy of ``normalizer`` with the shared-temperature-offset
-    behavior turned off, or ``normalizer`` itself if it's already off.
+    """Return a copy of ``normalizer`` with the global-mean-surface-temperature
+    removal turned off, or ``normalizer`` itself if it's already off.
     """
-    if not normalizer.use_shared_temperature_offset:
+    if not normalizer.remove_global_mean_surface_temperature:
         return normalizer
     return StandardNormalizer(
         means=normalizer.means,
         stds=normalizer.stds,
         fill_nans_on_normalize=normalizer.fill_nans_on_normalize,
         fill_nans_on_denormalize=normalizer.fill_nans_on_denormalize,
-        use_shared_temperature_offset=False,
+        remove_global_mean_surface_temperature=False,
     )
 
 
@@ -458,12 +463,12 @@ class NetworkAndLossNormalizationConfig:
             )
         else:
             built = self.network.build(names=names)
-        # The shared-temperature-offset flag is only meaningful for the
-        # network normalizer (paired normalize/denormalize). Strip it from
-        # the loss normalizer: there's no denormalize on the loss path, and
-        # offsets computed independently from target vs prediction inputs
+        # The remove_global_mean_surface_temperature flag is only meaningful
+        # for the network normalizer (paired normalize/denormalize). Strip it
+        # from the loss normalizer: there's no denormalize on the loss path,
+        # and offsets computed independently from target vs prediction inputs
         # would not cancel cleanly.
-        return _disable_shared_temperature_offset(built)
+        return _disable_global_mean_surface_temperature_removal(built)
 
     def load(self):
         self.network.load()

--- a/fme/core/test_normalizer.py
+++ b/fme/core/test_normalizer.py
@@ -232,6 +232,172 @@ def test_combined_normalization_cannot_set_both_loss_and_residual():
         )
 
 
+def _make_shared_offset_normalizer(means, stds):
+    return NormalizationConfig(
+        means=means,
+        stds=stds,
+        experimental_use_shared_temperature_offset=True,
+    ).build(list(means))
+
+
+def test_shared_temperature_offset_matches_users_worked_example():
+    # Worked example from the user: surface_temperature norm mean = 280K and
+    # the sample's mean surface_temperature = 285K -> offset = -5K. For
+    # air_temperature_4 with norm mean 250K and sample mean 245K, after adding
+    # the offset and subtracting the air_temperature_4 mean the sample's
+    # normalized values are -10 / std (= -2.5 with std=4).
+    means = {"surface_temperature": 280.0, "air_temperature_4": 250.0}
+    stds = {"surface_temperature": 2.0, "air_temperature_4": 4.0}
+    normalizer = _make_shared_offset_normalizer(means, stds)
+    tensors = move_tensordict_to_device(
+        {
+            "surface_temperature": torch.full((1, 4, 4), 285.0),
+            "air_temperature_4": torch.full((1, 4, 4), 245.0),
+        }
+    )
+    normalized = normalizer.normalize(tensors)
+    # surface_temperature: (285 + (-5) - 280) / 2 = 0
+    torch.testing.assert_close(
+        normalized["surface_temperature"],
+        torch.zeros_like(normalized["surface_temperature"]),
+    )
+    # air_temperature_4: (245 + (-5) - 250) / 4 = -2.5
+    torch.testing.assert_close(
+        normalized["air_temperature_4"],
+        torch.full_like(normalized["air_temperature_4"], -2.5),
+    )
+
+
+def test_shared_temperature_offset_round_trips_through_denormalize():
+    torch.manual_seed(0)
+    means = {
+        "surface_temperature": 288.0,
+        "air_temperature_0": 220.0,
+        "TMP850": 250.0,
+    }
+    stds = {"surface_temperature": 5.0, "air_temperature_0": 3.0, "TMP850": 4.0}
+    normalizer = _make_shared_offset_normalizer(means, stds)
+    tensors = move_tensordict_to_device(
+        {k: torch.randn(2, 4, 4) + means[k] for k in means}
+    )
+    round_tripped = normalizer.denormalize(normalizer.normalize(tensors))
+    for k in means:
+        torch.testing.assert_close(round_tripped[k], tensors[k])
+
+
+def test_shared_temperature_offset_preserves_horizontal_gradients():
+    # The offset is spatially constant per sample, so within-field gradients
+    # are unchanged (apart from the std rescaling that standard normalization
+    # would have done anyway). With std=1 the gradient is exactly preserved.
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 1.0}
+    normalizer = _make_shared_offset_normalizer(means, stds)
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": torch.tensor([[285.0, 290.0, 275.0]])}
+    )
+    normalized = normalizer.normalize(tensors)
+    raw_gradient = (
+        tensors["surface_temperature"][0, 1] - tensors["surface_temperature"][0, 0]
+    )
+    normalized_gradient = (
+        normalized["surface_temperature"][0, 1]
+        - normalized["surface_temperature"][0, 0]
+    )
+    torch.testing.assert_close(normalized_gradient, raw_gradient)
+
+
+def test_shared_temperature_offset_is_per_sample():
+    # Different batch elements get different offsets, applied independently.
+    means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
+    normalizer = _make_shared_offset_normalizer(means, stds)
+    surface_t = torch.tensor([[[285.0]], [[270.0]]])  # two samples
+    air_t_0 = torch.tensor([[[230.0]], [[230.0]]])
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": surface_t, "air_temperature_0": air_t_0}
+    )
+    normalized = normalizer.normalize(tensors)
+    # Sample 0: offset = 280 - 285 = -5; sample 1: offset = 280 - 270 = +10.
+    # air_temperature_0 normalized = (raw + offset - 220) / 1
+    expected = torch.tensor([[[230.0 + (-5.0) - 220.0]], [[230.0 + 10.0 - 220.0]]])
+    torch.testing.assert_close(normalized["air_temperature_0"].cpu(), expected)
+
+
+def test_shared_temperature_offset_raises_at_build_when_surface_temperature_missing():
+    normalization = NormalizationConfig(
+        means={"air_temperature_0": 220.0},
+        stds={"air_temperature_0": 1.0},
+        experimental_use_shared_temperature_offset=True,
+    )
+    with pytest.raises(ValueError, match="surface_temperature"):
+        normalization.build(["air_temperature_0"])
+
+
+def test_shared_temperature_offset_raises_at_normalize_when_input_missing():
+    means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
+    normalizer = _make_shared_offset_normalizer(means, stds)
+    tensors = move_tensordict_to_device({"air_temperature_0": torch.zeros(1, 4, 4)})
+    with pytest.raises(ValueError, match="surface_temperature"):
+        normalizer.normalize(tensors)
+
+
+def test_shared_temperature_offset_raises_when_denormalize_called_first():
+    means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
+    normalizer = _make_shared_offset_normalizer(means, stds)
+    with pytest.raises(RuntimeError, match="normalize"):
+        normalizer.denormalize(
+            move_tensordict_to_device({"air_temperature_0": torch.zeros(1, 4, 4)})
+        )
+
+
+def test_network_normalizer_has_shared_offset_but_loss_normalizer_does_not():
+    # When the flag is set on the network NormalizationConfig, only the
+    # network normalizer carries the offset behavior. The loss normalizer
+    # built from the combined config never has it -- offsets are unnecessary
+    # for the loss and would not cancel cleanly across separate normalize()
+    # calls on target vs. prediction.
+    combined = NetworkAndLossNormalizationConfig(
+        network=NormalizationConfig(
+            means={"surface_temperature": 280.0, "air_temperature_0": 220.0},
+            stds={"surface_temperature": 2.0, "air_temperature_0": 4.0},
+            experimental_use_shared_temperature_offset=True,
+        ),
+        residual=NormalizationConfig(
+            means={"air_temperature_0": 219.0},
+            stds={"air_temperature_0": 5.0},
+        ),
+    )
+    network_normalizer = combined.get_network_normalizer(
+        ["surface_temperature", "air_temperature_0"]
+    )
+    loss_normalizer = combined.get_loss_normalizer(
+        names=["surface_temperature", "air_temperature_0"],
+        residual_scaled_names=["air_temperature_0"],
+    )
+    assert network_normalizer.use_shared_temperature_offset
+    assert not loss_normalizer.use_shared_temperature_offset
+
+
+def test_loss_normalizer_strips_shared_offset_in_fallback_case():
+    # Even with no residual and no loss config -- where get_loss_normalizer
+    # falls back to building the network normalizer -- the loss normalizer
+    # must not carry the offset behavior.
+    combined = NetworkAndLossNormalizationConfig(
+        network=NormalizationConfig(
+            means={"surface_temperature": 280.0, "air_temperature_0": 220.0},
+            stds={"surface_temperature": 2.0, "air_temperature_0": 4.0},
+            experimental_use_shared_temperature_offset=True,
+        ),
+    )
+    loss_normalizer = combined.get_loss_normalizer(
+        names=["surface_temperature", "air_temperature_0"],
+        residual_scaled_names=[],
+    )
+    assert not loss_normalizer.use_shared_temperature_offset
+
+
 def test_normalization_config_with_means_and_stds_round_trip():
     config = NormalizationConfig(
         means={"a": 1.0, "b": 2.0},

--- a/fme/core/test_normalizer.py
+++ b/fme/core/test_normalizer.py
@@ -232,15 +232,15 @@ def test_combined_normalization_cannot_set_both_loss_and_residual():
         )
 
 
-def _make_shared_offset_normalizer(means, stds):
+def _make_temperature_offset_normalizer(means, stds):
     return NormalizationConfig(
         means=means,
         stds=stds,
-        experimental_use_shared_temperature_offset=True,
+        remove_global_mean_surface_temperature=True,
     ).build(list(means))
 
 
-def test_shared_temperature_offset_matches_users_worked_example():
+def test_remove_global_mean_surface_temperature_matches_users_worked_example():
     # Worked example from the user: surface_temperature norm mean = 280K and
     # the sample's mean surface_temperature = 285K -> offset = -5K. For
     # air_temperature_4 with norm mean 250K and sample mean 245K, after adding
@@ -248,7 +248,7 @@ def test_shared_temperature_offset_matches_users_worked_example():
     # normalized values are -10 / std (= -2.5 with std=4).
     means = {"surface_temperature": 280.0, "air_temperature_4": 250.0}
     stds = {"surface_temperature": 2.0, "air_temperature_4": 4.0}
-    normalizer = _make_shared_offset_normalizer(means, stds)
+    normalizer = _make_temperature_offset_normalizer(means, stds)
     tensors = move_tensordict_to_device(
         {
             "surface_temperature": torch.full((1, 4, 4), 285.0),
@@ -268,7 +268,7 @@ def test_shared_temperature_offset_matches_users_worked_example():
     )
 
 
-def test_shared_temperature_offset_round_trips_through_denormalize():
+def test_remove_global_mean_surface_temperature_round_trips_through_denormalize():
     torch.manual_seed(0)
     means = {
         "surface_temperature": 288.0,
@@ -276,7 +276,7 @@ def test_shared_temperature_offset_round_trips_through_denormalize():
         "TMP850": 250.0,
     }
     stds = {"surface_temperature": 5.0, "air_temperature_0": 3.0, "TMP850": 4.0}
-    normalizer = _make_shared_offset_normalizer(means, stds)
+    normalizer = _make_temperature_offset_normalizer(means, stds)
     tensors = move_tensordict_to_device(
         {k: torch.randn(2, 4, 4) + means[k] for k in means}
     )
@@ -285,13 +285,13 @@ def test_shared_temperature_offset_round_trips_through_denormalize():
         torch.testing.assert_close(round_tripped[k], tensors[k])
 
 
-def test_shared_temperature_offset_preserves_horizontal_gradients():
+def test_remove_global_mean_surface_temperature_preserves_horizontal_gradients():
     # The offset is spatially constant per sample, so within-field gradients
     # are unchanged (apart from the std rescaling that standard normalization
     # would have done anyway). With std=1 the gradient is exactly preserved.
     means = {"surface_temperature": 280.0}
     stds = {"surface_temperature": 1.0}
-    normalizer = _make_shared_offset_normalizer(means, stds)
+    normalizer = _make_temperature_offset_normalizer(means, stds)
     tensors = move_tensordict_to_device(
         {"surface_temperature": torch.tensor([[285.0, 290.0, 275.0]])}
     )
@@ -306,11 +306,11 @@ def test_shared_temperature_offset_preserves_horizontal_gradients():
     torch.testing.assert_close(normalized_gradient, raw_gradient)
 
 
-def test_shared_temperature_offset_is_per_sample():
+def test_remove_global_mean_surface_temperature_is_per_sample():
     # Different batch elements get different offsets, applied independently.
     means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
     stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
-    normalizer = _make_shared_offset_normalizer(means, stds)
+    normalizer = _make_temperature_offset_normalizer(means, stds)
     surface_t = torch.tensor([[[285.0]], [[270.0]]])  # two samples
     air_t_0 = torch.tensor([[[230.0]], [[230.0]]])
     tensors = move_tensordict_to_device(
@@ -323,36 +323,36 @@ def test_shared_temperature_offset_is_per_sample():
     torch.testing.assert_close(normalized["air_temperature_0"].cpu(), expected)
 
 
-def test_shared_temperature_offset_raises_at_build_when_surface_temperature_missing():
+def test_remove_global_mean_surface_temperature_raises_at_build_when_surface_temperature_missing():  # noqa: E501
     normalization = NormalizationConfig(
         means={"air_temperature_0": 220.0},
         stds={"air_temperature_0": 1.0},
-        experimental_use_shared_temperature_offset=True,
+        remove_global_mean_surface_temperature=True,
     )
     with pytest.raises(ValueError, match="surface_temperature"):
         normalization.build(["air_temperature_0"])
 
 
-def test_shared_temperature_offset_raises_at_normalize_when_input_missing():
+def test_remove_global_mean_surface_temperature_raises_at_normalize_when_input_missing():  # noqa: E501
     means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
     stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
-    normalizer = _make_shared_offset_normalizer(means, stds)
+    normalizer = _make_temperature_offset_normalizer(means, stds)
     tensors = move_tensordict_to_device({"air_temperature_0": torch.zeros(1, 4, 4)})
     with pytest.raises(ValueError, match="surface_temperature"):
         normalizer.normalize(tensors)
 
 
-def test_shared_temperature_offset_raises_when_denormalize_called_first():
+def test_remove_global_mean_surface_temperature_raises_when_denormalize_called_first():
     means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
     stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
-    normalizer = _make_shared_offset_normalizer(means, stds)
+    normalizer = _make_temperature_offset_normalizer(means, stds)
     with pytest.raises(RuntimeError, match="normalize"):
         normalizer.denormalize(
             move_tensordict_to_device({"air_temperature_0": torch.zeros(1, 4, 4)})
         )
 
 
-def test_network_normalizer_has_shared_offset_but_loss_normalizer_does_not():
+def test_network_normalizer_removes_global_mean_surface_temperature_but_loss_normalizer_does_not():  # noqa: E501
     # When the flag is set on the network NormalizationConfig, only the
     # network normalizer carries the offset behavior. The loss normalizer
     # built from the combined config never has it -- offsets are unnecessary
@@ -362,7 +362,7 @@ def test_network_normalizer_has_shared_offset_but_loss_normalizer_does_not():
         network=NormalizationConfig(
             means={"surface_temperature": 280.0, "air_temperature_0": 220.0},
             stds={"surface_temperature": 2.0, "air_temperature_0": 4.0},
-            experimental_use_shared_temperature_offset=True,
+            remove_global_mean_surface_temperature=True,
         ),
         residual=NormalizationConfig(
             means={"air_temperature_0": 219.0},
@@ -376,11 +376,11 @@ def test_network_normalizer_has_shared_offset_but_loss_normalizer_does_not():
         names=["surface_temperature", "air_temperature_0"],
         residual_scaled_names=["air_temperature_0"],
     )
-    assert network_normalizer.use_shared_temperature_offset
-    assert not loss_normalizer.use_shared_temperature_offset
+    assert network_normalizer.remove_global_mean_surface_temperature
+    assert not loss_normalizer.remove_global_mean_surface_temperature
 
 
-def test_loss_normalizer_strips_shared_offset_in_fallback_case():
+def test_loss_normalizer_strips_global_mean_surface_temperature_removal_in_fallback_case():  # noqa: E501
     # Even with no residual and no loss config -- where get_loss_normalizer
     # falls back to building the network normalizer -- the loss normalizer
     # must not carry the offset behavior.
@@ -388,14 +388,14 @@ def test_loss_normalizer_strips_shared_offset_in_fallback_case():
         network=NormalizationConfig(
             means={"surface_temperature": 280.0, "air_temperature_0": 220.0},
             stds={"surface_temperature": 2.0, "air_temperature_0": 4.0},
-            experimental_use_shared_temperature_offset=True,
+            remove_global_mean_surface_temperature=True,
         ),
     )
     loss_normalizer = combined.get_loss_normalizer(
         names=["surface_temperature", "air_temperature_0"],
         residual_scaled_names=[],
     )
-    assert not loss_normalizer.use_shared_temperature_offset
+    assert not loss_normalizer.remove_global_mean_surface_temperature
 
 
 def test_normalization_config_with_means_and_stds_round_trip():


### PR DESCRIPTION
Atmospheric warming/cooling signals show up as large temperature anomalies across many vertical levels at once. Normalizing each temperature field by its global mean leaves a slowly-varying global temperature offset embedded in every channel, which the network has to re-learn at every layer. This PR adds an opt-in normalization mode that strips the global-mean surface temperature anomaly from all temperature fields before normalization (and restores it after denormalization), so the network sees temperature gradients rather than absolute global temperatures.

The offset is computed per sample as `surface_temperature_norm_mean - sample.surface_temperature.mean(spatial dims)` and added to every temperature field on `normalize()`, then subtracted back on `denormalize()`. Cross-channel and horizontal gradients are preserved; only the global mean shifts. The flag is meaningful only for the network normalizer (paired normalize/denormalize); the loss normalizer always strips it because offsets computed independently from target vs. prediction inputs would not cancel cleanly.

Changes:
- `fme.core.normalizer.NormalizationConfig.remove_global_mean_surface_temperature`: new opt-in bool flag (default `False`).
- `fme.core.normalizer.StandardNormalizer`: caches the per-sample offset during `normalize()` and inverts it in `denormalize()`; raises if `surface_temperature` is missing from means or input tensors, or if `denormalize()` runs before `normalize()`.
- `fme.core.normalizer.NetworkAndLossNormalizationConfig.get_loss_normalizer`: strips the flag from the loss normalizer via the new `_disable_global_mean_surface_temperature_removal` helper.
- `fme.core.normalizer._GLOBAL_MEAN_SURFACE_TEMPERATURE_REFERENCE` / `_TEMPERATURE_FIELD_NAMES`: hard-coded reference field and target field list.
- `StandardNormalizer.from_state` reads the legacy `use_shared_temperature_offset` state-dict key as a fallback so existing checkpoints continue to load.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated