### PR TITLE
Enforce abstract-or-final rule and flatten in-repo inheritance

### DIFF
--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -328,6 +328,10 @@ class FCN3StepConfig(StepConfigABC):
     def load(self):
         self.normalization.load()
 
+    @property
+    def allow_missing_variables(self) -> bool:
+        return False
+
 
 class FCN3Step(StepABC):
     """

--- a/fme/core/benchmark/benchmark.py
+++ b/fme/core/benchmark/benchmark.py
@@ -3,7 +3,7 @@ import dataclasses
 import pathlib
 import time
 from collections.abc import Callable
-from typing import Self
+from typing import Self, final
 
 import dacite
 import matplotlib.pyplot as plt
@@ -271,6 +271,7 @@ class BenchmarkResult:
 
 class BenchmarkABC(abc.ABC):
     @classmethod
+    @final
     def new_from_fn(
         cls,
         fn: Callable[[Timer], TensorDict],
@@ -279,6 +280,10 @@ class BenchmarkABC(abc.ABC):
             @classmethod
             def new(cls) -> "FnBenchmark":
                 return FnBenchmark()
+
+            @classmethod
+            def new_for_regression(cls) -> "FnBenchmark | None":
+                return None
 
             def run_instance(self, timer: Timer) -> TensorDict:
                 return fn(timer)
@@ -295,6 +300,7 @@ class BenchmarkABC(abc.ABC):
         pass
 
     @classmethod
+    @abc.abstractmethod
     def new_for_regression(cls: type[Self]) -> Self | None:
         """
         Initialize any state needed for regression testing.
@@ -306,9 +312,10 @@ class BenchmarkABC(abc.ABC):
         This exists as a separate method from new so that it can
         use small data sizes more conducive to storing regression targets in git.
         """
-        return None
+        pass
 
     @classmethod
+    @final
     def run_benchmark(cls, iters=10, warmup=1) -> BenchmarkResult:
         if not torch.cuda.is_available():
             raise RuntimeError("CUDA is not available, cannot run benchmark.")
@@ -333,6 +340,7 @@ class BenchmarkABC(abc.ABC):
         )
 
     @classmethod
+    @final
     def run_regression(cls) -> TensorDict | None:
         benchmark = cls.new_for_regression()
         if benchmark is None:

--- a/fme/core/disco/_convolution.py
+++ b/fme/core/disco/_convolution.py
@@ -8,6 +8,7 @@
 
 import abc
 import math
+from typing import final
 
 import torch
 import torch.nn as nn
@@ -239,6 +240,7 @@ class DiscreteContinuousConv(nn.Module, metaclass=abc.ABCMeta):
             self.bias = None
 
     @property
+    @final
     def kernel_size(self):
         return self.filter_basis.kernel_size
 

--- a/fme/core/disco/_filter_basis.py
+++ b/fme/core/disco/_filter_basis.py
@@ -4,6 +4,7 @@
 
 import abc
 import math
+from typing import final
 
 import torch
 
@@ -39,6 +40,7 @@ class FilterBasis(metaclass=abc.ABCMeta):
         else:
             return f"{class_name}()"
 
+    @final
     def extra_repr(self):
         return f"kernel_shape={self.kernel_shape}"
 

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from copy import copy
 from typing import Any, TypeVar
 
+import dacite
 import torch
 from torch import nn
 
@@ -206,6 +207,14 @@ class MultiCallStepConfig(StepConfigABC):
 
     def load(self):
         self.wrapped_step.load()
+
+    @property
+    def allow_missing_variables(self) -> bool:
+        return self.wrapped_step.allow_missing_variables
+
+    @classmethod
+    def from_state(cls, state) -> "MultiCallStepConfig":
+        return dacite.from_dict(cls, state, config=dacite.Config(strict=True))
 
 
 def _extend_normalizer_with_multi_call_outputs(

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -160,6 +160,13 @@ class SeparateRadiationStepConfig(StepConfigABC):
     def get_next_step_forcing_names(self) -> list[str]:
         return self.next_step_forcing_names
 
+    def replace_prescribed_prognostic_names(self, names: list[str]) -> None:
+        pass
+
+    @property
+    def allow_missing_variables(self) -> bool:
+        return False
+
     @property
     def diagnostic_names(self) -> list[str]:
         return list(

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -253,6 +253,10 @@ class SecondaryModuleStepConfig(StepConfigABC):
     def load(self):
         self.normalization.load()
 
+    @property
+    def allow_missing_variables(self) -> bool:
+        return False
+
 
 class SecondaryModuleStep(StepABC):
     """

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -106,13 +106,14 @@ class StepConfigABC(abc.ABC):
     def get_ocean(self) -> OceanConfig | None:
         pass
 
+    @abc.abstractmethod
     def replace_prescribed_prognostic_names(self, names: list[str]) -> None:
         """Replace prescribed prognostic names (e.g. when loading from checkpoint)."""
-        pass
 
     @property
+    @abc.abstractmethod
     def allow_missing_variables(self) -> bool:
-        return False
+        pass
 
     @abc.abstractmethod
     def load(self):
@@ -122,8 +123,9 @@ class StepConfigABC(abc.ABC):
         pass
 
     @classmethod
+    @abc.abstractmethod
     def from_state(cls, state: Mapping[str, Any]) -> Self:
-        return dacite.from_dict(cls, state, config=dacite.Config(strict=True))
+        pass
 
 
 @dataclasses.dataclass
@@ -223,6 +225,10 @@ class StepSelector(StepConfigABC):
     def load(self):
         self._step_config_instance.load()
         self.config = dataclasses.asdict(self._step_config_instance)
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, Any]) -> Self:
+        return dacite.from_dict(cls, state, config=dacite.Config(strict=True))
 
 
 class StepABC(abc.ABC):

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -3,6 +3,7 @@ import datetime
 from collections.abc import Callable
 from unittest.mock import MagicMock
 
+import dacite
 import torch
 from torch import nn
 
@@ -124,6 +125,17 @@ class MockStepConfig(StepConfigABC):
 
     def load(self):
         pass
+
+    def replace_prescribed_prognostic_names(self, names: list[str]) -> None:
+        pass
+
+    @property
+    def allow_missing_variables(self) -> bool:
+        return False
+
+    @classmethod
+    def from_state(cls, state) -> "MockStepConfig":
+        return dacite.from_dict(cls, state, config=dacite.Config(strict=True))
 
 
 def test_register():

--- a/fme/downscaling/modules/physicsnemo_unets_v2/benchmark.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v2/benchmark.py
@@ -1,6 +1,5 @@
 import dataclasses
 from dataclasses import dataclass
-from typing import Self
 
 import torch
 
@@ -168,182 +167,181 @@ def _run_channels_last_diagnostics(
     )
 
 
-class SongUNetv2Benchmark(BenchmarkABC):
-    def __init__(
-        self,
-        model: SongUNetv2,
-        x: torch.Tensor,
-        noise_labels: torch.Tensor,
-        class_labels: torch.Tensor | None,
-        use_amp_bf16: bool = False,
-    ):
-        self.model = model
-        self.x = x
-        self.noise_labels = noise_labels
-        self.class_labels = class_labels
-        self.use_amp_bf16 = use_amp_bf16
-        self._channels_last_diagnostics = _run_channels_last_diagnostics(
-            model, x, noise_labels, class_labels
-        )
+@dataclass(frozen=True)
+class _SongUNetv2BenchmarkParams:
+    img_resolution: int
+    in_channels: int
+    out_channels: int
+    label_dim: int
+    model_channels: int
+    channel_mult: list[int]
+    use_apex_gn: bool = False
+    use_amp_bf16: bool = False
 
-    def _get_amp_context(self):
-        if self.use_amp_bf16:
-            return torch.amp.autocast(get_device().type, dtype=torch.bfloat16)
-        return torch.amp.autocast(get_device().type, enabled=False)
 
-    def run_instance(self, timer) -> TensorDict:
-        with self._get_amp_context():
-            result = self.model(
-                self.x,
-                self.noise_labels,
-                self.class_labels,
-                timer=timer,
+def _make_song_unet_benchmark(
+    *,
+    new_params: _SongUNetv2BenchmarkParams,
+    regression_params: _SongUNetv2BenchmarkParams | None,
+) -> type[BenchmarkABC]:
+    class _SongUNetv2BenchmarkVariant(BenchmarkABC):
+        def __init__(
+            self,
+            model: SongUNetv2,
+            x: torch.Tensor,
+            noise_labels: torch.Tensor,
+            class_labels: torch.Tensor | None,
+            use_amp_bf16: bool,
+        ):
+            self.model = model
+            self.x = x
+            self.noise_labels = noise_labels
+            self.class_labels = class_labels
+            self.use_amp_bf16 = use_amp_bf16
+            self._channels_last_diagnostics = _run_channels_last_diagnostics(
+                model, x, noise_labels, class_labels
             )
-        return {
-            "output": result.detach(),
-            "diagnostics": self._channels_last_diagnostics.to_tensor_dict(),
-        }
 
-    @classmethod
-    def new(cls) -> Self:
-        return cls._new_with_params(
-            img_resolution=64,
-            B=1,
-            in_channels=3,
-            out_channels=2,
-            label_dim=0,
-            model_channels=16,
-            channel_mult=[1, 2, 2, 2],
-            use_apex_gn=False,
-        )
+        def _get_amp_context(self):
+            if self.use_amp_bf16:
+                return torch.amp.autocast(get_device().type, dtype=torch.bfloat16)
+            return torch.amp.autocast(get_device().type, enabled=False)
 
-    @classmethod
-    def _new_with_params(
-        cls,
-        img_resolution: int,
-        B: int,
-        in_channels: int,
-        out_channels: int,
-        label_dim: int,
-        model_channels: int,
-        channel_mult: list[int],
-        use_apex_gn: bool = False,
-        use_amp_bf16: bool = False,
-    ) -> Self:
-        device = get_device()
-        model = SongUNetv2(
-            img_resolution=img_resolution,
-            in_channels=in_channels,
-            out_channels=out_channels,
-            label_dim=label_dim,
-            model_channels=model_channels,
-            channel_mult=channel_mult,
-            num_blocks=4,
-            attn_resolutions=[],
-            dropout=0.0,
-            use_apex_gn=use_apex_gn,
-        ).to(device)
-        model.eval()
+        def run_instance(self, timer) -> TensorDict:
+            with self._get_amp_context():
+                result = self.model(
+                    self.x,
+                    self.noise_labels,
+                    self.class_labels,
+                    timer=timer,
+                )
+            return {
+                "output": result.detach(),
+                "diagnostics": self._channels_last_diagnostics.to_tensor_dict(),
+            }
 
-        H = W = img_resolution
-        x = torch.randn(B, in_channels, H, W, device=device)
-        noise_labels = torch.rand(B, device=device)
-        class_labels = (
-            torch.randn(B, label_dim, device=device) if label_dim > 0 else None
-        )
-        if use_apex_gn:
-            if not apex_available():
-                raise ValueError("'apex' is not installed, set `use_apex_gn=False`")
-            x = x.to(memory_format=torch.channels_last)
+        @classmethod
+        def _build(
+            cls, params: _SongUNetv2BenchmarkParams
+        ) -> "_SongUNetv2BenchmarkVariant":
+            device = get_device()
+            model = SongUNetv2(
+                img_resolution=params.img_resolution,
+                in_channels=params.in_channels,
+                out_channels=params.out_channels,
+                label_dim=params.label_dim,
+                model_channels=params.model_channels,
+                channel_mult=params.channel_mult,
+                num_blocks=4,
+                attn_resolutions=[],
+                dropout=0.0,
+                use_apex_gn=params.use_apex_gn,
+            ).to(device)
+            model.eval()
 
-        return cls(
-            model=model,
-            x=x,
-            noise_labels=noise_labels,
-            class_labels=class_labels,
-            use_amp_bf16=use_amp_bf16,
-        )
+            B = 1
+            H = W = params.img_resolution
+            x = torch.randn(B, params.in_channels, H, W, device=device)
+            noise_labels = torch.rand(B, device=device)
+            class_labels = (
+                torch.randn(B, params.label_dim, device=device)
+                if params.label_dim > 0
+                else None
+            )
+            if params.use_apex_gn:
+                if not apex_available():
+                    raise ValueError(
+                        "'apex' is not installed, set `use_apex_gn=False`"
+                    )
+                x = x.to(memory_format=torch.channels_last)
 
-    @classmethod
-    def new_for_regression(cls) -> Self | None:
-        return cls._new_with_params(
-            img_resolution=16,
-            B=1,
-            in_channels=3,
-            out_channels=2,
-            label_dim=0,
-            model_channels=16,
-            channel_mult=[1, 2],
-            use_apex_gn=False,
-        )
+            return cls(
+                model=model,
+                x=x,
+                noise_labels=noise_labels,
+                class_labels=class_labels,
+                use_amp_bf16=params.use_amp_bf16,
+            )
 
-class SongUNetv2BenchmarkBf16(SongUNetv2Benchmark):
-    @classmethod
-    def new(cls) -> Self:
-        return cls._new_with_params(
-            img_resolution=64,
-            B=1,
-            in_channels=3,
-            out_channels=2,
-            label_dim=0,
-            model_channels=16,
-            channel_mult=[1, 2, 2, 2],
-            use_apex_gn=False,
-            use_amp_bf16=True,
-        )
+        @classmethod
+        def new(cls) -> "_SongUNetv2BenchmarkVariant":
+            return cls._build(new_params)
 
-    @classmethod
-    def new_for_regression(cls) -> Self | None:
-        return cls._new_with_params(
-            img_resolution=16,
-            B=1,
-            in_channels=3,
-            out_channels=2,
-            label_dim=0,
-            model_channels=16,
-            channel_mult=[1, 2],
-            use_apex_gn=False,
-            use_amp_bf16=True,
-        )
+        @classmethod
+        def new_for_regression(cls) -> "_SongUNetv2BenchmarkVariant | None":
+            if regression_params is None:
+                return None
+            return cls._build(regression_params)
+
+    return _SongUNetv2BenchmarkVariant
 
 
-class SongUNetv2BenchmarkApex(SongUNetv2Benchmark):
-    @classmethod
-    def new(cls) -> Self:
-        return cls._new_with_params(
-            img_resolution=512,
-            B=1,
-            in_channels=6,
-            out_channels=4,
-            label_dim=0,
-            model_channels=128, # min for apex gn
-            channel_mult=[1, 2, 2, 2],
-            use_apex_gn=True,
-        )
+SongUNetv2Benchmark = _make_song_unet_benchmark(
+    new_params=_SongUNetv2BenchmarkParams(
+        img_resolution=64,
+        in_channels=3,
+        out_channels=2,
+        label_dim=0,
+        model_channels=16,
+        channel_mult=[1, 2, 2, 2],
+    ),
+    regression_params=_SongUNetv2BenchmarkParams(
+        img_resolution=16,
+        in_channels=3,
+        out_channels=2,
+        label_dim=0,
+        model_channels=16,
+        channel_mult=[1, 2],
+    ),
+)
 
-    @classmethod
-    def new_for_regression(cls) -> Self | None:
-        return None
+SongUNetv2BenchmarkBf16 = _make_song_unet_benchmark(
+    new_params=_SongUNetv2BenchmarkParams(
+        img_resolution=64,
+        in_channels=3,
+        out_channels=2,
+        label_dim=0,
+        model_channels=16,
+        channel_mult=[1, 2, 2, 2],
+        use_amp_bf16=True,
+    ),
+    regression_params=_SongUNetv2BenchmarkParams(
+        img_resolution=16,
+        in_channels=3,
+        out_channels=2,
+        label_dim=0,
+        model_channels=16,
+        channel_mult=[1, 2],
+        use_amp_bf16=True,
+    ),
+)
 
+SongUNetv2BenchmarkApex = _make_song_unet_benchmark(
+    new_params=_SongUNetv2BenchmarkParams(
+        img_resolution=512,
+        in_channels=6,
+        out_channels=4,
+        label_dim=0,
+        model_channels=128,  # min for apex gn
+        channel_mult=[1, 2, 2, 2],
+        use_apex_gn=True,
+    ),
+    regression_params=None,
+)
 
-class SongUNetv2BenchmarkApexBf16(SongUNetv2Benchmark):
-    @classmethod
-    def new(cls) -> Self:
-        return cls._new_with_params(
-            img_resolution=512,
-            B=1,
-            in_channels=6,
-            out_channels=4,
-            label_dim=0,
-            model_channels=128, # min for apex gn
-            channel_mult=[1, 2, 2, 2],
-            use_apex_gn=True,
-            use_amp_bf16=True,
-        )
-
-    @classmethod
-    def new_for_regression(cls) -> Self | None:
-        return None
+SongUNetv2BenchmarkApexBf16 = _make_song_unet_benchmark(
+    new_params=_SongUNetv2BenchmarkParams(
+        img_resolution=512,
+        in_channels=6,
+        out_channels=4,
+        label_dim=0,
+        model_channels=128,  # min for apex gn
+        channel_mult=[1, 2, 2, 2],
+        use_apex_gn=True,
+        use_amp_bf16=True,
+    ),
+    regression_params=None,
+)
 
 
 register_benchmark("songunetv2")(SongUNetv2Benchmark)


### PR DESCRIPTION
Apply two new repo conventions, identified in offline discussion:

1. Methods on a class with in-repo subclasses must be `@abstractmethod` or `@final` (exception: `__init__` on `nn.Module` subclasses).
2. In-repo inheritance is at most 1 level deep, ignoring purely-abstract classes.

This PR corrects all existing violations. Each change is in its own commit so it can be split into separate PRs if preferred.

Changes:
- `fme.core.benchmark.benchmark.BenchmarkABC`: mark `new_from_fn`, `run_benchmark`, `run_regression` `@final`; promote `new_for_regression` to `@abstractmethod` and add an explicit `None`-returning implementation in the inner `FnBenchmark`.
- `fme.core.disco._filter_basis.FilterBasis.extra_repr`: mark `@final`.
- `fme.core.disco._convolution.DiscreteContinuousConv.kernel_size`: mark `@final`.
- `fme.core.step.step.StepConfigABC`: promote `replace_prescribed_prognostic_names`, `allow_missing_variables`, `from_state` to `@abstractmethod`; add explicit implementations to `MockStepConfig`, `SeparateRadiationStepConfig`, `StepSelector`, `MultiCallStepConfig`, `SecondaryModuleStepConfig`, `FCN3StepConfig` that previously relied on the inherited defaults.
- `fme.downscaling.modules.physicsnemo_unets_v2.benchmark`: flatten the `SongUNetv2Benchmark → SongUNetv2BenchmarkBf16/Apex/ApexBf16` chain by generating all four benchmarks from a single `_make_song_unet_benchmark` factory parameterized by a frozen `_SongUNetv2BenchmarkParams` dataclass. The benchmark body lives in one place; each registered benchmark is built by calling the factory with its own `(new_params, regression_params)` pair.

- [x] Tests added (existing tests cover behavior; no behavioral changes)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated