### PR TITLE
Mark dhconv timing test as serial

### DIFF
--- a/fme/core/models/conditional_sfno/test_s2convolutions.py
+++ b/fme/core/models/conditional_sfno/test_s2convolutions.py
@@ -53,6 +53,7 @@ def benchmark(fn, iters=10, warmup=1) -> BenchmarkResult:
         "it's testing speed of DHConv groups on GPU."
     ),
 )  # noqa: E501
+@pytest.mark.serial
 def test_contract_dhconv_groups_are_faster():
     B = 2
     C = 512


### PR DESCRIPTION
This PR marks a timing-sensitive test as serial, to avoid it flaking due to noisy xdist neighbors.

Changes:
- No public API changes.

- [ ] Tests added
