### PR TITLE
Add corrector regularization to training

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -109,7 +109,7 @@ from fme.core.dataset.utils import FillNaNsConfig
 from fme.core.dataset.xarray import OverwriteConfig, XarrayDataConfig
 from fme.core.generics.lr_tuning import LRTuningConfig
 from fme.core.gridded_ops import GriddedOperations
-from fme.core.loss import StepLossConfig
+from fme.core.loss import CorrectorRegularizationConfig, LossConfig, StepLossConfig
 from fme.core.normalizer import NormalizationConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
 from fme.core.optimization import CheckpointConfig

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -24,7 +24,7 @@ from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.single_module import step_with_adjustments
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.step.step import StepABC, StepConfigABC, StepResult, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 DEFAULT_TIMESTEP = datetime.timedelta(hours=6)
@@ -439,7 +439,7 @@ class FCN3Step(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         """
         Step the model forward one timestep given input data.
 
@@ -448,7 +448,8 @@ class FCN3Step(StepABC):
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            The denormalized output data at the next time step.
+            A :class:`StepResult` carrying the denormalized output data at
+            the next time step.
         """
         if args.labels is not None:
             raise ValueError("Labels are not supported for FCN3")

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1741,14 +1741,19 @@ class TrainStepper(
                     )
                     metrics[f"corrector_regularization_step_{step}"] = reg_loss.detach()
             if optimize_step:
-                optimization.accumulate_loss(step_total_loss)
                 if reg_loss is not None:
-                    optimization.accumulate_loss(reg_loss)
+                    # Combine before accumulate: step_total_loss and reg_loss
+                    # share the same forward graph. With gradient accumulation,
+                    # accumulate_loss backward()s immediately, so two separate
+                    # calls would backward the freed graph twice.
+                    optimization.accumulate_loss(step_total_loss + reg_loss)
                     if reg_loss_sum is None:
                         reg_loss_sum = reg_loss.detach()
                     else:
                         reg_loss_sum = reg_loss_sum + reg_loss.detach()
                     reg_loss_count += 1
+                else:
+                    optimization.accumulate_loss(step_total_loss)
         if reg_loss_sum is not None and reg_loss_count > 0:
             metrics["corrector_regularization"] = reg_loss_sum / reg_loss_count
         return output_list, _finalize_per_channel_losses(weighted_sums, total_counts)

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -57,7 +57,7 @@ from fme.core.step.multi_call import (
     replace_multi_call,
 )
 from fme.core.step.single_module import SingleModuleStepConfig
-from fme.core.step.step import StepABC, StepSelector
+from fme.core.step.step import StepABC, StepResult, StepSelector
 from fme.core.tensors import (
     add_ensemble_dim,
     fold_ensemble_dim,
@@ -1023,7 +1023,7 @@ class Stepper:
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         """
         Step the model forward one timestep given input data.
 
@@ -1032,11 +1032,12 @@ class Stepper:
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            The denormalized output data at the next time step.
+            A :class:`StepResult` carrying the denormalized output data at
+            the next time step.
         """
         args = args.apply_input_process_func(self._input_process_func)
-        output = self._step_obj.step(args=args, wrapper=wrapper)
-        return self._output_process_func(output)
+        step_result = self._step_obj.step(args=args, wrapper=wrapper)
+        return StepResult(output=self._output_process_func(step_result.output))
 
     def get_prediction_generator(
         self,
@@ -1044,7 +1045,7 @@ class Stepper:
         forcing_data: BatchData,
         n_forward_steps: int,
         optimizer: OptimizationABC,
-    ) -> Generator[TensorDict, None, None]:
+    ) -> Generator[StepResult, None, None]:
         """
         Predict multiple steps forward given initial condition and forcing data.
 
@@ -1094,7 +1095,7 @@ class Stepper:
         optimizer: OptimizationABC,
         labels: BatchLabels | None,
         data_mask: TensorMapping | None = None,
-    ) -> Generator[TensorDict, None, None]:
+    ) -> Generator[StepResult, None, None]:
         state = {k: ic_dict[k].squeeze(self.TIME_DIM) for k in ic_dict}
         for step in range(n_forward_steps):
             input_forcing = {
@@ -1115,7 +1116,7 @@ class Stepper:
                 return optimizer.checkpoint(module, step=step)
 
             with optimizer.autocast():
-                state = self.step(
+                step_result = self.step(
                     StepArgs(
                         input=input_data,
                         next_step_input_data=next_step_input_dict,
@@ -1124,8 +1125,8 @@ class Stepper:
                     ),
                     wrapper=checkpoint,
                 )
-            yield state
-            state = optimizer.detach_if_using_gradient_accumulation(state)
+            yield step_result
+            state = optimizer.detach_if_using_gradient_accumulation(step_result.output)
 
     def predict(
         self,
@@ -1177,14 +1178,15 @@ class Stepper:
                     f"{ic_batch_data.n_timesteps}."
                 )
             n_forward_steps = forcing_data.n_timesteps - self.n_ic_timesteps
-            output_list = list(
-                self.get_prediction_generator(
+            output_list = [
+                step_result.output
+                for step_result in self.get_prediction_generator(
                     initial_condition,
                     forcing_data,
                     n_forward_steps,
                     NullOptimization(),
                 )
-            )
+            ]
         data = process_prediction_generator_list(
             output_list,
             time=forcing_data.time[:, self.n_ic_timesteps :],
@@ -1656,8 +1658,10 @@ class TrainStepper(
                 contextlib.nullcontext() if optimize_step else torch.no_grad()
             )
             with grad_context:
-                gen_step = next(output_iterator)
-                gen_step = unfold_ensemble_dim(gen_step, n_ensemble=n_ensemble)
+                step_result = next(output_iterator)
+                gen_step = unfold_ensemble_dim(
+                    step_result.output, n_ensemble=n_ensemble
+                )
                 output_list.append(gen_step)
                 target_step = add_ensemble_dim(
                     {

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -39,7 +39,13 @@ from fme.core.generics.inference import PredictFunction
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
 from fme.core.labels import BatchLabels
-from fme.core.loss import ChannelLossInfo, StepLoss, StepLossConfig
+from fme.core.loss import (
+    ChannelLossInfo,
+    CorrectorRegularizationConfig,
+    StepLoss,
+    StepLossConfig,
+    WeightedMappingLoss,
+)
 from fme.core.normalizer import (
     NetworkAndLossNormalizationConfig,
     NormalizationConfig,
@@ -868,6 +874,22 @@ class Stepper:
             normalizer=loss_normalizer,
         )
 
+    def build_corrector_regularization_loss(
+        self, config: CorrectorRegularizationConfig
+    ) -> WeightedMappingLoss:
+        """Build a loss for penalizing corrector adjustments.
+
+        The returned loss compares per-variable corrections against a zero
+        baseline in the loss-normalized space.
+        """
+        loss_normalizer = self._step_obj.get_loss_normalizer()
+        return config.build(
+            gridded_ops=self._dataset_info.gridded_operations,
+            out_names=self.loss_names,
+            normalizer=loss_normalizer,
+            channel_dim=self.CHANNEL_DIM,
+        )
+
     @property
     def config(self) -> StepperConfig:
         return self._config
@@ -1033,11 +1055,15 @@ class Stepper:
 
         Returns:
             A :class:`StepResult` carrying the denormalized output data at
-            the next time step.
+            the next time step and, when a corrector is applied, the
+            per-variable corrections in physical space.
         """
         args = args.apply_input_process_func(self._input_process_func)
         step_result = self._step_obj.step(args=args, wrapper=wrapper)
-        return StepResult(output=self._output_process_func(step_result.output))
+        return StepResult(
+            output=self._output_process_func(step_result.output),
+            corrections=step_result.corrections,
+        )
 
     def get_prediction_generator(
         self,
@@ -1410,6 +1436,11 @@ class TrainStepperConfig:
             be less than or equal to the number of timesteps present
             in the training dataset samples.
         parameter_init: The parameter initialization configuration for fine-tuning.
+        corrector_regularization: Optional configuration for penalizing the
+            magnitude of corrector adjustments. When set, the configured loss
+            is applied between the per-variable corrector corrections
+            (post-corrector minus pre-corrector) and a zero baseline in the
+            loss-normalized space, and added to the training loss.
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
@@ -1419,6 +1450,7 @@ class TrainStepperConfig:
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=lambda: ParameterInitializationConfig()
     )
+    corrector_regularization: CorrectorRegularizationConfig | None = None
 
     def __post_init__(self):
         if self.n_ensemble == -1:
@@ -1542,6 +1574,15 @@ class TrainStepper(
         self._prognostic_names = self._stepper.prognostic_names
         self._derive_func = self._stepper.derive_func
         self._loss_obj = self._stepper.build_loss(config.loss)
+        self._corrector_reg_loss: WeightedMappingLoss | None = None
+        self._corrector_reg_weight: float = 0.0
+        if config.corrector_regularization is not None:
+            self._corrector_reg_loss = (
+                self._stepper.build_corrector_regularization_loss(
+                    config.corrector_regularization
+                )
+            )
+            self._corrector_reg_weight = config.corrector_regularization.weight
 
     def train_on_batch(
         self,
@@ -1649,6 +1690,8 @@ class TrainStepper(
         output_iterator = iter(output_generator)
         weighted_sums: dict[str, torch.Tensor] = {}
         total_counts: dict[str, int] = {}
+        reg_loss_sum: torch.Tensor | None = None
+        reg_loss_count: int = 0
         for step in range(n_forward_steps):
             if self._config.optimize_last_step_only:
                 optimize_step = step == n_loss_steps - 1
@@ -1679,8 +1722,35 @@ class TrainStepper(
                     weighted_sums=weighted_sums,
                     total_counts=total_counts,
                 )
+                reg_loss: torch.Tensor | None = None
+                if (
+                    self._corrector_reg_loss is not None
+                    and step_result.corrections is not None
+                ):
+                    corrections = unfold_ensemble_dim(
+                        step_result.corrections, n_ensemble=n_ensemble
+                    )
+                    zeros = {k: torch.zeros_like(v) for k, v in corrections.items()}
+                    reg_loss = (
+                        self._corrector_reg_weight
+                        * self._corrector_reg_loss(
+                            corrections,
+                            zeros,
+                            data_mask=input_batch_data.data_mask,
+                        ).total()
+                    )
+                    metrics[f"corrector_regularization_step_{step}"] = reg_loss.detach()
             if optimize_step:
                 optimization.accumulate_loss(step_total_loss)
+                if reg_loss is not None:
+                    optimization.accumulate_loss(reg_loss)
+                    if reg_loss_sum is None:
+                        reg_loss_sum = reg_loss.detach()
+                    else:
+                        reg_loss_sum = reg_loss_sum + reg_loss.detach()
+                    reg_loss_count += 1
+        if reg_loss_sum is not None and reg_loss_count > 0:
+            metrics["corrector_regularization"] = reg_loss_sum / reg_loss_count
         return output_list, _finalize_per_channel_losses(weighted_sums, total_counts)
 
     def _accumulate_step_loss(

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -65,7 +65,7 @@ from fme.core.coordinates import (
 from fme.core.dataset_info import DatasetInfo, MissingDatasetInfo
 from fme.core.device import get_device
 from fme.core.generics.optimization import OptimizationABC
-from fme.core.loss import StepLossConfig
+from fme.core.loss import CorrectorRegularizationConfig, LossConfig, StepLossConfig
 from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
 from fme.core.ocean import OceanConfig
 from fme.core.optimization import (
@@ -2526,3 +2526,101 @@ def test_predict_with_data_mask_zeros_masked_forcing():
     output, _ = stepper.predict(input_data, forcing_data)
     ic_a = input_data.as_batch_data().data["a"][:, 0]
     torch.testing.assert_close(output.data["a"][:, 0], ic_a)
+
+
+def test_train_on_batch_no_corrector_regularization_metric_when_unconfigured():
+    """When corrector_regularization is None, the metric is not recorded."""
+    torch.manual_seed(0)
+    n_steps = 2
+    data_with_ic = get_data(["a", "b"], n_samples=3, n_time=n_steps + 1).data
+    config = _get_stepper_config(["a", "b"], ["a", "b"])
+    stepper = _get_train_stepper(config, loss=StepLossConfig(type="MSE"))
+    stepped = stepper.train_on_batch(data=data_with_ic, optimization=NullOptimization())
+    assert "corrector_regularization" not in stepped.metrics
+    for step in range(n_steps):
+        assert f"corrector_regularization_step_{step}" not in stepped.metrics
+
+
+def test_train_on_batch_corrector_regularization_metric_when_configured():
+    """When corrector_regularization is set, per-step and aggregate metrics appear.
+
+    The default corrector is a no-op, so the regularization value is exactly 0.
+    """
+    torch.manual_seed(0)
+    n_steps = 2
+    data_with_ic = get_data(["a", "b"], n_samples=3, n_time=n_steps + 1).data
+    config = _get_stepper_config(["a", "b"], ["a", "b"])
+    reg = CorrectorRegularizationConfig(loss=LossConfig(type="MSE"), weight=1.0)
+    stepper = _get_train_stepper(
+        config,
+        loss=StepLossConfig(type="MSE"),
+        corrector_regularization=reg,
+    )
+    stepped = stepper.train_on_batch(data=data_with_ic, optimization=NullOptimization())
+    assert "corrector_regularization" in stepped.metrics
+    for step in range(n_steps):
+        assert f"corrector_regularization_step_{step}" in stepped.metrics
+        # default AtmosphereCorrector with no flags is a no-op: corrections = 0
+        torch.testing.assert_close(
+            stepped.metrics[f"corrector_regularization_step_{step}"],
+            torch.tensor(0.0, device=DEVICE),
+        )
+
+
+def test_train_on_batch_corrector_regularization_active_with_force_positive():
+    """A corrector that clips negatives produces non-zero regularization.
+
+    Uses ``Multiply(-1)`` so the network produces negative outputs from
+    non-negative inputs, and ``force_positive_names=["a"]`` clips them to 0.
+    The resulting corrections are non-zero, so the regularization loss is
+    strictly positive.
+    """
+    torch.manual_seed(0)
+    n_steps = 1
+    data_with_ic = get_data(["a"], n_samples=3, n_time=n_steps + 1).data
+    corrector_config = AtmosphereCorrectorConfig(force_positive_names=["a"])
+    config = _get_stepper_config(
+        ["a"], ["a"], module_name="AddOne", corrector=corrector_config
+    )
+    # AddOne would keep things positive — swap in Multiply(-1) by overriding
+    # the module config below
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": Multiply(-1.0)}
+                    ),
+                    in_names=["a"],
+                    out_names=["a"],
+                    normalization=NetworkAndLossNormalizationConfig(
+                        network=NormalizationConfig(means={"a": 0.0}, stds={"a": 1.0}),
+                    ),
+                    corrector=corrector_config,
+                )
+            ),
+        ),
+    )
+    reg = CorrectorRegularizationConfig(loss=LossConfig(type="MSE"), weight=2.0)
+    stepper = _get_train_stepper(
+        config,
+        loss=StepLossConfig(type="MSE"),
+        corrector_regularization=reg,
+    )
+    stepped = stepper.train_on_batch(data=data_with_ic, optimization=NullOptimization())
+    assert "corrector_regularization" in stepped.metrics
+    reg_value = stepped.metrics["corrector_regularization"].item()
+    assert reg_value > 0.0
+
+
+def test_corrector_regularization_config_rejects_invalid_loss_types():
+    """EnsembleLoss/NaN and global_mean_type are not valid for gen-vs-gen."""
+    with pytest.raises(ValueError, match="EnsembleLoss"):
+        CorrectorRegularizationConfig(loss=LossConfig(type="EnsembleLoss"))
+    with pytest.raises(ValueError, match="NaN"):
+        CorrectorRegularizationConfig(loss=LossConfig(type="NaN"))
+    with pytest.raises(ValueError, match="global_mean_type"):
+        CorrectorRegularizationConfig(
+            loss=LossConfig(type="MSE", global_mean_type="LpLoss")
+        )

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -1143,7 +1143,7 @@ def test_step():
 
     output = stepper.step(
         StepArgs(input=input_data, next_step_input_data={}, labels=None)
-    )
+    ).output
 
     torch.testing.assert_close(output["a"], input_data["a"] + 1)
     torch.testing.assert_close(output["b"], input_data["b"] + 1)
@@ -1155,7 +1155,7 @@ def test_step_with_diagnostic():
     input_data = {"a": torch.rand(n_samples, 5, 5).to(DEVICE)}
     output = stepper.step(
         StepArgs(input=input_data, next_step_input_data={}, labels=None)
-    )
+    ).output
     torch.testing.assert_close(output["a"], input_data["a"])
     torch.testing.assert_close(output["c"], input_data["a"])
 
@@ -1173,7 +1173,7 @@ def test_step_with_forcing_and_diagnostic(residual_prediction):
     input_data = {x: torch.rand(n_samples, 5, 5).to(DEVICE) for x in ["a", "b"]}
     output = stepper.step(
         StepArgs(input=input_data, next_step_input_data={}, labels=None)
-    )
+    ).output
     if residual_prediction:
         expected_a_output = 2 * input_data["a"] + 1 - norm_mean
     else:
@@ -1191,7 +1191,7 @@ def test_step_with_prescribed_ocean():
     ocean_data = {x: torch.rand(3, 5, 5).to(DEVICE) for x in ["a", "mask"]}
     output = stepper.step(
         StepArgs(input=input_data, next_step_input_data=ocean_data, labels=None)
-    )
+    ).output
     expected_a_output = torch.where(
         torch.round(ocean_data["mask"]).to(int) == 1,
         ocean_data["a"],

--- a/fme/core/distributed/parallel_tests/test_step.py
+++ b/fme/core/distributed/parallel_tests/test_step.py
@@ -461,7 +461,7 @@ def test_step_regression(
             input=input_data, next_step_input_data=next_step_input_data, labels=labels
         ),
         wrapper=lambda x: x,
-    )
+    ).output
 
     # Gather local outputs back to global for comparison
     output = dist.gather_spatial(output, img_shape)

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -736,6 +736,56 @@ class LossConfig:
         return final_loss.to(device=get_device())
 
 
+@dataclasses.dataclass
+class CorrectorRegularizationConfig:
+    """Configuration for penalizing the magnitude of corrector adjustments.
+
+    The configured loss is applied between the per-variable corrector
+    corrections (post-corrector minus pre-corrector outputs) and a zero
+    baseline, in the loss-normalized space. This produces an L1- or
+    L2-style penalty on the size of the corrector's adjustments.
+
+    Args:
+        loss: The loss function configuration. Comparisons are gen-vs-gen,
+            so ``EnsembleLoss``/``NaN`` are not supported and
+            ``global_mean_type`` must be ``None``.
+        weight: Scalar multiplier applied to the regularization term.
+    """
+
+    loss: LossConfig
+    weight: float = 1.0
+
+    def __post_init__(self):
+        if self.loss.type in ("EnsembleLoss", "NaN"):
+            raise ValueError(
+                f"CorrectorRegularizationConfig does not support loss type "
+                f"{self.loss.type!r}; corrections are compared against a "
+                "zero baseline, so only standard pointwise losses make sense."
+            )
+        if self.loss.global_mean_type is not None:
+            raise ValueError(
+                "CorrectorRegularizationConfig does not support "
+                "global_mean_type; corrections are compared against a zero "
+                "baseline, so a global-mean component is ill-defined."
+            )
+
+    def build(
+        self,
+        gridded_ops: GriddedOperations | None,
+        out_names: list[str],
+        normalizer: StandardNormalizer,
+        channel_dim: int = -3,
+    ) -> "WeightedMappingLoss":
+        bare_loss = self.loss.build(gridded_operations=gridded_ops)
+        return WeightedMappingLoss(
+            loss=bare_loss,
+            weights={},
+            out_names=out_names,
+            channel_dim=channel_dim,
+            normalizer=normalizer,
+        )
+
+
 class StepLoss(torch.nn.Module):
     def __init__(
         self, loss: WeightedMappingLoss, sqrt_loss_decay_constant: float = 0.0

--- a/fme/core/step/__init__.py
+++ b/fme/core/step/__init__.py
@@ -2,4 +2,4 @@ from .multi_call import MultiCallStep, MultiCallStepConfig
 from .radiation import SeparateRadiationStep, SeparateRadiationStepConfig
 from .secondary_module import SecondaryModuleStep, SecondaryModuleStepConfig
 from .single_module import SingleModuleStep, SingleModuleStepConfig
-from .step import StepABC, StepConfigABC, StepSelector
+from .step import StepABC, StepConfigABC, StepResult, StepSelector

--- a/fme/core/step/_multi_call.py
+++ b/fme/core/step/_multi_call.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from torch import nn
 
 from fme.core.step.args import StepArgs
+from fme.core.step.step import StepResult
 from fme.core.typing_ import TensorDict, TensorMapping
 
 LEVEL_PATTERN = re.compile(r"_(\d+)$")
@@ -13,7 +14,7 @@ TEMPLATE = "{name}{suffix}"
 
 StepMethod = Callable[
     [StepArgs, Callable[[nn.Module], nn.Module]],
-    TensorDict,
+    StepResult,
 ]
 
 
@@ -175,7 +176,7 @@ class MultiCall:
         for suffix, multiplier in self.forcing_multipliers.items():
             scale_forcing_func = self._get_scale_forcing_func(multiplier)
             scaled_args = args.apply_input_process_func(scale_forcing_func)
-            output = self._step(scaled_args, wrapper)
+            output = self._step(scaled_args, wrapper).output
 
             for name in self.output_names:
                 new_name = get_multi_call_name(name, suffix)

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -300,7 +300,7 @@ class MultiCallStep(StepABC):
         if self._multi_call is not None:
             multi_called_outputs = self._multi_call.step(args=args, wrapper=wrapper)
             output = {**multi_called_outputs, **step_result.output}
-            return StepResult(output=output)
+            return StepResult(output=output, corrections=step_result.corrections)
         return step_result
 
     def get_state(self) -> dict[str, Any]:

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -11,7 +11,7 @@ from fme.core.normalizer import StandardNormalizer
 from fme.core.ocean import OceanConfig
 from fme.core.step._multi_call import MultiCall, MultiCallConfig, StepMethod
 from fme.core.step.args import StepArgs
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.step.step import StepABC, StepConfigABC, StepResult, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -292,15 +292,16 @@ class MultiCallStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[torch.nn.Module], torch.nn.Module] = lambda x: x,
-    ) -> TensorDict:
-        state = self._wrapped_step.step(
+    ) -> StepResult:
+        step_result = self._wrapped_step.step(
             args=args,
             wrapper=wrapper,
         )
         if self._multi_call is not None:
             multi_called_outputs = self._multi_call.step(args=args, wrapper=wrapper)
-            state = {**multi_called_outputs, **state}
-        return state
+            output = {**multi_called_outputs, **step_result.output}
+            return StepResult(output=output)
+        return step_result
 
     def get_state(self) -> dict[str, Any]:
         """

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -20,7 +20,7 @@ from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.single_module import step_with_adjustments
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.step.step import StepABC, StepConfigABC, StepResult, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -344,7 +344,7 @@ class SeparateRadiationStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         """
         Step the model forward one timestep given input data.
 
@@ -353,7 +353,8 @@ class SeparateRadiationStep(StepABC):
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            The denormalized output data at the next time step.
+            A :class:`StepResult` carrying the denormalized output data at
+            the next time step.
         """
 
         def network_calls(input_norm: TensorDict) -> TensorDict:

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -25,7 +25,7 @@ from fme.core.step.secondary_decoder import (
     SecondaryDecoderConfig,
 )
 from fme.core.step.single_module import step_with_adjustments
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.step.step import StepABC, StepConfigABC, StepResult, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -382,7 +382,7 @@ class SecondaryModuleStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         """
         Step the model forward one timestep given input data.
 
@@ -391,7 +391,8 @@ class SecondaryModuleStep(StepABC):
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            The denormalized output data at the next time step.
+            A :class:`StepResult` carrying the denormalized output data at
+            the next time step.
         """
 
         def network_call(input_norm: TensorDict) -> TensorDict:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -543,7 +543,8 @@ def step_with_adjustments(
 
     Returns:
         A :class:`StepResult` carrying the denormalized output data at the
-        next time step.
+        next time step and, when a corrector is applied, the per-variable
+        corrections (post-corrector minus pre-corrector, in physical space).
     """
     if prescribed_prognostic_names is None:
         prescribed_prognostic_names = []
@@ -560,8 +561,11 @@ def step_with_adjustments(
     output = normalizer.denormalize(output_norm)
     if global_mean_removal is not None:
         output = global_mean_removal.inverse_transform(output)
+    corrections: TensorDict | None = None
     if corrector is not None:
+        pre_corrector_output = output
         output = corrector(input, output, next_step_input_data)
+        corrections = {k: output[k] - pre_corrector_output[k] for k in output}
     if ocean is not None:
         output = ocean(input, output, next_step_input_data)
     for name in prescribed_prognostic_names:
@@ -571,4 +575,4 @@ def step_with_adjustments(
             raise ValueError(
                 f"prescribed_prognostic_name '{name}' not in next_step_input_data"
             )
-    return StepResult(output=output)
+    return StepResult(output=output, corrections=corrections)

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -31,7 +31,7 @@ from fme.core.step.secondary_decoder import (
     SecondaryDecoder,
     SecondaryDecoderConfig,
 )
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.step.step import StepABC, StepConfigABC, StepResult, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 DEFAULT_TIMESTEP = datetime.timedelta(hours=6)
@@ -370,7 +370,7 @@ class SingleModuleStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         """
         Step the model forward one timestep given input data.
 
@@ -379,7 +379,8 @@ class SingleModuleStep(StepABC):
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            The denormalized output data at the next time step.
+            A :class:`StepResult` carrying the denormalized output data at
+            the next time step.
         """
 
         def network_call(input_norm: TensorDict) -> TensorDict:
@@ -510,7 +511,7 @@ def step_with_adjustments(
     prescribed_prognostic_names: list[str] | None = None,
     global_mean_removal: GlobalMeanRemoval | None = None,
     data_mask: TensorMapping | None = None,
-) -> TensorDict:
+) -> StepResult:
     """
     Step the model forward one timestep given input data.
 
@@ -541,7 +542,8 @@ def step_with_adjustments(
             ``global_mean_removal.forward_transform``.
 
     Returns:
-        The denormalized output data at the next time step.
+        A :class:`StepResult` carrying the denormalized output data at the
+        next time step.
     """
     if prescribed_prognostic_names is None:
         prescribed_prognostic_names = []
@@ -569,4 +571,4 @@ def step_with_adjustments(
             raise ValueError(
                 f"prescribed_prognostic_name '{name}' not in next_step_input_data"
             )
-    return output
+    return StepResult(output=output)

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -15,6 +15,13 @@ from fme.core.step.args import StepArgs
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
+@dataclasses.dataclass
+class StepResult:
+    """Return value of :meth:`StepABC.step`."""
+
+    output: TensorDict
+
+
 # Children still need to decorate with @dataclass, otherwise
 # they will be a dataclass with no dataclass fields.
 @dataclasses.dataclass
@@ -333,7 +340,7 @@ class StepABC(abc.ABC):
         self: SelfType,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         """
         Step the model forward one timestep given input data.
 
@@ -342,7 +349,8 @@ class StepABC(abc.ABC):
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            The denormalized output data at the next time step.
+            A :class:`StepResult` carrying the denormalized output at the
+            next time step.
         """
         pass
 

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -17,9 +17,15 @@ from fme.core.typing_ import TensorDict, TensorMapping
 
 @dataclasses.dataclass
 class StepResult:
-    """Return value of :meth:`StepABC.step`."""
+    """Return value of :meth:`StepABC.step`.
+
+    ``corrections`` is the difference between the post-corrector and
+    pre-corrector outputs, per variable, in physical (denormalized) space.
+    It is ``None`` when no corrector is applied.
+    """
 
     output: TensorDict
+    corrections: TensorDict | None = None
 
 
 # Children still need to decorate with @dataclass, otherwise

--- a/fme/core/step/test__multi_call.py
+++ b/fme/core/step/test__multi_call.py
@@ -19,7 +19,7 @@ from fme.core.registry.module import ModuleSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.multi_call import MultiCallStepConfig
 from fme.core.step.single_module import SingleModuleStepConfig
-from fme.core.step.step import StepSelector
+from fme.core.step.step import StepResult, StepSelector
 from fme.core.timing import GlobalTimer
 
 from ._multi_call import MultiCallConfig, get_multi_call_name
@@ -32,7 +32,11 @@ TEST_CONFIG = MultiCallConfig(
 
 
 def _step(args: StepArgs, wrapper: Callable[[nn.Module], nn.Module] = lambda x: x):
-    return {k: args.input["CO2"].detach().clone() for k in TEST_CONFIG.output_names}
+    return StepResult(
+        output={
+            k: args.input["CO2"].detach().clone() for k in TEST_CONFIG.output_names
+        },
+    )
 
 
 def test_multi_call_names():

--- a/fme/core/step/test_multi_call.py
+++ b/fme/core/step/test_multi_call.py
@@ -14,7 +14,7 @@ from .multi_call import (
     _extend_normalizer_with_multi_call_outputs,
     replace_multi_call,
 )
-from .step import StepSelector
+from .step import StepResult, StepSelector
 from .test_step_registry import MockStep, MockStepConfig
 
 
@@ -25,7 +25,7 @@ def test_multi_call(include_multi_call_in_loss: bool):
 
     def _step(args: StepArgs, wrapper=lambda x: x):
         prediction = {k: args.input["CO2"].detach().clone() for k in output_names}
-        return prediction
+        return StepResult(output=prediction)
 
     config = MultiCallStepConfig(
         wrapped_step=StepSelector(
@@ -60,7 +60,7 @@ def test_multi_call(include_multi_call_in_loss: bool):
                 labels=None,
             ),
             wrapper=lambda x: x,
-        )
+        ).output
     torch.testing.assert_close(out["b"], input["CO2"])
     torch.testing.assert_close(out["c"], input["CO2"])
     torch.testing.assert_close(out["c_doubled_co2"], input["CO2"] * 2)

--- a/fme/core/step/test_radiation.py
+++ b/fme/core/step/test_radiation.py
@@ -134,7 +134,7 @@ def test_detach_radiation(detach_radiation: bool):
     output_data = step.step(
         args=StepArgs(input=input_data, next_step_input_data=input_data, labels=None),
         wrapper=lambda x: x,
-    )
+    ).output
     for name, value in output_data.items():
         assert value.requires_grad, f"{name} should require grad"
     grad = torch.autograd.grad(
@@ -147,7 +147,7 @@ def test_detach_radiation(detach_radiation: bool):
     output_data = step.step(
         args=StepArgs(input=input_data, next_step_input_data=input_data, labels=None),
         wrapper=lambda x: x,
-    )
+    ).output
     grad = torch.autograd.grad(
         outputs=output_data["diagnostic_main"].sum(),
         inputs=input_data["forcing_rad"],
@@ -180,7 +180,7 @@ def test_residual_prediction(residual_prediction: bool):
             labels=None,
         ),
         wrapper=lambda x: x,
-    )
+    ).output
 
     for name in MAIN_PROGNOSTIC_NAMES:
         if residual_prediction:

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -539,7 +539,7 @@ def test_label_conditioned_step():
             ),
         ),
         wrapper=lambda x: x,
-    )
+    ).output
     h_sl, w_sl = dist.get_local_slices(DEFAULT_IMG_SHAPE)
     local_h = DEFAULT_IMG_SHAPE[0] if h_sl == slice(None) else h_sl.stop - h_sl.start
     local_w = DEFAULT_IMG_SHAPE[1] if w_sl == slice(None) else w_sl.stop - w_sl.start
@@ -753,7 +753,7 @@ def test_step_with_prescribed_prognostic_overwrites_output():
             labels=None,
         ),
         wrapper=lambda x: x,
-    )
+    ).output
     torch.testing.assert_close(output["diagnostic_main"], prescribed_value)
 
 
@@ -910,7 +910,7 @@ def test_secondary_module_full_field_and_residual():
         args=StepArgs(
             input=input_data, next_step_input_data=next_step_input_data, labels=None
         ),
-    )
+    ).output
     assert "prog" in output
     assert "diag" in output
     assert output["prog"].shape == (2, *img_shape)
@@ -961,8 +961,8 @@ def test_secondary_module_state_round_trip():
     args = StepArgs(
         input=input_data, next_step_input_data=next_step_input_data, labels=None
     )
-    out1 = step1.step(args=args)
-    out2 = step2.step(args=args)
+    out1 = step1.step(args=args).output
+    out2 = step2.step(args=args).output
     for name in out1:
         torch.testing.assert_close(out1[name], out2[name])
 
@@ -1007,7 +1007,7 @@ def test_secondary_module_residual_on_input_only_with_residual_prediction():
         args=StepArgs(
             input=input_data, next_step_input_data=next_step_input_data, labels=None
         ),
-    )
+    ).output
     assert output["prog_a"].shape == (2, *img_shape)
     assert output["prog_b"].shape == (2, *img_shape)
 
@@ -1085,7 +1085,7 @@ def test_step_with_data_mask():
             labels=None,
             data_mask=None,
         ),
-    )
+    ).output
     output_with_mask = step.step(
         args=StepArgs(
             input=input_data,
@@ -1093,7 +1093,7 @@ def test_step_with_data_mask():
             labels=None,
             data_mask=data_mask,
         ),
-    )
+    ).output
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_with_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_with_mask[name][:2], output_no_mask[name][:2])
@@ -1179,7 +1179,7 @@ def test_step_with_include_channel_mask_inputs():
             labels=None,
             data_mask=None,
         ),
-    )
+    ).output
     output_with_mask = step.step(
         args=StepArgs(
             input=input_data,
@@ -1187,7 +1187,7 @@ def test_step_with_include_channel_mask_inputs():
             labels=None,
             data_mask=data_mask,
         ),
-    )
+    ).output
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_with_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_with_mask[name][:2], output_no_mask[name][:2])
@@ -1231,7 +1231,7 @@ def test_step_with_include_channel_mask_inputs_no_data_mask():
             labels=None,
             data_mask=None,
         ),
-    )
+    ).output
     all_unmasked = {
         name: torch.ones(n_samples, dtype=torch.bool, device=fme.get_device())
         for name in step.input_names
@@ -1243,7 +1243,7 @@ def test_step_with_include_channel_mask_inputs_no_data_mask():
             labels=None,
             data_mask=all_unmasked,
         ),
-    )
+    ).output
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_no_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_no_mask[name], output_all_unmasked[name])
@@ -1305,7 +1305,7 @@ def test_step_shared_global_mean_removal():
     )
     output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in out_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1330,7 +1330,7 @@ def test_step_shared_global_mean_removal_with_extra_channels():
     )
     output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in out_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1345,7 +1345,7 @@ def test_step_per_channel_global_mean_removal():
     )
     output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in step.output_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1365,7 +1365,7 @@ def test_step_per_channel_global_mean_removal_with_extra_channels():
     )
     output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in step.output_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1392,10 +1392,10 @@ def _assert_global_mean_removal_affects_output(removal, in_names, out_names, mea
     )
     baseline_output = step_baseline.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     removal_output = step_with_removal.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     differs = any(
         not torch.allclose(baseline_output[name], removal_output[name])
         for name in out_names

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -17,11 +17,16 @@ from fme.ace.step.fcn3 import FCN3Config, FCN3Selector, FCN3StepConfig
 from fme.ace.testing.fv3gfs_data import get_scalar_dataset
 from fme.core.coordinates import HybridSigmaPressureCoordinate, LatLonCoordinates
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig, EnergyBudgetConfig
+from fme.core.corrector.registry import CorrectorABC
 from fme.core.dataset_info import DatasetInfo
 from fme.core.distributed.distributed import Distributed
 from fme.core.distributed.non_distributed import DummyWrapper
 from fme.core.labels import BatchLabels
-from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
+from fme.core.normalizer import (
+    NetworkAndLossNormalizationConfig,
+    NormalizationConfig,
+    StandardNormalizer,
+)
 from fme.core.registry import ModuleSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.global_mean_removal import (
@@ -35,9 +40,10 @@ from fme.core.step.single_module import (
     SingleModuleStepConfig,
     _apply_input_mask,
     _build_channel_mask_dict,
+    step_with_adjustments,
 )
-from fme.core.step.step import StepABC, StepSelector
-from fme.core.typing_ import TensorDict
+from fme.core.step.step import StepABC, StepResult, StepSelector
+from fme.core.typing_ import TensorDict, TensorMapping
 
 from .radiation import SeparateRadiationStepConfig
 
@@ -1471,3 +1477,80 @@ def test_step_shared_global_mean_removal_raises_on_masked_reference():
                 data_mask=data_mask,
             ),
         )
+
+
+class _AddConstantCorrector(CorrectorABC):
+    """Test-only corrector that adds a fixed per-variable constant to each output."""
+
+    def __init__(self, shifts: TensorDict):
+        self._shifts = shifts
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+    ) -> TensorDict:
+        return {k: v + self._shifts[k] for k, v in gen_data.items()}
+
+
+def _identity_network_call(input_norm: TensorDict) -> TensorDict:
+    return {k: v.clone() for k, v in input_norm.items()}
+
+
+def _build_standard_normalizer(
+    names: list[str], mean: float = 0.0, std: float = 1.0
+) -> StandardNormalizer:
+    device = fme.get_device()
+    return StandardNormalizer(
+        means={k: torch.tensor(mean, device=device) for k in names},
+        stds={k: torch.tensor(std, device=device) for k in names},
+    )
+
+
+def test_step_with_adjustments_no_corrector_has_no_corrections():
+    names = ["a", "b"]
+    n_samples = 2
+    input_data = {
+        k: torch.rand(n_samples, 4, 4, device=fme.get_device()) for k in names
+    }
+    result = step_with_adjustments(
+        input=input_data,
+        next_step_input_data={},
+        network_calls=_identity_network_call,
+        normalizer=_build_standard_normalizer(names),
+        corrector=None,
+        ocean=None,
+        residual_prediction=False,
+        prognostic_names=names,
+    )
+    assert isinstance(result, StepResult)
+    assert result.corrections is None
+    for k in names:
+        torch.testing.assert_close(result.output[k], input_data[k])
+
+
+def test_step_with_adjustments_corrections_equal_post_minus_pre():
+    names = ["a", "b"]
+    n_samples = 2
+    device = fme.get_device()
+    input_data = {k: torch.rand(n_samples, 4, 4, device=device) for k in names}
+    shifts = {
+        "a": torch.full((n_samples, 4, 4), 0.25, device=device),
+        "b": torch.full((n_samples, 4, 4), -0.5, device=device),
+    }
+    corrector = _AddConstantCorrector(shifts)
+    result = step_with_adjustments(
+        input=input_data,
+        next_step_input_data={},
+        network_calls=_identity_network_call,
+        normalizer=_build_standard_normalizer(names),
+        corrector=corrector,
+        ocean=None,
+        residual_prediction=False,
+        prognostic_names=names,
+    )
+    assert result.corrections is not None
+    for k in names:
+        torch.testing.assert_close(result.output[k], input_data[k] + shifts[k])
+        torch.testing.assert_close(result.corrections[k], shifts[k])

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -12,7 +12,7 @@ from fme.core.ocean import OceanConfig
 from fme.core.step.args import StepArgs
 from fme.core.typing_ import TensorDict, TensorMapping
 
-from .step import StepABC, StepConfigABC, StepSelector
+from .step import StepABC, StepConfigABC, StepResult, StepSelector
 
 
 class MockStep(StepABC):
@@ -61,7 +61,7 @@ class MockStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> TensorDict:
+    ) -> StepResult:
         raise NotImplementedError()
 
     def get_state(self):

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -1083,7 +1083,7 @@ class CoupledStepper:
             # predict and yield atmosphere steps
             for i_inner in range(self.n_inner_steps):
                 atmos_step_num = i_outer * self.n_inner_steps + i_inner
-                atmos_step = next(atmos_generator)
+                atmos_step = next(atmos_generator).output
                 yield ComponentStepPrediction(
                     realm="atmosphere",
                     data=atmos_step,
@@ -1123,7 +1123,7 @@ class CoupledStepper:
                         optimizer=optimizer,
                     )
                 )
-            )
+            ).output
             yield ComponentStepPrediction(
                 realm="ocean",
                 data=ocean_step,

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -40,7 +40,12 @@ from fme.core.dataset_info import DatasetInfo
 from fme.core.generics.inference import PredictFunction
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
-from fme.core.loss import StepLoss, StepLossConfig
+from fme.core.loss import (
+    CorrectorRegularizationConfig,
+    StepLoss,
+    StepLossConfig,
+    WeightedMappingLoss,
+)
 from fme.core.ocean import OceanConfig
 from fme.core.ocean_data import OceanData
 from fme.core.optimization import NullOptimization
@@ -743,10 +748,12 @@ class ComponentStepPrediction:
         realm: Literal["ocean", "atmosphere"],
         data: TensorDict,
         step: int,
+        corrections: TensorDict | None = None,
     ):
         self._realm: Literal["ocean", "atmosphere"] = realm
         self._data = data
         self._step = step
+        self._corrections = corrections
 
     @property
     def realm(self) -> Literal["ocean", "atmosphere"]:
@@ -759,6 +766,10 @@ class ComponentStepPrediction:
     @property
     def step(self) -> int:
         return self._step
+
+    @property
+    def corrections(self) -> TensorDict | None:
+        return self._corrections
 
 
 class CoupledStepper:
@@ -1083,11 +1094,13 @@ class CoupledStepper:
             # predict and yield atmosphere steps
             for i_inner in range(self.n_inner_steps):
                 atmos_step_num = i_outer * self.n_inner_steps + i_inner
-                atmos_step = next(atmos_generator).output
+                atmos_step_result = next(atmos_generator)
+                atmos_step = atmos_step_result.output
                 yield ComponentStepPrediction(
                     realm="atmosphere",
                     data=atmos_step,
                     step=atmos_step_num,
+                    corrections=atmos_step_result.corrections,
                 )
                 atmos_step = optimizer.detach_if_using_gradient_accumulation(atmos_step)
                 atmos_steps.append(atmos_step)
@@ -1114,7 +1127,7 @@ class CoupledStepper:
                 labels=ocean_window.labels,
             )
             # predict and yield a single ocean step
-            ocean_step = next(
+            ocean_step_result = next(
                 iter(
                     self.ocean.get_prediction_generator(
                         ocean_ic_state,
@@ -1123,11 +1136,13 @@ class CoupledStepper:
                         optimizer=optimizer,
                     )
                 )
-            ).output
+            )
+            ocean_step = ocean_step_result.output
             yield ComponentStepPrediction(
                 realm="ocean",
                 data=ocean_step,
                 step=i_outer,
+                corrections=ocean_step_result.corrections,
             )
 
             # prepare ic states for next coupled step
@@ -1303,10 +1318,12 @@ class ComponentEnsembleStepPrediction:
         realm: Literal["ocean", "atmosphere"],
         data: EnsembleTensorDict,
         step: int,
+        corrections: EnsembleTensorDict | None = None,
     ):
         self._realm: Literal["ocean", "atmosphere"] = realm
         self._data = data
         self._step = step
+        self._corrections = corrections
 
     @property
     def realm(self) -> Literal["ocean", "atmosphere"]:
@@ -1319,6 +1336,10 @@ class ComponentEnsembleStepPrediction:
     @property
     def step(self) -> int:
         return self._step
+
+    @property
+    def corrections(self) -> EnsembleTensorDict | None:
+        return self._corrections
 
     def detach_if_using_gradient_accumulation(
         self, optimizer: OptimizationABC
@@ -1333,6 +1354,7 @@ class ComponentEnsembleStepPrediction:
                 optimizer.detach_if_using_gradient_accumulation(self.data)
             ),
             step=self.step,
+            corrections=self._corrections,
         )
 
     def detach(self) -> "ComponentEnsembleStepPrediction":
@@ -1344,6 +1366,13 @@ class ComponentEnsembleStepPrediction:
             realm=self.realm,
             data=EnsembleTensorDict({k: v.detach() for k, v in self.data.items()}),
             step=self.step,
+            corrections=(
+                EnsembleTensorDict(
+                    {k: v.detach() for k, v in self._corrections.items()}
+                )
+                if self._corrections is not None
+                else None
+            ),
         )
 
 
@@ -1378,6 +1407,10 @@ class CoupledStepperTrainLoss:
         atmosphere_loss: StepLoss,
         ocean_schedule: ComponentLossSchedule,
         atmosphere_schedule: ComponentLossSchedule,
+        ocean_corrector_reg_loss: WeightedMappingLoss | None = None,
+        atmosphere_corrector_reg_loss: WeightedMappingLoss | None = None,
+        ocean_corrector_reg_weight: float = 0.0,
+        atmosphere_corrector_reg_weight: float = 0.0,
     ):
         self._loss_objs: dict[str, StepLoss] = {
             "ocean": ocean_loss,
@@ -1390,6 +1423,14 @@ class CoupledStepperTrainLoss:
         self._weights = {
             "ocean": ocean_schedule.loss_weight,
             "atmosphere": atmosphere_schedule.loss_weight,
+        }
+        self._corrector_reg_losses: dict[str, WeightedMappingLoss | None] = {
+            "ocean": ocean_corrector_reg_loss,
+            "atmosphere": atmosphere_corrector_reg_loss,
+        }
+        self._corrector_reg_weights = {
+            "ocean": ocean_corrector_reg_weight,
+            "atmosphere": atmosphere_corrector_reg_weight,
         }
 
     @property
@@ -1463,6 +1504,26 @@ class CoupledStepperTrainLoss:
         )
         return self._weights[realm] * loss_output.total()
 
+    def compute_corrector_regularization(
+        self,
+        prediction: ComponentEnsembleStepPrediction,
+    ) -> torch.Tensor | None:
+        """Compute the corrector regularization loss for one component step.
+
+        Returns ``None`` when this realm has no regularization configured,
+        the prediction has no corrections, or the step is not within the
+        realm's optimization window.
+        """
+        realm = prediction.realm
+        reg_loss = self._corrector_reg_losses[realm]
+        if reg_loss is None or prediction.corrections is None:
+            return None
+        if not self._schedules[realm].step_is_optimized(prediction.step):
+            return None
+        corrections = prediction.corrections
+        zeros = {k: torch.zeros_like(v) for k, v in corrections.items()}
+        return self._corrector_reg_weights[realm] * reg_loss(corrections, zeros).total()
+
 
 @dataclasses.dataclass
 class ComponentTrainingConfig:
@@ -1481,6 +1542,8 @@ class ComponentTrainingConfig:
             contributes to the loss and has gradients enabled).
         loss_weight: Weight applied to the loss for this component.
         parameter_init: Component-level parameter initialization.
+        corrector_regularization: Optional configuration for penalizing the
+            magnitude of this component's corrector adjustments.
     """
 
     loss: StepLossConfig
@@ -1490,6 +1553,7 @@ class ComponentTrainingConfig:
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=lambda: ParameterInitializationConfig()
     )
+    corrector_regularization: CorrectorRegularizationConfig | None = None
 
     @property
     def n_steps_max(self) -> int | None:
@@ -1648,11 +1712,33 @@ class CoupledTrainStepperConfig:
             loss_weight=self.atmosphere.loss_weight,
             n_steps_limit=n_steps_limit_atmos,
         )
+        ocean_corrector_reg_loss: WeightedMappingLoss | None = None
+        ocean_corrector_reg_weight = 0.0
+        if self.ocean.corrector_regularization is not None:
+            ocean_corrector_reg_loss = (
+                stepper.ocean.build_corrector_regularization_loss(
+                    self.ocean.corrector_regularization
+                )
+            )
+            ocean_corrector_reg_weight = self.ocean.corrector_regularization.weight
+        atmos_corrector_reg_loss: WeightedMappingLoss | None = None
+        atmos_corrector_reg_weight = 0.0
+        if self.atmosphere.corrector_regularization is not None:
+            atmos_corrector_reg_loss = (
+                stepper.atmosphere.build_corrector_regularization_loss(
+                    self.atmosphere.corrector_regularization
+                )
+            )
+            atmos_corrector_reg_weight = self.atmosphere.corrector_regularization.weight
         return CoupledStepperTrainLoss(
             ocean_loss=ocean_step_loss,
             atmosphere_loss=atmos_step_loss,
             ocean_schedule=ocean_schedule,
             atmosphere_schedule=atmos_schedule,
+            ocean_corrector_reg_loss=ocean_corrector_reg_loss,
+            atmosphere_corrector_reg_loss=atmos_corrector_reg_loss,
+            ocean_corrector_reg_weight=ocean_corrector_reg_weight,
+            atmosphere_corrector_reg_weight=atmos_corrector_reg_weight,
         )
 
     def get_train_stepper(
@@ -1804,10 +1890,14 @@ class CoupledTrainStepper(
         target_step = {
             k: v.select(time_dim, gen_step.step) for k, v in forward_data.items()
         }
+        ensemble_corrections: EnsembleTensorDict | None = None
+        if gen_step.corrections is not None:
+            ensemble_corrections = unfold_ensemble_dim(gen_step.corrections, n_ensemble)
         ensemble_step = ComponentEnsembleStepPrediction(
             realm=gen_step.realm,
             data=unfold_ensemble_dim(gen_step.data, n_ensemble),
             step=gen_step.step,
+            corrections=ensemble_corrections,
         )
         target_step_ensemble = add_ensemble_dim(target_step)
         if evaluate_all_steps:
@@ -1822,6 +1912,12 @@ class CoupledTrainStepper(
                 label = f"loss/{gen_step.realm}_step_{gen_step.step}"
                 metrics.add_metric(label, step_loss.detach(), gen_step.realm)
                 optimization.accumulate_loss(step_loss)
+        reg_loss = self._loss.compute_corrector_regularization(ensemble_step)
+        if reg_loss is not None:
+            realm = gen_step.realm
+            label = f"loss/{realm}_corrector_regularization_step_{gen_step.step}"
+            metrics.add_metric(label, reg_loss.detach(), realm)
+            optimization.accumulate_loss(reg_loss)
         output_list.append(
             ensemble_step.detach_if_using_gradient_accumulation(
                 optimization

--- a/fme/coupled/test_stepper_integrations.py
+++ b/fme/coupled/test_stepper_integrations.py
@@ -6,7 +6,7 @@ import torch
 
 from fme.ace.stepper.parameter_init import ParameterInitializationConfig
 from fme.core.coordinates import NullVerticalCoordinate
-from fme.core.loss import StepLossConfig
+from fme.core.loss import CorrectorRegularizationConfig, LossConfig, StepLossConfig
 from fme.core.optimization import NullOptimization, OptimizationConfig
 from fme.core.registry.module import ModuleSelector
 
@@ -558,3 +558,50 @@ def test_outer_steps_clamped_to_one_when_both_realms_sample_zero():
         assert tensor.shape[2] == 2  # [sample, ensemble, time, ...]
     for tensor in result.atmosphere.gen_data.values():
         assert tensor.shape[2] == 3
+
+
+def test_coupled_corrector_regularization_per_realm():
+    """corrector_regularization fires only for the configured realm.
+
+    Configures corrector_regularization on atmosphere only and verifies that
+    the metric is emitted for atmosphere steps but not ocean steps. The
+    default correctors are no-ops, so the regularization value is exactly
+    zero — this test pins down the wiring, not the magnitude.
+    """
+    train_stepper_config = CoupledTrainStepperConfig(
+        n_coupled_steps=2,
+        ocean=ComponentTrainingConfig(loss=StepLossConfig(type="MSE")),
+        atmosphere=ComponentTrainingConfig(
+            loss=StepLossConfig(type="MSE"),
+            corrector_regularization=CorrectorRegularizationConfig(
+                loss=LossConfig(type="MSE"), weight=1.0
+            ),
+        ),
+    )
+    train_stepper, coupled_data, _, _ = get_train_stepper_and_batch(
+        train_stepper_config=train_stepper_config,
+        ocean_in_names=["sst", "mask_0"],
+        ocean_out_names=["sst"],
+        atmosphere_in_names=["surface_temperature", "ocean_fraction"],
+        atmosphere_out_names=["surface_temperature"],
+        n_forward_times_ocean=2,
+        n_forward_times_atmosphere=4,
+        n_samples=1,
+    )
+    result = train_stepper.train_on_batch(
+        data=coupled_data.data,
+        optimization=NullOptimization(),
+    )
+    # atmosphere has 4 inner steps (n_coupled_steps=2 * inner=2)
+    for i in range(4):
+        key = f"loss/atmosphere_corrector_regularization_step_{i}"
+        assert key in result.atmosphere.metrics
+        # default AtmosphereCorrector with no flags is a no-op
+        torch.testing.assert_close(
+            result.atmosphere.metrics[key],
+            torch.tensor(0.0, device=result.atmosphere.metrics[key].device),
+        )
+    # Ocean realm has no regularization configured.
+    for i in range(2):
+        key = f"loss/ocean_corrector_regularization_step_{i}"
+        assert key not in result.ocean.metrics


### PR DESCRIPTION
Add an optional training-time penalty on the magnitude of corrector adjustments, enabling L1/L2 regularization that discourages the model from relying on the corrector. Supported for both single-module and coupled training; when configured, the specified loss is computed between each corrector's per-variable correction (post-corrector minus pre-corrector) and a zero baseline in the loss-normalized space, then accumulated into the training loss.

Changes:
- `fme.core.step.step.StepResult`: new dataclass replacing the bare `TensorDict` return type of `StepABC.step`; carries the denormalized output plus optional per-variable corrections. All `StepABC` implementations and consumers updated.
- `fme.core.step.single_module.step_with_adjustments`: records `corrections = post − pre` when a corrector runs; `MultiCallStep` forwards corrections from its wrapped step.
- `fme.core.loss.CorrectorRegularizationConfig`: new `LossConfig` + `weight` wrapper, with validation rejecting `EnsembleLoss`/`NaN`/`global_mean_type`.
- `fme.ace.stepper.single_module.TrainStepperConfig.corrector_regularization`: optional field; built via `Stepper.build_corrector_regularization_loss` and applied per optimized step in `TrainStepper._accumulate_loss`. Per-step (\`corrector_regularization_step_{i}\`) and epoch-aggregated (\`corrector_regularization\`) metrics.
- `fme.coupled.stepper.ComponentTrainingConfig.corrector_regularization`: per-realm version. \`CoupledStepperTrainLoss.compute_corrector_regularization\` wired into \`CoupledTrainStepper._accumulate_step_loss\`; emits \`loss/{realm}_corrector_regularization_step_{i}\`.
- \`fme.ace\` re-exports \`LossConfig\` and \`CorrectorRegularizationConfig\` so nested-dataclass symbol checks see them.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated