### PR TITLE
Allow training on a broader variable pool than inference uses

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -118,10 +118,12 @@ from fme.core.registry.module import ModuleSelector
 from fme.core.scheduler import SchedulerConfig, SequentialSchedulerConfig
 from fme.core.spatial_masking import StaticSpatialMaskingConfig
 from fme.core.step import (
+    InfillPredictionStepConfig,
     MultiCallStepConfig,
     SeparateRadiationStepConfig,
     SingleModuleStepConfig,
 )
+from fme.core.step.infill_prediction import InferenceSchemeConfig
 from fme.core.step.multi_call import MultiCallConfig
 from fme.core.typing_ import Slice
 

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -282,6 +282,10 @@ class FCN3StepConfig(StepConfigABC):
     def loss_names(self) -> list[str]:
         return self.output_names
 
+    @property
+    def all_training_names(self) -> list[str] | None:
+        return None
+
     def replace_ocean(self, ocean: OceanConfig | None):
         """
         Replace the ocean model with a new one.

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -683,7 +683,14 @@ class StepperConfig:
 
     @property
     def all_names(self) -> list[str]:
-        """Names of all variables."""
+        """Names of all variables.
+
+        When the step declares ``all_training_names``, the data loader fetches
+        that larger set so training can use more variables than inference.
+        """
+        training_names = self.step.all_training_names
+        if training_names is not None:
+            return training_names
         return list(set(self.input_names + self.output_names))
 
     @property

--- a/fme/core/step/__init__.py
+++ b/fme/core/step/__init__.py
@@ -1,3 +1,4 @@
+from .infill_prediction import InfillPredictionStep, InfillPredictionStepConfig
 from .multi_call import MultiCallStep, MultiCallStepConfig
 from .radiation import SeparateRadiationStep, SeparateRadiationStepConfig
 from .secondary_module import SecondaryModuleStep, SecondaryModuleStepConfig

--- a/fme/core/step/infill_prediction.py
+++ b/fme/core/step/infill_prediction.py
@@ -1,0 +1,456 @@
+import dataclasses
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import dacite
+import torch
+from torch import nn
+
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
+from fme.core.corrector.registry import CorrectorABC
+from fme.core.dataset_info import DatasetInfo
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.normalizer import NetworkAndLossNormalizationConfig, StandardNormalizer
+from fme.core.ocean import Ocean, OceanConfig
+from fme.core.optimization import NullOptimization
+from fme.core.packer import Packer
+from fme.core.registry import CorrectorSelector, ModuleSelector
+from fme.core.step.args import StepArgs
+from fme.core.step.secondary_decoder import (
+    NoSecondaryDecoder,
+    SecondaryDecoder,
+    SecondaryDecoderConfig,
+)
+from fme.core.step.single_module import (
+    _apply_input_mask,
+    _build_channel_mask_dict,
+    step_with_adjustments,
+)
+from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.stepper_state import StepperState
+from fme.core.typing_ import TensorDict, TensorMapping
+
+
+@dataclasses.dataclass
+class InferenceSchemeConfig:
+    """Defines how the model behaves at inference time.
+
+    This mirrors the variable routing of SingleModuleStepConfig for
+    standard forward prediction.
+
+    Attributes:
+        in_names: Input variable names for inference.
+        out_names: Output variable names for inference.
+        next_step_forcing_names: Input variables that come from the output
+            timestep.
+        prescribed_prognostic_names: Prognostic variables overwritten from
+            forcing.
+    """
+
+    in_names: list[str]
+    out_names: list[str]
+    next_step_forcing_names: list[str] = dataclasses.field(default_factory=list)
+    prescribed_prognostic_names: list[str] = dataclasses.field(default_factory=list)
+
+
+@StepSelector.register("infill_prediction")
+@dataclasses.dataclass
+class InfillPredictionStepConfig(StepConfigABC):
+    """Configuration for a step that trains on a broader variable pool than
+    it uses at inference time.
+
+    At inference time, the step behaves like ``SingleModuleStepConfig`` using
+    the ``inference_scheme``'s variable routing. During training, the data
+    loader fetches all variables in ``all_names`` and the step zero-fills any
+    missing variables, attaching per-channel mask indicators so the network
+    can distinguish real inputs from fill values.
+
+    Parameters:
+        builder: The module builder.
+        all_names: All variable names used during training.
+        forcing_names: Names of forcing (input-only) variables.
+        normalization: The normalization configuration.
+        inference_scheme: Defines variable routing at inference time.
+        include_channel_mask_inputs: Must be True. Appends per-variable
+            mask indicator channels so the network knows which inputs
+            are real vs masked.
+        secondary_decoder: Configuration for the secondary decoder.
+        ocean: The ocean configuration.
+        corrector: The corrector configuration.
+    """
+
+    builder: ModuleSelector
+    all_names: list[str]
+    forcing_names: list[str]
+    normalization: NetworkAndLossNormalizationConfig
+    inference_scheme: InferenceSchemeConfig
+    include_channel_mask_inputs: bool = True
+    secondary_decoder: SecondaryDecoderConfig | None = None
+    ocean: OceanConfig | None = None
+    corrector: AtmosphereCorrectorConfig | CorrectorSelector = dataclasses.field(
+        default_factory=lambda: AtmosphereCorrectorConfig()
+    )
+
+    def __post_init__(self):
+        if not self.include_channel_mask_inputs:
+            raise ValueError(
+                "include_channel_mask_inputs must be True for "
+                "InfillPredictionStepConfig"
+            )
+        all_set = set(self.all_names)
+        for name in self.inference_scheme.in_names:
+            if name not in all_set:
+                raise ValueError(
+                    f"inference_scheme.in_names contains '{name}' "
+                    f"which is not in all_names"
+                )
+        for name in self.inference_scheme.out_names:
+            if name not in all_set:
+                raise ValueError(
+                    f"inference_scheme.out_names contains '{name}' "
+                    f"which is not in all_names"
+                )
+        for name in self.forcing_names:
+            if name not in all_set:
+                raise ValueError(
+                    f"forcing_names contains '{name}' which is not in all_names"
+                )
+            if name in self.inference_scheme.out_names:
+                raise ValueError(
+                    f"forcing variable '{name}' must not be in "
+                    f"inference_scheme.out_names"
+                )
+        for name in self.inference_scheme.next_step_forcing_names:
+            if name not in self.inference_scheme.in_names:
+                raise ValueError(
+                    f"next_step_forcing_name '{name}' not in "
+                    f"inference_scheme.in_names"
+                )
+            if name in self.inference_scheme.out_names:
+                raise ValueError(
+                    f"next_step_forcing_name is an output variable: '{name}'"
+                )
+        for name in self.inference_scheme.prescribed_prognostic_names:
+            if name not in self.inference_scheme.out_names:
+                raise ValueError(
+                    f"prescribed_prognostic_name '{name}' must be in "
+                    f"inference_scheme.out_names"
+                )
+        if self.secondary_decoder is not None:
+            for name in self.secondary_decoder.secondary_diagnostic_names:
+                if name in self.inference_scheme.in_names:
+                    raise ValueError(
+                        f"secondary_diagnostic_name is an input variable: '{name}'"
+                    )
+                if name in self.inference_scheme.out_names:
+                    raise ValueError(
+                        f"secondary_diagnostic_name is an output variable: '{name}'"
+                    )
+
+    @property
+    def non_forcing_names(self) -> list[str]:
+        forcing_set = set(self.forcing_names)
+        return [n for n in self.all_names if n not in forcing_set]
+
+    @property
+    def n_ic_timesteps(self) -> int:
+        return 1
+
+    @property
+    def input_names(self) -> list[str]:
+        if self.ocean is None:
+            return self.inference_scheme.in_names
+        return list(set(self.inference_scheme.in_names).union(self.ocean.forcing_names))
+
+    @property
+    def output_names(self) -> list[str]:
+        secondary_names = (
+            self.secondary_decoder.secondary_diagnostic_names
+            if self.secondary_decoder is not None
+            else []
+        )
+        return list(set(self.inference_scheme.out_names).union(secondary_names))
+
+    @property
+    def next_step_input_names(self) -> list[str]:
+        input_only_names = set(self.input_names).difference(self.output_names)
+        result = set(input_only_names)
+        if self.ocean is not None:
+            result = result.union(self.ocean.forcing_names)
+        result = result.union(self.inference_scheme.prescribed_prognostic_names)
+        return list(result)
+
+    @property
+    def loss_names(self) -> list[str]:
+        return self.non_forcing_names
+
+    @property
+    def all_training_names(self) -> list[str] | None:
+        return list(self.all_names)
+
+    @property
+    def allow_missing_variables(self) -> bool:
+        return True
+
+    def get_next_step_forcing_names(self) -> list[str]:
+        return self.inference_scheme.next_step_forcing_names
+
+    def get_loss_normalizer(
+        self,
+        extra_names: list[str] | None = None,
+        extra_residual_scaled_names: list[str] | None = None,
+    ) -> StandardNormalizer:
+        if extra_names is None:
+            extra_names = []
+        return self.normalization.get_loss_normalizer(
+            names=list(set(self.all_names)) + extra_names,
+            residual_scaled_names=[],
+        )
+
+    def replace_ocean(self, ocean: OceanConfig | None):
+        self.ocean = ocean
+
+    def get_ocean(self) -> OceanConfig | None:
+        return self.ocean
+
+    def replace_prescribed_prognostic_names(self, names: list[str]) -> None:
+        for name in names:
+            if name not in self.inference_scheme.out_names:
+                raise ValueError(
+                    f"prescribed_prognostic_name '{name}' must be in "
+                    f"inference_scheme.out_names: {self.inference_scheme.out_names}"
+                )
+        self.inference_scheme.prescribed_prognostic_names = names
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, Any]) -> "InfillPredictionStepConfig":
+        return dacite.from_dict(
+            data_class=cls, data=state, config=dacite.Config(strict=True)
+        )
+
+    def get_step(
+        self,
+        dataset_info: DatasetInfo,
+        init_weights: Callable[[list[nn.Module]], None],
+    ) -> "InfillPredictionStep":
+        logging.info("Initializing InfillPredictionStep from provided config")
+        corrector = self.corrector.get_corrector(dataset_info)
+        normalizer = self.normalization.get_network_normalizer(
+            list(set(self.all_names))
+        )
+        return InfillPredictionStep(
+            config=self,
+            dataset_info=dataset_info,
+            corrector=corrector,
+            normalizer=normalizer,
+            init_weights=init_weights,
+        )
+
+    def load(self):
+        self.normalization.load()
+
+
+class InfillPredictionStep(StepABC):
+    """Step that trains with all_names but infers with a narrower routing.
+
+    Uses all_names for input channels (with channel mask indicators) and
+    non-forcing names for output channels. At training time, missing
+    variables are zero-filled and flagged via the per-channel mask so the
+    network learns to handle partial inputs. At inference time, the routing
+    matches ``inference_scheme``.
+    """
+
+    TIME_DIM = 1
+    CHANNEL_DIM = -3
+
+    def __init__(
+        self,
+        config: InfillPredictionStepConfig,
+        dataset_info: DatasetInfo,
+        corrector: CorrectorABC,
+        normalizer: StandardNormalizer,
+        init_weights: Callable[[list[nn.Module]], None],
+    ):
+        super().__init__()
+        self._config = config
+        self._normalizer = normalizer
+        self._corrector = corrector
+
+        n_in_channels = len(config.all_names) * 2
+        n_out_channels = len(config.non_forcing_names)
+        self.in_packer = Packer(config.all_names)
+        self.out_packer = Packer(config.non_forcing_names)
+
+        if config.ocean is not None:
+            self.ocean: Ocean | None = config.ocean.build(
+                config.inference_scheme.in_names,
+                config.inference_scheme.out_names,
+                dataset_info.timestep,
+            )
+        else:
+            self.ocean = None
+
+        module = config.builder.build(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            dataset_info=dataset_info,
+        )
+        self.module = module.to(get_device())
+
+        dist = Distributed.get_instance()
+
+        if config.secondary_decoder is not None:
+            self.secondary_decoder: SecondaryDecoder | NoSecondaryDecoder = (
+                config.secondary_decoder.build(
+                    n_in_channels=n_out_channels,
+                    dataset_info=dataset_info,
+                ).to(get_device())
+            )
+        else:
+            self.secondary_decoder = NoSecondaryDecoder()
+
+        init_weights(self.modules)
+        self._img_shape = dataset_info.img_shape
+        self._no_optimization = NullOptimization()
+
+        self.module = self.module.wrap_module(dist.wrap_module)
+        self.secondary_decoder = self.secondary_decoder.wrap_module(dist.wrap_module)
+        self._timestep = dataset_info.timestep
+
+    @property
+    def config(self) -> InfillPredictionStepConfig:
+        return self._config
+
+    @property
+    def normalizer(self) -> StandardNormalizer:
+        return self._normalizer
+
+    @property
+    def surface_temperature_name(self) -> str | None:
+        if self._config.ocean is not None:
+            return self._config.ocean.surface_temperature_name
+        return None
+
+    @property
+    def ocean_fraction_name(self) -> str | None:
+        if self._config.ocean is not None:
+            return self._config.ocean.ocean_fraction_name
+        return None
+
+    def prescribe_sst(
+        self,
+        mask_data: TensorMapping,
+        gen_data: TensorMapping,
+        target_data: TensorMapping,
+    ) -> TensorDict:
+        if self.ocean is None:
+            raise RuntimeError(
+                "The Ocean interface is missing but required to prescribe "
+                "sea surface temperature."
+            )
+        return self.ocean.prescriber(mask_data, gen_data, target_data)
+
+    @property
+    def modules(self) -> nn.ModuleList:
+        modules = [self.module.torch_module]
+        modules.extend(self.secondary_decoder.torch_modules)
+        return nn.ModuleList(modules)
+
+    def _fill_missing_inputs(
+        self, input_data: TensorMapping, data_mask: TensorMapping | None
+    ) -> tuple[TensorDict, TensorMapping]:
+        """Fill missing variables with zeros and build augmented data_mask."""
+        ref_tensor = next(iter(input_data.values()))
+        batch = ref_tensor.shape[0]
+        spatial = ref_tensor.shape[-2:]
+        device = ref_tensor.device
+
+        filled: TensorDict = {}
+        augmented_mask: dict[str, torch.Tensor] = {}
+
+        if data_mask is not None:
+            augmented_mask.update(data_mask)
+
+        for name in self._config.all_names:
+            if name in input_data:
+                filled[name] = input_data[name]
+                if name not in augmented_mask:
+                    augmented_mask[name] = torch.ones(
+                        batch, dtype=torch.bool, device=device
+                    )
+            else:
+                filled[name] = torch.zeros(batch, *spatial, device=device)
+                augmented_mask[name] = torch.zeros(
+                    batch, dtype=torch.bool, device=device
+                )
+
+        return filled, augmented_mask
+
+    def step(
+        self,
+        args: StepArgs,
+        wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
+    ) -> tuple[TensorDict, StepperState | None]:
+        has_all_names = all(n in args.input for n in self._config.all_names)
+        if has_all_names:
+            full_input = dict(args.input)
+            full_data_mask = args.data_mask
+        else:
+            full_input, full_data_mask = self._fill_missing_inputs(
+                args.input, args.data_mask
+            )
+
+        def network_call(input_norm: TensorDict) -> TensorDict:
+            if full_data_mask is not None:
+                input_norm = _apply_input_mask(input_norm, full_data_mask)
+            input_tensor = self.in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
+            mask_dict = _build_channel_mask_dict(
+                self._config.all_names, full_data_mask, input_tensor
+            )
+            mask_tensor = self.in_packer.pack(mask_dict, axis=self.CHANNEL_DIM)
+            input_tensor = torch.cat([input_tensor, mask_tensor], dim=self.CHANNEL_DIM)
+            output_tensor = self.module.wrap_module(wrapper)(
+                input_tensor,
+                labels=args.labels,
+            )
+            output_dict = self.out_packer.unpack(output_tensor, axis=self.CHANNEL_DIM)
+            secondary_output_dict = self.secondary_decoder.wrap_module(wrapper)(
+                output_tensor.detach()
+            )
+            output_dict.update(secondary_output_dict)
+            return output_dict
+
+        return step_with_adjustments(
+            input=full_input,
+            next_step_input_data=args.next_step_input_data,
+            network_calls=network_call,
+            normalizer=self.normalizer,
+            corrector=self._corrector,
+            ocean=self.ocean,
+            residual_prediction=False,
+            prognostic_names=self.prognostic_names,
+            prescribed_prognostic_names=(
+                self._config.inference_scheme.prescribed_prognostic_names
+            ),
+            data_mask=full_data_mask,
+            stepper_state=args.stepper_state,
+        )
+
+    def get_regularizer_loss(self):
+        return torch.tensor(0.0)
+
+    def get_state(self):
+        return {
+            "module": self.module.get_state(),
+            "secondary_decoder": self.secondary_decoder.get_module_state(),
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        module = state["module"]
+        if "module.device_buffer" in module:
+            del module["module.device_buffer"]
+        self.module.load_state(module)
+        if "secondary_decoder" in state:
+            self.secondary_decoder.load_module_state(state["secondary_decoder"])

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -190,6 +190,10 @@ class MultiCallStepConfig(StepConfigABC):
         else:
             return self.wrapped_step.loss_names
 
+    @property
+    def all_training_names(self) -> list[str] | None:
+        return self.wrapped_step.all_training_names
+
     def replace_ocean(self, ocean: OceanConfig | None):
         self.wrapped_step.replace_ocean(ocean)
 

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -230,6 +230,10 @@ class SeparateRadiationStepConfig(StepConfigABC):
     def loss_names(self) -> list[str]:
         return self.output_names
 
+    @property
+    def all_training_names(self) -> list[str] | None:
+        return None
+
     def replace_ocean(self, ocean: OceanConfig | None):
         self.ocean = ocean
 

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -213,6 +213,10 @@ class SecondaryModuleStepConfig(StepConfigABC):
     def loss_names(self) -> list[str]:
         return self.output_names
 
+    @property
+    def all_training_names(self) -> list[str] | None:
+        return None
+
     def replace_ocean(self, ocean: OceanConfig | None):
         """
         Replace the ocean model with a new one.

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -193,6 +193,10 @@ class SingleModuleStepConfig(StepConfigABC):
         return self.output_names
 
     @property
+    def all_training_names(self) -> list[str] | None:
+        return None
+
+    @property
     def allow_missing_variables(self) -> bool:
         return self.builder.allow_missing_variables
 

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -78,6 +78,19 @@ class StepConfigABC(abc.ABC):
         """
         pass
 
+    @property
+    @abc.abstractmethod
+    def all_training_names(self) -> list[str] | None:
+        """All variable names used during training.
+
+        Return ``None`` when training uses the same variables as inference
+        (``input_names`` plus ``output_names``). Return an explicit list when
+        the step accepts a broader variable pool during training than at
+        inference time, in which case the data loader will fetch this larger
+        set.
+        """
+        pass
+
     @abc.abstractmethod
     def get_next_step_forcing_names(self) -> list[str]:
         pass
@@ -197,6 +210,10 @@ class StepSelector(StepConfigABC):
         Names of variables to be included in the loss function.
         """
         return self._step_config_instance.loss_names
+
+    @property
+    def all_training_names(self) -> list[str] | None:
+        return self._step_config_instance.all_training_names
 
     def get_loss_normalizer(
         self,

--- a/fme/core/step/test_infill_prediction.py
+++ b/fme/core/step/test_infill_prediction.py
@@ -1,0 +1,265 @@
+import dataclasses
+import datetime
+
+import pytest
+import torch
+from torch import nn
+
+import fme
+from fme.core.coordinates import HybridSigmaPressureCoordinate, LatLonCoordinates
+from fme.core.dataset_info import DatasetInfo
+from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
+from fme.core.registry import ModuleSelector
+from fme.core.step.args import StepArgs
+from fme.core.step.infill_prediction import (
+    InferenceSchemeConfig,
+    InfillPredictionStep,
+    InfillPredictionStepConfig,
+)
+from fme.core.step.step import StepSelector
+
+IMG_SHAPE = (16, 32)
+TIMESTEP = datetime.timedelta(hours=6)
+STEP_ALL_NAMES = ["a", "b", "c", "forcing_x"]
+STEP_FORCING = ["forcing_x"]
+STEP_NON_FORCING = ["a", "b", "c"]
+
+
+def _norm_config(names: list[str]) -> NetworkAndLossNormalizationConfig:
+    return NetworkAndLossNormalizationConfig(
+        network=NormalizationConfig(
+            means={n: 0.0 for n in names},
+            stds={n: 1.0 for n in names},
+        ),
+    )
+
+
+def _make_step_config(
+    all_names: list[str] | None = None,
+    forcing_names: list[str] | None = None,
+    in_names: list[str] | None = None,
+    out_names: list[str] | None = None,
+) -> InfillPredictionStepConfig:
+    if all_names is None:
+        all_names = STEP_ALL_NAMES
+    if forcing_names is None:
+        forcing_names = STEP_FORCING
+    if in_names is None:
+        in_names = ["a", "b", "forcing_x"]
+    if out_names is None:
+        out_names = ["a", "b"]
+    return InfillPredictionStepConfig(
+        builder=ModuleSelector(
+            type="SphericalFourierNeuralOperatorNet",
+            config={"scale_factor": 1, "embed_dim": 4, "num_layers": 2},
+        ),
+        all_names=all_names,
+        forcing_names=forcing_names,
+        normalization=_norm_config(all_names),
+        inference_scheme=InferenceSchemeConfig(
+            in_names=in_names,
+            out_names=out_names,
+        ),
+    )
+
+
+def _make_dataset_info() -> DatasetInfo:
+    device = fme.get_device()
+    return DatasetInfo(
+        horizontal_coordinates=LatLonCoordinates(
+            lat=torch.zeros(IMG_SHAPE[0], device=device),
+            lon=torch.zeros(IMG_SHAPE[1], device=device),
+        ),
+        vertical_coordinate=HybridSigmaPressureCoordinate(
+            ak=torch.arange(7, device=device),
+            bk=torch.arange(7, device=device),
+        ),
+        timestep=TIMESTEP,
+    )
+
+
+def _make_step(
+    config: InfillPredictionStepConfig | None = None,
+) -> InfillPredictionStep:
+    if config is None:
+        config = _make_step_config()
+    dataset_info = _make_dataset_info()
+    return config.get_step(dataset_info, lambda _: None)
+
+
+def _tensor_dict(names: list[str], batch: int = 2) -> dict[str, torch.Tensor]:
+    device = fme.get_device()
+    return {n: torch.randn(batch, *IMG_SHAPE, device=device) for n in names}
+
+
+class TestInfillPredictionStepConfigValidation:
+    def test_valid_construction(self):
+        config = _make_step_config()
+        assert config.all_names == STEP_ALL_NAMES
+
+    def test_in_name_not_in_all_names_raises(self):
+        with pytest.raises(ValueError, match="inference_scheme.in_names"):
+            _make_step_config(in_names=["a", "b", "not_there"])
+
+    def test_out_name_not_in_all_names_raises(self):
+        with pytest.raises(ValueError, match="inference_scheme.out_names"):
+            _make_step_config(out_names=["a", "not_there"])
+
+    def test_forcing_not_in_all_names_raises(self):
+        with pytest.raises(ValueError, match="forcing_names"):
+            _make_step_config(forcing_names=["not_there"])
+
+    def test_forcing_in_out_names_raises(self):
+        with pytest.raises(ValueError, match="forcing variable"):
+            _make_step_config(
+                all_names=["a", "b", "c", "f"],
+                forcing_names=["f"],
+                in_names=["a", "f"],
+                out_names=["a", "f"],
+            )
+
+    def test_include_channel_mask_inputs_false_raises(self):
+        with pytest.raises(ValueError, match="include_channel_mask_inputs"):
+            InfillPredictionStepConfig(
+                builder=ModuleSelector(
+                    type="SphericalFourierNeuralOperatorNet",
+                    config={"scale_factor": 1, "embed_dim": 4, "num_layers": 2},
+                ),
+                all_names=["a", "b"],
+                forcing_names=[],
+                normalization=_norm_config(["a", "b"]),
+                inference_scheme=InferenceSchemeConfig(in_names=["a"], out_names=["a"]),
+                include_channel_mask_inputs=False,
+            )
+
+
+class TestInfillPredictionStepConfigProperties:
+    @pytest.fixture()
+    def config(self):
+        return _make_step_config()
+
+    def test_input_names(self, config):
+        assert set(config.input_names) == {"a", "b", "forcing_x"}
+
+    def test_output_names(self, config):
+        assert set(config.output_names) == {"a", "b"}
+
+    def test_loss_names(self, config):
+        assert set(config.loss_names) == set(STEP_NON_FORCING)
+
+    def test_all_training_names(self, config):
+        assert config.all_training_names == STEP_ALL_NAMES
+
+    def test_allow_missing_variables(self, config):
+        assert config.allow_missing_variables is True
+
+    def test_n_ic_timesteps(self, config):
+        assert config.n_ic_timesteps == 1
+
+    def test_non_forcing_names(self, config):
+        assert config.non_forcing_names == STEP_NON_FORCING
+
+    def test_next_step_forcing_names(self, config):
+        assert config.get_next_step_forcing_names() == []
+
+    def test_next_step_forcing_names_with_config(self):
+        config = InfillPredictionStepConfig(
+            builder=ModuleSelector(
+                type="SphericalFourierNeuralOperatorNet",
+                config={"scale_factor": 1, "embed_dim": 4, "num_layers": 2},
+            ),
+            all_names=["a", "b", "forcing_x"],
+            forcing_names=["forcing_x"],
+            normalization=_norm_config(["a", "b", "forcing_x"]),
+            inference_scheme=InferenceSchemeConfig(
+                in_names=["a", "b", "forcing_x"],
+                out_names=["a", "b"],
+                next_step_forcing_names=["forcing_x"],
+            ),
+        )
+        assert config.get_next_step_forcing_names() == ["forcing_x"]
+
+    def test_prognostic_names(self, config):
+        assert set(config.prognostic_names) == {"a", "b"}
+
+
+class TestInfillPredictionStepRegistry:
+    def test_selector_construction(self):
+        config = _make_step_config()
+        selector = StepSelector(
+            type="infill_prediction",
+            config=dataclasses.asdict(config),
+        )
+        assert selector.all_training_names == STEP_ALL_NAMES
+        assert set(selector.input_names) == {"a", "b", "forcing_x"}
+        assert set(selector.output_names) == {"a", "b"}
+
+    def test_selector_get_step(self):
+        config = _make_step_config()
+        selector = StepSelector(
+            type="infill_prediction",
+            config=dataclasses.asdict(config),
+        )
+        dataset_info = _make_dataset_info()
+        step = selector.get_step(dataset_info)
+        assert isinstance(step, InfillPredictionStep)
+
+
+class TestInfillPredictionStep:
+    def test_forward_with_full_input(self):
+        step = _make_step()
+        input_data = _tensor_dict(STEP_ALL_NAMES)
+        next_step = _tensor_dict(step.next_step_input_names)
+        data_mask = {
+            n: torch.ones(2, dtype=torch.bool, device=fme.get_device())
+            for n in STEP_ALL_NAMES
+        }
+        output, _ = step.step(
+            StepArgs(
+                input=input_data,
+                next_step_input_data=next_step,
+                data_mask=data_mask,
+            )
+        )
+        assert set(output.keys()) == set(STEP_NON_FORCING)
+        for v in output.values():
+            assert v.shape == (2, *IMG_SHAPE)
+
+    def test_forward_with_partial_input(self):
+        step = _make_step()
+        inference_names = ["a", "b", "forcing_x"]
+        input_data = _tensor_dict(inference_names)
+        next_step = _tensor_dict(step.next_step_input_names)
+        output, _ = step.step(
+            StepArgs(
+                input=input_data,
+                next_step_input_data=next_step,
+            )
+        )
+        assert set(output.keys()) == set(STEP_NON_FORCING)
+        for v in output.values():
+            assert v.shape == (2, *IMG_SHAPE)
+
+    def test_output_excludes_forcing(self):
+        step = _make_step()
+        input_data = _tensor_dict(STEP_ALL_NAMES)
+        next_step = _tensor_dict(step.next_step_input_names)
+        output, _ = step.step(
+            StepArgs(
+                input=input_data,
+                next_step_input_data=next_step,
+            )
+        )
+        for name in STEP_FORCING:
+            assert name not in output
+
+    def test_modules_list(self):
+        step = _make_step()
+        assert isinstance(step.modules, nn.ModuleList)
+        assert len(step.modules) >= 1
+
+    def test_get_and_load_state(self):
+        step = _make_step()
+        state = step.get_state()
+        assert "module" in state
+        step.load_state(state)

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -108,6 +108,10 @@ class MockStepConfig(StepConfigABC):
         return self.out_names
 
     @property
+    def all_training_names(self) -> list[str] | None:
+        return None
+
+    @property
     def n_ic_timesteps(self) -> int:
         raise NotImplementedError()
 


### PR DESCRIPTION
Extracts the "training supports a broader variable pool than inference" piece from `feature/combine-infill-prediction` so it can land independently of the multi-task training work, which will follow in a separate PR.

Changes:
- `fme.core.step.step.StepConfigABC.all_training_names`: new abstract property; returning `None` (the default added on each existing subclass) preserves the old `input_names + output_names` behavior, while returning an explicit list tells the data loader to fetch the broader training set.
- `fme.ace.stepper.single_module.StepperConfig.all_names`: returns `step.all_training_names` when set, falls back to the previous union otherwise.
- `fme.core.step.infill_prediction.InfillPredictionStepConfig` / `InfillPredictionStep` / `InferenceSchemeConfig`: first consumer. Training pulls all `all_names` variables, missing ones are zero-filled, and per-channel mask indicators are appended so the network knows which inputs are real. At inference the step routes via `inference_scheme` and behaves like `SingleModuleStep`. Registered as `"infill_prediction"` and re-exported from `fme.ace`.

- [x] Tests added (`fme/core/step/test_infill_prediction.py`)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated