### PR TITLE
Stabilize synthetic stats fixtures used by training tests

### DIFF
--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -54,7 +54,7 @@ from fme.ace.testing import (
     MonthlyReferenceData,
     patch_cm4_solar_constant,
     save_nd_netcdf,
-    save_scalar_netcdf,
+    save_stats_netcdfs,
     save_stepper_checkpoint,
 )
 from fme.ace.train.train import build_trainer, prepare_directory
@@ -488,7 +488,6 @@ def _setup(
     derived_forcings=None,
     use_schedule: bool = False,
     validate_using_ema: bool = False,
-    stats_std_fill_value: float | None = None,
     multi_validation: bool = False,
     use_variable_masking: bool = False,
 ):
@@ -553,14 +552,10 @@ def _setup(
             variable_names=partial_names,
             timestep_days=timestep_days,
         )
-    save_scalar_netcdf(
+    save_stats_netcdfs(
         stats_dir / "stats-mean.nc",
-        variable_names=all_variable_names,
-    )
-    save_scalar_netcdf(
         stats_dir / "stats-stddev.nc",
         variable_names=all_variable_names,
-        fill_value=stats_std_fill_value,
     )
 
     monthly_dim_sizes: DimSizes
@@ -1132,7 +1127,6 @@ def test_train_and_inference_with_derived_forcings(
         crps_training=crps_training,
         log_validation_maps=log_validation_maps,
         derived_forcings=derived_forcings,
-        stats_std_fill_value=1.0,
     )
     with patch_cm4_solar_constant(1.0):
         with mock_wandb() as wandb:

--- a/fme/ace/testing/__init__.py
+++ b/fme/ace/testing/__init__.py
@@ -7,6 +7,7 @@ from .fv3gfs_data import (
     get_nd_dataset,
     save_nd_netcdf,
     save_scalar_netcdf,
+    save_stats_netcdfs,
 )
 from .insolation import patch_cm4_solar_constant
 from .stepper_checkpoint import save_stepper_checkpoint

--- a/fme/ace/testing/fv3gfs_data.py
+++ b/fme/ace/testing/fv3gfs_data.py
@@ -102,9 +102,25 @@ def save_scalar_netcdf(
     filename,
     variable_names: list[str],
     fill_value: float | None = None,
+    center: float = 0.0,
 ):
-    ds = get_scalar_dataset(variable_names, fill_value=fill_value)
+    ds = get_scalar_dataset(variable_names, fill_value=fill_value, center=center)
     ds.to_netcdf(filename, format="NETCDF4_CLASSIC")
+
+
+def save_stats_netcdfs(
+    mean_filename,
+    std_filename,
+    variable_names: list[str],
+):
+    """Write a paired (mean, std) stats file with sensible centers.
+
+    Means are centered at 0 and stds at 1 so that random per-variable noise
+    never produces a near-zero or negative std, which would cause normalized
+    inputs to blow up.
+    """
+    save_scalar_netcdf(mean_filename, variable_names=variable_names)
+    save_scalar_netcdf(std_filename, variable_names=variable_names, center=1.0)
 
 
 @dataclasses.dataclass
@@ -113,11 +129,8 @@ class StatsData:
     names: list[str]
 
     def __post_init__(self):
-        save_scalar_netcdf(
+        save_stats_netcdfs(
             self.mean_filename,
-            variable_names=self.names,
-        )
-        save_scalar_netcdf(
             self.std_filename,
             variable_names=self.names,
         )
@@ -295,13 +308,14 @@ def get_nd_dataset(
 def get_scalar_dataset(
     variable_names: Iterable[str],
     fill_value: float | None = None,
+    center: float = 0.0,
 ):
     data_vars = {}
     for name in variable_names:
         if fill_value is not None:
             value = fill_value
         else:
-            value = np.random.randn()
+            value = center + np.random.uniform(-0.05, 0.05)
         data_vars[name] = xr.DataArray(value, attrs={"units": "m", "long_name": name})
 
     ds = xr.Dataset(data_vars=data_vars)

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -15,7 +15,7 @@ from fme.ace.data_loading.batch_data import BatchData, PrognosticState
 from fme.ace.data_loading.inference import ExplicitIndices, ForcingDataLoaderConfig
 from fme.ace.data_loading.test_data_loader import _get_coords
 from fme.ace.requirements import DataRequirements
-from fme.ace.testing import save_scalar_netcdf
+from fme.ace.testing import save_stats_netcdfs
 from fme.core.coordinates import (
     HorizontalCoordinates,
     OptionalDepthCoordinate,
@@ -358,8 +358,11 @@ def create_coupled_data_on_disk(
     stats_dir = data_dir / "stats"
     stats_dir.mkdir()
     all_names = list(set(ocean_names + atmosphere_names))
-    save_scalar_netcdf(stats_dir / "means.nc", variable_names=all_names)
-    save_scalar_netcdf(stats_dir / "stds.nc", variable_names=all_names)
+    save_stats_netcdfs(
+        stats_dir / "means.nc",
+        stats_dir / "stds.nc",
+        variable_names=all_names,
+    )
     return MockCoupledData(
         ocean=MockComponentData(
             ds=ocean_ds,


### PR DESCRIPTION
Fixes flakiness in \`fme/coupled/test_train.py::test_train_and_inference[3-True]\` (and the GPU-skipped \`test_train_and_inference_with_derived_forcings\`) by removing a hidden source of pathological inputs in the synthetic stats fixtures.

The integration tests built per-variable normalization stats by drawing \`np.random.randn()\` for both means and stds. Stds occasionally landed near zero or negative, which made normalized inputs blow up. The CRPS + \`NoiseConditionedSFNO\` training case amplified that through multi-step rollouts and produced inference outputs in the \`1e+3\` to \`1e+17\` range and occasional NaN values. Variation between runs came from \`list(set(...))\` of variable names depending on \`PYTHONHASHSEED\`, so the same test would pull a pathological std assignment on some CI invocations but not others. Verified locally on CPU: five runs of the CRPS case with the old behavior produced \`PRESsfc\` magnitudes ranging from \`1e+0\` to \`3e+3\` (one run with std drawn at \`-1.2\`); after the fix all five runs stayed at \`~1e+0\` with no NaN/Inf.

Changes:
- \`fme.ace.testing.fv3gfs_data.get_scalar_dataset\` / \`save_scalar_netcdf\`: replace the \`randn()\` default with \`center + uniform(-0.05, 0.05)\` so per-variable noise stays bounded.
- \`fme.ace.testing.save_stats_netcdfs\`: new helper that writes a paired mean/std file with the std centered at 1.0, so callers cannot forget to keep stds bounded away from zero.
- Route \`StatsData\`, \`fme.coupled.data_loading.test_data_loader.create_coupled_data_on_disk\`, and \`fme.ace.test_train._setup\` through the new helper. Drop the now-redundant \`stats_std_fill_value\` parameter from \`_setup\`.

- [x] Tests added (existing integration tests continue to pass; the fix is on the test fixture itself)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #1143