### PR TITLE
Fix zonal mean aggregator coarsening bug

### DIFF
--- a/fme/ace/aggregator/inference/test_zonal_mean.py
+++ b/fme/ace/aggregator/inference/test_zonal_mean.py
@@ -185,6 +185,54 @@ def test_zonal_mean_time_coarsening(n_time):
         )
 
 
+@pytest.mark.parametrize("n_ic_steps", [1, 2])
+def test_zonal_mean_time_coarsening_initial_condition_offset(n_ic_steps):
+    """During inference the initial condition advances the global timestep
+    counter by ``n_ic_steps`` before any window is recorded to this aggregator.
+    The first recorded window therefore starts at a global time index that is
+    not necessarily a multiple of the coarsening factor. This previously caused
+    a size mismatch between the destination slice and the coarsened source.
+    """
+    n_sample, ny, nx = 2, 10, 20
+    n_time_in_memory = 20
+    n_time = 8761  # -> coarsening factor of 3 with a max size of 4096
+
+    agg = ZonalMeanAggregator(
+        zonal_mean,
+        n_timesteps=n_time,
+        zonal_mean_max_size=2**12,
+    )
+    factor = agg.time_coarsening_factor
+    assert factor == 3
+
+    n_forward = n_time - n_ic_steps
+    for i_time in range(n_ic_steps, n_ic_steps + n_forward, n_time_in_memory):
+        steps = min(n_time_in_memory, n_ic_steps + n_forward - i_time)
+        # zonal mean of forward step k (0-indexed from the first recorded step)
+        # is set equal to k, constant in latitude.
+        forward_index = torch.arange(
+            start=i_time - n_ic_steps,
+            end=i_time - n_ic_steps + steps,
+            dtype=torch.float32,
+            device=get_device(),
+        )
+        arr = forward_index[None, :, None, None].expand(n_sample, steps, ny, nx)
+        agg.record_batch(_make_batch_data({"a": arr}, {"a": arr}, i_time_start=i_time))
+
+    # number of coarse columns actually filled by the recorded forward steps
+    n_filled = n_forward // factor
+    for data in (agg._target_data, agg._gen_data):
+        assert data is not None
+        assert data["a"].shape == (n_sample, n_time // factor, ny)
+        coarsened = (data["a"] / agg._n_batches)[0, :n_filled, 0]
+        # group g averages forward steps {factor*g, ..., factor*g + factor - 1}
+        expected = (
+            torch.arange(n_filled, dtype=torch.float32, device=get_device()) * factor
+            + (factor - 1) / 2
+        )
+        torch.testing.assert_close(coarsened, expected)
+
+
 @pytest.mark.parametrize("zonal_mean_max_size", [4, 2**14, 2**16])
 def test_zonal_mean_time_coarsening_override(zonal_mean_max_size):
     n_time = 2**16

--- a/fme/ace/aggregator/inference/zonal_mean.py
+++ b/fme/ace/aggregator/inference/zonal_mean.py
@@ -143,6 +143,12 @@ class ZonalMeanAggregator:
         self.logged_batch_skip = False
         self._buffer_target: TensorDict | None = None
         self._buffer_gen: TensorDict | None = None
+        # Global time index of the first recorded batch. Coarsening groups are
+        # aligned to this origin rather than to absolute index 0, since
+        # inference begins recording after the initial condition has advanced
+        # the global time counter by ``n_ic_steps``, which may not be a multiple
+        # of the coarsening factor.
+        self._i_time_offset: int | None = None
 
     def record_batch(
         self,
@@ -160,6 +166,15 @@ class ZonalMeanAggregator:
             self._gen_data = self._initialize_zeros_zonal_mean_from_batch(
                 gen_data, self._n_timesteps
             )
+
+        if self._i_time_offset is None:
+            self._i_time_offset = i_time_start
+        # Align coarsening groups to the first recorded timestep rather than to
+        # absolute index 0, so that a recording origin that is not a multiple of
+        # the coarsening factor (e.g. after ``n_ic_steps`` initial condition
+        # steps) does not misalign the destination slice from the coarsened
+        # source.
+        i_time_start = i_time_start - self._i_time_offset
 
         window_steps = next(iter(target_data.values())).shape[1]
 
@@ -191,43 +206,64 @@ class ZonalMeanAggregator:
             i_time_start + window_steps
         ) - self.last_step * self.time_coarsening_factor
 
-        buffer = {}
-        for name, tensor in target_data.items():
-            if name in self._target_data:
-                if self._buffer_target:
-                    tensor = torch.cat(
-                        [
-                            self._buffer_target[name],
-                            tensor[:, 0 : window_steps - buffer_size, :],
-                        ],
-                        dim=self._time_dim,
-                    )
-                self._target_data[name][:, time_slice, :] += self._coarsen_tensor(
-                    self._zonal_mean(tensor)
-                )
-                if buffer_size > 0:
-                    buffer[name] = tensor[:, -buffer_size:, :]
-        self._buffer_target = buffer
+        # number of (zonal-meaned) timesteps consumed into complete coarsening
+        # groups by this window, including any steps carried over in the buffer.
+        n_coarsened_steps = (
+            time_slice.stop - time_slice.start
+        ) * self.time_coarsening_factor
 
-        buffer = {}
-        for name, tensor in gen_data.items():
-            if name in self._gen_data:
-                if self._buffer_gen:
-                    tensor = torch.cat(
-                        [
-                            self._buffer_gen[name],
-                            tensor[:, 0 : window_steps - buffer_size, :],
-                        ],
-                        dim=self._time_dim,
-                    )
-                self._gen_data[name][:, time_slice, :] += self._coarsen_tensor(
-                    self._zonal_mean(tensor)
-                )
-                if buffer_size > 0:
-                    buffer[name] = tensor[:, -buffer_size:, :]
-        self._buffer_gen = buffer
+        self._buffer_target = self._accumulate(
+            self._target_data,
+            target_data,
+            self._buffer_target,
+            time_slice,
+            n_coarsened_steps,
+            buffer_size,
+        )
+        self._buffer_gen = self._accumulate(
+            self._gen_data,
+            gen_data,
+            self._buffer_gen,
+            time_slice,
+            n_coarsened_steps,
+            buffer_size,
+        )
 
         self._n_batches[:, time_slice, :] += 1
+
+    def _accumulate(
+        self,
+        accumulator: TensorDict,
+        data: TensorMapping,
+        buffer: TensorDict | None,
+        time_slice: slice,
+        n_coarsened_steps: int,
+        buffer_size: int,
+    ) -> TensorDict:
+        """Coarsen a window and accumulate it into ``accumulator``.
+
+        Any leftover timesteps from the previous window held in ``buffer`` are
+        prepended before coarsening. The leftover steps of the combined window
+        that do not fill a complete coarsening group are returned as the new
+        buffer. Coarsening is applied after the zonal mean; since the zonal mean
+        acts independently per timestep this is equivalent to coarsening the raw
+        field but avoids buffering the full longitudinal data.
+        """
+        new_buffer: TensorDict = {}
+        for name, tensor in data.items():
+            if name not in accumulator:
+                continue
+            zonal_mean = self._zonal_mean(tensor)
+            if buffer is not None and name in buffer:
+                zonal_mean = torch.cat([buffer[name], zonal_mean], dim=self._time_dim)
+            accumulator[name][:, time_slice, :] += self._coarsen_tensor(
+                zonal_mean.narrow(self._time_dim, 0, n_coarsened_steps)
+            )
+            if buffer_size > 0:
+                new_buffer[name] = zonal_mean.narrow(
+                    self._time_dim, n_coarsened_steps, buffer_size
+                )
+        return new_buffer
 
     def _get_data(self) -> dict[str, _RawData]:
         if self._gen_data is None or self._target_data is None:


### PR DESCRIPTION
The `ZonalMeanAggregator `crashed during inline inference whenever automatic time coarsening was active (i.e. when the number of inference timesteps exceeds zonal_mean_max_size). The coarsening groups were aligned to the absolute global time index, but inference begins recording after the initial condition has advanced the global counter by `n_ic_steps`, so the first window could start at an index that is not a multiple of the coarsening factor, leaving the destination slice and the coarsened source off by one. 

There is a second bug in the buffer-carryover logic: when leftover steps from the previous window were prepended, the new buffer was taken from the wrong slice, duplicating one timestep and dropping another at every window boundary (this went unnoticed because the existing test only checked the first coarse column). 

This PR fixes both issues by aligning coarsening to the first recorded timestep rather than absolute index 0, and by consolidating the target/generated accumulation into a single helper that coarsens the complete-group portion of the combined buffer+window and carries the true remainder forward. 

- [x] Tests added

Resolves #1216 and #860
