### PR TITLE
Allow precomputed net surface flux forcing in ocean's `hfds` prescribing

### DIFF
--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -19,6 +19,11 @@ from fme.core.ocean_data import HasOceanDepthIntegral, OceanData
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
+# Name of the precomputed net surface energy flux forcing, if present. Must match
+# the default name of the ace-side NetSurfaceEnergyFluxConfig deriver (fme.core
+# cannot import fme.ace, so the coupling is by value).
+NET_SURFACE_ENERGY_FLUX_NAME = "net_surface_energy_flux"
+
 
 @dataclasses.dataclass
 class SeaIceFractionConfig:
@@ -210,11 +215,23 @@ def _compute_ocean_net_surface_energy_flux(
 
     This extends the atmosphere net surface energy flux with SST-dependent
     heat transport by precipitation and evaporation.
+
+    The atmosphere net surface energy flux (``base_flux``) is taken directly from
+    a precomputed ``net_surface_energy_flux`` forcing field when present (e.g. the
+    derived forcing fed to the network); otherwise it is computed from the
+    constituent atmosphere fluxes. The two are equivalent by construction, but the
+    precomputed path is needed when the constituents have been dropped from the
+    forcing (only the net flux is kept). The SST-dependent mass heat flux term is
+    always computed from the constituent precipitation and latent heat fluxes,
+    which must remain available in ``forcing_data``.
     """
     atmos = AtmosphereData(forcing_data)
-    base_flux = (
-        atmos.net_surface_energy_flux
-    )  # missing: - calving * LATENT_HEAT_OF_FREEZING
+    if NET_SURFACE_ENERGY_FLUX_NAME in forcing_data:
+        base_flux = forcing_data[NET_SURFACE_ENERGY_FLUX_NAME]
+    else:
+        base_flux = (
+            atmos.net_surface_energy_flux
+        )  # missing: - calving * LATENT_HEAT_OF_FREEZING
     mass_heat_flux = (
         SPECIFIC_HEAT_OF_SEA_WATER_CM4
         * (

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -19,11 +19,6 @@ from fme.core.ocean_data import HasOceanDepthIntegral, OceanData
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
-# Name of the precomputed net surface energy flux forcing, if present. Must match
-# the default name of the ace-side NetSurfaceEnergyFluxConfig deriver (fme.core
-# cannot import fme.ace, so the coupling is by value).
-NET_SURFACE_ENERGY_FLUX_NAME = "net_surface_energy_flux"
-
 
 @dataclasses.dataclass
 class SeaIceFractionConfig:
@@ -206,6 +201,13 @@ class OceanCorrector(CorrectorABC):
         return dict(gen_data)
 
 
+# Name of the precomputed net surface energy flux forcing, if present. Must
+# match the name of the equivalent property on AtmosphereData, and assumed to be
+# computed in the same way (i.e., not including the SST-dependent mass heat flux
+# term).
+NET_SURFACE_ENERGY_FLUX_NAME = "net_surface_energy_flux"
+
+
 def _compute_ocean_net_surface_energy_flux(
     forcing_data: TensorMapping,
     sst: torch.Tensor,
@@ -216,14 +218,13 @@ def _compute_ocean_net_surface_energy_flux(
     This extends the atmosphere net surface energy flux with SST-dependent
     heat transport by precipitation and evaporation.
 
-    The atmosphere net surface energy flux (``base_flux``) is taken directly from
-    a precomputed ``net_surface_energy_flux`` forcing field when present (e.g. the
-    derived forcing fed to the network); otherwise it is computed from the
-    constituent atmosphere fluxes. The two are equivalent by construction, but the
-    precomputed path is needed when the constituents have been dropped from the
-    forcing (only the net flux is kept). The SST-dependent mass heat flux term is
-    always computed from the constituent precipitation and latent heat fluxes,
-    which must remain available in ``forcing_data``.
+    The atmosphere net surface energy flux (``base_flux``) is taken directly
+    from a precomputed ``net_surface_energy_flux`` forcing field when present;
+    otherwise it is computed from the constituent atmosphere fluxes. The two are
+    equivalent by construction. The SST-dependent mass heat flux term is always
+    computed from the constituent precipitation and latent heat fluxes, which
+    must remain available in ``forcing_data``.
+
     """
     atmos = AtmosphereData(forcing_data)
     if NET_SURFACE_ENERGY_FLUX_NAME in forcing_data:

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -4,8 +4,10 @@ import pytest
 import torch
 
 from fme import get_device
+from fme.core.atmosphere_data import AtmosphereData
 from fme.core.coordinates import DepthCoordinate
 from fme.core.corrector.ocean import (
+    NET_SURFACE_ENERGY_FLUX_NAME,
     OceanCorrector,
     OceanCorrectorConfig,
     OceanHeatContentBudgetConfig,
@@ -212,6 +214,32 @@ def _make_atmos_forcing_data(shape, device=DEVICE):
         "PRATEsfc": torch.full(shape, 1e-4, device=device),
         "total_frozen_precipitation_rate": torch.full(shape, 1e-5, device=device),
     }
+
+
+def test_compute_ocean_net_surface_energy_flux_uses_forcing_value():
+    """A precomputed net_surface_energy_flux forcing is used as the base flux,
+    falling back to the constituent fluxes when absent. The SST-dependent mass
+    heat flux term is added in both cases."""
+    sst = torch.full(IMG_SHAPE, 300.0, device=DEVICE)
+    forcing = _make_atmos_forcing_data(IMG_SHAPE)
+
+    # Constituent path: no precomputed net flux present.
+    constituent_result = _compute_ocean_net_surface_energy_flux(forcing, sst)
+    base_flux = AtmosphereData(forcing).net_surface_energy_flux
+
+    # Equivalence: a precomputed net flux equal to the constituent base flux
+    # reproduces the constituent path exactly.
+    forcing_equal = {**forcing, NET_SURFACE_ENERGY_FLUX_NAME: base_flux.clone()}
+    equal_result = _compute_ocean_net_surface_energy_flux(forcing_equal, sst)
+    torch.testing.assert_close(equal_result, constituent_result)
+
+    # Sentinel: a distinct precomputed value is used verbatim as the base flux,
+    # with the mass heat flux term (constituent_result - base_flux) still added.
+    mass_heat_flux = constituent_result - base_flux
+    sentinel = torch.full(IMG_SHAPE, -1234.0, device=DEVICE)
+    forcing_sentinel = {**forcing, NET_SURFACE_ENERGY_FLUX_NAME: sentinel}
+    sentinel_result = _compute_ocean_net_surface_energy_flux(forcing_sentinel, sst)
+    torch.testing.assert_close(sentinel_result, sentinel + mass_heat_flux)
 
 
 def test_surface_energy_flux_correction_resid():


### PR DESCRIPTION
`_compute_ocean_net_surface_energy_flux` now defaults to taking the atmosphere net surface energy flux (`base_flux`) from a precomputed `"net_surface_energy_flux"` forcing field when present, falling back to computing it from the constituent fluxes otherwise. The two are equivalent by construction, but the former allows for dropping many of the individual surface flux terms from the set of input forcings to the network.

The SST-dependent mass heat flux term is still computed from the constituent precipitation and latent heat fluxes, which must remain available in `forcing_data`.

Changes:
- symbol (e.g. `fme.core.my_function`) or script and concise description of changes or added feature
- Can group multiple related symbols on a single bullet

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)
