### PR TITLE
add PRMSL to SHiELD+ training datasets processing configs

### DIFF
--- a/scripts/data_process/configs/shield-amip-ensemble-c96-1deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-amip-ensemble-c96-1deg-8layer.yaml
@@ -1,10 +1,10 @@
 runs:
   ic_0001: gs://vcm-ml-raw-flexible-retention/2024-06-29-C96-SHiELD-AMIP/regridded-zarrs/gaussian_grid_180_by_360/ic_0001
   ic_0002: gs://vcm-ml-raw-flexible-retention/2024-06-29-C96-SHiELD-AMIP/regridded-zarrs/gaussian_grid_180_by_360/ic_0002
-data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset
+data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset-stats
-  beaker_dataset: 2026-01-28-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset-stats
+  beaker_dataset: 2026-06-08-vertically-resolved-c96-1deg-shield-amip-ensemble-dataset-stats
   start_date: "1940-01-01"
   end_date: "2021-12-31"
   data_type: FV3GFS
@@ -44,6 +44,7 @@ dataset_computation:
       - SNOWsfc
     full_state.zarr:
       - PRESsfc
+      - PRMSL
       - HGTsfc
       - RH500
       - RH850
@@ -93,8 +94,8 @@ dataset_computation:
     total_frozen_precip_rate: None
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-1deg-daily-shield-amip-ensemble-dataset
-  stats_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-1deg-daily-shield-amip-ensemble-dataset-stats
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-1deg-daily-shield-amip-ensemble-dataset
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-1deg-daily-shield-amip-ensemble-dataset-stats
   snapshot_names:
     - PRESsfc
     - Q2m

--- a/scripts/data_process/configs/shield-amip-ensemble-c96-4deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-amip-ensemble-c96-4deg-8layer.yaml
@@ -1,10 +1,10 @@
 runs:
   ic_0001: gs://vcm-ml-raw-flexible-retention/2024-06-29-C96-SHiELD-AMIP/regridded-zarrs/gaussian_grid_45_by_90/ic_0001
   ic_0002: gs://vcm-ml-raw-flexible-retention/2024-06-29-C96-SHiELD-AMIP/regridded-zarrs/gaussian_grid_45_by_90/ic_0002
-data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-4deg-shield-amip-ensemble-dataset
+data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-4deg-shield-amip-ensemble-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-4deg-shield-amip-ensemble-dataset-stats
-  beaker_dataset: 2026-01-28-vertically-resolved-c96-4deg-shield-amip-ensemble-dataset-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-4deg-shield-amip-ensemble-dataset-stats
+  beaker_dataset: 2026-06-08-vertically-resolved-c96-4deg-shield-amip-ensemble-dataset-stats
   start_date: "1940-01-01"
   end_date: "2021-12-31"
   data_type: FV3GFS
@@ -44,6 +44,7 @@ dataset_computation:
       - SNOWsfc
     full_state.zarr:
       - PRESsfc
+      - PRMSL
       - HGTsfc
       - RH500
       - RH850
@@ -94,8 +95,8 @@ dataset_computation:
     total_frozen_precip_rate: None
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
-  stats_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats
   snapshot_names:
     - PRESsfc
     - Q2m

--- a/scripts/data_process/configs/shield-ramped-climSST-random-CO2-ensemble-c96-1deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-ramped-climSST-random-CO2-ensemble-c96-1deg-8layer.yaml
@@ -8,10 +8,10 @@ runs:
   ramped-sst-1xCO2-random-perturbation-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-08-22-C96-SHiELD/regridded-zarrs/gaussian_grid_180_by_360/ramped-sst-1xCO2-random-perturbation-ic_0003
   ramped-sst-2xCO2-random-perturbation-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-08-22-C96-SHiELD/regridded-zarrs/gaussian_grid_180_by_360/ramped-sst-2xCO2-random-perturbation-ic_0003
   ramped-sst-4xCO2-random-perturbation-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-08-22-C96-SHiELD/regridded-zarrs/gaussian_grid_180_by_360/ramped-sst-4xCO2-random-perturbation-ic_0003
-data_output_directory: gs://vcm-ml-intermediate/2025-08-22-vertically-resolved-1deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset
+data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-1deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-02-06-vertically-resolved-1deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-stats
-  beaker_dataset: 2026-02-06-vertically-resolved-1deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-1deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-stats
+  beaker_dataset: 2026-06-08-vertically-resolved-1deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-stats
   start_date: "2020-01-01T06:00:00"
   end_date: null
   data_type: FV3GFS
@@ -64,6 +64,7 @@ dataset_computation:
       - eastward_wind
       - pressure_thickness_of_atmospheric_layer
       - PRESsfc
+      - PRMSL
       - HGTsfc
       - column_soil_moisture
       - soil_moisture_0

--- a/scripts/data_process/configs/shield-ramped-climSST-random-CO2-ensemble-c96-4deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-ramped-climSST-random-CO2-ensemble-c96-4deg-8layer.yaml
@@ -8,10 +8,10 @@ runs:
   ramped-sst-1xCO2-random-perturbation-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-08-22-C96-SHiELD/regridded-zarrs/gaussian_grid_45_by_90/ramped-sst-1xCO2-random-perturbation-ic_0003
   ramped-sst-2xCO2-random-perturbation-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-08-22-C96-SHiELD/regridded-zarrs/gaussian_grid_45_by_90/ramped-sst-2xCO2-random-perturbation-ic_0003
   ramped-sst-4xCO2-random-perturbation-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-08-22-C96-SHiELD/regridded-zarrs/gaussian_grid_45_by_90/ramped-sst-4xCO2-random-perturbation-ic_0003
-data_output_directory: gs://vcm-ml-intermediate/2025-08-22-vertically-resolved-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg
+data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-02-06-vertically-resolved-4deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-stats
-  beaker_dataset: 2026-02-06-vertically-resolved-4deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-4deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-stats
+  beaker_dataset: 2026-06-08-vertically-resolved-4deg-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-stats
   start_date: "2020-01-01T06:00:00"
   end_date: null
   data_type: FV3GFS
@@ -67,6 +67,7 @@ dataset_computation:
       - eastward_wind
       - pressure_thickness_of_atmospheric_layer
       - PRESsfc
+      - PRMSL
       - HGTsfc
       - column_soil_moisture
       - soil_moisture_0
@@ -108,8 +109,8 @@ dataset_computation:
       - tendency_of_air_temperature_due_to_shortwave_heating
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2025-08-22-vertically-resolved-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-daily
-  stats_output_directory: gs://vcm-ml-intermediate/2025-08-22-vertically-resolved-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-daily-stats
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-daily
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-c96-shield-ramped-climSST-random-CO2-ensemble-fme-dataset-4deg-daily-stats
   snapshot_names:
     - PRESsfc
     - Q2m

--- a/scripts/data_process/configs/shield-som-ensemble-c96-1deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-som-ensemble-c96-1deg-8layer.yaml
@@ -19,10 +19,10 @@ runs:
   4xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2024-07-03-C96-SHiELD-SOM/regridded-zarrs/gaussian_grid_180_by_360/4xCO2-ic_0003
   4xCO2-ic_0004: gs://vcm-ml-raw-flexible-retention/2024-07-03-C96-SHiELD-SOM/regridded-zarrs/gaussian_grid_180_by_360/4xCO2-ic_0004
   4xCO2-ic_0005: gs://vcm-ml-raw-flexible-retention/2024-07-03-C96-SHiELD-SOM/regridded-zarrs/gaussian_grid_180_by_360/4xCO2-ic_0005
-data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-1deg-c96-shield-som-ensemble-fme-dataset
+data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-1deg-c96-shield-som-ensemble-fme-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-1deg-c96-shield-som-ensemble-fme-dataset-stats
-  beaker_dataset: 2026-01-28-vertically-resolved-1deg-fme-c96-shield-som-ensemble-dataset-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-1deg-c96-shield-som-ensemble-fme-dataset-stats
+  beaker_dataset: 2026-06-08-vertically-resolved-1deg-fme-c96-shield-som-ensemble-dataset-stats
   # These datasets already exclude the one-year divergence period for each
   # ensemble member, so we can use data from all times when computing the
   # stats.
@@ -85,6 +85,7 @@ dataset_computation:
       - eastward_wind
       - pressure_thickness_of_atmospheric_layer
       - PRESsfc
+      - PRMSL
       - HGTsfc
       - column_soil_moisture
       - soil_moisture_0

--- a/scripts/data_process/configs/shield-som-ensemble-c96-4deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-som-ensemble-c96-4deg-8layer.yaml
@@ -22,10 +22,10 @@ runs:
   4xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2024-07-03-C96-SHiELD-SOM/regridded-zarrs/gaussian_grid_45_by_90/4xCO2-ic_0003
   4xCO2-ic_0004: gs://vcm-ml-raw-flexible-retention/2024-07-03-C96-SHiELD-SOM/regridded-zarrs/gaussian_grid_45_by_90/4xCO2-ic_0004
   4xCO2-ic_0005: gs://vcm-ml-raw-flexible-retention/2024-07-03-C96-SHiELD-SOM/regridded-zarrs/gaussian_grid_45_by_90/4xCO2-ic_0005
-data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-4deg-c96-shield-som-ensemble-fme-dataset
+data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-4deg-c96-shield-som-ensemble-fme-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-4deg-c96-shield-som-ensemble-fme-dataset-stats
-  beaker_dataset: 2026-01-28-vertically-resolved-4deg-fme-c96-shield-som-ensemble-dataset-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-4deg-c96-shield-som-ensemble-fme-dataset-stats
+  beaker_dataset: 2026-06-08-vertically-resolved-4deg-fme-c96-shield-som-ensemble-dataset-stats
   # These datasets already exclude the one-year divergence period for each
   # ensemble member, so we can use data from all times when computing the
   # stats.
@@ -91,6 +91,7 @@ dataset_computation:
       - eastward_wind
       - pressure_thickness_of_atmospheric_layer
       - PRESsfc
+      - PRMSL
       - HGTsfc
       - column_soil_moisture
       - soil_moisture_0
@@ -129,8 +130,8 @@ dataset_computation:
     total_frozen_precip_rate: None
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-4deg-daily-c96-shield-som-ensemble-fme-dataset
-  stats_output_directory: gs://vcm-ml-intermediate/2026-01-28-vertically-resolved-4deg-daily-c96-shield-som-ensemble-fme-dataset-stats
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-4deg-daily-c96-shield-som-ensemble-fme-dataset
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-08-vertically-resolved-4deg-daily-c96-shield-som-ensemble-fme-dataset-stats
   snapshot_names:
     - PRESsfc
     - Q2m


### PR DESCRIPTION
Adds PRMSL as a variable to datasets used in ACE2S-SHiELD+ training and 4 deg versions:
- shield-ramped-climSST-random-CO2-ensemble-c96-1(4)deg-8layer
- shield-amip-ensemble-c96-1(4)deg-8layer
- shield-som-ensemble-c96-1(4)deg-8layer

