### PR TITLE
Add configurable global mean removal transform

### DIFF
--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -53,6 +53,7 @@ from fme.core.optimization import NullOptimization
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.spatial_masking import NullSpatialMasking, StaticSpatialMaskingConfig
 from fme.core.step.args import StepArgs
+from fme.core.step.global_mean_removal import GlobalMeanRemovalConfigUnion
 from fme.core.step.multi_call import (
     MultiCallConfig,
     MultiCallStepConfig,
@@ -109,6 +110,9 @@ class SingleModuleStepperConfig:
             loss. The same loss configuration as specified in 'loss' is used.
         residual_prediction: Whether to have ML module predict tendencies for
             prognostic variables.
+        global_mean_removal: Optional configuration for removing global means
+            from fields before normalization and restoring them after
+            denormalization. Passed through to ``SingleModuleStepConfig``.
     """
 
     builder: ModuleSelector
@@ -130,6 +134,7 @@ class SingleModuleStepperConfig:
     multi_call: MultiCallConfig | None = None
     include_multi_call_in_loss: bool = False
     residual_prediction: bool = False
+    global_mean_removal: GlobalMeanRemovalConfigUnion | None = None
 
     def __post_init__(self):
         for name in self.prescribed_prognostic_names:
@@ -308,6 +313,7 @@ class SingleModuleStepperConfig:
             next_step_forcing_names=self.next_step_forcing_names,
             prescribed_prognostic_names=self.prescribed_prognostic_names,
             residual_prediction=self.residual_prediction,
+            global_mean_removal=self.global_mean_removal,
         )
 
 

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -73,6 +73,27 @@ class GlobalMeanRemoval(abc.ABC):
         """
 
 
+class NoGlobalMeanRemoval(GlobalMeanRemoval):
+    """No-op implementation used when global mean removal is disabled."""
+
+    @property
+    def n_extra_input_channels(self) -> int:
+        return 0
+
+    def forward_transform(
+        self,
+        input: TensorMapping,
+        data_mask: TensorMapping | None,
+    ) -> TensorDict:
+        return dict(input)
+
+    def inverse_transform(self, output: TensorDict) -> TensorDict:
+        return output
+
+    def get_extra_channels(self) -> torch.Tensor | None:
+        return None
+
+
 class SharedGlobalMeanRemoval(GlobalMeanRemoval):
     """Remove a single reference field's global mean from a set of fields.
 

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -180,7 +180,15 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
 
 
 class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
-    """Remove each field's own per-sample global mean."""
+    """Shift each field's per-sample spatial mean to its climatology.
+
+    For each field, ``forward_transform`` adds ``clim_mean - sample_mean``
+    so the field's spatial mean is equal to its climatology mean in
+    physical space; after normalization the field's spatial mean is
+    approximately zero.  This mirrors ``SharedGlobalMeanRemoval`` but
+    computes the offset per field rather than from a single reference
+    field.
+    """
 
     def __init__(
         self,
@@ -193,7 +201,7 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
         self._append_as_input = append_as_input
         self._means = means
         self._stds = stds
-        self._cached_sample_means: dict[str, torch.Tensor] | None = None
+        self._cached_shifts: dict[str, torch.Tensor] | None = None
         self._cached_extra: torch.Tensor | None = None
 
     @property
@@ -206,7 +214,7 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
         data_mask: TensorMapping | None,
     ) -> TensorDict:
         result = dict(input)
-        sample_means: dict[str, torch.Tensor] = {}
+        shifts: dict[str, torch.Tensor] = {}
         spatial_shape: tuple[int, ...] | None = None
 
         for name in self._field_names:
@@ -215,23 +223,24 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
             t = result[name]
             if spatial_shape is None:
                 spatial_shape = t.shape[1:]
-            raw_mean = t.mean(dim=tuple(range(1, t.ndim)))
+            sample_mean = t.mean(dim=tuple(range(1, t.ndim)))
+            shift = self._means[name] - sample_mean
             if data_mask is not None and name in data_mask:
                 mask = data_mask[name]
-                raw_mean = torch.where(mask, raw_mean, torch.zeros_like(raw_mean))
-            sample_means[name] = raw_mean
-            broadcast = raw_mean.view(raw_mean.shape[0], *(1,) * (t.ndim - 1))
-            result[name] = t - broadcast
+                shift = torch.where(mask, shift, torch.zeros_like(shift))
+            shifts[name] = shift
+            broadcast = shift.view(shift.shape[0], *(1,) * (t.ndim - 1))
+            result[name] = t + broadcast
 
-        self._cached_sample_means = sample_means
+        self._cached_shifts = shifts
 
         if self._append_as_input and spatial_shape is not None:
             channels: list[torch.Tensor] = []
             for name in self._field_names:
-                if name not in sample_means:
+                if name not in shifts:
                     continue
-                sm = sample_means[name]
-                normalized = (sm - self._means[name]) / self._stds[name]
+                sh = shifts[name]
+                normalized = -sh / self._stds[name]
                 ch = normalized.view(-1, 1, *(1,) * len(spatial_shape)).expand(
                     -1, 1, *spatial_shape
                 )
@@ -243,16 +252,16 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
         return result
 
     def inverse_transform(self, output: TensorDict) -> TensorDict:
-        if self._cached_sample_means is None:
+        if self._cached_shifts is None:
             raise RuntimeError("inverse_transform() called before forward_transform().")
         result = dict(output)
         for name in self._field_names:
-            if name not in result or name not in self._cached_sample_means:
+            if name not in result or name not in self._cached_shifts:
                 continue
             t = result[name]
-            sm = self._cached_sample_means[name]
-            broadcast = sm.view(sm.shape[0], *(1,) * (t.ndim - 1))
-            result[name] = t + broadcast
+            sh = self._cached_shifts[name]
+            broadcast = sh.view(sh.shape[0], *(1,) * (t.ndim - 1))
+            result[name] = t - broadcast
         return result
 
     def get_extra_channels(self) -> torch.Tensor | None:
@@ -320,18 +329,22 @@ class SharedGlobalMeanRemovalConfig:
 
 @dataclasses.dataclass
 class PerChannelGlobalMeanRemovalConfig:
-    """Remove each field's own per-sample global mean.
+    """Shift each field's per-sample spatial mean to its climatology.
 
-    Unlike ``SharedGlobalMeanRemovalConfig``, per-channel removal
-    requires each field to be present in the input so its individual
-    mean can be computed.
+    For each listed field, ``forward_transform`` adds
+    ``clim_mean - sample_mean`` so that after normalization the field's
+    spatial mean is approximately zero (avoiding large constant biases
+    on the network input).  Unlike ``SharedGlobalMeanRemovalConfig``,
+    per-channel removal requires each field to be present in the input
+    so its individual sample mean can be computed.
 
     Parameters:
         kind: Must be ``"per_channel"``.
         field_names: Names of fields to process. ``None`` means all
             input fields.  Explicit names must be input fields.
-        append_as_input: If true, each field's removed sample mean
-            (normalized) is appended as an extra network input channel.
+        append_as_input: If true, each field's normalized sample-mean
+            anomaly ``(sample_mean - clim_mean) / clim_std`` is appended
+            as an extra network input channel.
     """
 
     kind: Literal["per_channel"] = "per_channel"

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -1,0 +1,334 @@
+import abc
+import dataclasses
+from collections.abc import Mapping
+from typing import Any, Literal, Self
+
+import dacite
+import torch
+
+from fme.core.normalizer import StandardNormalizer
+from fme.core.typing_ import TensorDict, TensorMapping
+
+DEFAULT_TEMPERATURE_FIELD_NAMES: list[str] = [
+    "surface_temperature",
+    "TMP2m",
+    "TMP850",
+    "air_temperature_0",
+    "air_temperature_1",
+    "air_temperature_2",
+    "air_temperature_3",
+    "air_temperature_4",
+    "air_temperature_5",
+    "air_temperature_6",
+    "air_temperature_7",
+]
+
+
+class GlobalMeanRemoval(abc.ABC):
+    """Removes global means from fields before normalization and restores
+    them after denormalization.
+
+    Call sequence per step: ``forward_transform`` -> ``get_extra_channels``
+    -> ``inverse_transform``.
+    """
+
+    @property
+    @abc.abstractmethod
+    def n_extra_input_channels(self) -> int:
+        """Number of extra channels appended to the network input."""
+
+    @abc.abstractmethod
+    def forward_transform(
+        self,
+        input: TensorMapping,
+        data_mask: TensorMapping | None,
+    ) -> TensorDict:
+        """Remove global means from denormalized input fields.
+
+        Caches internal state needed by ``inverse_transform`` and
+        ``get_extra_channels``.
+        """
+
+    @abc.abstractmethod
+    def inverse_transform(self, output: TensorDict) -> TensorDict:
+        """Restore global means on denormalized output fields."""
+
+    @abc.abstractmethod
+    def get_extra_channels(self) -> torch.Tensor | None:
+        """Return ``[batch, n_extra, *spatial]`` normalized extra channels.
+
+        Returns ``None`` when ``n_extra_input_channels == 0``.  Must be
+        called after ``forward_transform``.
+        """
+
+
+class SharedGlobalMeanRemoval(GlobalMeanRemoval):
+    """Remove a single reference field's global mean from a set of fields."""
+
+    def __init__(
+        self,
+        reference_field: str,
+        field_names: frozenset[str],
+        append_as_input: bool,
+        reference_mean: torch.Tensor,
+        reference_std: torch.Tensor,
+    ):
+        self._reference_field = reference_field
+        self._field_names = field_names
+        self._append_as_input = append_as_input
+        self._reference_mean = reference_mean
+        self._reference_std = reference_std
+        self._cached_offset: torch.Tensor | None = None
+        self._cached_extra: torch.Tensor | None = None
+
+    @property
+    def n_extra_input_channels(self) -> int:
+        return 1 if self._append_as_input else 0
+
+    def forward_transform(
+        self,
+        input: TensorMapping,
+        data_mask: TensorMapping | None,
+    ) -> TensorDict:
+        ref_name = self._reference_field
+        if ref_name not in input:
+            raise ValueError(
+                f"Reference field '{ref_name}' is not present in the input."
+            )
+        if data_mask is not None and ref_name in data_mask:
+            if not data_mask[ref_name].all():
+                raise ValueError(
+                    f"Reference field '{ref_name}' is masked for some samples, "
+                    "which is not supported for shared global mean removal."
+                )
+        ref = input[ref_name]
+        sample_mean = ref.mean(dim=tuple(range(1, ref.ndim)))
+        offset = self._reference_mean - sample_mean
+        self._cached_offset = offset
+
+        if self._append_as_input:
+            normalized_mean = -offset / self._reference_std
+            spatial_shape = ref.shape[1:]
+            self._cached_extra = normalized_mean.view(
+                -1, 1, *(1,) * len(spatial_shape)
+            ).expand(-1, 1, *spatial_shape)
+        else:
+            self._cached_extra = None
+
+        result = dict(input)
+        for name in self._field_names:
+            if name not in result:
+                continue
+            t = result[name]
+            broadcast = offset.view(offset.shape[0], *(1,) * (t.ndim - 1))
+            result[name] = t + broadcast
+        return result
+
+    def inverse_transform(self, output: TensorDict) -> TensorDict:
+        if self._cached_offset is None:
+            raise RuntimeError("inverse_transform() called before forward_transform().")
+        offset = self._cached_offset
+        result = dict(output)
+        for name in self._field_names:
+            if name not in result:
+                continue
+            t = result[name]
+            broadcast = offset.view(offset.shape[0], *(1,) * (t.ndim - 1))
+            result[name] = t - broadcast
+        return result
+
+    def get_extra_channels(self) -> torch.Tensor | None:
+        return self._cached_extra
+
+
+class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
+    """Remove each field's own per-sample global mean."""
+
+    def __init__(
+        self,
+        field_names: list[str],
+        append_as_input: bool,
+        means: TensorDict,
+        stds: TensorDict,
+    ):
+        self._field_names = field_names
+        self._append_as_input = append_as_input
+        self._means = means
+        self._stds = stds
+        self._cached_sample_means: dict[str, torch.Tensor] | None = None
+        self._cached_extra: torch.Tensor | None = None
+
+    @property
+    def n_extra_input_channels(self) -> int:
+        return len(self._field_names) if self._append_as_input else 0
+
+    def forward_transform(
+        self,
+        input: TensorMapping,
+        data_mask: TensorMapping | None,
+    ) -> TensorDict:
+        result = dict(input)
+        sample_means: dict[str, torch.Tensor] = {}
+        spatial_shape: tuple[int, ...] | None = None
+
+        for name in self._field_names:
+            if name not in result:
+                continue
+            t = result[name]
+            if spatial_shape is None:
+                spatial_shape = t.shape[1:]
+            raw_mean = t.mean(dim=tuple(range(1, t.ndim)))
+            if data_mask is not None and name in data_mask:
+                mask = data_mask[name]
+                raw_mean = torch.where(mask, raw_mean, torch.zeros_like(raw_mean))
+            sample_means[name] = raw_mean
+            broadcast = raw_mean.view(raw_mean.shape[0], *(1,) * (t.ndim - 1))
+            result[name] = t - broadcast
+
+        self._cached_sample_means = sample_means
+
+        if self._append_as_input and spatial_shape is not None:
+            channels: list[torch.Tensor] = []
+            for name in self._field_names:
+                if name not in sample_means:
+                    continue
+                sm = sample_means[name]
+                normalized = (sm - self._means[name]) / self._stds[name]
+                ch = normalized.view(-1, 1, *(1,) * len(spatial_shape)).expand(
+                    -1, 1, *spatial_shape
+                )
+                channels.append(ch)
+            self._cached_extra = torch.cat(channels, dim=1) if channels else None
+        else:
+            self._cached_extra = None
+
+        return result
+
+    def inverse_transform(self, output: TensorDict) -> TensorDict:
+        if self._cached_sample_means is None:
+            raise RuntimeError("inverse_transform() called before forward_transform().")
+        result = dict(output)
+        for name in self._field_names:
+            if name not in result or name not in self._cached_sample_means:
+                continue
+            t = result[name]
+            sm = self._cached_sample_means[name]
+            broadcast = sm.view(sm.shape[0], *(1,) * (t.ndim - 1))
+            result[name] = t + broadcast
+        return result
+
+    def get_extra_channels(self) -> torch.Tensor | None:
+        return self._cached_extra
+
+
+@dataclasses.dataclass
+class GlobalMeanRemovalConfig(abc.ABC):
+    """Base configuration for global mean removal."""
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, Any]) -> Self:
+        return dacite.from_dict(cls, state, dacite.Config(strict=True))
+
+    @abc.abstractmethod
+    def build(
+        self,
+        normalizer: StandardNormalizer,
+        in_names: list[str],
+    ) -> GlobalMeanRemoval: ...
+
+    @abc.abstractmethod
+    def get_n_extra_input_channels(self, in_names: list[str]) -> int: ...
+
+    @abc.abstractmethod
+    def validate_names(self, in_names: list[str], out_names: list[str]) -> None: ...
+
+
+@dataclasses.dataclass
+class SharedGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
+    """Remove a shared reference field's global mean from specified fields.
+
+    Parameters:
+        kind: Must be ``"shared"``.
+        reference_field: Name of the field whose per-sample spatial mean
+            determines the offset applied to all ``field_names``.
+        field_names: Names of fields to shift by the shared offset.
+        append_as_input: If true, the removed sample mean (normalized) is
+            appended as an extra network input channel.
+    """
+
+    kind: Literal["shared"] = "shared"
+    reference_field: str = "surface_temperature"
+    field_names: list[str] = dataclasses.field(
+        default_factory=lambda: list(DEFAULT_TEMPERATURE_FIELD_NAMES)
+    )
+    append_as_input: bool = False
+
+    def get_n_extra_input_channels(self, in_names: list[str]) -> int:
+        return 1 if self.append_as_input else 0
+
+    def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
+        if self.reference_field not in in_names:
+            raise ValueError(
+                f"reference_field '{self.reference_field}' not in in_names: "
+                f"{in_names}"
+            )
+
+    def build(
+        self,
+        normalizer: StandardNormalizer,
+        in_names: list[str],
+    ) -> SharedGlobalMeanRemoval:
+        return SharedGlobalMeanRemoval(
+            reference_field=self.reference_field,
+            field_names=frozenset(self.field_names),
+            append_as_input=self.append_as_input,
+            reference_mean=normalizer.means[self.reference_field],
+            reference_std=normalizer.stds[self.reference_field],
+        )
+
+
+@dataclasses.dataclass
+class PerChannelGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
+    """Remove each field's own per-sample global mean.
+
+    Parameters:
+        kind: Must be ``"per_channel"``.
+        field_names: Names of fields to process. ``None`` means all
+            input fields.
+        append_as_input: If true, each field's removed sample mean
+            (normalized) is appended as an extra network input channel.
+    """
+
+    kind: Literal["per_channel"] = "per_channel"
+    field_names: list[str] | None = None
+    append_as_input: bool = False
+
+    def _resolve_names(self, in_names: list[str]) -> list[str]:
+        return self.field_names if self.field_names is not None else list(in_names)
+
+    def get_n_extra_input_channels(self, in_names: list[str]) -> int:
+        return len(self._resolve_names(in_names)) if self.append_as_input else 0
+
+    def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
+        if self.field_names is not None:
+            for name in self.field_names:
+                if name not in in_names:
+                    raise ValueError(f"field_name '{name}' not in in_names: {in_names}")
+
+    def build(
+        self,
+        normalizer: StandardNormalizer,
+        in_names: list[str],
+    ) -> PerChannelGlobalMeanRemoval:
+        names = self._resolve_names(in_names)
+        return PerChannelGlobalMeanRemoval(
+            field_names=names,
+            append_as_input=self.append_as_input,
+            means={n: normalizer.means[n] for n in names},
+            stds={n: normalizer.stds[n] for n in names},
+        )
+
+
+GlobalMeanRemovalConfigUnion = (
+    SharedGlobalMeanRemovalConfig | PerChannelGlobalMeanRemovalConfig
+)

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -295,9 +295,6 @@ class SharedGlobalMeanRemovalConfig:
     )
     append_as_input: bool = False
 
-    def get_n_extra_input_channels(self, in_names: list[str]) -> int:
-        return 1 if self.append_as_input else 0
-
     def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
         if self.reference_field not in in_names:
             raise ValueError(
@@ -353,9 +350,6 @@ class PerChannelGlobalMeanRemovalConfig:
 
     def _resolve_names(self, in_names: list[str]) -> list[str]:
         return self.field_names if self.field_names is not None else list(in_names)
-
-    def get_n_extra_input_channels(self, in_names: list[str]) -> int:
-        return len(self._resolve_names(in_names)) if self.append_as_input else 0
 
     def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
         if self.field_names is not None:

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -239,25 +239,7 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
 
 
 @dataclasses.dataclass
-class GlobalMeanRemovalConfig(abc.ABC):
-    """Base configuration for global mean removal."""
-
-    @abc.abstractmethod
-    def build(
-        self,
-        normalizer: StandardNormalizer,
-        in_names: list[str],
-    ) -> GlobalMeanRemoval: ...
-
-    @abc.abstractmethod
-    def get_n_extra_input_channels(self, in_names: list[str]) -> int: ...
-
-    @abc.abstractmethod
-    def validate_names(self, in_names: list[str], out_names: list[str]) -> None: ...
-
-
-@dataclasses.dataclass
-class SharedGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
+class SharedGlobalMeanRemovalConfig:
     """Remove a shared reference field's global mean from specified fields.
 
     Fields in ``field_names`` that appear only in the output (not the
@@ -316,7 +298,7 @@ class SharedGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
 
 
 @dataclasses.dataclass
-class PerChannelGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
+class PerChannelGlobalMeanRemovalConfig:
     """Remove each field's own per-sample global mean.
 
     Unlike ``SharedGlobalMeanRemovalConfig``, per-channel removal

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -39,6 +39,14 @@ class GlobalMeanRemoval(abc.ABC):
     so all listed fields — whether input, output, or both — share the
     same global-mean offset.
 
+    Note:
+        "Global mean" here refers to a *cellwise* (unweighted) spatial
+        mean of each sample, not the area-weighted global mean used
+        elsewhere in ACE for stats and metrics.  The two differ slightly
+        on a non-uniform grid; this transform uses the cellwise mean
+        for simplicity, since the network learns to compensate during
+        end-to-end training.
+
     Call sequence per step: ``forward_transform`` -> ``get_extra_channels``
     -> ``inverse_transform``.
     """
@@ -95,12 +103,14 @@ class NoGlobalMeanRemoval(GlobalMeanRemoval):
 
 
 class SharedGlobalMeanRemoval(GlobalMeanRemoval):
-    """Remove a single reference field's global mean from a set of fields.
+    """Remove a single reference field's cellwise global mean from a set
+    of fields.
 
     All listed fields share the same offset (derived from the reference
-    field), regardless of whether they appear in the input, the output,
-    or both.  See ``GlobalMeanRemoval`` for details on the asymmetric
-    forward/inverse behavior for output-only fields.
+    field's cellwise spatial mean), regardless of whether they appear in
+    the input, the output, or both.  See ``GlobalMeanRemoval`` for
+    details on the asymmetric forward/inverse behavior for output-only
+    fields, and on the choice of cellwise (vs. area-weighted) mean.
     """
 
     def __init__(
@@ -180,14 +190,16 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
 
 
 class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
-    """Shift each field's per-sample spatial mean to its climatology.
+    """Shift each field's per-sample cellwise spatial mean to its climatology.
 
     For each field, ``forward_transform`` adds ``clim_mean - sample_mean``
-    so the field's spatial mean is equal to its climatology mean in
-    physical space; after normalization the field's spatial mean is
-    approximately zero.  This mirrors ``SharedGlobalMeanRemoval`` but
-    computes the offset per field rather than from a single reference
-    field.
+    (where ``sample_mean`` is the cellwise, unweighted spatial mean) so
+    the field's spatial mean equals its climatology mean in physical
+    space; after normalization the field's spatial mean is approximately
+    zero.  This mirrors ``SharedGlobalMeanRemoval`` but computes the
+    offset per field rather than from a single reference field.  See
+    ``GlobalMeanRemoval`` for the choice of cellwise (vs. area-weighted)
+    mean.
     """
 
     def __init__(
@@ -270,7 +282,12 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
 
 @dataclasses.dataclass
 class SharedGlobalMeanRemovalConfig:
-    """Remove a shared reference field's global mean from specified fields.
+    """Remove a shared reference field's cellwise global mean from specified
+    fields.
+
+    The offset is derived from the reference field's *cellwise* (unweighted)
+    spatial mean, not the area-weighted mean used elsewhere in ACE — see
+    ``GlobalMeanRemoval`` for the rationale.
 
     Fields in ``field_names`` that appear only in the output (not the
     input) are still un-shifted by ``inverse_transform``, so the network
@@ -280,8 +297,9 @@ class SharedGlobalMeanRemovalConfig:
 
     Parameters:
         kind: Must be ``"shared"``.
-        reference_field: Name of the field whose per-sample spatial mean
-            determines the offset applied to all ``field_names``.
+        reference_field: Name of the field whose per-sample cellwise
+            spatial mean determines the offset applied to all
+            ``field_names``.
         field_names: Names of fields to shift by the shared offset.
             Fields may be inputs, outputs, or both.
         append_as_input: If true, the removed sample mean (normalized) is
@@ -326,14 +344,17 @@ class SharedGlobalMeanRemovalConfig:
 
 @dataclasses.dataclass
 class PerChannelGlobalMeanRemovalConfig:
-    """Shift each field's per-sample spatial mean to its climatology.
+    """Shift each field's per-sample cellwise spatial mean to its climatology.
 
     For each listed field, ``forward_transform`` adds
-    ``clim_mean - sample_mean`` so that after normalization the field's
+    ``clim_mean - sample_mean`` (where ``sample_mean`` is the cellwise,
+    unweighted spatial mean) so that after normalization the field's
     spatial mean is approximately zero (avoiding large constant biases
-    on the network input).  Unlike ``SharedGlobalMeanRemovalConfig``,
-    per-channel removal requires each field to be present in the input
-    so its individual sample mean can be computed.
+    on the network input).  See ``GlobalMeanRemoval`` for the choice of
+    cellwise (vs. area-weighted) mean.  Unlike
+    ``SharedGlobalMeanRemovalConfig``, per-channel removal requires each
+    field to be present in the input so its individual sample mean can
+    be computed.
 
     Parameters:
         kind: Must be ``"per_channel"``.

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -1,9 +1,8 @@
 import abc
 import dataclasses
-from collections.abc import Mapping
-from typing import Any, Literal, Self
+import logging
+from typing import Literal
 
-import dacite
 import torch
 
 from fme.core.normalizer import StandardNormalizer
@@ -24,9 +23,21 @@ DEFAULT_TEMPERATURE_FIELD_NAMES: list[str] = [
 ]
 
 
+logger = logging.getLogger(__name__)
+
+
 class GlobalMeanRemoval(abc.ABC):
     """Removes global means from fields before normalization and restores
     them after denormalization.
+
+    ``forward_transform`` shifts input fields toward their climatological
+    means.  ``inverse_transform`` reverses that shift on output fields.
+    Fields listed in ``field_names`` that appear only in the output (e.g.
+    diagnostic temperatures) are not shifted by ``forward_transform``
+    (they are not inputs), but *are* un-shifted by ``inverse_transform``.
+    The network learns to compensate for this through end-to-end training,
+    so all listed fields — whether input, output, or both — share the
+    same global-mean offset.
 
     Call sequence per step: ``forward_transform`` -> ``get_extra_channels``
     -> ``inverse_transform``.
@@ -63,7 +74,13 @@ class GlobalMeanRemoval(abc.ABC):
 
 
 class SharedGlobalMeanRemoval(GlobalMeanRemoval):
-    """Remove a single reference field's global mean from a set of fields."""
+    """Remove a single reference field's global mean from a set of fields.
+
+    All listed fields share the same offset (derived from the reference
+    field), regardless of whether they appear in the input, the output,
+    or both.  See ``GlobalMeanRemoval`` for details on the asymmetric
+    forward/inverse behavior for output-only fields.
+    """
 
     def __init__(
         self,
@@ -225,10 +242,6 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
 class GlobalMeanRemovalConfig(abc.ABC):
     """Base configuration for global mean removal."""
 
-    @classmethod
-    def from_state(cls, state: Mapping[str, Any]) -> Self:
-        return dacite.from_dict(cls, state, dacite.Config(strict=True))
-
     @abc.abstractmethod
     def build(
         self,
@@ -247,11 +260,18 @@ class GlobalMeanRemovalConfig(abc.ABC):
 class SharedGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
     """Remove a shared reference field's global mean from specified fields.
 
+    Fields in ``field_names`` that appear only in the output (not the
+    input) are still un-shifted by ``inverse_transform``, so the network
+    learns to produce them in the offset-shifted space.  Fields that
+    appear in neither input nor output are silently ignored (a warning
+    is logged).
+
     Parameters:
         kind: Must be ``"shared"``.
         reference_field: Name of the field whose per-sample spatial mean
             determines the offset applied to all ``field_names``.
         field_names: Names of fields to shift by the shared offset.
+            Fields may be inputs, outputs, or both.
         append_as_input: If true, the removed sample mean (normalized) is
             appended as an extra network input channel.
     """
@@ -272,6 +292,14 @@ class SharedGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
                 f"reference_field '{self.reference_field}' not in in_names: "
                 f"{in_names}"
             )
+        all_names = set(in_names) | set(out_names)
+        for name in self.field_names:
+            if name not in all_names:
+                logger.warning(
+                    "global_mean_removal field_name '%s' is not in "
+                    "in_names or out_names and will have no effect",
+                    name,
+                )
 
     def build(
         self,
@@ -291,10 +319,14 @@ class SharedGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
 class PerChannelGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
     """Remove each field's own per-sample global mean.
 
+    Unlike ``SharedGlobalMeanRemovalConfig``, per-channel removal
+    requires each field to be present in the input so its individual
+    mean can be computed.
+
     Parameters:
         kind: Must be ``"per_channel"``.
         field_names: Names of fields to process. ``None`` means all
-            input fields.
+            input fields.  Explicit names must be input fields.
         append_as_input: If true, each field's removed sample mean
             (normalized) is appended as an extra network input channel.
     """
@@ -311,8 +343,15 @@ class PerChannelGlobalMeanRemovalConfig(GlobalMeanRemovalConfig):
 
     def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
         if self.field_names is not None:
+            all_names = set(in_names) | set(out_names)
             for name in self.field_names:
-                if name not in in_names:
+                if name not in all_names:
+                    logger.warning(
+                        "global_mean_removal field_name '%s' is not in "
+                        "in_names or out_names and will have no effect",
+                        name,
+                    )
+                elif name not in in_names:
                     raise ValueError(f"field_name '{name}' not in in_names: {in_names}")
 
     def build(

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -416,20 +416,43 @@ class SingleModuleStep(StepABC):
             output_dict.update(secondary_output_dict)
             return output_dict
 
-        output = step_with_adjustments(
-            input=step_input,
-            next_step_input_data=args.next_step_input_data,
-            network_calls=network_call,
-            normalizer=self.normalizer,
-            corrector=self._corrector,
-            ocean=self.ocean,
-            residual_prediction=self._config.residual_prediction,
-            prognostic_names=self.prognostic_names,
-            prescribed_prognostic_names=self._config.prescribed_prognostic_names,
-        )
-
         if self._global_mean_removal is not None:
+            # Run network only; defer corrector/ocean/prescribed to after
+            # inverse_transform so they operate in physical space.
+            output = step_with_adjustments(
+                input=step_input,
+                next_step_input_data=args.next_step_input_data,
+                network_calls=network_call,
+                normalizer=self.normalizer,
+                corrector=None,
+                ocean=None,
+                residual_prediction=self._config.residual_prediction,
+                prognostic_names=self.prognostic_names,
+            )
             output = self._global_mean_removal.inverse_transform(output)
+            output = self._corrector(args.input, output, args.next_step_input_data)
+            if self.ocean is not None:
+                output = self.ocean(args.input, output, args.next_step_input_data)
+            for name in self._config.prescribed_prognostic_names:
+                if name in args.next_step_input_data:
+                    output = {**output, name: args.next_step_input_data[name]}
+                else:
+                    raise ValueError(
+                        f"prescribed_prognostic_name '{name}' "
+                        "not in next_step_input_data"
+                    )
+        else:
+            output = step_with_adjustments(
+                input=step_input,
+                next_step_input_data=args.next_step_input_data,
+                network_calls=network_call,
+                normalizer=self.normalizer,
+                corrector=self._corrector,
+                ocean=self.ocean,
+                residual_prediction=self._config.residual_prediction,
+                prognostic_names=self.prognostic_names,
+                prescribed_prognostic_names=self._config.prescribed_prognostic_names,
+            )
 
         return output
 
@@ -514,7 +537,7 @@ def step_with_adjustments(
     next_step_input_data: TensorMapping,
     network_calls: Callable[[TensorDict], TensorDict],
     normalizer: StandardNormalizer,
-    corrector: CorrectorABC,
+    corrector: CorrectorABC | None,
     ocean: Ocean | None,
     residual_prediction: bool,
     prognostic_names: list[str],

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -24,6 +24,7 @@ from fme.core.step.args import StepArgs
 from fme.core.step.global_mean_removal import (
     GlobalMeanRemoval,
     GlobalMeanRemovalConfigUnion,
+    NoGlobalMeanRemoval,
 )
 from fme.core.step.secondary_decoder import (
     NoSecondaryDecoder,
@@ -272,14 +273,14 @@ class SingleModuleStep(StepABC):
         if config.include_channel_mask_inputs:
             n_in_channels *= 2
         if config.global_mean_removal is not None:
-            self._global_mean_removal: GlobalMeanRemoval | None = (
+            self._global_mean_removal: GlobalMeanRemoval = (
                 config.global_mean_removal.build(
                     normalizer=normalizer, in_names=config.in_names
                 )
             )
             n_in_channels += self._global_mean_removal.n_extra_input_channels
         else:
-            self._global_mean_removal = None
+            self._global_mean_removal = NoGlobalMeanRemoval()
         n_out_channels = len(config.out_names)
         self.in_packer = Packer(config.in_names)
         self.out_packer = Packer(config.out_names)
@@ -380,12 +381,6 @@ class SingleModuleStep(StepABC):
         Returns:
             The denormalized output data at the next time step.
         """
-        if self._global_mean_removal is not None:
-            step_input: TensorMapping = self._global_mean_removal.forward_transform(
-                args.input, args.data_mask
-            )
-        else:
-            step_input = args.input
 
         def network_call(input_norm: TensorDict) -> TensorDict:
             if args.data_mask is not None:
@@ -399,12 +394,9 @@ class SingleModuleStep(StepABC):
                 input_tensor = torch.cat(
                     [input_tensor, mask_tensor], dim=self.CHANNEL_DIM
                 )
-            if self._global_mean_removal is not None:
-                extra = self._global_mean_removal.get_extra_channels()
-                if extra is not None:
-                    input_tensor = torch.cat(
-                        [input_tensor, extra], dim=self.CHANNEL_DIM
-                    )
+            extra = self._global_mean_removal.get_extra_channels()
+            if extra is not None:
+                input_tensor = torch.cat([input_tensor, extra], dim=self.CHANNEL_DIM)
             output_tensor = self.module.wrap_module(wrapper)(
                 input_tensor,
                 labels=args.labels,
@@ -416,45 +408,19 @@ class SingleModuleStep(StepABC):
             output_dict.update(secondary_output_dict)
             return output_dict
 
-        if self._global_mean_removal is not None:
-            # Run network only; defer corrector/ocean/prescribed to after
-            # inverse_transform so they operate in physical space.
-            output = step_with_adjustments(
-                input=step_input,
-                next_step_input_data=args.next_step_input_data,
-                network_calls=network_call,
-                normalizer=self.normalizer,
-                corrector=None,
-                ocean=None,
-                residual_prediction=self._config.residual_prediction,
-                prognostic_names=self.prognostic_names,
-            )
-            output = self._global_mean_removal.inverse_transform(output)
-            output = self._corrector(args.input, output, args.next_step_input_data)
-            if self.ocean is not None:
-                output = self.ocean(args.input, output, args.next_step_input_data)
-            for name in self._config.prescribed_prognostic_names:
-                if name in args.next_step_input_data:
-                    output = {**output, name: args.next_step_input_data[name]}
-                else:
-                    raise ValueError(
-                        f"prescribed_prognostic_name '{name}' "
-                        "not in next_step_input_data"
-                    )
-        else:
-            output = step_with_adjustments(
-                input=step_input,
-                next_step_input_data=args.next_step_input_data,
-                network_calls=network_call,
-                normalizer=self.normalizer,
-                corrector=self._corrector,
-                ocean=self.ocean,
-                residual_prediction=self._config.residual_prediction,
-                prognostic_names=self.prognostic_names,
-                prescribed_prognostic_names=self._config.prescribed_prognostic_names,
-            )
-
-        return output
+        return step_with_adjustments(
+            input=args.input,
+            next_step_input_data=args.next_step_input_data,
+            network_calls=network_call,
+            normalizer=self.normalizer,
+            corrector=self._corrector,
+            ocean=self.ocean,
+            residual_prediction=self._config.residual_prediction,
+            prognostic_names=self.prognostic_names,
+            prescribed_prognostic_names=self._config.prescribed_prognostic_names,
+            global_mean_removal=self._global_mean_removal,
+            data_mask=args.data_mask,
+        )
 
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
@@ -542,6 +508,8 @@ def step_with_adjustments(
     residual_prediction: bool,
     prognostic_names: list[str],
     prescribed_prognostic_names: list[str] | None = None,
+    global_mean_removal: GlobalMeanRemoval | None = None,
+    data_mask: TensorMapping | None = None,
 ) -> TensorDict:
     """
     Step the model forward one timestep given input data.
@@ -563,17 +531,33 @@ def step_with_adjustments(
         prognostic_names: Names of prognostic variables.
         prescribed_prognostic_names: Prognostic names to overwrite from
             next_step_input_data after the ocean step (e.g. for inference).
+        global_mean_removal: Optional transform that removes per-sample
+            global means before normalization and restores them after
+            denormalization. When provided, ``forward_transform`` is called
+            before the normalizer and ``inverse_transform`` after
+            denormalization but before the corrector/ocean/prescribed steps,
+            so those adjustments operate in physical space.
+        data_mask: Per-variable boolean masks passed to
+            ``global_mean_removal.forward_transform``.
 
     Returns:
         The denormalized output data at the next time step.
     """
     if prescribed_prognostic_names is None:
         prescribed_prognostic_names = []
-    input_norm = normalizer.normalize(input)
+    if global_mean_removal is not None:
+        network_input: TensorMapping = global_mean_removal.forward_transform(
+            input, data_mask
+        )
+    else:
+        network_input = input
+    input_norm = normalizer.normalize(network_input)
     output_norm = network_calls(input_norm)
     if residual_prediction:
         output_norm = add_names(input_norm, output_norm, prognostic_names)
     output = normalizer.denormalize(output_norm)
+    if global_mean_removal is not None:
+        output = global_mean_removal.inverse_transform(output)
     if corrector is not None:
         output = corrector(input, output, next_step_input_data)
     if ocean is not None:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -21,6 +21,10 @@ from fme.core.optimization import NullOptimization
 from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.step.args import StepArgs
+from fme.core.step.global_mean_removal import (
+    GlobalMeanRemoval,
+    GlobalMeanRemovalConfigUnion,
+)
 from fme.core.step.secondary_decoder import (
     NoSecondaryDecoder,
     SecondaryDecoder,
@@ -58,6 +62,10 @@ class SingleModuleStepConfig(StepConfigABC):
             ``len(in_names)`` additional float channels (1.0 = present, 0.0 =
             masked) after the regular input channels, doubling the total input
             channel count.
+        global_mean_removal: Optional configuration for removing global means
+            from fields before normalization and restoring them after
+            denormalization. Supports shared (single reference field) or
+            per-channel removal, with optional extra input channels.
     """
 
     builder: ModuleSelector
@@ -73,9 +81,12 @@ class SingleModuleStepConfig(StepConfigABC):
     prescribed_prognostic_names: list[str] = dataclasses.field(default_factory=list)
     residual_prediction: bool = False
     include_channel_mask_inputs: bool = False
+    global_mean_removal: GlobalMeanRemovalConfigUnion | None = None
 
     def __post_init__(self):
         self.crps_training = None  # unused, kept for backwards compatibility
+        if self.global_mean_removal is not None:
+            self.global_mean_removal.validate_names(self.in_names, self.out_names)
         for name in self.prescribed_prognostic_names:
             if name not in self.out_names:
                 raise ValueError(
@@ -260,6 +271,15 @@ class SingleModuleStep(StepABC):
         n_in_channels = len(config.in_names)
         if config.include_channel_mask_inputs:
             n_in_channels *= 2
+        if config.global_mean_removal is not None:
+            self._global_mean_removal: GlobalMeanRemoval | None = (
+                config.global_mean_removal.build(
+                    normalizer=normalizer, in_names=config.in_names
+                )
+            )
+            n_in_channels += self._global_mean_removal.n_extra_input_channels
+        else:
+            self._global_mean_removal = None
         n_out_channels = len(config.out_names)
         self.in_packer = Packer(config.in_names)
         self.out_packer = Packer(config.out_names)
@@ -360,6 +380,12 @@ class SingleModuleStep(StepABC):
         Returns:
             The denormalized output data at the next time step.
         """
+        if self._global_mean_removal is not None:
+            step_input: TensorMapping = self._global_mean_removal.forward_transform(
+                args.input, args.data_mask
+            )
+        else:
+            step_input = args.input
 
         def network_call(input_norm: TensorDict) -> TensorDict:
             if args.data_mask is not None:
@@ -373,6 +399,12 @@ class SingleModuleStep(StepABC):
                 input_tensor = torch.cat(
                     [input_tensor, mask_tensor], dim=self.CHANNEL_DIM
                 )
+            if self._global_mean_removal is not None:
+                extra = self._global_mean_removal.get_extra_channels()
+                if extra is not None:
+                    input_tensor = torch.cat(
+                        [input_tensor, extra], dim=self.CHANNEL_DIM
+                    )
             output_tensor = self.module.wrap_module(wrapper)(
                 input_tensor,
                 labels=args.labels,
@@ -384,8 +416,8 @@ class SingleModuleStep(StepABC):
             output_dict.update(secondary_output_dict)
             return output_dict
 
-        return step_with_adjustments(
-            input=args.input,
+        output = step_with_adjustments(
+            input=step_input,
             next_step_input_data=args.next_step_input_data,
             network_calls=network_call,
             normalizer=self.normalizer,
@@ -395,6 +427,11 @@ class SingleModuleStep(StepABC):
             prognostic_names=self.prognostic_names,
             prescribed_prognostic_names=self._config.prescribed_prognostic_names,
         )
+
+        if self._global_mean_removal is not None:
+            output = self._global_mean_removal.inverse_transform(output)
+
+        return output
 
     def get_regularizer_loss(self):
         return torch.tensor(0.0)

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -1,0 +1,375 @@
+import dataclasses
+
+import dacite
+import pytest
+import torch
+
+from fme.core.device import move_tensordict_to_device
+from fme.core.step.global_mean_removal import (
+    GlobalMeanRemovalConfigUnion,
+    PerChannelGlobalMeanRemovalConfig,
+    SharedGlobalMeanRemovalConfig,
+)
+
+
+def _build_normalizer_for(means, stds):
+    from fme.core.normalizer import NormalizationConfig
+
+    return NormalizationConfig(means=means, stds=stds).build(list(means))
+
+
+# ── SharedGlobalMeanRemoval ─────────────────────────────────────────────
+
+
+def _make_shared(means, stds, append_as_input=False):
+    normalizer = _build_normalizer_for(means, stds)
+    config = SharedGlobalMeanRemovalConfig(
+        reference_field="surface_temperature",
+        field_names=list(means.keys()),
+        append_as_input=append_as_input,
+    )
+    return config.build(normalizer, list(means.keys()))
+
+
+def test_shared_worked_example():
+    means = {"surface_temperature": 280.0, "air_temperature_4": 250.0}
+    stds = {"surface_temperature": 2.0, "air_temperature_4": 4.0}
+    transform = _make_shared(means, stds)
+    tensors = move_tensordict_to_device(
+        {
+            "surface_temperature": torch.full((1, 4, 4), 285.0),
+            "air_temperature_4": torch.full((1, 4, 4), 245.0),
+        }
+    )
+    result = transform.forward_transform(tensors, None)
+    # offset = 280 - 285 = -5; shifted = 285 + (-5) = 280
+    torch.testing.assert_close(
+        result["surface_temperature"],
+        torch.full_like(result["surface_temperature"], 280.0),
+    )
+    # shifted air_temperature_4 = 245 + (-5) = 240
+    torch.testing.assert_close(
+        result["air_temperature_4"],
+        torch.full_like(result["air_temperature_4"], 240.0),
+    )
+
+
+def test_shared_round_trip():
+    torch.manual_seed(0)
+    means = {"surface_temperature": 288.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 5.0, "air_temperature_0": 3.0}
+    transform = _make_shared(means, stds)
+    tensors = move_tensordict_to_device(
+        {k: torch.randn(2, 4, 4) + means[k] for k in means}
+    )
+    result = transform.forward_transform(tensors, None)
+    restored = transform.inverse_transform(result)
+    for k in means:
+        torch.testing.assert_close(restored[k], tensors[k])
+
+
+def test_shared_preserves_horizontal_gradients():
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 1.0}
+    transform = _make_shared(means, stds)
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": torch.tensor([[285.0, 290.0, 275.0]])}
+    )
+    result = transform.forward_transform(tensors, None)
+    raw_grad = (
+        tensors["surface_temperature"][0, 1] - tensors["surface_temperature"][0, 0]
+    )
+    shifted_grad = (
+        result["surface_temperature"][0, 1] - result["surface_temperature"][0, 0]
+    )
+    torch.testing.assert_close(shifted_grad, raw_grad)
+
+
+def test_shared_is_per_sample():
+    means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
+    transform = _make_shared(means, stds)
+    surface_t = torch.tensor([[[285.0]], [[270.0]]])
+    air_t_0 = torch.tensor([[[230.0]], [[230.0]]])
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": surface_t, "air_temperature_0": air_t_0}
+    )
+    result = transform.forward_transform(tensors, None)
+    # sample 0: offset = 280 - 285 = -5; sample 1: offset = 280 - 270 = +10
+    expected = torch.tensor([[[230.0 + (-5.0)]], [[230.0 + 10.0]]])
+    torch.testing.assert_close(result["air_temperature_0"].cpu(), expected)
+
+
+def test_shared_no_extra_channels():
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 1.0}
+    transform = _make_shared(means, stds)
+    assert transform.n_extra_input_channels == 0
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": torch.full((2, 4, 4), 285.0)}
+    )
+    transform.forward_transform(tensors, None)
+    assert transform.get_extra_channels() is None
+
+
+def test_shared_extra_channels():
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 5.0}
+    transform = _make_shared(means, stds, append_as_input=True)
+    assert transform.n_extra_input_channels == 1
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": torch.full((2, 4, 4), 285.0)}
+    )
+    transform.forward_transform(tensors, None)
+    extra = transform.get_extra_channels()
+    assert extra is not None
+    assert extra.shape == (2, 1, 4, 4)
+    # sample_mean = 285, normalized = (285 - 280) / 5 = 1.0
+    torch.testing.assert_close(extra, torch.full_like(extra, 1.0))
+
+
+def test_shared_raises_on_masked_reference():
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 1.0}
+    transform = _make_shared(means, stds)
+    tensors = move_tensordict_to_device(
+        {"surface_temperature": torch.full((2, 4, 4), 285.0)}
+    )
+    data_mask = {"surface_temperature": torch.tensor([True, False])}
+    with pytest.raises(ValueError, match="masked"):
+        transform.forward_transform(tensors, data_mask)
+
+
+def test_shared_raises_on_missing_reference():
+    means = {"surface_temperature": 280.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 1.0, "air_temperature_0": 1.0}
+    transform = _make_shared(means, stds)
+    tensors = move_tensordict_to_device(
+        {"air_temperature_0": torch.full((2, 4, 4), 225.0)}
+    )
+    with pytest.raises(ValueError, match="not present"):
+        transform.forward_transform(tensors, None)
+
+
+def test_shared_inverse_before_forward_raises():
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 1.0}
+    transform = _make_shared(means, stds)
+    with pytest.raises(RuntimeError, match="forward_transform"):
+        transform.inverse_transform({"surface_temperature": torch.zeros(1, 4, 4)})
+
+
+# ── PerChannelGlobalMeanRemoval ─────────────────────────────────────────
+
+
+def _make_per_channel(means, stds, field_names=None, append_as_input=False):
+    normalizer = _build_normalizer_for(means, stds)
+    config = PerChannelGlobalMeanRemovalConfig(
+        field_names=field_names,
+        append_as_input=append_as_input,
+    )
+    return config.build(normalizer, list(means.keys()))
+
+
+def test_per_channel_removes_correct_means():
+    means = {"a": 10.0, "b": 20.0}
+    stds = {"a": 1.0, "b": 1.0}
+    transform = _make_per_channel(means, stds)
+    tensors = move_tensordict_to_device(
+        {
+            "a": torch.tensor([[[12.0, 14.0]]]),  # mean = 13
+            "b": torch.tensor([[[22.0, 28.0]]]),  # mean = 25
+        }
+    )
+    result = transform.forward_transform(tensors, None)
+    # a: [12 - 13, 14 - 13] = [-1, 1]
+    torch.testing.assert_close(result["a"], torch.tensor([[[-1.0, 1.0]]]))
+    # b: [22 - 25, 28 - 25] = [-3, 3]
+    torch.testing.assert_close(result["b"], torch.tensor([[[-3.0, 3.0]]]))
+
+
+def test_per_channel_round_trip():
+    torch.manual_seed(0)
+    means = {"a": 10.0, "b": 20.0}
+    stds = {"a": 2.0, "b": 3.0}
+    transform = _make_per_channel(means, stds)
+    tensors = move_tensordict_to_device(
+        {k: torch.randn(3, 8, 8) + means[k] for k in means}
+    )
+    result = transform.forward_transform(tensors, None)
+    restored = transform.inverse_transform(result)
+    for k in means:
+        torch.testing.assert_close(restored[k], tensors[k])
+
+
+def test_per_channel_is_per_sample():
+    means = {"a": 0.0}
+    stds = {"a": 1.0}
+    transform = _make_per_channel(means, stds)
+    tensors = move_tensordict_to_device(
+        {"a": torch.tensor([[[10.0, 20.0]], [[100.0, 200.0]]])}
+    )
+    result = transform.forward_transform(tensors, None)
+    # sample 0: mean=15, sample 1: mean=150
+    torch.testing.assert_close(
+        result["a"], torch.tensor([[[-5.0, 5.0]], [[-50.0, 50.0]]])
+    )
+
+
+def test_per_channel_no_extra_channels():
+    means = {"a": 0.0}
+    stds = {"a": 1.0}
+    transform = _make_per_channel(means, stds)
+    assert transform.n_extra_input_channels == 0
+    tensors = move_tensordict_to_device({"a": torch.full((2, 4, 4), 5.0)})
+    transform.forward_transform(tensors, None)
+    assert transform.get_extra_channels() is None
+
+
+def test_per_channel_extra_channels():
+    means = {"a": 10.0, "b": 20.0}
+    stds = {"a": 2.0, "b": 5.0}
+    transform = _make_per_channel(means, stds, append_as_input=True)
+    assert transform.n_extra_input_channels == 2
+    tensors = move_tensordict_to_device(
+        {
+            "a": torch.full((1, 4, 4), 14.0),  # mean=14
+            "b": torch.full((1, 4, 4), 25.0),  # mean=25
+        }
+    )
+    transform.forward_transform(tensors, None)
+    extra = transform.get_extra_channels()
+    assert extra is not None
+    assert extra.shape == (1, 2, 4, 4)
+    # a: (14 - 10) / 2 = 2.0
+    torch.testing.assert_close(extra[:, 0], torch.full((1, 4, 4), 2.0))
+    # b: (25 - 20) / 5 = 1.0
+    torch.testing.assert_close(extra[:, 1], torch.full((1, 4, 4), 1.0))
+
+
+def test_per_channel_with_field_names_subset():
+    means = {"a": 10.0, "b": 20.0}
+    stds = {"a": 2.0, "b": 5.0}
+    transform = _make_per_channel(means, stds, field_names=["a"])
+    tensors = move_tensordict_to_device(
+        {"a": torch.full((1, 4, 4), 14.0), "b": torch.full((1, 4, 4), 25.0)}
+    )
+    result = transform.forward_transform(tensors, None)
+    # a was shifted
+    torch.testing.assert_close(result["a"], torch.full((1, 4, 4), 0.0))
+    # b was NOT shifted
+    torch.testing.assert_close(result["b"], torch.full((1, 4, 4), 25.0))
+
+
+def test_per_channel_masked_uses_zero():
+    means = {"a": 10.0}
+    stds = {"a": 2.0}
+    transform = _make_per_channel(means, stds, append_as_input=True)
+    tensors = move_tensordict_to_device(
+        {"a": torch.tensor([[[14.0, 14.0]], [[14.0, 14.0]]])}
+    )
+    data_mask = {"a": torch.tensor([True, False])}
+    result = transform.forward_transform(tensors, data_mask)
+    # sample 0 (unmasked): mean=14, shifted to 0
+    torch.testing.assert_close(result["a"][0], torch.zeros(1, 2))
+    # sample 1 (masked): mean→0, so no shift (14 - 0 = 14)
+    torch.testing.assert_close(result["a"][1], torch.full((1, 2), 14.0))
+
+    extra = transform.get_extra_channels()
+    assert extra is not None
+    # sample 0: (14 - 10) / 2 = 2.0
+    assert extra[0, 0, 0, 0].item() == pytest.approx(2.0)
+    # sample 1 (masked): (0 - 10) / 2 = -5.0
+    assert extra[1, 0, 0, 0].item() == pytest.approx(-5.0)
+
+
+def test_per_channel_inverse_before_forward_raises():
+    means = {"a": 0.0}
+    stds = {"a": 1.0}
+    transform = _make_per_channel(means, stds)
+    with pytest.raises(RuntimeError, match="forward_transform"):
+        transform.inverse_transform({"a": torch.zeros(1, 4, 4)})
+
+
+# ── Config validation ───────────────────────────────────────────────────
+
+
+def test_shared_config_validates_reference_field():
+    config = SharedGlobalMeanRemovalConfig(reference_field="missing")
+    with pytest.raises(ValueError, match="reference_field"):
+        config.validate_names(["a", "b"], ["a", "b"])
+
+
+def test_per_channel_config_validates_field_names():
+    config = PerChannelGlobalMeanRemovalConfig(field_names=["missing"])
+    with pytest.raises(ValueError, match="field_name"):
+        config.validate_names(["a", "b"], ["a", "b"])
+
+
+def test_per_channel_config_none_field_names_means_all():
+    config = PerChannelGlobalMeanRemovalConfig(field_names=None)
+    config.validate_names(["a", "b"], ["a", "b"])
+    assert config.get_n_extra_input_channels(["a", "b"]) == 0
+    config_with_input = PerChannelGlobalMeanRemovalConfig(
+        field_names=None, append_as_input=True
+    )
+    assert config_with_input.get_n_extra_input_channels(["a", "b"]) == 2
+
+
+# ── Dacite union serialization ──────────────────────────────────────────
+
+
+def test_shared_config_round_trips_through_dacite():
+    config = SharedGlobalMeanRemovalConfig(
+        reference_field="surface_temperature",
+        field_names=["surface_temperature", "air_temperature_0"],
+        append_as_input=True,
+    )
+    data = dataclasses.asdict(config)
+    restored = dacite.from_dict(
+        SharedGlobalMeanRemovalConfig, data, dacite.Config(strict=True)
+    )
+    assert config == restored
+
+
+def test_per_channel_config_round_trips_through_dacite():
+    config = PerChannelGlobalMeanRemovalConfig(
+        field_names=["a", "b"],
+        append_as_input=True,
+    )
+    data = dataclasses.asdict(config)
+    restored = dacite.from_dict(
+        PerChannelGlobalMeanRemovalConfig, data, dacite.Config(strict=True)
+    )
+    assert config == restored
+
+
+def test_union_resolved_by_kind_via_dacite():
+    @dataclasses.dataclass
+    class Container:
+        removal: GlobalMeanRemovalConfigUnion | None = None
+
+    shared_data = {
+        "removal": {
+            "kind": "shared",
+            "reference_field": "surface_temperature",
+            "field_names": ["surface_temperature"],
+            "append_as_input": False,
+        }
+    }
+    result = dacite.from_dict(Container, shared_data, dacite.Config(strict=True))
+    assert isinstance(result.removal, SharedGlobalMeanRemovalConfig)
+
+    per_ch_data = {
+        "removal": {
+            "kind": "per_channel",
+            "field_names": ["a"],
+            "append_as_input": True,
+        }
+    }
+    result2 = dacite.from_dict(Container, per_ch_data, dacite.Config(strict=True))
+    assert isinstance(result2.removal, PerChannelGlobalMeanRemovalConfig)
+
+    none_data: dict = {}
+    result3 = dacite.from_dict(Container, none_data, dacite.Config(strict=True))
+    assert result3.removal is None

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -268,7 +268,7 @@ def test_per_channel_masked_uses_zero():
     tensors = move_tensordict_to_device(
         {"a": torch.tensor([[[14.0, 14.0]], [[14.0, 14.0]]])}
     )
-    data_mask = {"a": torch.tensor([True, False])}
+    data_mask = move_tensordict_to_device({"a": torch.tensor([True, False])})
     result = transform.forward_transform(tensors, data_mask)
     # sample 0 (unmasked): mean=14, shifted to 0
     torch.testing.assert_close(result["a"][0].cpu(), torch.zeros(1, 2))

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -183,9 +183,9 @@ def test_per_channel_removes_correct_means():
     )
     result = transform.forward_transform(tensors, None)
     # a: [12 - 13, 14 - 13] = [-1, 1]
-    torch.testing.assert_close(result["a"], torch.tensor([[[-1.0, 1.0]]]))
+    torch.testing.assert_close(result["a"].cpu(), torch.tensor([[[-1.0, 1.0]]]))
     # b: [22 - 25, 28 - 25] = [-3, 3]
-    torch.testing.assert_close(result["b"], torch.tensor([[[-3.0, 3.0]]]))
+    torch.testing.assert_close(result["b"].cpu(), torch.tensor([[[-3.0, 3.0]]]))
 
 
 def test_per_channel_round_trip():
@@ -212,7 +212,7 @@ def test_per_channel_is_per_sample():
     result = transform.forward_transform(tensors, None)
     # sample 0: mean=15, sample 1: mean=150
     torch.testing.assert_close(
-        result["a"], torch.tensor([[[-5.0, 5.0]], [[-50.0, 50.0]]])
+        result["a"].cpu(), torch.tensor([[[-5.0, 5.0]], [[-50.0, 50.0]]])
     )
 
 
@@ -242,9 +242,9 @@ def test_per_channel_extra_channels():
     assert extra is not None
     assert extra.shape == (1, 2, 4, 4)
     # a: (14 - 10) / 2 = 2.0
-    torch.testing.assert_close(extra[:, 0], torch.full((1, 4, 4), 2.0))
+    torch.testing.assert_close(extra[:, 0].cpu(), torch.full((1, 4, 4), 2.0))
     # b: (25 - 20) / 5 = 1.0
-    torch.testing.assert_close(extra[:, 1], torch.full((1, 4, 4), 1.0))
+    torch.testing.assert_close(extra[:, 1].cpu(), torch.full((1, 4, 4), 1.0))
 
 
 def test_per_channel_with_field_names_subset():
@@ -256,9 +256,9 @@ def test_per_channel_with_field_names_subset():
     )
     result = transform.forward_transform(tensors, None)
     # a was shifted
-    torch.testing.assert_close(result["a"], torch.full((1, 4, 4), 0.0))
+    torch.testing.assert_close(result["a"].cpu(), torch.full((1, 4, 4), 0.0))
     # b was NOT shifted
-    torch.testing.assert_close(result["b"], torch.full((1, 4, 4), 25.0))
+    torch.testing.assert_close(result["b"].cpu(), torch.full((1, 4, 4), 25.0))
 
 
 def test_per_channel_masked_uses_zero():
@@ -271,9 +271,9 @@ def test_per_channel_masked_uses_zero():
     data_mask = {"a": torch.tensor([True, False])}
     result = transform.forward_transform(tensors, data_mask)
     # sample 0 (unmasked): mean=14, shifted to 0
-    torch.testing.assert_close(result["a"][0], torch.zeros(1, 2))
+    torch.testing.assert_close(result["a"][0].cpu(), torch.zeros(1, 2))
     # sample 1 (masked): mean→0, so no shift (14 - 0 = 14)
-    torch.testing.assert_close(result["a"][1], torch.full((1, 2), 14.0))
+    torch.testing.assert_close(result["a"][1].cpu(), torch.full((1, 2), 14.0))
 
     extra = transform.get_extra_channels()
     assert extra is not None

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -376,13 +376,16 @@ def test_per_channel_config_raises_on_output_only_field():
 
 
 def test_per_channel_config_none_field_names_means_all():
+    means = {"a": 0.0, "b": 0.0}
+    stds = {"a": 1.0, "b": 1.0}
+    normalizer = _build_normalizer_for(means, stds)
     config = PerChannelGlobalMeanRemovalConfig(field_names=None)
     config.validate_names(["a", "b"], ["a", "b"])
-    assert config.get_n_extra_input_channels(["a", "b"]) == 0
+    assert config.build(normalizer, ["a", "b"]).n_extra_input_channels == 0
     config_with_input = PerChannelGlobalMeanRemovalConfig(
         field_names=None, append_as_input=True
     )
-    assert config_with_input.get_n_extra_input_channels(["a", "b"]) == 2
+    assert config_with_input.build(normalizer, ["a", "b"]).n_extra_input_channels == 2
 
 
 # ── Dacite union serialization ──────────────────────────────────────────

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -182,10 +182,10 @@ def test_per_channel_removes_correct_means():
         }
     )
     result = transform.forward_transform(tensors, None)
-    # a: [12 - 13, 14 - 13] = [-1, 1]
-    torch.testing.assert_close(result["a"].cpu(), torch.tensor([[[-1.0, 1.0]]]))
-    # b: [22 - 25, 28 - 25] = [-3, 3]
-    torch.testing.assert_close(result["b"].cpu(), torch.tensor([[[-3.0, 3.0]]]))
+    # a: shift = 10 - 13 = -3; result = [12 - 3, 14 - 3] = [9, 11]
+    torch.testing.assert_close(result["a"].cpu(), torch.tensor([[[9.0, 11.0]]]))
+    # b: shift = 20 - 25 = -5; result = [22 - 5, 28 - 5] = [17, 23]
+    torch.testing.assert_close(result["b"].cpu(), torch.tensor([[[17.0, 23.0]]]))
 
 
 def test_per_channel_round_trip():
@@ -210,7 +210,9 @@ def test_per_channel_is_per_sample():
         {"a": torch.tensor([[[10.0, 20.0]], [[100.0, 200.0]]])}
     )
     result = transform.forward_transform(tensors, None)
-    # sample 0: mean=15, sample 1: mean=150
+    # clim_mean=0, so shift per sample is -sample_mean
+    # sample 0: mean=15 → shift=-15 → [10-15, 20-15] = [-5, 5]
+    # sample 1: mean=150 → shift=-150 → [100-150, 200-150] = [-50, 50]
     torch.testing.assert_close(
         result["a"].cpu(), torch.tensor([[[-5.0, 5.0]], [[-50.0, 50.0]]])
     )
@@ -255,13 +257,13 @@ def test_per_channel_with_field_names_subset():
         {"a": torch.full((1, 4, 4), 14.0), "b": torch.full((1, 4, 4), 25.0)}
     )
     result = transform.forward_transform(tensors, None)
-    # a was shifted
-    torch.testing.assert_close(result["a"].cpu(), torch.full((1, 4, 4), 0.0))
+    # a: shift = 10 - 14 = -4; result = 14 - 4 = 10 (== clim_mean)
+    torch.testing.assert_close(result["a"].cpu(), torch.full((1, 4, 4), 10.0))
     # b was NOT shifted
     torch.testing.assert_close(result["b"].cpu(), torch.full((1, 4, 4), 25.0))
 
 
-def test_per_channel_masked_uses_zero():
+def test_per_channel_masked_no_shift():
     means = {"a": 10.0}
     stds = {"a": 2.0}
     transform = _make_per_channel(means, stds, append_as_input=True)
@@ -270,17 +272,17 @@ def test_per_channel_masked_uses_zero():
     )
     data_mask = move_tensordict_to_device({"a": torch.tensor([True, False])})
     result = transform.forward_transform(tensors, data_mask)
-    # sample 0 (unmasked): mean=14, shifted to 0
-    torch.testing.assert_close(result["a"][0].cpu(), torch.zeros(1, 2))
-    # sample 1 (masked): mean→0, so no shift (14 - 0 = 14)
+    # sample 0 (unmasked): shift = 10 - 14 = -4; result = 14 - 4 = 10
+    torch.testing.assert_close(result["a"][0].cpu(), torch.full((1, 2), 10.0))
+    # sample 1 (masked): no shift, unchanged
     torch.testing.assert_close(result["a"][1].cpu(), torch.full((1, 2), 14.0))
 
     extra = transform.get_extra_channels()
     assert extra is not None
-    # sample 0: (14 - 10) / 2 = 2.0
+    # sample 0: -shift/std = -(-4)/2 = 2.0
     assert extra[0, 0, 0, 0].item() == pytest.approx(2.0)
-    # sample 1 (masked): (0 - 10) / 2 = -5.0
-    assert extra[1, 0, 0, 0].item() == pytest.approx(-5.0)
+    # sample 1 (masked): no shift, extra = 0
+    assert extra[1, 0, 0, 0].item() == pytest.approx(0.0)
 
 
 def test_per_channel_inverse_before_forward_raises():
@@ -289,6 +291,59 @@ def test_per_channel_inverse_before_forward_raises():
     transform = _make_per_channel(means, stds)
     with pytest.raises(RuntimeError, match="forward_transform"):
         transform.inverse_transform({"a": torch.zeros(1, 4, 4)})
+
+
+def test_per_channel_post_normalization_mean_is_near_zero():
+    """Regression: per-channel must shift toward each field's climatology,
+    not to zero in physical space.  After the shift, the normalizer is
+    applied; the post-normalization spatial mean must be ≈ 0 so the
+    network does not see a large constant bias (a previous implementation
+    shifted to zero in physical space, producing a post-normalization
+    bias of ``-clim_mean / clim_std`` ≈ -19 for absolute temperatures).
+    """
+    torch.manual_seed(0)
+    # Realistic climatology: surface temperature ~288 K, std ~15 K.
+    means = {"surface_temperature": 288.0, "air_temperature_0": 220.0}
+    stds = {"surface_temperature": 15.0, "air_temperature_0": 10.0}
+    normalizer = _build_normalizer_for(means, stds)
+    transform = _make_per_channel(means, stds)
+
+    tensors = move_tensordict_to_device(
+        {
+            "surface_temperature": torch.randn(2, 8, 16) * 12.0 + 295.0,
+            "air_temperature_0": torch.randn(2, 8, 16) * 8.0 + 215.0,
+        }
+    )
+    shifted = transform.forward_transform(tensors, None)
+    normalized = normalizer.normalize(shifted)
+    for name in means:
+        sample_means = normalized[name].mean(dim=tuple(range(1, normalized[name].ndim)))
+        torch.testing.assert_close(
+            sample_means.cpu(),
+            torch.zeros_like(sample_means.cpu()),
+            atol=1e-5,
+            rtol=0.0,
+        )
+
+
+def test_per_channel_post_normalization_mean_near_zero_when_masked():
+    """Masked samples are skipped (shift = 0), but unmasked samples must
+    still land near zero in normalized space."""
+    means = {"a": 100.0}
+    stds = {"a": 5.0}
+    normalizer = _build_normalizer_for(means, stds)
+    transform = _make_per_channel(means, stds)
+
+    # Two samples, both with physical mean 110; one is masked.
+    tensors = move_tensordict_to_device({"a": torch.full((2, 4, 4), 110.0)})
+    data_mask = move_tensordict_to_device({"a": torch.tensor([True, False])})
+    shifted = transform.forward_transform(tensors, data_mask)
+    normalized = normalizer.normalize(shifted)
+    # Unmasked sample: spatial mean ≈ 0 in normalized space.
+    assert normalized["a"][0].mean().abs().item() < 1e-5
+    # Masked sample: not shifted, so it retains (110 - 100) / 5 = 2.0
+    # — this is fine because _apply_input_mask zeros the channel later.
+    assert normalized["a"][1].mean().item() == pytest.approx(2.0)
 
 
 # ── Config validation ───────────────────────────────────────────────────

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -300,10 +300,24 @@ def test_shared_config_validates_reference_field():
         config.validate_names(["a", "b"], ["a", "b"])
 
 
-def test_per_channel_config_validates_field_names():
+def test_shared_config_warns_on_unknown_field_names(caplog):
+    config = SharedGlobalMeanRemovalConfig(
+        reference_field="a", field_names=["a", "missing"]
+    )
+    config.validate_names(["a", "b"], ["a", "b"])
+    assert "will have no effect" in caplog.text
+
+
+def test_per_channel_config_warns_on_unknown_field_names(caplog):
     config = PerChannelGlobalMeanRemovalConfig(field_names=["missing"])
+    config.validate_names(["a", "b"], ["a", "b"])
+    assert "will have no effect" in caplog.text
+
+
+def test_per_channel_config_raises_on_output_only_field():
+    config = PerChannelGlobalMeanRemovalConfig(field_names=["c"])
     with pytest.raises(ValueError, match="field_name"):
-        config.validate_names(["a", "b"], ["a", "b"])
+        config.validate_names(["a", "b"], ["a", "b", "c"])
 
 
 def test_per_channel_config_none_field_names_means_all():

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -1370,6 +1370,55 @@ def test_step_per_channel_global_mean_removal_with_extra_channels():
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
 
+def test_step_global_mean_removal_affects_output():
+    """Verify the transform is actually invoked during step.
+
+    The per-field unit tests in ``test_global_mean_removal.py`` cover the
+    forward/inverse value behavior. This test ties that unit coverage to the
+    full step by confirming that enabling ``global_mean_removal`` produces a
+    different output than disabling it, with all other state (seed, weights,
+    inputs) held fixed.
+    """
+    in_names = ["forcing_shared", "forcing_rad"]
+    out_names = ["diagnostic_main", "diagnostic_rad"]
+    means = {n: 0.0 for n in set(in_names + out_names)}
+    stds = {n: 1.0 for n in set(in_names + out_names)}
+    n_samples = 2
+    torch.manual_seed(0)
+    step_baseline = _make_global_mean_removal_step(
+        None, in_names, out_names, means=means, stds=stds
+    )
+    torch.manual_seed(0)
+    step_with_removal = _make_global_mean_removal_step(
+        PerChannelGlobalMeanRemovalConfig(field_names=in_names),
+        in_names,
+        out_names,
+        means=means,
+        stds=stds,
+    )
+    input_data = get_tensor_dict(
+        step_baseline.input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    # Shift inputs so they have a non-zero spatial mean per channel; otherwise
+    # forward_transform would be a no-op and the outputs would coincide.
+    input_data = {k: v + 5.0 for k, v in input_data.items()}
+    next_step = get_tensor_dict(
+        step_baseline.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    baseline_output = step_baseline.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    removal_output = step_with_removal.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    differs = False
+    for name in out_names:
+        if not torch.allclose(baseline_output[name], removal_output[name]):
+            differs = True
+            break
+    assert differs, "global_mean_removal had no effect on step outputs"
+
+
 def test_step_shared_global_mean_removal_raises_on_masked_reference():
     in_names = ["surface_temperature", "air_temperature_0"]
     out_names = ["surface_temperature", "air_temperature_0"]

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -1370,18 +1370,7 @@ def test_step_per_channel_global_mean_removal_with_extra_channels():
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
 
-def test_step_global_mean_removal_affects_output():
-    """Verify the transform is actually invoked during step.
-
-    The per-field unit tests in ``test_global_mean_removal.py`` cover the
-    forward/inverse value behavior. This test ties that unit coverage to the
-    full step by confirming that enabling ``global_mean_removal`` produces a
-    different output than disabling it, with all other state (seed, weights,
-    inputs) held fixed.
-    """
-    in_names = ["forcing_shared", "forcing_rad"]
-    out_names = ["diagnostic_main", "diagnostic_rad"]
-    means = {n: 0.0 for n in set(in_names + out_names)}
+def _assert_global_mean_removal_affects_output(removal, in_names, out_names, means):
     stds = {n: 1.0 for n in set(in_names + out_names)}
     n_samples = 2
     torch.manual_seed(0)
@@ -1390,11 +1379,7 @@ def test_step_global_mean_removal_affects_output():
     )
     torch.manual_seed(0)
     step_with_removal = _make_global_mean_removal_step(
-        PerChannelGlobalMeanRemovalConfig(field_names=in_names),
-        in_names,
-        out_names,
-        means=means,
-        stds=stds,
+        removal, in_names, out_names, means=means, stds=stds
     )
     input_data = get_tensor_dict(
         step_baseline.input_names, DEFAULT_IMG_SHAPE, n_samples
@@ -1411,12 +1396,50 @@ def test_step_global_mean_removal_affects_output():
     removal_output = step_with_removal.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
     )
-    differs = False
-    for name in out_names:
-        if not torch.allclose(baseline_output[name], removal_output[name]):
-            differs = True
-            break
+    differs = any(
+        not torch.allclose(baseline_output[name], removal_output[name])
+        for name in out_names
+    )
     assert differs, "global_mean_removal had no effect on step outputs"
+
+
+def test_step_per_channel_global_mean_removal_affects_output():
+    """Verify PerChannelGlobalMeanRemoval is actually invoked during step.
+
+    The per-field unit tests in ``test_global_mean_removal.py`` cover the
+    forward/inverse value behavior. This test ties that unit coverage to the
+    full step by confirming that enabling ``global_mean_removal`` produces a
+    different output than disabling it, with all other state (seed, weights,
+    inputs) held fixed.
+    """
+    in_names = ["forcing_shared", "forcing_rad"]
+    out_names = ["diagnostic_main", "diagnostic_rad"]
+    means = {n: 0.0 for n in set(in_names + out_names)}
+    _assert_global_mean_removal_affects_output(
+        PerChannelGlobalMeanRemovalConfig(field_names=in_names),
+        in_names,
+        out_names,
+        means,
+    )
+
+
+def test_step_shared_global_mean_removal_affects_output():
+    """Verify SharedGlobalMeanRemoval is actually invoked during step.
+
+    Companion to the PerChannel version above; same rationale.
+    """
+    in_names = ["surface_temperature", "air_temperature_0"]
+    out_names = ["surface_temperature", "air_temperature_0"]
+    means = {n: 280.0 for n in set(in_names + out_names)}
+    _assert_global_mean_removal_affects_output(
+        SharedGlobalMeanRemovalConfig(
+            reference_field="surface_temperature",
+            field_names=in_names,
+        ),
+        in_names,
+        out_names,
+        means,
+    )
 
 
 def test_step_shared_global_mean_removal_raises_on_masked_reference():

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -24,6 +24,10 @@ from fme.core.labels import BatchLabels
 from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
 from fme.core.registry import ModuleSelector
 from fme.core.step.args import StepArgs
+from fme.core.step.global_mean_removal import (
+    PerChannelGlobalMeanRemovalConfig,
+    SharedGlobalMeanRemovalConfig,
+)
 from fme.core.step.multi_call import MultiCallConfig, MultiCallStepConfig
 from fme.core.step.secondary_decoder import SecondaryDecoderConfig
 from fme.core.step.secondary_module import SecondaryModuleStepConfig
@@ -1243,3 +1247,155 @@ def test_step_with_include_channel_mask_inputs_no_data_mask():
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_no_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_no_mask[name], output_all_unmasked[name])
+
+
+def _make_global_mean_removal_step(
+    global_mean_removal, in_names=None, out_names=None, means=None, stds=None
+):
+    if in_names is None:
+        in_names = ["forcing_shared", "forcing_rad"]
+    if out_names is None:
+        out_names = ["diagnostic_main", "diagnostic_rad"]
+    all_names = list(set(in_names + out_names))
+    if means is None:
+        means = {name: 0.0 for name in all_names}
+    if stds is None:
+        stds = {name: 1.0 for name in all_names}
+    normalization = NetworkAndLossNormalizationConfig(
+        network=NormalizationConfig(means=means, stds=stds),
+    )
+    config = StepSelector(
+        type="single_module",
+        config=dataclasses.asdict(
+            SingleModuleStepConfig(
+                builder=ModuleSelector(
+                    type="SphericalFourierNeuralOperatorNet",
+                    config={
+                        "scale_factor": 1,
+                        "embed_dim": 4,
+                        "num_layers": 2,
+                    },
+                ),
+                in_names=in_names,
+                out_names=out_names,
+                normalization=normalization,
+                global_mean_removal=global_mean_removal,
+            ),
+        ),
+    )
+    return get_step(config, DEFAULT_IMG_SHAPE)
+
+
+def test_step_shared_global_mean_removal():
+    in_names = ["surface_temperature", "air_temperature_0"]
+    out_names = ["surface_temperature", "air_temperature_0"]
+    means = {n: 280.0 for n in in_names}
+    stds = {n: 5.0 for n in in_names}
+    removal = SharedGlobalMeanRemovalConfig(
+        reference_field="surface_temperature",
+        field_names=in_names,
+    )
+    step = _make_global_mean_removal_step(
+        removal, in_names, out_names, means=means, stds=stds
+    )
+    n_samples = 2
+    input_data = get_tensor_dict(step.input_names, DEFAULT_IMG_SHAPE, n_samples)
+    next_step = get_tensor_dict(
+        step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    output = step.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    for name in out_names:
+        assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
+
+
+def test_step_shared_global_mean_removal_with_extra_channels():
+    in_names = ["surface_temperature", "air_temperature_0"]
+    out_names = ["surface_temperature", "air_temperature_0"]
+    means = {n: 280.0 for n in in_names}
+    stds = {n: 5.0 for n in in_names}
+    removal = SharedGlobalMeanRemovalConfig(
+        reference_field="surface_temperature",
+        field_names=in_names,
+        append_as_input=True,
+    )
+    step = _make_global_mean_removal_step(
+        removal, in_names, out_names, means=means, stds=stds
+    )
+    n_samples = 2
+    input_data = get_tensor_dict(step.input_names, DEFAULT_IMG_SHAPE, n_samples)
+    next_step = get_tensor_dict(
+        step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    output = step.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    for name in out_names:
+        assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
+
+
+def test_step_per_channel_global_mean_removal():
+    removal = PerChannelGlobalMeanRemovalConfig(field_names=None)
+    step = _make_global_mean_removal_step(removal)
+    n_samples = 2
+    input_data = get_tensor_dict(step.input_names, DEFAULT_IMG_SHAPE, n_samples)
+    next_step = get_tensor_dict(
+        step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    output = step.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    for name in step.output_names:
+        assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
+
+
+def test_step_per_channel_global_mean_removal_with_extra_channels():
+    in_names = ["forcing_shared", "forcing_rad"]
+    out_names = ["diagnostic_main", "diagnostic_rad"]
+    removal = PerChannelGlobalMeanRemovalConfig(
+        field_names=in_names,
+        append_as_input=True,
+    )
+    step = _make_global_mean_removal_step(removal, in_names, out_names)
+    n_samples = 2
+    input_data = get_tensor_dict(step.input_names, DEFAULT_IMG_SHAPE, n_samples)
+    next_step = get_tensor_dict(
+        step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    output = step.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    for name in step.output_names:
+        assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
+
+
+def test_step_shared_global_mean_removal_raises_on_masked_reference():
+    in_names = ["surface_temperature", "air_temperature_0"]
+    out_names = ["surface_temperature", "air_temperature_0"]
+    means = {n: 280.0 for n in in_names}
+    stds = {n: 5.0 for n in in_names}
+    removal = SharedGlobalMeanRemovalConfig(
+        reference_field="surface_temperature",
+        field_names=in_names,
+    )
+    step = _make_global_mean_removal_step(
+        removal, in_names, out_names, means=means, stds=stds
+    )
+    n_samples = 2
+    input_data = get_tensor_dict(step.input_names, DEFAULT_IMG_SHAPE, n_samples)
+    next_step = get_tensor_dict(
+        step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    data_mask = {
+        "surface_temperature": torch.tensor([True, False], device=fme.get_device()),
+    }
+    with pytest.raises(ValueError, match="masked"):
+        step.step(
+            args=StepArgs(
+                input=input_data,
+                next_step_input_data=next_step,
+                labels=None,
+                data_mask=data_mask,
+            ),
+        )


### PR DESCRIPTION
Add an optional `global_mean_removal` config to `SingleModuleStepConfig` (and `SingleModuleStepperConfig`) that removes per-sample global means from fields before normalization and restores them after denormalization. This lets the network operate on anomalies relative to the current global mean, which can improve generalization for temperature-like fields under climate drift.

Changes:
- `fme.core.step.global_mean_removal`: new module with `SharedGlobalMeanRemoval` (single reference field offset applied to a set of fields) and `PerChannelGlobalMeanRemoval` (each field's own mean removed independently). Both support optionally appending the removed mean as extra normalized input channels.
- `fme.core.step.SingleModuleStepConfig`: new optional `global_mean_removal` field; forward transform applied before normalization, inverse transform applied after denormalization
- `fme.ace.stepper.SingleModuleStepperConfig`: passes `global_mean_removal` through to `SingleModuleStepConfig`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated