### PR TITLE
Extract NameAndPrefixMatcher to shared `fme.core` module

### DIFF
--- a/fme/core/name_and_prefix_matcher.py
+++ b/fme/core/name_and_prefix_matcher.py
@@ -29,6 +29,8 @@ class NameAndPrefixMatcher:
             return r"|".join(regex)
         return None
 
-    def matches(self, name: str) -> bool:
+    def match(self, name: str) -> bool:
         """Return whether ``name`` matches any configured name or prefix."""
-        return bool(self._regex and re.match(self._regex, name))
+        if self._regex is None:
+            return False
+        return bool(re.match(self._regex, name))

--- a/fme/core/name_and_prefix_matcher.py
+++ b/fme/core/name_and_prefix_matcher.py
@@ -1,0 +1,34 @@
+import re
+
+
+class NameAndPrefixMatcher:
+    """Match variable names against a list of names and prefixes.
+
+    The matching convention is:
+        - A bare name (e.g. ``thetao``) matches the 2D variable ``thetao`` and
+          all of its 3D levels ``thetao_<level>``.
+        - A trailing-underscore prefix (e.g. ``thetao_``) matches all
+          ``thetao_<level>``.
+        - An explicit ``name_<level>`` (e.g. ``thetao_0``) matches exactly.
+    """
+
+    def __init__(self, names_and_prefixes: list[str] | None = None):
+        self._regex = self._build_regex(names_and_prefixes)
+
+    def _build_regex(self, names_and_prefixes: list[str] | None) -> str | None:
+        if names_and_prefixes:
+            regex = []
+            for name in names_and_prefixes:
+                if name.endswith("_"):
+                    regex.append(rf"^{name}\d+$")
+                elif not re.match(r".+_\d+$", name):
+                    regex.append(f"^{name}$")
+                    regex.append(rf"^{name}_\d+$")
+                else:
+                    regex.append(rf"^{name}$")
+            return r"|".join(regex)
+        return None
+
+    def matches(self, name: str) -> bool:
+        """Return whether ``name`` matches any configured name or prefix."""
+        return bool(self._regex and re.match(self._regex, name))

--- a/fme/core/spatial_masking.py
+++ b/fme/core/spatial_masking.py
@@ -72,6 +72,7 @@ class StaticSpatialMaskingConfig:
         Build StaticSpatialMasking.
 
         """
+        exclude = NameAndPrefixMatcher(self.exclude_names_and_prefixes)
         if isinstance(self.fill_value, float):
             return StaticSpatialMasking(
                 mask_value=self.mask_value,
@@ -79,7 +80,7 @@ class StaticSpatialMaskingConfig:
                     lambda: torch.as_tensor(self.fill_value)
                 ),
                 mask=mask,
-                exclude_names_and_prefixes=self.exclude_names_and_prefixes,
+                exclude=exclude,
             )
         if means is None:
             raise ValueError(
@@ -90,7 +91,7 @@ class StaticSpatialMaskingConfig:
             mask_value=self.mask_value,
             fill_value=means,
             mask=mask,
-            exclude_names_and_prefixes=self.exclude_names_and_prefixes,
+            exclude=exclude,
         )
 
 
@@ -100,7 +101,7 @@ class StaticSpatialMasking:
         mask_value: int,
         fill_value: float | TensorMapping,
         mask: HasGetSpatialMask,
-        exclude_names_and_prefixes: list[str] | None = None,
+        exclude: NameAndPrefixMatcher = NameAndPrefixMatcher(),
     ):
         if isinstance(fill_value, float):
             fill_mapping: TensorMapping = collections.defaultdict(
@@ -111,10 +112,10 @@ class StaticSpatialMasking:
         self._fill_mapping = fill_mapping
         self._mask_value = mask_value
         self._mask = mask
-        self._exclude_matcher = NameAndPrefixMatcher(exclude_names_and_prefixes)
+        self._exclude = exclude
 
-    def _masks(self, name: str):
-        return not self._exclude_matcher.matches(name)
+    def _masks(self, name: str) -> bool:
+        return not self._exclude.match(name)
 
     def __call__(self, data: TensorMapping) -> TensorDict:
         """

--- a/fme/core/spatial_masking.py
+++ b/fme/core/spatial_masking.py
@@ -1,11 +1,11 @@
 import collections
 import dataclasses
-import re
 from collections.abc import Callable
 from typing import Literal, Protocol, runtime_checkable
 
 import torch
 
+from fme.core.name_and_prefix_matcher import NameAndPrefixMatcher
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -111,25 +111,10 @@ class StaticSpatialMasking:
         self._fill_mapping = fill_mapping
         self._mask_value = mask_value
         self._mask = mask
-        self._exclude_regex = self._build_regex(exclude_names_and_prefixes)
-
-    def _build_regex(self, names_and_prefixes: list[str] | None) -> str | None:
-        if names_and_prefixes:
-            regex = []
-            for name in names_and_prefixes:
-                if name.endswith("_"):
-                    regex.append(rf"^{name}\d+$")
-                elif not re.match(r".+_\d+$", name):
-                    regex.append(f"^{name}$")
-                    regex.append(rf"^{name}_\d+$")
-                else:
-                    regex.append(rf"^{name}$")
-            return r"|".join(regex)
-        return None
+        self._exclude_matcher = NameAndPrefixMatcher(exclude_names_and_prefixes)
 
     def _masks(self, name: str):
-        exclude = self._exclude_regex and re.match(self._exclude_regex, name)
-        return not exclude
+        return not self._exclude_matcher.matches(name)
 
     def __call__(self, data: TensorMapping) -> TensorDict:
         """

--- a/fme/core/test_name_and_prefix_matcher.py
+++ b/fme/core/test_name_and_prefix_matcher.py
@@ -1,0 +1,52 @@
+from fme.core.name_and_prefix_matcher import NameAndPrefixMatcher
+
+
+def test_empty_matcher_matches_nothing():
+    matcher = NameAndPrefixMatcher()
+    assert not matcher.matches("thetao")
+    assert not matcher.matches("thetao_0")
+
+    matcher = NameAndPrefixMatcher([])
+    assert not matcher.matches("thetao")
+    assert not matcher.matches("thetao_0")
+
+
+def test_bare_name_matches_2d_and_levels():
+    matcher = NameAndPrefixMatcher(["thetao"])
+    # bare name matches the 2D variable
+    assert matcher.matches("thetao")
+    # and all of its 3D levels
+    assert matcher.matches("thetao_0")
+    assert matcher.matches("thetao_12")
+    # but not a different variable sharing a prefix
+    assert not matcher.matches("thetao_extra")
+    assert not matcher.matches("other")
+
+
+def test_trailing_underscore_prefix_matches_levels_only():
+    matcher = NameAndPrefixMatcher(["thetao_"])
+    # prefix matches all levels
+    assert matcher.matches("thetao_0")
+    assert matcher.matches("thetao_12")
+    # but not the bare 2D variable
+    assert not matcher.matches("thetao")
+    # and not a different variable
+    assert not matcher.matches("other_0")
+
+
+def test_explicit_name_level_matches_exactly():
+    matcher = NameAndPrefixMatcher(["thetao_0"])
+    assert matcher.matches("thetao_0")
+    # other levels of the same variable are not matched
+    assert not matcher.matches("thetao_1")
+    # the bare variable is not matched
+    assert not matcher.matches("thetao")
+
+
+def test_multiple_names_and_prefixes():
+    matcher = NameAndPrefixMatcher(["PRESsfc", "so_", "thetao_0"])
+    assert matcher.matches("PRESsfc")
+    assert matcher.matches("so_3")
+    assert matcher.matches("thetao_0")
+    assert not matcher.matches("so")
+    assert not matcher.matches("thetao_1")

--- a/fme/core/test_name_and_prefix_matcher.py
+++ b/fme/core/test_name_and_prefix_matcher.py
@@ -3,50 +3,50 @@ from fme.core.name_and_prefix_matcher import NameAndPrefixMatcher
 
 def test_empty_matcher_matches_nothing():
     matcher = NameAndPrefixMatcher()
-    assert not matcher.matches("thetao")
-    assert not matcher.matches("thetao_0")
+    assert not matcher.match("thetao")
+    assert not matcher.match("thetao_0")
 
     matcher = NameAndPrefixMatcher([])
-    assert not matcher.matches("thetao")
-    assert not matcher.matches("thetao_0")
+    assert not matcher.match("thetao")
+    assert not matcher.match("thetao_0")
 
 
 def test_bare_name_matches_2d_and_levels():
     matcher = NameAndPrefixMatcher(["thetao"])
     # bare name matches the 2D variable
-    assert matcher.matches("thetao")
+    assert matcher.match("thetao")
     # and all of its 3D levels
-    assert matcher.matches("thetao_0")
-    assert matcher.matches("thetao_12")
+    assert matcher.match("thetao_0")
+    assert matcher.match("thetao_12")
     # but not a different variable sharing a prefix
-    assert not matcher.matches("thetao_extra")
-    assert not matcher.matches("other")
+    assert not matcher.match("thetao_extra")
+    assert not matcher.match("other")
 
 
 def test_trailing_underscore_prefix_matches_levels_only():
     matcher = NameAndPrefixMatcher(["thetao_"])
     # prefix matches all levels
-    assert matcher.matches("thetao_0")
-    assert matcher.matches("thetao_12")
+    assert matcher.match("thetao_0")
+    assert matcher.match("thetao_12")
     # but not the bare 2D variable
-    assert not matcher.matches("thetao")
+    assert not matcher.match("thetao")
     # and not a different variable
-    assert not matcher.matches("other_0")
+    assert not matcher.match("other_0")
 
 
 def test_explicit_name_level_matches_exactly():
     matcher = NameAndPrefixMatcher(["thetao_0"])
-    assert matcher.matches("thetao_0")
+    assert matcher.match("thetao_0")
     # other levels of the same variable are not matched
-    assert not matcher.matches("thetao_1")
+    assert not matcher.match("thetao_1")
     # the bare variable is not matched
-    assert not matcher.matches("thetao")
+    assert not matcher.match("thetao")
 
 
 def test_multiple_names_and_prefixes():
     matcher = NameAndPrefixMatcher(["PRESsfc", "so_", "thetao_0"])
-    assert matcher.matches("PRESsfc")
-    assert matcher.matches("so_3")
-    assert matcher.matches("thetao_0")
-    assert not matcher.matches("so")
-    assert not matcher.matches("thetao_1")
+    assert matcher.match("PRESsfc")
+    assert matcher.match("so_3")
+    assert matcher.match("thetao_0")
+    assert not matcher.match("so")
+    assert not matcher.match("thetao_1")


### PR DESCRIPTION
Move the prefix-aware name/prefix matching logic out of StaticSpatialMasking into a new shared `NameAndPrefixMatcher` in `fme/core/name_and_prefix_matcher.py`, exposing a single `match(name) -> bool` method. The matching semantics are preserved exactly: a bare name matches the 2D variable and its 3D levels, a trailing-underscore prefix matches all levels, and an explicit `name_<level>` matches exactly.

Spatial masking now constructs and uses `NameAndPrefixMatcher` in place of its private `_build_regex`. Pure refactor, no behavior change.

Changes:
- `StaticSpatialMasking` init arg `exclude_names_and_prefixes: list[str]` removed in favor of `exclude: NameAndPrefixMatcher = NameAndPrefixMatcher()`. The `NameAndPrefixMatcher` object is built from the configured `exclude_names_and_prefixes` in `StaticSpatialMaskingConfig.build()`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated