### PR TITLE
Enable affine_norms and normalize_big_skip in NoiseConditionedSFNO baselines

### DIFF
--- a/configs/baselines/amip-c96-shield/train-baseline.yaml
+++ b/configs/baselines/amip-c96-shield/train-baseline.yaml
@@ -103,6 +103,8 @@ stepper:
           separable: false
           spectral_layers: 3
           spectral_transform: sht
+          affine_norms: true
+          normalize_big_skip: true
       normalization:
         network:
           global_means_path: /statsdata/centering.nc

--- a/configs/baselines/climsst/train-baseline-4deg.yaml
+++ b/configs/baselines/climsst/train-baseline-4deg.yaml
@@ -111,6 +111,8 @@ stepper:
           separable: false
           spectral_layers: 3
           spectral_transform: sht
+          affine_norms: true
+          normalize_big_skip: true
       normalization:
         network:
           global_means_path: /statsdata/centering.nc

--- a/configs/baselines/climsst/train-baseline.yaml
+++ b/configs/baselines/climsst/train-baseline.yaml
@@ -110,6 +110,8 @@ stepper:
           separable: false
           spectral_layers: 3
           spectral_transform: sht
+          affine_norms: true
+          normalize_big_skip: true
       normalization:
         network:
           global_means_path: /statsdata/centering.nc

--- a/configs/baselines/era5/ace-train-config.yaml
+++ b/configs/baselines/era5/ace-train-config.yaml
@@ -104,6 +104,8 @@ stepper:
           separable: false
           spectral_layers: 3
           spectral_transform: sht
+          affine_norms: true
+          normalize_big_skip: true
       normalization:
         network:
           global_means_path: /statsdata/centering.nc


### PR DESCRIPTION
Update the baseline training configs that use `NoiseConditionedSFNO` to enable `affine_norms` and `normalize_big_skip`, which do not significantly affect behavior and make the models more directly comparable to labelled variants.

Changes:
- `configs/baselines/amip-c96-shield/train-baseline.yaml`, `configs/baselines/era5/ace-train-config.yaml`, `configs/baselines/climsst/train-baseline.yaml`, `configs/baselines/climsst/train-baseline-4deg.yaml`: set `affine_norms: true` and `normalize_big_skip: true` on the `NoiseConditionedSFNO` builder config.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated