### PR TITLE
Serialized mixture of experts checkpoint

### DIFF
--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -20,7 +20,7 @@ from fme.downscaling.data import (
 from fme.downscaling.models import CheckpointModelConfig, DiffusionModel
 from fme.downscaling.predict import EventConfig
 from fme.downscaling.predictors import (
-    DenoisingMoECheckpointConfig,
+    DenoisingMoEBundledConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     PatchPredictionConfig,
@@ -178,7 +178,7 @@ class PairedEventConfig(EventConfig):
 
 @dataclasses.dataclass
 class EvaluatorConfig:
-    model: DenoisingMoEConfig | DenoisingMoECheckpointConfig | CheckpointModelConfig
+    model: DenoisingMoEConfig | DenoisingMoEBundledConfig | CheckpointModelConfig
     experiment_dir: str
     data: PairedDataLoaderConfig
     logging: LoggingConfig

--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -20,6 +20,7 @@ from fme.downscaling.data import (
 from fme.downscaling.models import CheckpointModelConfig, DiffusionModel
 from fme.downscaling.predict import EventConfig
 from fme.downscaling.predictors import (
+    DenoisingMoECheckpointConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     PatchPredictionConfig,
@@ -177,7 +178,7 @@ class PairedEventConfig(EventConfig):
 
 @dataclasses.dataclass
 class EvaluatorConfig:
-    model: DenoisingMoEConfig | CheckpointModelConfig
+    model: DenoisingMoEConfig | DenoisingMoECheckpointConfig | CheckpointModelConfig
     experiment_dir: str
     data: PairedDataLoaderConfig
     logging: LoggingConfig

--- a/fme/downscaling/inference/inference.py
+++ b/fme/downscaling/inference/inference.py
@@ -14,7 +14,7 @@ from fme.core.logging_utils import LoggingConfig
 from ..data import DataLoaderConfig
 from ..models import CheckpointModelConfig, DiffusionModel
 from ..predictors import (
-    DenoisingMoECheckpointConfig,
+    DenoisingMoEBundledConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     PatchPredictionConfig,
@@ -226,7 +226,7 @@ class InferenceConfig:
             entity: my_organization
     """
 
-    model: DenoisingMoEConfig | DenoisingMoECheckpointConfig | CheckpointModelConfig
+    model: DenoisingMoEConfig | DenoisingMoEBundledConfig | CheckpointModelConfig
     data: DataLoaderConfig
     experiment_dir: str
     outputs: list[EventConfig | TimeRangeConfig]

--- a/fme/downscaling/inference/inference.py
+++ b/fme/downscaling/inference/inference.py
@@ -14,6 +14,7 @@ from fme.core.logging_utils import LoggingConfig
 from ..data import DataLoaderConfig
 from ..models import CheckpointModelConfig, DiffusionModel
 from ..predictors import (
+    DenoisingMoECheckpointConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     PatchPredictionConfig,
@@ -225,7 +226,7 @@ class InferenceConfig:
             entity: my_organization
     """
 
-    model: DenoisingMoEConfig | CheckpointModelConfig
+    model: DenoisingMoEConfig | DenoisingMoECheckpointConfig | CheckpointModelConfig
     data: DataLoaderConfig
     experiment_dir: str
     outputs: list[EventConfig | TimeRangeConfig]

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -247,7 +247,6 @@ class DiffusionModelConfig:
         # runtime names exposed by the built DiffusionModel. All rename
         # application happens here: normalizer keys, in_names, out_names. The
         # DiffusionModel itself just stores what it is given.
-        rename = rename or None
         rename_map = rename or {}
         in_names = [rename_map.get(n, n) for n in self.in_names]
         out_names = [rename_map.get(n, n) for n in self.out_names]

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -242,10 +242,16 @@ class DiffusionModelConfig:
         rename: dict[str, str] | None = None,
         static_inputs: StaticInputs | None = None,
     ) -> "DiffusionModel":
-        invert_rename = {v: k for k, v in (rename or {}).items()}
-        orig_in_names = [invert_rename.get(name, name) for name in self.in_names]
-        orig_out_names = [invert_rename.get(name, name) for name in self.out_names]
-        normalizer = self.normalization.build(orig_in_names, orig_out_names, rename)
+        # self.in_names / self.out_names are the ORIGINAL (training-time) names
+        # keying the normalization means/stds. `rename` translates them to the
+        # runtime names exposed by the built DiffusionModel. All rename
+        # application happens here: normalizer keys, in_names, out_names. The
+        # DiffusionModel itself just stores what it is given.
+        rename = rename or None
+        rename_map = rename or {}
+        in_names = [rename_map.get(n, n) for n in self.in_names]
+        out_names = [rename_map.get(n, n) for n in self.out_names]
+        normalizer = self.normalization.build(self.in_names, self.out_names, rename)
         loss = self.loss.build(gridded_operations=None)
         # We always use standard score normalization, so sigma_data is
         # always 1.0. See below for standard score normalization:
@@ -253,7 +259,7 @@ class DiffusionModelConfig:
         sigma_data = 1.0
 
         num_static_in_channels = len(static_inputs.fields) if static_inputs else 0
-        n_in_channels = len(self.in_names) + num_static_in_channels
+        n_in_channels = len(in_names) + num_static_in_channels
         if self.use_fine_topography and (
             not static_inputs or len(static_inputs.fields) == 0
         ):
@@ -271,7 +277,7 @@ class DiffusionModelConfig:
 
         module = self.module.build(
             n_in_channels=n_in_channels,
-            n_out_channels=len(self.out_names),
+            n_out_channels=len(out_names),
             coarse_shape=coarse_shape,
             downscale_factor=downscale_factor,
             sigma_data=sigma_data,
@@ -287,6 +293,8 @@ class DiffusionModelConfig:
             downscale_factor=downscale_factor,
             sigma_data=sigma_data,
             full_fine_coords=full_fine_coords,
+            in_names=in_names,
+            out_names=out_names,
             static_inputs=static_inputs,
         )
 
@@ -344,15 +352,21 @@ class DiffusionModel:
         downscale_factor: int,
         sigma_data: float,
         full_fine_coords: LatLonCoordinates,
+        in_names: list[str],
+        out_names: list[str],
         static_inputs: StaticInputs | None = None,
     ) -> None:
         """
         Args:
-            config: The configuration object for the diffusion model.
+            config: The configuration object for the diffusion model. Holds the
+                original training-time ``in_names``/``out_names``; the runtime
+                names are passed separately because rename is applied in
+                ``DiffusionModelConfig.build``.
             module: The neural network module used for downscaling. Note: this
                 should *not* be DistributedDataParallel since it is wrapped by
                 it in this init method.
             normalizer: The normalizer object used for data normalization.
+                Built with the rename already applied to its keys.
             loss: The loss function used for training the model.
             coarse_shape: The height (lat) and width (lon) of the
                 coarse-resolution input data used to train the model
@@ -363,6 +377,10 @@ class DiffusionModel:
                 model preconditioning.
             full_fine_coords: The full fine-resolution domain coordinates.
                 Serves as the canonical source of truth for the model output grid.
+            in_names: Runtime input variable names (i.e. ``rename`` already
+                applied to ``config.in_names``).
+            out_names: Runtime output variable names (i.e. ``rename`` already
+                applied to ``config.out_names``).
             static_inputs: Static inputs to the model. May be None when
                 no static data is needed. If present, coordinates
                 must match full_fine_coords.
@@ -374,14 +392,16 @@ class DiffusionModel:
         self.module = dist.wrap_module(module.to(get_device()))
         self.normalizer = normalizer
         self.loss = loss
-        self.in_packer = Packer(config.in_names)
-        self.out_packer = Packer(config.out_names)
         self.config = config
+        self.in_names = in_names
+        self.out_names = out_names
+        self.in_packer = Packer(self.in_names)
+        self.out_packer = Packer(self.out_names)
         self._channel_axis = -3
         self.full_fine_coords = full_fine_coords.to(get_device())
         self.static_inputs = static_inputs.to_device() if static_inputs else None
         self._loss_weight_tensor = _build_variable_loss_weight_tensor(
-            config.loss_weights.output_channels, config.out_names
+            config.loss_weights.output_channels, self.out_names
         )
 
     @property
@@ -669,11 +689,18 @@ class DiffusionModel:
     def from_state(
         cls,
         state: Mapping[str, Any],
+        rename: dict[str, str] | None = None,
     ) -> "DiffusionModel":
         """
         Reconstruct model from state (used during training checkpoint resumption).
         Requires full_fine_coords in state. For old checkpoints without it, use
         CheckpointModelConfig with fine_coordinates_path for backwards compatibility.
+
+        Args:
+            state: Saved DiffusionModel state from ``get_state``.
+            rename: Optional ``{original: renamed}`` mapping to apply at build
+                time. Not stored in ``state``; supply it here if the caller
+                needs the reloaded model to expose renamed runtime names.
         """
         static_inputs_state = state.get("static_inputs")
         static_inputs = (
@@ -699,6 +726,7 @@ class DiffusionModel:
             state["coarse_shape"],
             state["downscale_factor"],
             full_fine_coords=full_fine_coords,
+            rename=rename,
             static_inputs=static_inputs,
         )
         model.module.load_state_dict(state["module"], strict=True)
@@ -707,8 +735,8 @@ class DiffusionModel:
     @cached_property
     def metadata(self):
         return DiffusionModelMetadata(
-            in_names=self.config.in_names,
-            out_names=self.config.out_names,
+            in_names=self.in_names,
+            out_names=self.out_names,
             coarse_shape=self.coarse_shape,
             downscale_factor=self.downscale_factor,
             sigma_data=self.sigma_data,
@@ -765,7 +793,6 @@ class CheckpointModelConfig:
         # For config validation testing, we don't want to load immediately
         # so we defer until build or properties are accessed.
         self._checkpoint_is_loaded = False
-        self._rename = self.rename or {}
         if "module" in (self.model_updates or {}):
             raise ValueError("'module' cannot be updated in model_updates.")
         if self.fine_topography_path is not None:
@@ -781,14 +808,6 @@ class CheckpointModelConfig:
             checkpoint_data = torch.load(
                 self.checkpoint_path, map_location="cpu", weights_only=False
             )
-            checkpoint_data["model"]["config"]["in_names"] = [
-                self._rename.get(name, name)
-                for name in checkpoint_data["model"]["config"]["in_names"]
-            ]
-            checkpoint_data["model"]["config"]["out_names"] = [
-                self._rename.get(name, name)
-                for name in checkpoint_data["model"]["config"]["out_names"]
-            ]
             self._checkpoint_data = checkpoint_data
             self._checkpoint_is_loaded = True
             if self.model_updates is not None:
@@ -839,7 +858,7 @@ class CheckpointModelConfig:
             coarse_shape=self._checkpoint["model"]["coarse_shape"],
             downscale_factor=self._checkpoint["model"]["downscale_factor"],
             full_fine_coords=full_fine_coords,
-            rename=self._rename,
+            rename=self.rename,
             static_inputs=static_inputs,
         )
         model.module.load_state_dict(self._checkpoint["model"]["module"])
@@ -861,8 +880,14 @@ class CheckpointModelConfig:
 
     @property
     def in_names(self):
-        return self._checkpoint["model"]["config"]["in_names"]
+        rename = self.rename or {}
+        return [
+            rename.get(n, n) for n in self._checkpoint["model"]["config"]["in_names"]
+        ]
 
     @property
     def out_names(self):
-        return self._checkpoint["model"]["config"]["out_names"]
+        rename = self.rename or {}
+        return [
+            rename.get(n, n) for n in self._checkpoint["model"]["config"]["out_names"]
+        ]

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -24,6 +24,7 @@ from fme.downscaling.data import (
 )
 from fme.downscaling.models import CheckpointModelConfig, DiffusionModel
 from fme.downscaling.predictors import (
+    DenoisingMoECheckpointConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     PatchPredictionConfig,
@@ -242,7 +243,7 @@ class Downscaler:
 
 @dataclasses.dataclass
 class DownscalerConfig:
-    model: DenoisingMoEConfig | CheckpointModelConfig
+    model: DenoisingMoEConfig | DenoisingMoECheckpointConfig | CheckpointModelConfig
     experiment_dir: str
     data: DataLoaderConfig
     logging: LoggingConfig

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -24,7 +24,7 @@ from fme.downscaling.data import (
 )
 from fme.downscaling.models import CheckpointModelConfig, DiffusionModel
 from fme.downscaling.predictors import (
-    DenoisingMoECheckpointConfig,
+    DenoisingMoEBundledConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     PatchPredictionConfig,
@@ -243,7 +243,7 @@ class Downscaler:
 
 @dataclasses.dataclass
 class DownscalerConfig:
-    model: DenoisingMoEConfig | DenoisingMoECheckpointConfig | CheckpointModelConfig
+    model: DenoisingMoEConfig | DenoisingMoEBundledConfig | CheckpointModelConfig
     experiment_dir: str
     data: DataLoaderConfig
     logging: LoggingConfig

--- a/fme/downscaling/predictors/__init__.py
+++ b/fme/downscaling/predictors/__init__.py
@@ -1,11 +1,13 @@
 from .composite import PatchPredictionConfig, PatchPredictor
 from .serial_denoising import (
     DenoisingExpertCheckpointConfig,
+    DenoisingMoECheckpointConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
 )
 
 __all__ = [
+    "DenoisingMoECheckpointConfig",
     "DenoisingMoEConfig",
     "DenoisingExpertCheckpointConfig",
     "DenoisingMoEPredictor",

--- a/fme/downscaling/predictors/__init__.py
+++ b/fme/downscaling/predictors/__init__.py
@@ -1,13 +1,13 @@
 from .composite import PatchPredictionConfig, PatchPredictor
 from .serial_denoising import (
     DenoisingExpertCheckpointConfig,
-    DenoisingMoECheckpointConfig,
+    DenoisingMoEBundledConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
 )
 
 __all__ = [
-    "DenoisingMoECheckpointConfig",
+    "DenoisingMoEBundledConfig",
     "DenoisingMoEConfig",
     "DenoisingExpertCheckpointConfig",
     "DenoisingMoEPredictor",

--- a/fme/downscaling/predictors/serial_denoising.py
+++ b/fme/downscaling/predictors/serial_denoising.py
@@ -1,4 +1,6 @@
 import dataclasses
+from collections.abc import Mapping
+from typing import Any
 
 import torch
 
@@ -146,11 +148,15 @@ class DenoisingMoEConfig:
         sigma_ranges = [
             (rc.sigma_min, rc.sigma_max) for rc in self.denoising_expert_configs
         ]
+        expert_renames = [
+            rc.checkpoint_config.rename for rc in self.denoising_expert_configs
+        ]
         return DenoisingMoEPredictor(
             experts=experts,
             sigma_ranges=sigma_ranges,
             num_diffusion_generation_steps=self.num_diffusion_generation_steps,
             churn=self.churn,
+            expert_renames=expert_renames,
         )
 
     @property
@@ -170,11 +176,16 @@ class DenoisingMoEPredictor:
         sigma_ranges: list[tuple[float, float]],
         num_diffusion_generation_steps: int,
         churn: float,
+        expert_renames: list[dict[str, str] | None] | None = None,
     ) -> None:
         if not experts:
             raise ValueError("experts must be non-empty.")
         if len(experts) != len(sigma_ranges):
             raise ValueError("experts and sigma_ranges must have the same length.")
+        if expert_renames is None:
+            expert_renames = [None] * len(experts)
+        if len(expert_renames) != len(experts):
+            raise ValueError("expert_renames and experts must have the same length.")
         self._experts = experts
         self._primary = experts[0]
         self._sigma_ranges = sigma_ranges
@@ -183,6 +194,7 @@ class DenoisingMoEPredictor:
         self._sigma_schedule_max = sigma_ranges[-1][1]
         self._num_diffusion_generation_steps = num_diffusion_generation_steps
         self._churn = churn
+        self._expert_renames = expert_renames
         self._dispatch_module = _SigmaDispatchModule(
             sigma_ranges,
             [e.module for e in experts],
@@ -275,4 +287,92 @@ class DenoisingMoEPredictor:
         loss = self._primary.loss(generated_norm, targets_norm)
         return ModelOutputs(
             prediction=generated, target=targets, loss=loss, latent_steps=latent_steps
+        )
+
+    def get_state(self) -> Mapping[str, Any]:
+        """Serialize to a single state dict reloadable via
+        ``DenoisingMoECheckpointConfig``.
+
+        Contains each expert's full ``DiffusionModel`` state plus the MoE-level
+        routing and sampler parameters and the per-expert rename mappings (from
+        the original ``CheckpointModelConfig``s) so the reloaded predictor
+        exposes the same runtime variable names.
+        """
+        return {
+            "experts": [expert.get_state() for expert in self._experts],
+            "sigma_ranges": [list(r) for r in self._sigma_ranges],
+            "num_diffusion_generation_steps": self._num_diffusion_generation_steps,
+            "churn": self._churn,
+            "expert_renames": self._expert_renames,
+        }
+
+    def save(self, path: str) -> None:
+        torch.save(self.get_state(), path)
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, Any]) -> "DenoisingMoEPredictor":
+        expert_states = state["experts"]
+        expert_renames = state.get("expert_renames") or [None] * len(expert_states)
+        experts = [
+            DiffusionModel.from_state(s, rename=r)
+            for s, r in zip(expert_states, expert_renames, strict=True)
+        ]
+        sigma_ranges = [(float(lo), float(hi)) for lo, hi in state["sigma_ranges"]]
+        return cls(
+            experts=experts,
+            sigma_ranges=sigma_ranges,
+            num_diffusion_generation_steps=int(state["num_diffusion_generation_steps"]),
+            churn=float(state["churn"]),
+            expert_renames=list(expert_renames),
+        )
+
+
+@dataclasses.dataclass
+class DenoisingMoECheckpointConfig:
+    """
+    Loads a ``DenoisingMoEPredictor`` from a single bundled checkpoint produced
+    by ``DenoisingMoEPredictor.save``. The bundle contains every expert's
+    weights and config plus the MoE-level sigma ranges and sampler parameters,
+    so no original per-expert checkpoint paths are required.
+
+    Parameters:
+        mixture_of_experts_path: Path to a bundle written by
+            ``DenoisingMoEPredictor.save``. Named distinctly from
+            ``CheckpointModelConfig.checkpoint_path`` so the two configs are
+            unambiguous when used as alternatives in a YAML model union.
+    """
+
+    mixture_of_experts_path: str
+
+    def __post_init__(self) -> None:
+        self._state_is_loaded = False
+        self._state: Mapping[str, Any] | None = None
+
+    @property
+    def _bundle(self) -> Mapping[str, Any]:
+        if not self._state_is_loaded:
+            self._state = torch.load(
+                self.mixture_of_experts_path,
+                map_location="cpu",
+                weights_only=False,
+            )
+            self._state_is_loaded = True
+        assert self._state is not None
+        return self._state
+
+    def build(self) -> "DenoisingMoEPredictor":
+        return DenoisingMoEPredictor.from_state(self._bundle)
+
+    @property
+    def data_requirements(self) -> DataRequirements:
+        expert_config = self._bundle["experts"][0]["config"]
+        renames = self._bundle.get("expert_renames") or [None]
+        rename = renames[0] or {}
+        in_names = [rename.get(n, n) for n in expert_config["in_names"]]
+        out_names = [rename.get(n, n) for n in expert_config["out_names"]]
+        return DataRequirements(
+            fine_names=out_names,
+            coarse_names=list(set(in_names).union(out_names)),
+            n_timesteps=1,
+            use_fine_topography=expert_config["use_fine_topography"],
         )

--- a/fme/downscaling/predictors/serial_denoising.py
+++ b/fme/downscaling/predictors/serial_denoising.py
@@ -361,7 +361,10 @@ class DenoisingMoECheckpointConfig:
         return self._state
 
     def build(self) -> "DenoisingMoEPredictor":
-        return DenoisingMoEPredictor.from_state(self._bundle)
+        predictor = DenoisingMoEPredictor.from_state(self._bundle)
+        for expert in predictor._experts:
+            expert.module.eval()
+        return predictor
 
     @property
     def data_requirements(self) -> DataRequirements:

--- a/fme/downscaling/predictors/serial_denoising.py
+++ b/fme/downscaling/predictors/serial_denoising.py
@@ -182,9 +182,7 @@ class DenoisingMoEPredictor:
             raise ValueError("experts must be non-empty.")
         if len(experts) != len(sigma_ranges):
             raise ValueError("experts and sigma_ranges must have the same length.")
-        if expert_renames is None:
-            expert_renames = [None] * len(experts)
-        if len(expert_renames) != len(experts):
+        if expert_renames is not None and len(expert_renames) != len(experts):
             raise ValueError("expert_renames and experts must have the same length.")
         self._experts = experts
         self._primary = experts[0]
@@ -329,7 +327,7 @@ class DenoisingMoEPredictor:
 
 
 @dataclasses.dataclass
-class DenoisingMoECheckpointConfig:
+class DenoisingMoEBundledConfig:
     """
     Loads a ``DenoisingMoEPredictor`` from a single bundled checkpoint produced
     by ``DenoisingMoEPredictor.save``. The bundle contains every expert's

--- a/fme/downscaling/predictors/test_serial_denoising.py
+++ b/fme/downscaling/predictors/test_serial_denoising.py
@@ -9,7 +9,7 @@ from fme.downscaling.data import StaticInputs
 from fme.downscaling.models import CheckpointModelConfig
 from fme.downscaling.predictors.serial_denoising import (
     DenoisingExpertCheckpointConfig,
-    DenoisingMoECheckpointConfig,
+    DenoisingMoEBundledConfig,
     DenoisingMoEConfig,
     DenoisingMoEPredictor,
     _SigmaDispatchModule,
@@ -206,7 +206,7 @@ def test_save_and_load_roundtrip_preserves_predictor(tmp_path):
     ckpt = tmp_path / "moe.pt"
     predictor.save(str(ckpt))
 
-    loaded = DenoisingMoECheckpointConfig(mixture_of_experts_path=str(ckpt)).build()
+    loaded = DenoisingMoEBundledConfig(mixture_of_experts_path=str(ckpt)).build()
 
     assert loaded._sigma_ranges == predictor._sigma_ranges
     assert (
@@ -228,7 +228,7 @@ def test_loaded_predictor_dispatches_to_same_experts(tmp_path):
     predictor = _build_two_expert_predictor()
     ckpt = tmp_path / "moe.pt"
     predictor.save(str(ckpt))
-    loaded = DenoisingMoECheckpointConfig(mixture_of_experts_path=str(ckpt)).build()
+    loaded = DenoisingMoEBundledConfig(mixture_of_experts_path=str(ckpt)).build()
 
     x = torch.randn(
         1, 1, 16, 32, device=next(predictor._experts[0].module.parameters()).device
@@ -246,7 +246,7 @@ def test_checkpoint_config_data_requirements(tmp_path):
     ckpt = tmp_path / "moe.pt"
     predictor.save(str(ckpt))
 
-    reqs = DenoisingMoECheckpointConfig(
+    reqs = DenoisingMoEBundledConfig(
         mixture_of_experts_path=str(ckpt)
     ).data_requirements
     assert reqs.fine_names == ["x"]
@@ -306,9 +306,7 @@ def test_save_preserves_rename_applied_by_checkpoint_model_config(tmp_path):
 
     bundle_path = tmp_path / "moe.pt"
     predictor.save(str(bundle_path))
-    loaded = DenoisingMoECheckpointConfig(
-        mixture_of_experts_path=str(bundle_path)
-    ).build()
+    loaded = DenoisingMoEBundledConfig(mixture_of_experts_path=str(bundle_path)).build()
 
     for expert in loaded._experts:
         assert expert.in_names == ["renamed_x"]
@@ -317,7 +315,7 @@ def test_save_preserves_rename_applied_by_checkpoint_model_config(tmp_path):
         assert expert.config.out_names == ["x"]
     assert loaded._expert_renames == [{"x": "renamed_x"}, {"x": "renamed_x"}]
 
-    reqs = DenoisingMoECheckpointConfig(
+    reqs = DenoisingMoEBundledConfig(
         mixture_of_experts_path=str(bundle_path)
     ).data_requirements
     assert reqs.fine_names == ["renamed_x"]

--- a/fme/downscaling/predictors/test_serial_denoising.py
+++ b/fme/downscaling/predictors/test_serial_denoising.py
@@ -6,13 +6,17 @@ import torch
 
 from fme.core.coordinates import LatLonCoordinates
 from fme.downscaling.data import StaticInputs
+from fme.downscaling.models import CheckpointModelConfig
 from fme.downscaling.predictors.serial_denoising import (
     DenoisingExpertCheckpointConfig,
+    DenoisingMoECheckpointConfig,
     DenoisingMoEConfig,
+    DenoisingMoEPredictor,
     _SigmaDispatchModule,
     _validate_experts_compatible,
     _validate_sigma_ranges,
 )
+from fme.downscaling.test_models import _get_diffusion_model, make_fine_coords
 
 
 def _range(sigma_min: float, sigma_max: float) -> DenoisingExpertCheckpointConfig:
@@ -130,3 +134,150 @@ def test_validate_experts_compatible():
     )
     with pytest.raises(ValueError, match="metadata"):
         _validate_experts_compatible([e0, e1])
+
+
+def _build_two_expert_predictor() -> DenoisingMoEPredictor:
+    """Two-expert MoE with real DiffusionModel experts (different weights)."""
+    coarse_shape = (8, 16)
+    fine_shape = (16, 32)
+    fine_coords = make_fine_coords(fine_shape)
+    experts = [
+        _get_diffusion_model(
+            coarse_shape=coarse_shape,
+            downscale_factor=2,
+            full_fine_coords=fine_coords,
+            predict_residual=False,
+            use_fine_topography=False,
+            static_inputs=StaticInputs(fields=[], coords=fine_coords),
+        )
+        for _ in range(2)
+    ]
+    return DenoisingMoEPredictor(
+        experts=experts,
+        sigma_ranges=[(0.1, 0.5), (0.5, 1.0)],
+        num_diffusion_generation_steps=4,
+        churn=0.25,
+    )
+
+
+def test_save_and_load_roundtrip_preserves_predictor(tmp_path):
+    predictor = _build_two_expert_predictor()
+    ckpt = tmp_path / "moe.pt"
+    predictor.save(str(ckpt))
+
+    loaded = DenoisingMoECheckpointConfig(mixture_of_experts_path=str(ckpt)).build()
+
+    assert loaded._sigma_ranges == predictor._sigma_ranges
+    assert (
+        loaded._num_diffusion_generation_steps
+        == predictor._num_diffusion_generation_steps
+    )
+    assert loaded._churn == predictor._churn
+    assert len(loaded._experts) == len(predictor._experts)
+    for orig_expert, new_expert in zip(predictor._experts, loaded._experts):
+        for p_orig, p_new in zip(
+            orig_expert.module.parameters(), new_expert.module.parameters()
+        ):
+            assert torch.equal(p_orig.cpu(), p_new.cpu())
+
+
+def test_loaded_predictor_dispatches_to_same_experts(tmp_path):
+    """The reloaded predictor must route the same sigma to the same expert
+    (i.e. produce bitwise-identical generations)."""
+    predictor = _build_two_expert_predictor()
+    ckpt = tmp_path / "moe.pt"
+    predictor.save(str(ckpt))
+    loaded = DenoisingMoECheckpointConfig(mixture_of_experts_path=str(ckpt)).build()
+
+    x = torch.randn(
+        1, 1, 16, 32, device=next(predictor._experts[0].module.parameters()).device
+    )
+    x_lr = torch.randn_like(x)
+    for sigma_val in [0.2, 0.7]:
+        sigma = torch.tensor(sigma_val)
+        orig = predictor._dispatch_module(x, x_lr, sigma)
+        new = loaded._dispatch_module(x, x_lr, sigma)
+        assert torch.allclose(orig.cpu(), new.cpu(), atol=1e-5, rtol=1e-5)
+
+
+def test_checkpoint_config_data_requirements(tmp_path):
+    predictor = _build_two_expert_predictor()
+    ckpt = tmp_path / "moe.pt"
+    predictor.save(str(ckpt))
+
+    reqs = DenoisingMoECheckpointConfig(
+        mixture_of_experts_path=str(ckpt)
+    ).data_requirements
+    assert reqs.fine_names == ["x"]
+    assert set(reqs.coarse_names) == {"x"}
+    assert reqs.n_timesteps == 1
+    assert reqs.use_fine_topography is False
+
+
+def test_save_preserves_rename_applied_by_checkpoint_model_config(tmp_path):
+    """``CheckpointModelConfig.rename`` mutates in_names/out_names at load time,
+    so the renamed names are part of the built ``DiffusionModel.config`` and must
+    survive the MoE save/reload roundtrip.
+    """
+    coarse_shape = (8, 16)
+    fine_shape = (16, 32)
+    fine_coords = make_fine_coords(fine_shape)
+
+    expert_ckpts: list[str] = []
+    for i in range(2):
+        # Train-time names use "x"; downstream consumers will see "renamed_x".
+        model = _get_diffusion_model(
+            coarse_shape=coarse_shape,
+            downscale_factor=2,
+            full_fine_coords=fine_coords,
+            predict_residual=False,
+            use_fine_topography=False,
+            static_inputs=StaticInputs(fields=[], coords=fine_coords),
+        )
+        path = tmp_path / f"expert_{i}.ckpt"
+        torch.save({"model": model.get_state()}, path)
+        expert_ckpts.append(str(path))
+
+    moe_config = DenoisingMoEConfig(
+        denoising_expert_configs=[
+            DenoisingExpertCheckpointConfig(
+                checkpoint_config=CheckpointModelConfig(
+                    checkpoint_path=p, rename={"x": "renamed_x"}
+                ),
+                sigma_min=lo,
+                sigma_max=hi,
+            )
+            for p, (lo, hi) in zip(expert_ckpts, [(0.1, 0.5), (0.5, 1.0)])
+        ],
+        num_diffusion_generation_steps=4,
+        churn=0.25,
+    )
+    predictor = moe_config.build()
+    # Sanity: each expert exposes runtime (renamed) names while config retains
+    # the original training-time names. Rename is owned by the predictor, not
+    # the model.
+    for expert in predictor._experts:
+        assert expert.in_names == ["renamed_x"]
+        assert expert.out_names == ["renamed_x"]
+        assert expert.config.in_names == ["x"]
+        assert expert.config.out_names == ["x"]
+    assert predictor._expert_renames == [{"x": "renamed_x"}, {"x": "renamed_x"}]
+
+    bundle_path = tmp_path / "moe.pt"
+    predictor.save(str(bundle_path))
+    loaded = DenoisingMoECheckpointConfig(
+        mixture_of_experts_path=str(bundle_path)
+    ).build()
+
+    for expert in loaded._experts:
+        assert expert.in_names == ["renamed_x"]
+        assert expert.out_names == ["renamed_x"]
+        assert expert.config.in_names == ["x"]
+        assert expert.config.out_names == ["x"]
+    assert loaded._expert_renames == [{"x": "renamed_x"}, {"x": "renamed_x"}]
+
+    reqs = DenoisingMoECheckpointConfig(
+        mixture_of_experts_path=str(bundle_path)
+    ).data_requirements
+    assert reqs.fine_names == ["renamed_x"]
+    assert set(reqs.coarse_names) == {"renamed_x"}

--- a/fme/downscaling/predictors/test_serial_denoising.py
+++ b/fme/downscaling/predictors/test_serial_denoising.py
@@ -141,7 +141,16 @@ def test_validate_experts_compatible():
 
 
 def test_generate_on_batch_returns_scalar_loss():
-    """Two-expert MoE with real DiffusionModel experts (different weights)."""
+    """``DenoisingMoEPredictor.generate_on_batch`` must reduce the per-component
+    loss list returned by ``self._primary.loss(...)`` to a scalar tensor, the
+    same way ``DiffusionModel.generate_on_batch`` does.
+
+    Regression for the post-#1159 loss-architecture refactor: the loss module
+    now returns ``list[LossComponent]``; if the MoE predictor forgets to unpack
+    and ``.mean()`` it, ``ModelOutputs.loss`` is a list and downstream
+    consumers (``PatchPredictor`` accumulator, loss aggregator) explode with a
+    confusing ``TypeError`` or ``AttributeError`` deep in unrelated code.
+    """
     coarse_shape = (8, 16)
     fine_shape = (16, 32)
     fine_coords = make_fine_coords(fine_shape)
@@ -169,16 +178,7 @@ def test_generate_on_batch_returns_scalar_loss():
 
 
 def _build_two_expert_predictor() -> DenoisingMoEPredictor:
-    """``DenoisingMoEPredictor.generate_on_batch`` must reduce the per-component
-    loss list returned by ``self._primary.loss(...)`` to a scalar tensor, the
-    same way ``DiffusionModel.generate_on_batch`` does.
-
-    Regression for the post-#1159 loss-architecture refactor: the loss module
-    now returns ``list[LossComponent]``; if the MoE predictor forgets to unpack
-    and ``.mean()`` it, ``ModelOutputs.loss`` is a list and downstream
-    consumers (``PatchPredictor`` accumulator, loss aggregator) explode with a
-    confusing ``TypeError`` or ``AttributeError`` deep in unrelated code.
-    """
+    """Two-expert MoE with real DiffusionModel experts (different weights)."""
     coarse_shape = (8, 16)
     fine_shape = (16, 32)
     fine_coords = make_fine_coords(fine_shape)

--- a/scripts/downscaling/bundle_denoising_moe_checkpoint.py
+++ b/scripts/downscaling/bundle_denoising_moe_checkpoint.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""
+Bundle a mixture-of-experts denoising predictor into a single self-contained
+checkpoint.
+
+Reads a YAML describing a ``DenoisingMoEConfig`` (the list of expert
+checkpoints, sigma ranges, and sampler parameters), builds the
+``DenoisingMoEPredictor``, and saves it to one ``.pt`` file. That file can
+then be loaded later via
+``DenoisingMoECheckpointConfig(mixture_of_experts_path=...)`` with no need to
+retain the original per-expert checkpoint paths or any rename mappings.
+
+Usage:
+    python bundle_denoising_moe_checkpoint.py <moe_config.yaml> <output.pt>
+
+Example config (moe_config.yaml):
+    num_diffusion_generation_steps: 18
+    churn: 0.0
+    denoising_expert_configs:
+      - sigma_min: 0.002
+        sigma_max: 1.0
+        checkpoint_config:
+          checkpoint_path: /path/to/low_noise_expert.ckpt
+          rename: {x: renamed_x}
+      - sigma_min: 1.0
+        sigma_max: 80.0
+        checkpoint_config:
+          checkpoint_path: /path/to/high_noise_expert.ckpt
+          rename: {x: renamed_x}
+"""
+
+import argparse
+from typing import cast
+
+import dacite
+import yaml
+
+from fme.core.device import get_device
+from fme.downscaling.models import CheckpointModelConfig
+from fme.downscaling.modules.physicsnemo_unets_v2.group_norm import apex_available
+from fme.downscaling.predictors import DenoisingMoEConfig
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument(
+        "config_path",
+        type=str,
+        help="Path to a YAML file describing a DenoisingMoEConfig.",
+    )
+    parser.add_argument(
+        "output_path",
+        type=str,
+        help="Path to write the bundled MoE checkpoint (.pt).",
+    )
+    return parser.parse_args()
+
+
+def _force_disable_apex_gn(cfg: CheckpointModelConfig) -> bool | None:
+    """Set ``use_apex_gn=False`` on the loaded expert checkpoint's UNet config
+    so the module can be built without apex. Returns the previous value so the
+    caller can restore it in the saved bundle.
+
+    Reaches into the loaded checkpoint dict because ``CheckpointModelConfig``
+    intentionally refuses ``model_updates`` for the ``module`` field.
+    """
+    module_config = cfg._checkpoint["model"]["config"]["module"]["config"]
+    prev = module_config.get("use_apex_gn")
+    module_config["use_apex_gn"] = False
+    return prev
+
+
+def _force_disable_amp_bf16(cfg: CheckpointModelConfig) -> bool | None:
+    """Set ``use_amp_bf16=False`` on the loaded expert checkpoint so the module
+    can be built on devices that reject bf16 autocast (currently MPS). Returns
+    the previous value so the caller can restore it in the saved bundle.
+    """
+    model_config = cfg._checkpoint["model"]["config"]
+    prev = model_config.get("use_amp_bf16")
+    model_config["use_amp_bf16"] = False
+    return prev
+
+
+def main(config_path: str, output_path: str) -> None:
+    with open(config_path) as f:
+        raw = yaml.safe_load(f)
+    moe_config: DenoisingMoEConfig = dacite.from_dict(
+        data_class=DenoisingMoEConfig,
+        data=raw,
+        config=dacite.Config(strict=True),
+    )
+
+    # apex's optimized GroupNorm isn't installable on macOS / CPU-only boxes;
+    # bf16 autocast isn't supported on MPS. Build with both off where needed,
+    # then restore the original settings in the saved bundle so a GPU consumer
+    # can still use them when loading.
+    on_mps = get_device().type == "mps"
+    apex_originals: list[bool | None] = []
+    bf16_originals: list[bool | None] = []
+    if not apex_available():
+        print("apex not available locally; building experts with use_apex_gn=False.")
+        for rc in moe_config.denoising_expert_configs:
+            apex_originals.append(_force_disable_apex_gn(rc.checkpoint_config))
+    if on_mps:
+        print("MPS does not support bf16 autocast; building with use_amp_bf16=False.")
+        for rc in moe_config.denoising_expert_configs:
+            bf16_originals.append(_force_disable_amp_bf16(rc.checkpoint_config))
+
+    predictor = moe_config.build()
+
+    if apex_originals:
+        for expert, prev in zip(predictor._experts, apex_originals, strict=True):
+            if prev is not None:
+                cast(dict, expert.config.module.config)["use_apex_gn"] = prev
+        print("Restored original use_apex_gn settings in the saved bundle.")
+    if bf16_originals:
+        for expert, prev in zip(predictor._experts, bf16_originals, strict=True):
+            if prev is not None:
+                expert.config.use_amp_bf16 = prev
+        print("Restored original use_amp_bf16 settings in the saved bundle.")
+
+    predictor.save(output_path)
+    print(f"Wrote MoE bundle to {output_path}")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.config_path, args.output_path)


### PR DESCRIPTION
This PR adds the ability to serialize a denoising mixture of experts predictor for inference so that it can just be loaded by providing a single `mixture_of_experts_path` in the config, instead of having to specify individual model paths and the range of noise each is intended to be routed for.

The changes are separated into individual commits for easier reviewing.

Changes:
- renaming functionality (used to handle the cases when ACE output field names differ from the input field names used to train the model) are consolidated into the `DiffusionModelConfig.build`. Previously, renaming was in two different places: the `CheckpointModelConfig` did the channel renaming in the config before calling `build` and `DiffusionModelConfig.build` would do some inverse lookups to make sure the normalizer names matched the renamed set. This update makes the renaming cleaner and ensures that the serialized MoE checkpoint works if renaming is done (before it would not because the renamed normalizer names in the serialized MoEPredictor would no longer need renaming).
- Add a `DenoisingMoEPredictor.save` method so that this predictor can be serialized. Add a `DenoisingMoECheckpointConfig` class that only needs a path arg. 
- Add `DenoisingMoECheckpointConfig` as an option to use when providing a checkpoint config in the entrypoints (inference, predict, evaluator). Add a script that takes a `DenoisingMoECheckpointConfig`, builds, and saves the predictor while allowing for this to be done on a local environment that may lack the apex and type options specified in the checkpoints. 

I verified that a bundled predictor loaded using `DenoisingMoECheckpointConfig` works for prediction ([beaker link](https://beaker.org/orgs/ai2/workspaces/climate-titan/work/01KT569NV57WHAF7S84CWNPNTH?taskId=01KT569P0SZSF9CDWECWDGRRPX&jobId=01KT569P3ZAFGX0S1659CNG5CZ)).

- [x] Tests added 