### PR TITLE
Deduplicate validation callback

### DIFF
--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -322,20 +322,25 @@ def test_empty_validation_raises(tmp_path):
 
 
 class TestGetValidationCallback:
-    @staticmethod
-    def _make_entry(name, weight=1.0):
-        config = _make_validation_config(name=name, weight=weight)
-        data = MagicMock()
-        return (config, data, name)
+    """Smoke test for `get_validation_callback` wiring.
 
-    @staticmethod
-    def _call(entries, run_validation_side_effect):
+    Helper behavior (weighted loss, missing-metric raise, overlap raise, etc.)
+    is covered by `TestBuildValidationCallback` in
+    `fme.core.generics.test_trainer`. This test only verifies that entry name
+    and weight flow correctly from config through to the shared helper.
+    """
+
+    def test_entries_wired_to_tasks(self):
         from fme.ace.train.train import get_validation_callback
 
+        entries = [
+            (_make_validation_config(name="a", weight=2.0), MagicMock(), "a"),
+            (_make_validation_config(name="b", weight=3.0), MagicMock(), "b"),
+        ]
         stepper = MagicMock()
         with patch(
             "fme.core.generics.trainer.run_validation",
-            side_effect=run_validation_side_effect,
+            side_effect=[{"a/mean/loss": 0.1}, {"b/mean/loss": 0.2}],
         ):
             callback = get_validation_callback(
                 validation_entries=entries,
@@ -346,45 +351,7 @@ class TestGetValidationCallback:
                 save_per_epoch_diagnostics=False,
                 output_dir="/tmp/out",
             )
-            return callback(epoch=1)
-
-    def test_single_entry(self):
-        entries = [self._make_entry("val")]
-        logs, loss = self._call(
-            entries,
-            [{"val/mean/loss": 0.5, "val/other": 1.0}],
-        )
-        assert loss == 0.5
-        assert logs == {"val/mean/loss": 0.5, "val/other": 1.0}
-
-    def test_zero_weight_excluded_from_loss(self):
-        entries = [
-            self._make_entry("val_0", weight=1.0),
-            self._make_entry("val_extra", weight=0.0),
-        ]
-        logs, loss = self._call(
-            entries,
-            [
-                {"val_0/mean/loss": 0.5},
-                {"val_extra/mean/loss": 999.0},
-            ],
-        )
-        assert loss == 0.5
-        assert "val_0/mean/loss" in logs
-        assert "val_extra/mean/loss" in logs
-
-    def test_multiple_weighted_entries(self):
-        entries = [
-            self._make_entry("a", weight=2.0),
-            self._make_entry("b", weight=3.0),
-        ]
-        logs, loss = self._call(
-            entries,
-            [
-                {"a/mean/loss": 0.1},
-                {"b/mean/loss": 0.2},
-            ],
-        )
+            _, loss = callback(epoch=1)
         assert loss == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
 
 

--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -334,7 +334,7 @@ class TestGetValidationCallback:
 
         stepper = MagicMock()
         with patch(
-            "fme.ace.train.train.run_validation",
+            "fme.core.generics.trainer.run_validation",
             side_effect=run_validation_side_effect,
         ):
             callback = get_validation_callback(

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -83,9 +83,11 @@ from fme.core.generics.trainer import (
     TrainConfigProtocol,
     Trainer,
     ValidationCallback,
+    ValidationTask,
+    build_validation_callback,
     inference_one_epoch,
 )
-from fme.core.generics.validation import run_validation, run_validation_loop
+from fme.core.generics.validation import run_validation_loop
 
 
 def get_validation_callback(
@@ -97,46 +99,45 @@ def get_validation_callback(
     save_per_epoch_diagnostics: bool,
     output_dir: str,
 ) -> ValidationCallback:
-    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
-        all_logs: dict[str, Any] = {}
-        weighted_loss = 0.0
-        for entry_config, data, name in validation_entries:
-            data.set_epoch(epoch)
-            aggregator = entry_config.aggregator.build(
+    tasks: list[ValidationTask] = [
+        ValidationTask(
+            name=name,
+            data=data,
+            aggregator_factory=_make_ace_validation_aggregator_factory(
+                entry_config=entry_config,
+                name=name,
                 dataset_info=dataset_info,
                 loss_scaling=loss_scaling,
-                save_diagnostics=save_per_epoch_diagnostics,
-                output_dir=os.path.join(output_dir, name),
-                channel_mean_names=loss_names,
-            )
-            logs = run_validation(
-                train_stepper=stepper,
-                validation_data=data,
-                aggregator=aggregator,
-                label=name,
-                diagnostics_subdir=f"epoch_{epoch:04d}",
-                record_logs=lambda logs: None,
-            )
-            overlap = all_logs.keys() & logs.keys()
-            if overlap:
-                raise RuntimeError(
-                    f"Validation entry {name!r} produced log keys that "
-                    f"overlap with earlier entries: {sorted(overlap)}"
-                )
-            all_logs.update(logs)
-            if entry_config.weight > 0:
-                metric_key = f"{name}/mean/loss"
-                loss = logs.get(metric_key)
-                if loss is None:
-                    raise RuntimeError(
-                        f"Validation entry {name!r} with "
-                        f"weight={entry_config.weight} did not produce "
-                        f"expected metric key {metric_key!r}."
-                    )
-                weighted_loss += entry_config.weight * loss
-        return all_logs, weighted_loss
+                loss_names=loss_names,
+                save_per_epoch_diagnostics=save_per_epoch_diagnostics,
+                output_dir=output_dir,
+            ),
+            weight=entry_config.weight,
+        )
+        for entry_config, data, name in validation_entries
+    ]
+    return build_validation_callback(tasks=tasks, stepper=stepper)
 
-    return validation_callback
+
+def _make_ace_validation_aggregator_factory(
+    entry_config: InlineValidationConfig,
+    name: str,
+    dataset_info: DatasetInfo,
+    loss_scaling: dict[str, torch.Tensor] | None,
+    loss_names: Sequence[str] | None,
+    save_per_epoch_diagnostics: bool,
+    output_dir: str,
+):
+    def factory():
+        return entry_config.aggregator.build(
+            dataset_info=dataset_info,
+            loss_scaling=loss_scaling,
+            save_diagnostics=save_per_epoch_diagnostics,
+            output_dir=os.path.join(output_dir, name),
+            channel_mean_names=loss_names,
+        )
+
+    return factory
 
 
 def get_validate_stepper_callback(

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -27,6 +27,8 @@ from fme.core.generics.trainer import (
     Trainer,
     TrainOutputABC,
     TrainStepperABC,
+    ValidationTask,
+    build_validation_callback,
     count_parameters,
     epoch_checkpoint_enabled,
     inference_one_epoch,
@@ -1598,3 +1600,118 @@ def test_finetune_ema_checkpoint_loads_ema_state(tmp_path: str):
 
     # decay is from stage2 config, not the checkpoint
     assert float(stage2_ema_state["decay"]) == pytest.approx(stage2_decay)
+
+
+class TestBuildValidationCallback:
+    """Unit tests for the generic ``build_validation_callback`` helper.
+
+    These cover behavior shared between ACE and coupled training. ACE/coupled
+    test suites only verify the trainer-specific wiring (factory closures,
+    config passthrough) on top of this.
+    """
+
+    @staticmethod
+    def _make_task(name, weight=1.0, aggregator=None):
+        data = unittest.mock.MagicMock()
+        if aggregator is None:
+            aggregator = unittest.mock.MagicMock()
+        return ValidationTask(
+            name=name,
+            data=data,
+            aggregator_factory=lambda: aggregator,
+            weight=weight,
+        )
+
+    @staticmethod
+    def _call(tasks, run_validation_side_effect, epoch=1):
+        stepper = unittest.mock.MagicMock()
+        with unittest.mock.patch(
+            "fme.core.generics.trainer.run_validation",
+            side_effect=run_validation_side_effect,
+        ):
+            callback = build_validation_callback(tasks=tasks, stepper=stepper)
+            return callback(epoch=epoch)
+
+    def test_single_entry_weighted_loss(self):
+        tasks = [self._make_task("val", weight=2.0)]
+        logs, loss = self._call(tasks, [{"val/mean/loss": 0.5, "val/other": 1.0}])
+        assert loss == pytest.approx(2.0 * 0.5)
+        assert logs == {"val/mean/loss": 0.5, "val/other": 1.0}
+
+    def test_zero_weight_excluded_from_loss_but_logs_kept(self):
+        tasks = [
+            self._make_task("a", weight=1.0),
+            self._make_task("b", weight=0.0),
+        ]
+        logs, loss = self._call(
+            tasks,
+            [
+                {"a/mean/loss": 0.5},
+                {"b/mean/loss": 999.0},
+            ],
+        )
+        assert loss == pytest.approx(0.5)
+        assert "a/mean/loss" in logs
+        assert "b/mean/loss" in logs
+
+    def test_multiple_weighted_entries_sum_weighted(self):
+        tasks = [
+            self._make_task("a", weight=2.0),
+            self._make_task("b", weight=3.0),
+        ]
+        _, loss = self._call(
+            tasks,
+            [{"a/mean/loss": 0.1}, {"b/mean/loss": 0.2}],
+        )
+        assert loss == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
+
+    def test_missing_metric_for_weighted_entry_raises(self):
+        tasks = [self._make_task("a", weight=1.0)]
+        with pytest.raises(RuntimeError, match="did not produce expected metric key"):
+            self._call(tasks, [{"a/other_metric": 1.0}])
+
+    def test_missing_metric_for_zero_weight_entry_is_skipped(self):
+        tasks = [self._make_task("a", weight=0.0)]
+        logs, loss = self._call(tasks, [{"a/other_metric": 1.0}])
+        assert loss == 0.0
+        assert "a/other_metric" in logs
+
+    def test_overlapping_log_keys_between_entries_raises(self):
+        tasks = [
+            self._make_task("a", weight=1.0),
+            self._make_task("b", weight=1.0),
+        ]
+        with pytest.raises(RuntimeError, match="overlap with earlier entries"):
+            self._call(
+                tasks,
+                [
+                    {"shared/key": 0.1, "a/mean/loss": 0.5},
+                    {"shared/key": 0.2, "b/mean/loss": 0.6},
+                ],
+            )
+
+    def test_set_epoch_called_on_each_data(self):
+        tasks = [self._make_task("a"), self._make_task("b")]
+        self._call(
+            tasks,
+            [{"a/mean/loss": 0.1}, {"b/mean/loss": 0.2}],
+            epoch=7,
+        )
+        for task in tasks:
+            task.data.set_epoch.assert_called_once_with(7)
+
+    def test_aggregator_factory_called_per_invocation(self):
+        factory = unittest.mock.MagicMock(return_value=unittest.mock.MagicMock())
+        data = unittest.mock.MagicMock()
+        task: ValidationTask = ValidationTask(
+            name="a", data=data, aggregator_factory=factory, weight=1.0
+        )
+        stepper = unittest.mock.MagicMock()
+        with unittest.mock.patch(
+            "fme.core.generics.trainer.run_validation",
+            side_effect=[{"a/mean/loss": 0.1}, {"a/mean/loss": 0.2}],
+        ):
+            callback = build_validation_callback(tasks=[task], stepper=stepper)
+            callback(epoch=1)
+            callback(epoch=2)
+        assert factory.call_count == 2

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -50,6 +50,7 @@
 
 import abc
 import contextlib
+import dataclasses
 import gc
 import logging
 import os
@@ -57,7 +58,7 @@ import signal
 import sys
 import time
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, ClassVar, Generic, Protocol, TypeVar
 
 import torch
@@ -76,6 +77,7 @@ from fme.core.generics.lr_tuning import (
 )
 from fme.core.generics.metrics_aggregator import MetricsAggregator
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
+from fme.core.generics.validation import run_validation
 from fme.core.optimization import NullOptimization, Optimization
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingJob
@@ -768,6 +770,67 @@ class Trainer:
             )
             logging.info(f"Saving epoch checkpoint to {epoch_checkpoint_path}")
             self.save_checkpoint(epoch_checkpoint_path, include_optimization=True)
+
+
+@dataclasses.dataclass
+class ValidationTask(Generic[BD, TO]):
+    """One per-epoch validation run, packaged for ``build_validation_callback``.
+
+    Attributes:
+        name: Used as the log key prefix and output subdirectory.
+        data: Validation dataset; ``set_epoch`` is called on it each epoch.
+        aggregator_factory: Builds the aggregator. Called once per epoch,
+            preserving the existing per-epoch construction semantics.
+        weight: Contribution weight for the combined validation loss. Zero means
+            the task runs but does not contribute to the metric.
+    """
+
+    name: str
+    data: GriddedDataABC[BD]
+    aggregator_factory: Callable[[], AggregatorABC[TO]]
+    weight: float = 0.0
+
+
+def build_validation_callback(
+    tasks: Sequence[ValidationTask[BD, TO]],
+    stepper: TrainStepperABC[PS, BD, FD, SD, TO],
+) -> ValidationCallback:
+    """Build a ``ValidationCallback`` shared between ACE and coupled training."""
+
+    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
+        all_logs: dict[str, Any] = {}
+        weighted_loss = 0.0
+        for task in tasks:
+            task.data.set_epoch(epoch)
+            aggregator = task.aggregator_factory()
+            logs = run_validation(
+                train_stepper=stepper,
+                validation_data=task.data,
+                aggregator=aggregator,
+                label=task.name,
+                diagnostics_subdir=f"epoch_{epoch:04d}",
+                record_logs=lambda logs: None,
+            )
+            overlap = all_logs.keys() & logs.keys()
+            if overlap:
+                raise RuntimeError(
+                    f"Validation entry {task.name!r} produced log keys that "
+                    f"overlap with earlier entries: {sorted(overlap)}"
+                )
+            all_logs.update(logs)
+            if task.weight > 0:
+                metric_key = f"{task.name}/mean/loss"
+                loss = logs.get(metric_key)
+                if loss is None:
+                    raise RuntimeError(
+                        f"Validation entry {task.name!r} with "
+                        f"weight={task.weight} did not produce "
+                        f"expected metric key {metric_key!r}."
+                    )
+                weighted_loss += task.weight * loss
+        return all_logs, weighted_loss
+
+    return validation_callback
 
 
 def inference_one_epoch(

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -371,20 +371,25 @@ def test_duplicate_validation_names_raises(tmp_path):
 
 
 class TestGetValidationCallback:
-    @staticmethod
-    def _make_entry(name, weight=1.0):
-        config = _make_validation_config(name=name, weight=weight)
-        data = MagicMock()
-        return (config, data, name)
+    """Smoke test for `get_validation_callback` wiring.
 
-    @staticmethod
-    def _call(entries, run_validation_side_effect):
+    Helper behavior (weighted loss, missing-metric raise, overlap raise, etc.)
+    is covered by `TestBuildValidationCallback` in
+    `fme.core.generics.test_trainer`. This test only verifies that entry name
+    and weight flow correctly from config through to the shared helper.
+    """
+
+    def test_entries_wired_to_tasks(self):
         from fme.coupled.train.train import get_validation_callback
 
+        entries = [
+            (_make_validation_config(name="a", weight=2.0), MagicMock(), "a"),
+            (_make_validation_config(name="b", weight=3.0), MagicMock(), "b"),
+        ]
         stepper = MagicMock()
         with patch(
             "fme.core.generics.trainer.run_validation",
-            side_effect=run_validation_side_effect,
+            side_effect=[{"a/mean/loss": 0.1}, {"b/mean/loss": 0.2}],
         ):
             callback = get_validation_callback(
                 validation_entries=entries,
@@ -394,45 +399,7 @@ class TestGetValidationCallback:
                 save_per_epoch_diagnostics=False,
                 output_dir="/tmp/out",
             )
-            return callback(epoch=1)
-
-    def test_single_entry(self):
-        entries = [self._make_entry("val")]
-        logs, loss = self._call(
-            entries,
-            [{"val/mean/loss": 0.5, "val/other": 1.0}],
-        )
-        assert loss == 0.5
-        assert logs == {"val/mean/loss": 0.5, "val/other": 1.0}
-
-    def test_zero_weight_excluded_from_loss(self):
-        entries = [
-            self._make_entry("val_0", weight=1.0),
-            self._make_entry("val_extra", weight=0.0),
-        ]
-        logs, loss = self._call(
-            entries,
-            [
-                {"val_0/mean/loss": 0.5},
-                {"val_extra/mean/loss": 999.0},
-            ],
-        )
-        assert loss == 0.5
-        assert "val_0/mean/loss" in logs
-        assert "val_extra/mean/loss" in logs
-
-    def test_multiple_weighted_entries(self):
-        entries = [
-            self._make_entry("a", weight=2.0),
-            self._make_entry("b", weight=3.0),
-        ]
-        logs, loss = self._call(
-            entries,
-            [
-                {"a/mean/loss": 0.1},
-                {"b/mean/loss": 0.2},
-            ],
-        )
+            _, loss = callback(epoch=1)
         assert loss == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
 
 

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -383,7 +383,7 @@ class TestGetValidationCallback:
 
         stepper = MagicMock()
         with patch(
-            "fme.coupled.train.train.run_validation",
+            "fme.core.generics.trainer.run_validation",
             side_effect=run_validation_side_effect,
         ):
             callback = get_validation_callback(

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -20,9 +20,11 @@ from fme.core.generics.trainer import (
     AggregatorBuilderABC,
     InferenceCallback,
     Trainer,
+    ValidationTask,
+    build_validation_callback,
     inference_one_epoch,
 )
-from fme.core.generics.validation import run_validation, run_validation_loop
+from fme.core.generics.validation import run_validation_loop
 from fme.coupled.aggregator import OneStepAggregator, TrainAggregator
 from fme.coupled.data_loading.gridded_data import InferenceGriddedData
 from fme.coupled.dataset_info import CoupledDatasetInfo
@@ -44,45 +46,40 @@ def get_validation_callback(
     save_per_epoch_diagnostics: bool,
     output_dir: str,
 ):
-    def validation_callback(epoch: int) -> tuple[dict[str, Any], float]:
-        all_logs: dict[str, Any] = {}
-        weighted_loss = 0.0
-        for entry_config, data, name in validation_entries:
-            data.set_epoch(epoch)
-            aggregator = OneStepAggregator(
+    tasks: list[ValidationTask] = [
+        ValidationTask(
+            name=name,
+            data=data,
+            aggregator_factory=_make_coupled_validation_aggregator_factory(
+                name=name,
                 dataset_info=dataset_info,
-                save_diagnostics=save_per_epoch_diagnostics,
-                output_dir=os.path.join(output_dir, name),
                 loss_scaling=loss_scaling,
-            )
-            logs = run_validation(
-                train_stepper=stepper,
-                validation_data=data,
-                aggregator=aggregator,
-                label=name,
-                diagnostics_subdir=f"epoch_{epoch:04d}",
-                record_logs=lambda logs: None,
-            )
-            overlap = all_logs.keys() & logs.keys()
-            if overlap:
-                raise RuntimeError(
-                    f"Validation entry {name!r} produced log keys that "
-                    f"overlap with earlier entries: {sorted(overlap)}"
-                )
-            all_logs.update(logs)
-            if entry_config.weight > 0:
-                metric_key = f"{name}/mean/loss"
-                loss = logs.get(metric_key)
-                if loss is None:
-                    raise RuntimeError(
-                        f"Validation entry {name!r} with "
-                        f"weight={entry_config.weight} did not produce "
-                        f"expected metric key {metric_key!r}."
-                    )
-                weighted_loss += entry_config.weight * loss
-        return all_logs, weighted_loss
+                save_per_epoch_diagnostics=save_per_epoch_diagnostics,
+                output_dir=output_dir,
+            ),
+            weight=entry_config.weight,
+        )
+        for entry_config, data, name in validation_entries
+    ]
+    return build_validation_callback(tasks=tasks, stepper=stepper)
 
-    return validation_callback
+
+def _make_coupled_validation_aggregator_factory(
+    name: str,
+    dataset_info: CoupledDatasetInfo,
+    loss_scaling: CoupledTensorMapping,
+    save_per_epoch_diagnostics: bool,
+    output_dir: str,
+):
+    def factory():
+        return OneStepAggregator(
+            dataset_info=dataset_info,
+            save_diagnostics=save_per_epoch_diagnostics,
+            output_dir=os.path.join(output_dir, name),
+            loss_scaling=loss_scaling,
+        )
+
+    return factory
 
 
 def get_validate_stepper_callback(


### PR DESCRIPTION
The two `get_validation_callback` implementations in `fme.ace.train.train` and `fme.coupled.train.train` had drifted into near-identical copies of the same per-entry loop (set_epoch, build aggregator, run_validation, overlap-check, weighted-loss with raise-on-missing for `weight>0`). This PR extracts the shared logic into a generic `build_validation_callback` helper in `fme.core.generics.trainer` parameterized by a `ValidationTask` dataclass, so each trainer only owns the trainer-specific aggregator construction. Follows the same pattern as #1205's inference callback dedup; this is the sibling refactor flagged in that PR's pre-review.

No behavior change in `get_validation_callback`: both bodies were already identical modulo aggregator construction, including the raise-on-missing-metric path for `weight>0` entries — so this is a pure refactor (unlike #1205, which fixed a silent-failure path on the coupled side).

Changes:
- `fme.core.generics.trainer.ValidationTask`, `fme.core.generics.trainer.build_validation_callback`: new dataclass + helper that runs each task sequentially via `run_validation` and computes the weighted training-time validation loss
- `fme.ace.train.train.get_validation_callback`, `fme.coupled.train.train.get_validation_callback`: now build `ValidationTask` lists and delegate to the shared helper; per-trainer aggregator construction lives in new `_make_ace_validation_aggregator_factory` / `_make_coupled_validation_aggregator_factory` closures
- Tests: helper-behavior tests moved into `fme.core.generics.test_trainer.TestBuildValidationCallback` (8 tests, covering single/multi-weighted, zero-weight exclusion, set_epoch propagation, per-invocation factory calls, **plus two previously-untested behaviors**: missing-metric raise for `weight>0` and overlapping-log-keys raise). Each trainer-side `TestGetValidationCallback` is trimmed to one wiring smoke test that verifies config → task name/weight flow

- [x] Tests added (helper behavior covered in the generic location; two new behaviors covered for the first time)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated