### PR TITLE
Skip flaky derived-forcings train test on GPU

### DIFF
--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -1097,6 +1097,7 @@ def test_train_without_inline_inference(tmp_path, very_fast_only: bool):
     assert val_extra_output.exists()
 
 
+@pytest.mark.skipif(torch.cuda.is_available(), reason="flaky on GPU")
 @pytest.mark.parametrize(
     "insolation_config",
     [


### PR DESCRIPTION
`test_train_and_inference_with_derived_forcings` has been flaky when run on GPU, so skip it in that environment until the underlying flakiness can be investigated and fixed. The test still runs on CPU.

Changes:
- `fme/ace/test_train.py::test_train_and_inference_with_derived_forcings`: add `@pytest.mark.skipif(torch.cuda.is_available(), ...)` to skip on GPU

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)