### PR TITLE
Fix channel_mean broken by variable filtering in step_means metrics

### DIFF
--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -30,6 +30,7 @@ def get_one_step_ensemble_aggregator(
     metadata: Mapping[str, VariableMetadata] | None = None,
     target: Literal["norm", "denorm"] = "denorm",
     channel_mean_names: Sequence[str] | None = None,
+    report_variables: Sequence[str] | None = None,
 ) -> "SelectStepEnsembleAggregator":
     return SelectStepEnsembleAggregator(
         aggregator=_EnsembleAggregator(
@@ -38,6 +39,7 @@ def get_one_step_ensemble_aggregator(
             metadata=metadata,
             target=target,
             channel_mean_names=channel_mean_names,
+            report_variables=report_variables,
         ),
         i_target_time=target_time,
     )
@@ -166,6 +168,7 @@ class _EnsembleAggregator:
         metadata: Mapping[str, VariableMetadata] | None = None,
         target: Literal["norm", "denorm"] = "denorm",
         channel_mean_names: Sequence[str] | None = None,
+        report_variables: Sequence[str] | None = None,
     ):
         """
         Args:
@@ -182,6 +185,10 @@ class _EnsembleAggregator:
                 computed over all variables present in the data. Names that
                 are not present in the data raise KeyError. Ignored when
                 target is "denorm".
+            report_variables: If set, only per-variable entries for these
+                variables will appear in logs and datasets. Aggregate entries
+                like ``channel_mean`` are always included. All variables are
+                still used for channel-mean computation.
         """
         self._gridded_operations = gridded_operations
         self._n_batches = 0
@@ -192,6 +199,9 @@ class _EnsembleAggregator:
         self._diverging_metrics = {"ssr_bias"}
         self._target = target
         self._channel_mean_names = channel_mean_names
+        self._report_variables = (
+            frozenset(report_variables) if report_variables is not None else None
+        )
 
     def _get_variable_metrics(self, gen_data: TensorMapping):
         if self._variable_metrics is None:
@@ -257,8 +267,10 @@ class _EnsembleAggregator:
         if self._variable_metrics is None or self._n_batches == 0:
             raise ValueError("No batches have been recorded.")
         data: dict[str, torch.Tensor] = {}
+        all_variable_names: set[str] = set()
         for metric in sorted(self._variable_metrics):
             for key in sorted(self._variable_metrics[metric]):
+                all_variable_names.add(key)
                 metric_value = self._dist.reduce_mean(
                     self._variable_metrics[metric][key].get()
                 )
@@ -289,6 +301,13 @@ class _EnsembleAggregator:
                 if names:
                     scalars = [data[f"{metric}/{key}"] for key in names]
                     data[f"{metric}/channel_mean"] = sum(scalars) / len(scalars)
+        if self._report_variables is not None:
+            excluded = all_variable_names - self._report_variables
+            data = {
+                k: v
+                for k, v in data.items()
+                if not any(seg in excluded for seg in k.split("/"))
+            }
         return data
 
     @torch.no_grad()

--- a/fme/ace/aggregator/one_step/reduced.py
+++ b/fme/ace/aggregator/one_step/reduced.py
@@ -10,11 +10,7 @@ from fme.core.distributed import Distributed
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.typing_ import TensorMapping
 
-from ..inference.build_context import (
-    MetricBuildContext,
-    MetricNotSupportedError,
-    maybe_filter,
-)
+from ..inference.build_context import MetricBuildContext, MetricNotSupportedError
 from ..inference.data import InferenceBatchData, MetricBuildResult, SubAggregator
 from .build_context import OneStepBuildContext, OneStepMetricBuildResult
 from .reduced_metrics import AreaWeightedReducedMetric, ReducedMetric
@@ -44,6 +40,7 @@ class MeanAggregator:
         target: Literal["norm", "denorm"] = "denorm",
         channel_mean_names: Sequence[str] | None = None,
         log_loss: bool = True,
+        report_variables: Sequence[str] | None = None,
     ):
         """
         Args:
@@ -60,6 +57,10 @@ class MeanAggregator:
             channel_mean_names: Names to include in channel-mean metrics. If None,
                 channel means will not be logged.
             log_loss: Whether to log the mean loss across batches.
+            report_variables: If set, only per-variable entries for these
+                variables will appear in logs and datasets. Aggregate entries
+                like ``channel_mean`` are always included. All variables are
+                still used for channel-mean computation.
         """
         self._gridded_operations = gridded_operations
         self._n_batches = 0
@@ -67,6 +68,9 @@ class MeanAggregator:
         self._target_time = target_time
         self._target = target
         self._log_loss = log_loss
+        self._report_variables = (
+            frozenset(report_variables) if report_variables is not None else None
+        )
         self._dist = Distributed.get_instance()
 
         device = get_device()
@@ -133,16 +137,25 @@ class MeanAggregator:
         if self._n_batches == 0:
             raise ValueError("No batches have been recorded.")
         data: dict[str, torch.Tensor] = {}
+        all_variable_names: set[str] = set()
         if self._log_loss:
             data["loss"] = self._loss / self._n_batches
         for name, metric in self._variable_metrics.items():
             metric_results = metric.get()
+            all_variable_names.update(metric_results.keys())
             for key in metric_results:
                 data[f"{name}/{key}"] = metric_results[key] / self._n_batches
             if self._target == "norm":
                 data[f"{name}/channel_mean"] = (
                     metric.get_channel_mean() / self._n_batches
                 )
+        if self._report_variables is not None:
+            excluded = all_variable_names - self._report_variables
+            data = {
+                k: v
+                for k, v in data.items()
+                if not any(seg in excluded for seg in k.split("/"))
+            }
         for key in sorted(data.keys()):
             data[key] = float(self._dist.reduce_mean(data[key].detach()).cpu().numpy())
         return data
@@ -230,9 +243,10 @@ class StepMeanMetricConfig:
                     if is_norm
                     else None
                 ),
+                report_variables=self.variables,
             )
         )
-        return MetricBuildResult(aggregator=maybe_filter(agg, self.variables))
+        return MetricBuildResult(aggregator=agg)
 
 
 @dataclasses.dataclass

--- a/fme/ace/aggregator/one_step/test_ensemble.py
+++ b/fme/ace/aggregator/one_step/test_ensemble.py
@@ -255,6 +255,55 @@ def test_aggregator_norm_logs_channel_mean_subset():
         )
 
 
+def test_aggregator_report_variables_filters_per_variable_but_keeps_channel_mean():
+    torch.manual_seed(0)
+    area_weights = torch.ones([4, 4], device=get_device())
+    names = ["a", "b", "c"]
+    target = _make_ensemble_batch(names)
+    gen = _make_ensemble_batch(names)
+
+    agg_full = _EnsembleAggregator(
+        gridded_operations=LatLonOperations(area_weights),
+        log_mean_maps=False,
+        target="norm",
+        channel_mean_names=names,
+    )
+    agg_full.record_batch(
+        target_data=target,
+        gen_data=gen,
+        target_data_norm=target,
+        gen_data_norm=gen,
+    )
+    full_logs = agg_full.get_logs(label="metrics")
+
+    agg_filtered = _EnsembleAggregator(
+        gridded_operations=LatLonOperations(area_weights),
+        log_mean_maps=False,
+        target="norm",
+        channel_mean_names=names,
+        report_variables=["a"],
+    )
+    agg_filtered.record_batch(
+        target_data=target,
+        gen_data=gen,
+        target_data_norm=target,
+        gen_data_norm=gen,
+    )
+    filtered_logs = agg_filtered.get_logs(label="metrics")
+
+    for metric in ("crps", "ssr_bias", "ensemble_mean_rmse"):
+        assert f"metrics/{metric}/a" in filtered_logs
+        assert f"metrics/{metric}/b" not in filtered_logs
+        assert f"metrics/{metric}/c" not in filtered_logs
+        assert f"metrics/{metric}/channel_mean" in filtered_logs
+        torch.testing.assert_close(
+            torch.tensor(float(filtered_logs[f"metrics/{metric}/channel_mean"])),
+            torch.tensor(float(full_logs[f"metrics/{metric}/channel_mean"])),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+
 def test_aggregator_norm_raises_on_unknown_channel_mean_names():
     """Names in channel_mean_names that aren't in the data raise KeyError."""
     torch.manual_seed(0)

--- a/fme/ace/aggregator/one_step/test_reduced.py
+++ b/fme/ace/aggregator/one_step/test_reduced.py
@@ -91,6 +91,40 @@ def test_i_time_start_gets_correct_time_longer_windows(
     )
 
 
+def test_report_variables_filters_per_variable_but_keeps_channel_mean():
+    area_weights = torch.ones([4, 4]).to(get_device())
+    agg = MeanAggregator(
+        LatLonOperations(area_weights),
+        target="norm",
+        include_bias=False,
+        include_grad_mag_percent_diff=False,
+        channel_mean_names=["a", "b", "c"],
+        report_variables=["a"],
+    )
+    sample_data = {
+        "a": torch.randn(2, 3, 4, 4, device=get_device()),
+        "b": torch.randn(2, 3, 4, 4, device=get_device()),
+        "c": torch.randn(2, 3, 4, 4, device=get_device()),
+    }
+    agg.record_batch(
+        target_data=sample_data,
+        gen_data=sample_data,
+        target_data_norm=sample_data,
+        gen_data_norm=sample_data,
+    )
+    logs = agg.get_logs(label="m")
+    assert "m/weighted_rmse/a" in logs
+    assert "m/weighted_rmse/b" not in logs
+    assert "m/weighted_rmse/c" not in logs
+    assert "m/weighted_rmse/channel_mean" in logs
+
+    ds = agg.get_dataset()
+    assert "weighted_rmse-a" in ds.data_vars
+    assert "weighted_rmse-b" not in ds.data_vars
+    assert "weighted_rmse-c" not in ds.data_vars
+    assert "weighted_rmse-channel_mean" in ds.data_vars
+
+
 def test_loss():
     """
     Basic test the aggregator combines loss correctly


### PR DESCRIPTION
`StepMeanMetricConfig` wrapped its aggregator with `VariableFilterAdapter`, which filtered variables out of `record_batch` input. This starved the inner `MeanAggregator` of variables needed for `channel_mean` computation, raising `KeyError` when `channel_mean_names` referenced variables not in the filtered subset (e.g. when inference `step_means` configs specify a `variables` list that is a subset of the loss variable names).

Replace input-level filtering with output-level filtering: add a `report_variables` parameter to `MeanAggregator` and `_EnsembleAggregator` that computes metrics over all variables but only includes the requested subset in `get_logs`/`get_dataset` output. Aggregate entries like `channel_mean` are always included.

Changes:
- `MeanAggregator`: add `report_variables` param, filter per-variable entries in `_get_data()`
- `_EnsembleAggregator`: same pattern
- `StepMeanMetricConfig.build()`: pass `variables` as `report_variables` instead of wrapping with `maybe_filter`
- Remove unused `maybe_filter` import from `reduced.py`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated