### PR TITLE
Fix histogram ckpt selection and percentile frac_of_target reporting

### DIFF
--- a/fme/core/histogram.py
+++ b/fme/core/histogram.py
@@ -597,7 +597,7 @@ class ComparedDynamicTailsHistograms(ComparedDynamicHistograms):
                     )
         for key, value in target_metrics.items():
             return_metrics[f"prediction_frac_of_target/{key}"] = (
-                value / return_metrics[key]
+                return_metrics[key] / value
             )
         return return_metrics
 

--- a/fme/core/test_histogram.py
+++ b/fme/core/test_histogram.py
@@ -163,6 +163,24 @@ def test_compared_dynamic_histograms(shape, percentiles):
     all(ds.coords["source"] == ["target", "prediction"])
 
 
+def test_compared_dynamic_histograms_prediction_frac_is_prediction_over_target():
+    n_bins = 300
+    histogram = ComparedDynamicHistograms(
+        n_bins,
+        percentiles=[99.0],
+        compute_percentile_frac=True,
+    )
+    shape = (2, 8, 16)
+    target = {"x": torch.full(shape, 2.0)}
+    prediction = {"x": torch.full(shape, 4.0)}
+    histogram.record_batch(target, prediction)
+    wandb_result = histogram.get_wandb()
+
+    assert wandb_result[
+        "prediction_frac_of_target/99.0th-percentile/x"
+    ] == pytest.approx(2.0)
+
+
 @pytest.mark.parametrize(
     "target, prediction",
     [
@@ -308,3 +326,30 @@ def test_compared_dynamic_tails_histograms():
     for var in ["y", "z"]:
         assert f"0.0001th-percentile/{var}" in wandb_result
         assert f"prediction_frac_of_target/0.0001th-percentile/{var}" in wandb_result
+
+
+def test_compared_dynamic_tails_histograms_prediction_frac_is_prediction_over_target():
+    n_bins = 300
+    histogram = ComparedDynamicTailsHistograms(
+        n_bins,
+        percentiles=[99.0],
+        left_tailed_variables=["lower"],
+    )
+    shape = (2, 8, 16)
+    target = {
+        "upper": torch.full(shape, 2.0),
+        "lower": torch.full(shape, 2.0),
+    }
+    prediction = {
+        "upper": torch.full(shape, 4.0),
+        "lower": torch.full(shape, 4.0),
+    }
+    histogram.record_batch(target, prediction)
+    wandb_result = histogram.get_wandb()
+
+    assert wandb_result[
+        "prediction_frac_of_target/99.0th-percentile/upper"
+    ] == pytest.approx(2.0)
+    assert wandb_result[
+        "prediction_frac_of_target/1.0th-percentile/lower"
+    ] == pytest.approx(2.0)

--- a/fme/downscaling/aggregators/generation.py
+++ b/fme/downscaling/aggregators/generation.py
@@ -312,9 +312,9 @@ class GenerationAggregator:
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         include_positional_comparisons: bool = True,
         histogram_ckpt_selection_metric: str = (
-            "prediction_frac_of_target/99.9999th-percentile"
+            "histogram/prediction_frac_of_target/99.9999th-percentile"
         ),
-        best_ckpt_selection_metric: str = "relative_crps_bicubic",
+        best_ckpt_selection_metric: str = "metrics/relative_crps_bicubic",
     ) -> None:
         self._agg = Aggregator(
             dims,

--- a/fme/downscaling/aggregators/generation.py
+++ b/fme/downscaling/aggregators/generation.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Collection, Mapping
 from typing import Any
 
@@ -50,6 +51,50 @@ def _get_map_caption(key: str, data: torch.Tensor) -> str:
     vmin, vmax = data.min(), data.max()
     caption = f"{key},  mean: {avg:.4g}, min: {vmin:.4g}, max: {vmax:.4g}"
     return caption
+
+
+def _get_complement_percentile_prefix(prefix):
+    """
+    Given a prefix containing a percentile value, return a prefix with
+    100 minus that percentile. Returns None if no percentile pattern is found.
+    Ex. "prediction_frac_of_target/99.9999th-percentile"
+        -> "prediction_frac_of_target/0.0001th-percentile", or
+        "some_var/percentile/99.9999" -> "some_var/percentile/0.0001".
+    """
+    match = re.search(
+        r"(\d+(?:\.\d+)?)(?:th)?[-_/]percentile|percentile[-_/](\d+(?:\.\d+)?)",
+        prefix,
+    )
+    if match is None:
+        return None
+    if match.group(1) is not None:
+        num_str = match.group(1)
+        num_start, num_end = match.start(1), match.end(1)
+    else:
+        num_str = match.group(2)
+        num_start, num_end = match.start(2), match.end(2)
+    complement = 100 - float(num_str)
+    if "." in num_str:
+        decimal_places = len(num_str.split(".")[1])
+        complement_str = f"{complement:.{decimal_places}f}"
+    else:
+        complement_str = str(int(complement))
+    return prefix[:num_start] + complement_str + prefix[num_end:]
+
+
+def _get_channel_mean_scalar_metric(metrics, prefix="relative_crps_bicubic"):
+    # This ensures that left tailed extreme values are also considered
+    # in checkpoint selection if 99.x percentile is used as metric
+    prefixes = [prefix]
+    if "percentile" in prefix:
+        complement = _get_complement_percentile_prefix(prefix)
+        if complement is not None and complement != prefix:
+            prefixes.append(complement)
+    channel_metric = [v for k, v in metrics.items() if any(p in k for p in prefixes)]
+    if len(channel_metric) == 0:
+        return float("inf")
+    else:
+        return sum(channel_metric) / len(channel_metric)
 
 
 class RelativeCRPSInterpAggregator:
@@ -266,6 +311,10 @@ class GenerationAggregator:
         ssim_kwargs: Mapping[str, Any] | None = None,
         variable_metadata: Mapping[str, VariableMetadata] | None = None,
         include_positional_comparisons: bool = True,
+        histogram_ckpt_selection_metric: str = (
+            "prediction_frac_of_target/99.9999th-percentile"
+        ),
+        best_ckpt_selection_metric: str = "relative_crps_bicubic",
     ) -> None:
         self._agg = Aggregator(
             dims,
@@ -301,6 +350,8 @@ class GenerationAggregator:
             self._single_sample_aggregators.append(
                 MeanMapAggregator(variable_metadata, name="single_sample_time_mean")
             )
+        self._histogram_ckpt_selection_metric = histogram_ckpt_selection_metric
+        self._best_ckpt_selection_metric = best_ckpt_selection_metric
         self._wandb_logs: Mapping[str, Any] | None = None
 
     @torch.no_grad()
@@ -364,3 +415,23 @@ class GenerationAggregator:
             if hasattr(agg, "get_dataset"):
                 ds = ds.merge(agg.get_dataset())
         return ds
+
+    def get_checkpoint_selection_metrics(self) -> dict[str, float]:
+        """
+        Get the checkpoint selection metrics from the underlying aggregator.
+        """
+        metrics: dict[str, float] = {}
+        wandb_logs = self.get_wandb()
+        # Compute channel mean of all percentile*_frac_of_target
+        histogram_tail_metric = _get_channel_mean_scalar_metric(
+            wandb_logs,
+            self._histogram_ckpt_selection_metric,
+        )
+        if "frac_of_target" in self._histogram_ckpt_selection_metric:
+            histogram_tail_metric = abs(1.0 - histogram_tail_metric)
+        metrics[self._histogram_ckpt_selection_metric] = histogram_tail_metric
+        metrics[self._best_ckpt_selection_metric] = _get_channel_mean_scalar_metric(
+            wandb_logs,
+            self._best_ckpt_selection_metric,
+        )
+        return metrics

--- a/fme/downscaling/aggregators/generation.py
+++ b/fme/downscaling/aggregators/generation.py
@@ -82,7 +82,7 @@ def _get_complement_percentile_prefix(prefix):
     return prefix[:num_start] + complement_str + prefix[num_end:]
 
 
-def _get_channel_mean_scalar_metric(metrics, prefix="relative_crps_bicubic"):
+def _get_channel_mean_scalar_metric(metrics, prefix="metrics/relative_crps_bicubic"):
     # This ensures that left tailed extreme values are also considered
     # in checkpoint selection if 99.x percentile is used as metric
     prefixes = [prefix]

--- a/fme/downscaling/aggregators/generation.py
+++ b/fme/downscaling/aggregators/generation.py
@@ -301,6 +301,7 @@ class GenerationAggregator:
             self._single_sample_aggregators.append(
                 MeanMapAggregator(variable_metadata, name="single_sample_time_mean")
             )
+        self._wandb_logs: Mapping[str, Any] | None = None
 
     @torch.no_grad()
     def record_batch(
@@ -341,16 +342,17 @@ class GenerationAggregator:
         """
         Get the wandb output to log from all sub aggregators.
         """
-        ret = {**self._agg.get_wandb(prefix)}
-        for comparison in self._probabilistic_comparisons:
-            ret.update(comparison.get_wandb(prefix))
-        for coarse_comparison in self._probabilistic_coarse_comparisons:
-            ret.update(coarse_comparison.get_wandb(prefix))
-        ret.update(self._latent_step_aggregator.get_wandb(prefix))
-        for single_sample_record in self._single_sample_aggregators:
-            ret.update(single_sample_record.get_wandb(prefix))
-
-        return ret
+        if self._wandb_logs is None:
+            ret = {**self._agg.get_wandb(prefix)}
+            for comparison in self._probabilistic_comparisons:
+                ret.update(comparison.get_wandb(prefix))
+            for coarse_comparison in self._probabilistic_coarse_comparisons:
+                ret.update(coarse_comparison.get_wandb(prefix))
+            ret.update(self._latent_step_aggregator.get_wandb(prefix))
+            for single_sample_record in self._single_sample_aggregators:
+                ret.update(single_sample_record.get_wandb(prefix))
+            self._wandb_logs = ret
+        return self._wandb_logs
 
     def get_dataset(self) -> xr.Dataset:
         """

--- a/fme/downscaling/aggregators/test_aggregators.py
+++ b/fme/downscaling/aggregators/test_aggregators.py
@@ -12,7 +12,7 @@ from fme.downscaling.data import BatchData, BatchedLatLonCoordinates, PairedBatc
 
 from .. import metrics_and_maths
 from ..models import ModelOutputs
-from .generation import GenerationAggregator
+from .generation import GenerationAggregator, _get_complement_percentile_prefix
 from .main import (
     LossVsNoiseAggregator,
     Mean,
@@ -421,3 +421,25 @@ def test_upsample_tensor():
     t = torch.tensor([[1, 2], [3, 4]])
     expected = torch.tensor([[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]])
     assert torch.equal(expected, upsample_tensor(t, 2))
+
+
+@pytest.mark.parametrize(
+    "prefix, expected",
+    [
+        (
+            "histogram/prediction_frac_of_target/99.99th-percentile/var0",
+            "histogram/prediction_frac_of_target/0.01th-percentile/var0",
+        ),
+        (
+            "some_metric/percentile/99.9999/var0",
+            "some_metric/percentile/0.0001/var0",
+        ),
+        (
+            "no_percentile_here/some_metric",
+            None,
+        ),
+    ],
+)
+def test_get_complement_percentile_prefix(prefix, expected):
+    result = _get_complement_percentile_prefix(prefix)
+    assert result == expected

--- a/fme/downscaling/aggregators/test_aggregators.py
+++ b/fme/downscaling/aggregators/test_aggregators.py
@@ -12,7 +12,11 @@ from fme.downscaling.data import BatchData, BatchedLatLonCoordinates, PairedBatc
 
 from .. import metrics_and_maths
 from ..models import ModelOutputs
-from .generation import GenerationAggregator, _get_complement_percentile_prefix
+from .generation import (
+    GenerationAggregator,
+    _get_channel_mean_scalar_metric,
+    _get_complement_percentile_prefix,
+)
 from .main import (
     LossVsNoiseAggregator,
     Mean,
@@ -443,3 +447,31 @@ def test_upsample_tensor():
 def test_get_complement_percentile_prefix(prefix, expected):
     result = _get_complement_percentile_prefix(prefix)
     assert result == expected
+
+
+def test_get_channel_mean_scalar_metric_excludes_matching_maps():
+    metrics = {
+        "generation/maps/relative_crps_bicubic/var0": object(),
+        "generation/metrics/relative_crps_bicubic/var0": 1.0,
+        "generation/metrics/relative_crps_bicubic/var1": 3.0,
+        "generation/some_other/prediction_frac_of_target/99.9999th-percentile/var0": (
+            object()
+        ),
+        "generation/histogram/prediction_frac_of_target/99.9999th-percentile/var0": (
+            1.02
+        ),
+        "generation/histogram/prediction_frac_of_target/0.0001th-percentile/var0": (
+            0.98
+        ),
+    }
+
+    best_result = _get_channel_mean_scalar_metric(
+        metrics, prefix="metrics/relative_crps_bicubic"
+    )
+    histogram_result = _get_channel_mean_scalar_metric(
+        metrics,
+        prefix="histogram/prediction_frac_of_target/99.9999th-percentile",
+    )
+
+    assert best_result == 2.0
+    assert histogram_result == 1.0

--- a/fme/downscaling/aggregators/test_aggregators.py
+++ b/fme/downscaling/aggregators/test_aggregators.py
@@ -475,3 +475,28 @@ def test_get_channel_mean_scalar_metric_excludes_matching_maps():
 
     assert best_result == 2.0
     assert histogram_result == 1.0
+
+
+def test_generation_aggregator_get_checkpoint_selection_metrics():
+    aggregator = GenerationAggregator(["lat", "lon"], downscale_factor=2)
+    aggregator._wandb_logs = {
+        "generation/maps/relative_crps_bicubic/var0": object(),
+        "generation/metrics/relative_crps_bicubic/var0": 1.0,
+        "generation/metrics/relative_crps_bicubic/var1": 3.0,
+        "generation/some_other/prediction_frac_of_target/99.9999th-percentile/var0": (
+            object()
+        ),
+        "generation/histogram/prediction_frac_of_target/99.9999th-percentile/var0": (
+            1.2
+        ),
+        "generation/histogram/prediction_frac_of_target/0.0001th-percentile/var0": (
+            0.9
+        ),
+    }
+
+    metrics = aggregator.get_checkpoint_selection_metrics()
+
+    assert metrics["metrics/relative_crps_bicubic"] == 2.0
+    assert metrics[
+        "histogram/prediction_frac_of_target/99.9999th-percentile"
+    ] == pytest.approx(0.05)

--- a/fme/downscaling/test_train.py
+++ b/fme/downscaling/test_train.py
@@ -15,13 +15,7 @@ from fme.core.testing.model import compare_restored_parameters
 from fme.core.testing.wandb import mock_wandb
 from fme.downscaling.data import RegionSamplingConfig
 from fme.downscaling.test_utils import create_test_data_on_disk, data_paths_helper
-from fme.downscaling.train import (
-    Trainer,
-    TrainerConfig,
-    _get_complement_percentile_prefix,
-    main,
-    restore_checkpoint,
-)
+from fme.downscaling.train import Trainer, TrainerConfig, main, restore_checkpoint
 from fme.downscaling.typing_ import FineResCoarseResPair
 
 NUM_TIMESTEPS = 4
@@ -341,25 +335,3 @@ def test_resume_two_workers(default_trainer_config, tmp_path, skip_slow: bool):
     initial_process.check_returncode()
     resume_process = subprocess.run(command)
     resume_process.check_returncode()
-
-
-@pytest.mark.parametrize(
-    "prefix, expected",
-    [
-        (
-            "histogram/prediction_frac_of_target/99.99th-percentile/var0",
-            "histogram/prediction_frac_of_target/0.01th-percentile/var0",
-        ),
-        (
-            "some_metric/percentile/99.9999/var0",
-            "some_metric/percentile/0.0001/var0",
-        ),
-        (
-            "no_percentile_here/some_metric",
-            None,
-        ),
-    ],
-)
-def test_get_complement_percentile_prefix(prefix, expected):
-    result = _get_complement_percentile_prefix(prefix)
-    assert result == expected

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -3,7 +3,6 @@ import contextlib
 import dataclasses
 import logging
 import os
-import re
 import shutil
 import time
 import uuid
@@ -142,9 +141,9 @@ class Trainer:
                 self.config.checkpoint_dir, "best_histogram_tail.ckpt"
             )
 
-        self._best_valid_loss_name = "generation/metrics/relative_crps_bicubic"
+        self._best_valid_loss_name = "relative_crps_bicubic"
         self._best_histogram_tail_name = (
-            "generation/histogram/prediction_frac_of_target/99.9999th-percentile"
+            "prediction_frac_of_target/99.9999th-percentile"
         )
 
     def _get_batch_generator(
@@ -261,6 +260,8 @@ class Trainer:
                 self.model.downscale_factor,
                 percentiles=[99.99, 99.9999],
                 include_positional_comparisons=include_positional_comparisons,
+                histogram_ckpt_selection_metric=self._best_histogram_tail_name,
+                best_ckpt_selection_metric=self._best_valid_loss_name,
             )
             batch: PairedBatchData
             validation_batch_generator = self._get_batch_generator(
@@ -296,13 +297,9 @@ class Trainer:
             {**generation_metrics, **validation_metrics},
             self.num_batches_seen,
         )
-        channel_mean_checkpoint_metrics = {
-            prefix: _get_channel_mean_scalar_metric(generation_metrics, prefix)
-            for prefix in [
-                self._best_valid_loss_name,
-                self._best_histogram_tail_name,
-            ]
-        }
+        channel_mean_checkpoint_metrics = (
+            generation_aggregator.get_checkpoint_selection_metrics()
+        )
         return channel_mean_checkpoint_metrics
 
     @property
@@ -329,7 +326,7 @@ class Trainer:
                     "best checkpoint."
                 )
         if self.best_histogram_tail_checkpoint_path is not None:
-            histogram_tail_metric = self._get_best_histogram_tail_metric(valid_metrics)
+            histogram_tail_metric = valid_metrics[self._best_histogram_tail_name]
             if histogram_tail_metric < self.best_histogram_tail_metric:
                 logging.info("Saving checkpoint for best histogram tail.")
                 self.best_histogram_tail_metric = histogram_tail_metric
@@ -342,12 +339,6 @@ class Trainer:
                 )
         else:
             raise ValueError("Best checkpoint path is not set")
-
-    def _get_best_histogram_tail_metric(self, valid_metrics: dict[str, float]) -> float:
-        metric = valid_metrics[self._best_histogram_tail_name]
-        if "frac_of_target" in self._best_histogram_tail_name:
-            return abs(1.0 - metric)
-        return metric
 
     def save_epoch_checkpoints(self) -> None:
         if self.epoch_checkpoint_path is not None:
@@ -518,52 +509,6 @@ class TrainerConfig:
         self.logging.configure_logging(
             self.experiment_dir, log_filename, config=config, resumable=True
         )
-
-
-def _get_complement_percentile_prefix(prefix):
-    """
-    Given a prefix containing a percentile value, return a prefix with
-    100 minus that percentile. Returns None if no percentile pattern is found.
-    Ex. "prediction_frac_of_target/99.9999th-percentile"
-        -> "prediction_frac_of_target/0.0001th-percentile", or
-        "some_var/percentile/99.9999" -> "some_var/percentile/0.0001".
-    """
-    match = re.search(
-        r"(\d+(?:\.\d+)?)(?:th)?[-_/]percentile|percentile[-_/](\d+(?:\.\d+)?)",
-        prefix,
-    )
-    if match is None:
-        return None
-    if match.group(1) is not None:
-        num_str = match.group(1)
-        num_start, num_end = match.start(1), match.end(1)
-    else:
-        num_str = match.group(2)
-        num_start, num_end = match.start(2), match.end(2)
-    complement = 100 - float(num_str)
-    if "." in num_str:
-        decimal_places = len(num_str.split(".")[1])
-        complement_str = f"{complement:.{decimal_places}f}"
-    else:
-        complement_str = str(int(complement))
-    return prefix[:num_start] + complement_str + prefix[num_end:]
-
-
-def _get_channel_mean_scalar_metric(
-    metrics, prefix="generation/metrics/relative_crps_bicubic"
-):
-    prefixes = [prefix]
-    if "percentile" in prefix:
-        complement = _get_complement_percentile_prefix(prefix)
-        if complement is not None and complement != prefix:
-            prefixes.append(complement)
-    channel_metric = [
-        v for k, v in metrics.items() if any(k.startswith(p) for p in prefixes)
-    ]
-    if len(channel_metric) == 0:
-        return float("inf")
-    else:
-        return sum(channel_metric) / len(channel_metric)
 
 
 def _resume_from_results_dir_if_not_preempted(experiment_dir, resume_results_dir):

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -329,14 +329,10 @@ class Trainer:
                     "best checkpoint."
                 )
         if self.best_histogram_tail_checkpoint_path is not None:
-            if (
-                valid_metrics[self._best_histogram_tail_name]
-                < self.best_histogram_tail_metric
-            ):
+            histogram_tail_metric = self._get_best_histogram_tail_metric(valid_metrics)
+            if histogram_tail_metric < self.best_histogram_tail_metric:
                 logging.info("Saving checkpoint for best histogram tail.")
-                self.best_histogram_tail_metric = valid_metrics[
-                    self._best_histogram_tail_name
-                ]
+                self.best_histogram_tail_metric = histogram_tail_metric
                 with best_checkpoint_context():
                     _save_checkpoint(self, self.best_histogram_tail_checkpoint_path)
             else:
@@ -346,6 +342,12 @@ class Trainer:
                 )
         else:
             raise ValueError("Best checkpoint path is not set")
+
+    def _get_best_histogram_tail_metric(self, valid_metrics: dict[str, float]) -> float:
+        metric = valid_metrics[self._best_histogram_tail_name]
+        if "frac_of_target" in self._best_histogram_tail_name:
+            return abs(1.0 - metric)
+        return metric
 
     def save_epoch_checkpoints(self) -> None:
         if self.epoch_checkpoint_path is not None:

--- a/fme/downscaling/train.py
+++ b/fme/downscaling/train.py
@@ -141,9 +141,9 @@ class Trainer:
                 self.config.checkpoint_dir, "best_histogram_tail.ckpt"
             )
 
-        self._best_valid_loss_name = "relative_crps_bicubic"
+        self._best_valid_loss_name = "metrics/relative_crps_bicubic"
         self._best_histogram_tail_name = (
-            "prediction_frac_of_target/99.9999th-percentile"
+            "histogram/prediction_frac_of_target/99.9999th-percentile"
         )
 
     def _get_batch_generator(


### PR DESCRIPTION
This fixes two bugs related to the percentile fraction of target metrics:

1) 'best histogram checkpoint' selection in downscaling was switched to use this metric but was still picking the checkpoint by minimizing the value. This fixes the selection to minimize abs(1.0 - percentile_frac_of_target).
2) `ComparedDynamicTailsHistograms.get_wandb` had numerator/denominator flipped (is ok in ComparedDynamicHistograms`)
3) Moves the calculation of the best checkpoint selection metrics (always expected to be minimized) into the generation aggregator. They are accessed by the trainer by called the new method `GenerationAggregator.get_checkpoint_selection_metrics`
 

- [x] Tests added 