### PR TITLE
Fix DenoisingMoEPredictor.generate_on_batch loss reduction

### DIFF
--- a/fme/downscaling/predictors/serial_denoising.py
+++ b/fme/downscaling/predictors/serial_denoising.py
@@ -272,7 +272,8 @@ class DenoisingMoEPredictor:
         )
         targets = {k: v.unsqueeze(1) for k, v in targets.items()}
 
-        loss = self._primary.loss(generated_norm, targets_norm)
+        [loss_component] = self._primary.loss(generated_norm, targets_norm)
+        loss = loss_component.loss.mean()
         return ModelOutputs(
             prediction=generated, target=targets, loss=loss, latent_steps=latent_steps
         )

--- a/fme/downscaling/predictors/test_serial_denoising.py
+++ b/fme/downscaling/predictors/test_serial_denoising.py
@@ -9,9 +9,15 @@ from fme.downscaling.data import StaticInputs
 from fme.downscaling.predictors.serial_denoising import (
     DenoisingExpertCheckpointConfig,
     DenoisingMoEConfig,
+    DenoisingMoEPredictor,
     _SigmaDispatchModule,
     _validate_experts_compatible,
     _validate_sigma_ranges,
+)
+from fme.downscaling.test_models import (
+    _get_diffusion_model,
+    make_fine_coords,
+    make_paired_batch_data,
 )
 
 
@@ -130,3 +136,40 @@ def test_validate_experts_compatible():
     )
     with pytest.raises(ValueError, match="metadata"):
         _validate_experts_compatible([e0, e1])
+
+
+def test_generate_on_batch_returns_scalar_loss():
+    """``DenoisingMoEPredictor.generate_on_batch`` must reduce the per-component
+    loss list returned by ``self._primary.loss(...)`` to a scalar tensor, the
+    same way ``DiffusionModel.generate_on_batch`` does.
+
+    Regression for the post-#1159 loss-architecture refactor: the loss module
+    now returns ``list[LossComponent]``; if the MoE predictor forgets to unpack
+    and ``.mean()`` it, ``ModelOutputs.loss`` is a list and downstream
+    consumers (``PatchPredictor`` accumulator, loss aggregator) explode with a
+    confusing ``TypeError`` or ``AttributeError`` deep in unrelated code.
+    """
+    coarse_shape = (8, 16)
+    fine_shape = (16, 32)
+    fine_coords = make_fine_coords(fine_shape)
+    experts = [
+        _get_diffusion_model(
+            coarse_shape=coarse_shape,
+            downscale_factor=2,
+            full_fine_coords=fine_coords,
+            predict_residual=False,
+            use_fine_topography=False,
+            static_inputs=StaticInputs(fields=[], coords=fine_coords),
+        )
+        for _ in range(2)
+    ]
+    predictor = DenoisingMoEPredictor(
+        experts=experts,
+        sigma_ranges=[(0.1, 0.5), (0.5, 1.0)],
+        num_diffusion_generation_steps=4,
+        churn=0.0,
+    )
+    batch = make_paired_batch_data(coarse_shape, fine_shape, batch_size=1)
+    outputs = predictor.generate_on_batch(batch, n_samples=1)
+    assert isinstance(outputs.loss, torch.Tensor)
+    assert outputs.loss.ndim == 0

--- a/fme/downscaling/predictors/test_serial_denoising.py
+++ b/fme/downscaling/predictors/test_serial_denoising.py
@@ -9,15 +9,9 @@ from fme.downscaling.data import StaticInputs
 from fme.downscaling.predictors.serial_denoising import (
     DenoisingExpertCheckpointConfig,
     DenoisingMoEConfig,
-    DenoisingMoEPredictor,
     _SigmaDispatchModule,
     _validate_experts_compatible,
     _validate_sigma_ranges,
-)
-from fme.downscaling.test_models import (
-    _get_diffusion_model,
-    make_fine_coords,
-    make_paired_batch_data,
 )
 
 
@@ -136,40 +130,3 @@ def test_validate_experts_compatible():
     )
     with pytest.raises(ValueError, match="metadata"):
         _validate_experts_compatible([e0, e1])
-
-
-def test_generate_on_batch_returns_scalar_loss():
-    """``DenoisingMoEPredictor.generate_on_batch`` must reduce the per-component
-    loss list returned by ``self._primary.loss(...)`` to a scalar tensor, the
-    same way ``DiffusionModel.generate_on_batch`` does.
-
-    Regression for the post-#1159 loss-architecture refactor: the loss module
-    now returns ``list[LossComponent]``; if the MoE predictor forgets to unpack
-    and ``.mean()`` it, ``ModelOutputs.loss`` is a list and downstream
-    consumers (``PatchPredictor`` accumulator, loss aggregator) explode with a
-    confusing ``TypeError`` or ``AttributeError`` deep in unrelated code.
-    """
-    coarse_shape = (8, 16)
-    fine_shape = (16, 32)
-    fine_coords = make_fine_coords(fine_shape)
-    experts = [
-        _get_diffusion_model(
-            coarse_shape=coarse_shape,
-            downscale_factor=2,
-            full_fine_coords=fine_coords,
-            predict_residual=False,
-            use_fine_topography=False,
-            static_inputs=StaticInputs(fields=[], coords=fine_coords),
-        )
-        for _ in range(2)
-    ]
-    predictor = DenoisingMoEPredictor(
-        experts=experts,
-        sigma_ranges=[(0.1, 0.5), (0.5, 1.0)],
-        num_diffusion_generation_steps=4,
-        churn=0.0,
-    )
-    batch = make_paired_batch_data(coarse_shape, fine_shape, batch_size=1)
-    outputs = predictor.generate_on_batch(batch, n_samples=1)
-    assert isinstance(outputs.loss, torch.Tensor)
-    assert outputs.loss.ndim == 0


### PR DESCRIPTION
PR #1159 changed self.loss to return `list[LossComponent]`. DiffusionModel.generate_on_batch was updated to unpack that list and call .mean(), but DenoisingMoEPredictor was not updated. Downstream calls of `generate_on_batch` from the MoE predictor would error.

