### PR TITLE
Update NoiseConditionedSFNO and SFNONetConfig defaults

### DIFF
--- a/fme/ace/registry/stochastic_sfno.py
+++ b/fme/ace/registry/stochastic_sfno.py
@@ -177,7 +177,7 @@ NoiseConditionedSFNO = NoiseConditionedModel
 
 # this is based on the call signature of SphericalFourierNeuralOperatorNet at
 # https://github.com/NVIDIA/modulus/blob/b8e27c5c4ebc409e53adaba9832138743ede2785/modulus/models/sfno/sfnonet.py#L292  # noqa: E501
-@ModuleSelector.register("NoiseConditionedSFNO")
+@ModuleSelector.register("NoiseConditionedSFNO-v1")
 @dataclasses.dataclass
 class NoiseConditionedSFNOBuilder(ModuleConfig):
     """
@@ -368,4 +368,75 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
             inverse_sht=inverse_sht,
             lmax=lmax,
             mmax=mmax,
+        )
+
+
+@ModuleSelector.register("NoiseConditionedSFNO")
+@dataclasses.dataclass
+class NoiseConditionedSFNOV0Builder(ModuleConfig):
+    """Backwards-compatible configuration for NoiseConditionedSFNO.
+
+    New configurations should use NoiseConditionedSFNO-v1 instead.
+    """
+
+    spectral_transform: Literal["sht"] = "sht"
+    filter_type: Literal["linear", "makani-linear"] = "linear"
+    operator_type: Literal["dhconv"] = "dhconv"
+    residual_filter_factor: int = 1
+    embed_dim: int = 256
+    noise_embed_dim: int = 256
+    context_pos_embed_dim: int = 0
+    label_embed_dim: int = 0
+    noise_type: Literal["isotropic", "gaussian"] = "gaussian"
+    global_layer_norm: bool = False
+    num_layers: int = 12
+    use_mlp: bool = True
+    mlp_ratio: float = 2.0
+    activation_function: str = "gelu"
+    encoder_layers: int = 1
+    pos_embed: bool = True
+    big_skip: bool = True
+    rank: float = 1.0
+    factorization: None = None
+    separable: bool = False
+    complex_network: bool = True
+    complex_activation: str = "real"
+    spectral_layers: int = 1
+    checkpointing: int = 0
+    data_grid: Literal["legendre-gauss", "equiangular"] = "legendre-gauss"
+    filter_residual: bool = False
+    filter_output: bool = False
+    local_blocks: list[int] | None = None
+    normalize_big_skip: bool = False
+    affine_norms: bool = False
+    filter_num_groups: int = 1
+    lora_rank: int = 0
+    lora_alpha: float | None = None
+    spectral_lora_rank: int = 0
+    spectral_lora_alpha: float | None = None
+    filter_preserves_global_mean: bool = False
+
+    def __post_init__(self):
+        if self.context_pos_embed_dim > 0 and self.pos_embed:
+            raise ValueError(
+                "context_pos_embed_dim and pos_embed should not both be set"
+            )
+        if self.factorization is not None:
+            raise ValueError("The 'factorization' parameter is no longer supported.")
+        if self.separable:
+            raise ValueError("The 'separable' parameter is no longer supported.")
+        if self.operator_type != "dhconv":
+            raise ValueError(
+                "Only 'dhconv' operator_type is supported for "
+                "NoiseConditionedSFNO models."
+            )
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        dataset_info: DatasetInfo,
+    ):
+        return NoiseConditionedSFNOBuilder(**dataclasses.asdict(self)).build(
+            n_in_channels, n_out_channels, dataset_info
         )

--- a/fme/ace/registry/stochastic_sfno.py
+++ b/fme/ace/registry/stochastic_sfno.py
@@ -258,7 +258,7 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
     label_embed_dim: int = 0
     noise_type: Literal["isotropic", "gaussian"] = "gaussian"
     global_layer_norm: bool = False
-    num_layers: int = 12
+    num_layers: int = 8
     use_mlp: bool = True
     mlp_ratio: float = 2.0
     activation_function: str = "gelu"
@@ -277,8 +277,8 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
     filter_residual: bool = False
     filter_output: bool = False
     local_blocks: list[int] | None = None
-    normalize_big_skip: bool = False
-    affine_norms: bool = False
+    normalize_big_skip: bool = True
+    affine_norms: bool = True
     filter_num_groups: int = 1
     lora_rank: int = 0
     lora_alpha: float | None = None

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -223,7 +223,7 @@ def _get_test_yaml_files(
             embed_dim=12,
         )
         spatial_dimensions_str = "latlon"
-    elif nettype == "NoiseConditionedSFNO":
+    elif nettype == "NoiseConditionedSFNO-v1":
         net_config = dict(
             num_layers=2,
             embed_dim=12,
@@ -235,7 +235,7 @@ def _get_test_yaml_files(
         else:
             spatial_dimensions_str = "latlon"
 
-    if nettype == "NoiseConditionedSFNO":
+    if nettype == "NoiseConditionedSFNO-v1":
         conditional = True
     else:
         conditional = False
@@ -646,7 +646,7 @@ class TrainAndInferenceTestSettings:
 _TRAIN_AND_INFERENCE_CASES = [
     pytest.param(
         TrainAndInferenceTestSettings(
-            nettype="NoiseConditionedSFNO",
+            nettype="NoiseConditionedSFNO-v1",
             crps_training=True,
             use_schedule=True,
         ),
@@ -672,7 +672,7 @@ _TRAIN_AND_INFERENCE_CASES = [
     ),
     pytest.param(
         TrainAndInferenceTestSettings(
-            nettype="NoiseConditionedSFNO",
+            nettype="NoiseConditionedSFNO-v1",
             use_variable_masking=True,
         ),
         id="SFNO-masking",
@@ -682,7 +682,7 @@ _TRAIN_AND_INFERENCE_CASES = [
     ),
     pytest.param(
         TrainAndInferenceTestSettings(
-            nettype="NoiseConditionedSFNO",
+            nettype="NoiseConditionedSFNO-v1",
             crps_training=True,
             use_schedule=True,
             validate_using_ema=True,
@@ -870,7 +870,7 @@ def _get_reproducible_trainer(config_dict, seed):
     return build_trainer(builders, config)
 
 
-@pytest.mark.parametrize("nettype", ["NoiseConditionedSFNO"])
+@pytest.mark.parametrize("nettype", ["NoiseConditionedSFNO-v1"])
 def test_set_seed(tmp_path, nettype, very_fast_only: bool):
     """Test that set_seed leads to identical training outcomes."""
     if very_fast_only:
@@ -900,7 +900,7 @@ def test_set_seed(tmp_path, nettype, very_fast_only: bool):
     )
 
 
-@pytest.mark.parametrize("nettype", ["NoiseConditionedSFNO"])
+@pytest.mark.parametrize("nettype", ["NoiseConditionedSFNO-v1"])
 @pytest.mark.parametrize("save_type", ["restart", "all"])
 def test_restore_checkpoint(
     tmp_path,

--- a/fme/core/distributed/parallel_tests/test_step.py
+++ b/fme/core/distributed/parallel_tests/test_step.py
@@ -21,7 +21,7 @@ import torch
 from torch import nn
 
 import fme
-from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNOBuilder
+from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNOV0Builder
 from fme.ace.testing.fv3gfs_data import get_scalar_dataset
 from fme.core.coordinates import HybridSigmaPressureCoordinate, LatLonCoordinates
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig, EnergyBudgetConfig
@@ -82,7 +82,7 @@ def get_single_module_noise_conditioned_selector(
                 builder=ModuleSelector(
                     type="NoiseConditionedSFNO",
                     config=dataclasses.asdict(
-                        NoiseConditionedSFNOBuilder(
+                        NoiseConditionedSFNOV0Builder(
                             embed_dim=4,
                             noise_embed_dim=4,
                             noise_type="isotropic",
@@ -165,7 +165,7 @@ def get_single_module_with_atmosphere_corrector_selector(
                 builder=ModuleSelector(
                     type="NoiseConditionedSFNO",
                     config=dataclasses.asdict(
-                        NoiseConditionedSFNOBuilder(
+                        NoiseConditionedSFNOV0Builder(
                             embed_dim=4,
                             noise_embed_dim=4,
                             noise_type="isotropic",

--- a/fme/core/models/conditional_sfno/sfnonet.py
+++ b/fme/core/models/conditional_sfno/sfnonet.py
@@ -95,7 +95,7 @@ class SFNONetConfig:
     filter_type: str = "linear"
     scale_factor: int = 1
     global_layer_norm: bool = False
-    num_layers: int = 12
+    num_layers: int = 8
     use_mlp: bool = True
     mlp_ratio: float = 2.0
     activation_function: str = "gelu"
@@ -110,8 +110,8 @@ class SFNONetConfig:
     filter_residual: bool = False
     filter_output: bool = False
     local_blocks: list[int] | None = None
-    normalize_big_skip: bool = False
-    affine_norms: bool = False
+    normalize_big_skip: bool = True
+    affine_norms: bool = True
     lora_rank: int = 0
     lora_alpha: float | None = None
     spectral_lora_rank: int = 0

--- a/fme/core/models/conditional_sfno/sfnonet.py
+++ b/fme/core/models/conditional_sfno/sfnonet.py
@@ -95,7 +95,7 @@ class SFNONetConfig:
     filter_type: str = "linear"
     scale_factor: int = 1
     global_layer_norm: bool = False
-    num_layers: int = 8
+    num_layers: int = 12
     use_mlp: bool = True
     mlp_ratio: float = 2.0
     activation_function: str = "gelu"
@@ -110,8 +110,8 @@ class SFNONetConfig:
     filter_residual: bool = False
     filter_output: bool = False
     local_blocks: list[int] | None = None
-    normalize_big_skip: bool = True
-    affine_norms: bool = True
+    normalize_big_skip: bool = False
+    affine_norms: bool = False
     lora_rank: int = 0
     lora_alpha: float | None = None
     spectral_lora_rank: int = 0

--- a/fme/core/registry/module.py
+++ b/fme/core/registry/module.py
@@ -60,6 +60,7 @@ class ModuleConfig(abc.ABC):
 
 CONDITIONAL_BUILDERS = [
     "NoiseConditionedSFNO",
+    "NoiseConditionedSFNO-v1",
     "LocalNet",
 ]
 

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -159,7 +159,7 @@ def get_single_module_noise_conditioned_selector(
         config=dataclasses.asdict(
             SingleModuleStepConfig(
                 builder=ModuleSelector(
-                    type="NoiseConditionedSFNO",
+                    type="NoiseConditionedSFNO-v1",
                     config=dataclasses.asdict(
                         NoiseConditionedSFNOBuilder(
                             embed_dim=4,
@@ -204,7 +204,7 @@ def get_label_conditioned_selector(
         config=dataclasses.asdict(
             SingleModuleStepConfig(
                 builder=ModuleSelector(
-                    type="NoiseConditionedSFNO",
+                    type="NoiseConditionedSFNO-v1",
                     conditional=True,
                     config=dataclasses.asdict(
                         NoiseConditionedSFNOBuilder(

--- a/fme/coupled/test_train.py
+++ b/fme/coupled/test_train.py
@@ -213,7 +213,7 @@ def _write_test_yaml_files(
 
     # Configure atmosphere network and loss based on crps_training
     if crps_training:
-        atmos_network_type = "NoiseConditionedSFNO"
+        atmos_network_type = "NoiseConditionedSFNO-v1"
         loss_type = "EnsembleLoss"
         loss_kwargs = "{'crps_weight': 1.0, 'energy_score_weight': 0.0}"
     else:


### PR DESCRIPTION
Update defaults for NoiseConditionedSFNO and its underlying SFNONetConfig to reflect current best practices from recent experiments.

Changes:
- `fme.ace.registry.stochastic_sfno.NoiseConditionedSFNOBuilder` and `fme.core.models.conditional_sfno.sfnonet.SFNONetConfig`: set `affine_norms=True`, `normalize_big_skip=True`, `num_layers=8`

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
