### PR TITLE
thread global mean removal state through forward/inverse explicitly

### DIFF
--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -45,26 +45,45 @@ def extra_channel_source_field(name: str) -> str | None:
     return None
 
 
+@dataclasses.dataclass
+class GlobalMeanRemovalState:
+    """Opaque token produced by ``forward_transform`` and consumed by the
+    same ``GlobalMeanRemoval`` instance via ``inverse_transform`` and
+    ``extras_normalized``.
+
+    Callers should thread this value from ``forward_transform`` through
+    to those methods, but not read its fields directly — layout is an
+    implementation detail.
+    """
+
+    shifts: dict[str, torch.Tensor]
+    extras: TensorDict
+
+
 class GlobalMeanRemoval(abc.ABC):
     """Removes global means from fields before normalization and restores
     them after denormalization.
 
     ``forward_transform`` shifts input fields toward their climatological
-    means.  ``inverse_transform`` reverses that shift on output fields.
+    means and returns a ``GlobalMeanRemovalState`` that must be passed
+    back to ``inverse_transform`` to reverse the shift on output fields.
+    Threading the state explicitly (rather than caching it on the
+    instance) makes the transform stateless and order-independent.
+
+    Optional synthetic input channels (when ``append_as_input=True``) are
+    produced by ``forward_transform`` already in *normalized* space and
+    exposed via ``extras_normalized(state)`` as a name -> tensor mapping
+    keyed by ``extra_channel_names``.  Callers append the sentinel names
+    to their input packer's name list and merge the dict into the
+    normalized-input dict, so the extras flow through packing and the
+    channel-mask machinery uniformly with real input channels.
+
     Fields listed in ``field_names`` that appear only in the output (e.g.
     diagnostic temperatures) are not shifted by ``forward_transform``
     (they are not inputs), but *are* un-shifted by ``inverse_transform``.
     The network learns to compensate for this through end-to-end training,
     so all listed fields — whether input, output, or both — share the
     same global-mean offset.
-
-    Optional synthetic input channels (when ``append_as_input=True``) are
-    produced by ``forward_transform`` already in *normalized* space and
-    exposed via ``extras_normalized()`` as a name -> tensor mapping
-    keyed by ``extra_channel_names``.  Callers append the sentinel names
-    to their input packer's name list and merge the dict into the
-    normalized-input dict, so the extras flow through packing and the
-    channel-mask machinery uniformly with real input channels.
 
     Note:
         "Global mean" here refers to a *cellwise* (unweighted) spatial
@@ -73,9 +92,6 @@ class GlobalMeanRemoval(abc.ABC):
         on a non-uniform grid; this transform uses the cellwise mean
         for simplicity, since the network learns to compensate during
         end-to-end training.
-
-    Call sequence per step: ``forward_transform`` -> ``extras_normalized``
-    -> ``inverse_transform``.
     """
 
     @property
@@ -98,26 +114,38 @@ class GlobalMeanRemoval(abc.ABC):
         self,
         input: TensorMapping,
         data_mask: TensorMapping | None,
-    ) -> TensorDict:
+    ) -> tuple[TensorDict, GlobalMeanRemovalState]:
         """Remove global means from denormalized input fields.
 
-        Caches internal state needed by ``inverse_transform`` and
-        ``extras_normalized``.
+        Returns:
+            ``(shifted_input, state)``.  ``state`` is an opaque value
+            that must be passed back to ``inverse_transform`` to reverse
+            the shift, and to ``extras_normalized`` to obtain the
+            synthetic input channels.
         """
 
     @abc.abstractmethod
-    def inverse_transform(self, output: TensorDict) -> TensorDict:
-        """Restore global means on denormalized output fields."""
+    def inverse_transform(
+        self,
+        output: TensorDict,
+        state: GlobalMeanRemovalState,
+    ) -> TensorDict:
+        """Restore global means on denormalized output fields using
+        ``state`` produced by ``forward_transform``.
+        """
 
-    @abc.abstractmethod
-    def extras_normalized(self) -> TensorDict:
+    def extras_normalized(
+        self,
+        state: GlobalMeanRemovalState,
+    ) -> TensorDict:
         """Return the synthetic input channels in *normalized* space,
         keyed by the names in ``extra_channel_names``.
 
-        Each value has shape ``[batch, *spatial]`` (no channel dim).
-        Returns an empty dict when no extras are configured.  Must be
-        called after ``forward_transform``.
+        Each value has shape ``[batch, *spatial]`` (no channel dim) so
+        it can be fed to the same packer that handles real inputs.
+        Returns an empty dict if no extra channels are configured.
         """
+        return dict(state.extras)
 
 
 class NoGlobalMeanRemoval(GlobalMeanRemoval):
@@ -131,14 +159,15 @@ class NoGlobalMeanRemoval(GlobalMeanRemoval):
         self,
         input: TensorMapping,
         data_mask: TensorMapping | None,
+    ) -> tuple[TensorDict, GlobalMeanRemovalState]:
+        return dict(input), GlobalMeanRemovalState(shifts={}, extras={})
+
+    def inverse_transform(
+        self,
+        output: TensorDict,
+        state: GlobalMeanRemovalState,
     ) -> TensorDict:
-        return dict(input)
-
-    def inverse_transform(self, output: TensorDict) -> TensorDict:
         return output
-
-    def extras_normalized(self) -> TensorDict:
-        return {}
 
 
 def _broadcast_to_spatial(
@@ -174,8 +203,6 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         self._append_as_input = append_as_input
         self._reference_mean = reference_mean
         self._reference_std = reference_std
-        self._cached_offset: torch.Tensor | None = None
-        self._cached_extras: TensorDict = {}
 
     @property
     def extra_channel_names(self) -> list[str]:
@@ -187,7 +214,7 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         self,
         input: TensorMapping,
         data_mask: TensorMapping | None,
-    ) -> TensorDict:
+    ) -> tuple[TensorDict, GlobalMeanRemovalState]:
         ref_name = self._reference_field
         if ref_name not in input:
             raise ValueError(
@@ -202,18 +229,14 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         ref = input[ref_name]
         sample_mean = ref.mean(dim=tuple(range(1, ref.ndim)))
         offset = self._reference_mean - sample_mean
-        self._cached_offset = offset
         spatial_shape = tuple(ref.shape[1:])
 
+        extras: TensorDict = {}
         if self._append_as_input:
             normalized_mean = -offset / self._reference_std
-            self._cached_extras = {
-                _extra_channel_name(ref_name): _broadcast_to_spatial(
-                    normalized_mean, spatial_shape
-                )
-            }
-        else:
-            self._cached_extras = {}
+            extras[_extra_channel_name(ref_name)] = _broadcast_to_spatial(
+                normalized_mean, spatial_shape
+            )
 
         result = dict(input)
         for name in self._field_names:
@@ -222,23 +245,25 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
             t = result[name]
             broadcast = offset.view(offset.shape[0], *(1,) * (t.ndim - 1))
             result[name] = t + broadcast
-        return result
 
-    def inverse_transform(self, output: TensorDict) -> TensorDict:
-        if self._cached_offset is None:
-            raise RuntimeError("inverse_transform() called before forward_transform().")
-        offset = self._cached_offset
+        # All listed fields share the same offset; inverse will un-shift
+        # those that appear in the output (including output-only fields).
+        shifts = {name: offset for name in self._field_names}
+        return result, GlobalMeanRemovalState(shifts=shifts, extras=extras)
+
+    def inverse_transform(
+        self,
+        output: TensorDict,
+        state: GlobalMeanRemovalState,
+    ) -> TensorDict:
         result = dict(output)
-        for name in self._field_names:
+        for name, shift in state.shifts.items():
             if name not in result:
                 continue
             t = result[name]
-            broadcast = offset.view(offset.shape[0], *(1,) * (t.ndim - 1))
+            broadcast = shift.view(shift.shape[0], *(1,) * (t.ndim - 1))
             result[name] = t - broadcast
         return result
-
-    def extras_normalized(self) -> TensorDict:
-        return dict(self._cached_extras)
 
 
 class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
@@ -265,8 +290,6 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
         self._append_as_input = append_as_input
         self._means = means
         self._stds = stds
-        self._cached_shifts: dict[str, torch.Tensor] | None = None
-        self._cached_extras: TensorDict = {}
 
     @property
     def extra_channel_names(self) -> list[str]:
@@ -278,7 +301,7 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
         self,
         input: TensorMapping,
         data_mask: TensorMapping | None,
-    ) -> TensorDict:
+    ) -> tuple[TensorDict, GlobalMeanRemovalState]:
         result = dict(input)
         shifts: dict[str, torch.Tensor] = {}
         spatial_shape: tuple[int, ...] | None = None
@@ -298,8 +321,6 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
             broadcast = shift.view(shift.shape[0], *(1,) * (t.ndim - 1))
             result[name] = t + broadcast
 
-        self._cached_shifts = shifts
-
         extras: TensorDict = {}
         if self._append_as_input and spatial_shape is not None:
             for name in self._field_names:
@@ -309,25 +330,22 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
                 extras[_extra_channel_name(name)] = _broadcast_to_spatial(
                     normalized, spatial_shape
                 )
-        self._cached_extras = extras
 
-        return result
+        return result, GlobalMeanRemovalState(shifts=shifts, extras=extras)
 
-    def inverse_transform(self, output: TensorDict) -> TensorDict:
-        if self._cached_shifts is None:
-            raise RuntimeError("inverse_transform() called before forward_transform().")
+    def inverse_transform(
+        self,
+        output: TensorDict,
+        state: GlobalMeanRemovalState,
+    ) -> TensorDict:
         result = dict(output)
-        for name in self._field_names:
-            if name not in result or name not in self._cached_shifts:
+        for name, shift in state.shifts.items():
+            if name not in result:
                 continue
             t = result[name]
-            sh = self._cached_shifts[name]
-            broadcast = sh.view(sh.shape[0], *(1,) * (t.ndim - 1))
+            broadcast = shift.view(shift.shape[0], *(1,) * (t.ndim - 1))
             result[name] = t - broadcast
         return result
-
-    def extras_normalized(self) -> TensorDict:
-        return dict(self._cached_extras)
 
 
 @dataclasses.dataclass

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -25,6 +25,7 @@ from fme.core.step.args import StepArgs
 from fme.core.step.global_mean_removal import (
     GlobalMeanRemoval,
     GlobalMeanRemovalConfigUnion,
+    GlobalMeanRemovalState,
     NoGlobalMeanRemoval,
     extra_channel_source_field,
 )
@@ -550,24 +551,25 @@ def step_with_adjustments(
     """
     if prescribed_prognostic_names is None:
         prescribed_prognostic_names = []
+    gmr_state: GlobalMeanRemovalState | None = None
     if global_mean_removal is not None:
-        network_input: TensorMapping = global_mean_removal.forward_transform(
+        network_input, gmr_state = global_mean_removal.forward_transform(
             input, data_mask
         )
     else:
-        network_input = input
+        network_input = dict(input)
     input_norm = normalizer.normalize(network_input)
-    if global_mean_removal is not None:
+    if global_mean_removal is not None and gmr_state is not None:
         # Synthetic GMR channels are produced in normalized space; merge
         # them in after normalization so the network sees a single uniform
         # input dict.
-        input_norm = {**input_norm, **global_mean_removal.extras_normalized()}
+        input_norm = {**input_norm, **global_mean_removal.extras_normalized(gmr_state)}
     output_norm = network_calls(input_norm)
     if residual_prediction:
         output_norm = add_names(input_norm, output_norm, prognostic_names)
     output = normalizer.denormalize(output_norm)
-    if global_mean_removal is not None:
-        output = global_mean_removal.inverse_transform(output)
+    if global_mean_removal is not None and gmr_state is not None:
+        output = global_mean_removal.inverse_transform(output, gmr_state)
     if corrector is not None:
         corrector_state: CorrectorState | None = (
             stepper_state.corrector_state if stepper_state is not None else None

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -556,19 +556,19 @@ def step_with_adjustments(
         network_input, gmr_state = global_mean_removal.forward_transform(
             input, data_mask
         )
-    else:
-        network_input = dict(input)
-    input_norm = normalizer.normalize(network_input)
-    if global_mean_removal is not None and gmr_state is not None:
+        input_norm = normalizer.normalize(network_input)
         # Synthetic GMR channels are produced in normalized space; merge
         # them in after normalization so the network sees a single uniform
         # input dict.
         input_norm = {**input_norm, **global_mean_removal.extras_normalized(gmr_state)}
+    else:
+        input_norm = normalizer.normalize(input)
     output_norm = network_calls(input_norm)
     if residual_prediction:
         output_norm = add_names(input_norm, output_norm, prognostic_names)
     output = normalizer.denormalize(output_norm)
-    if global_mean_removal is not None and gmr_state is not None:
+    if global_mean_removal is not None:
+        assert gmr_state is not None
         output = global_mean_removal.inverse_transform(output, gmr_state)
     if corrector is not None:
         corrector_state: CorrectorState | None = (

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -41,7 +41,7 @@ def test_shared_worked_example():
             "air_temperature_4": torch.full((1, 4, 4), 245.0),
         }
     )
-    result = transform.forward_transform(tensors, None)
+    result, _ = transform.forward_transform(tensors, None)
     # offset = 280 - 285 = -5; shifted = 285 + (-5) = 280
     torch.testing.assert_close(
         result["surface_temperature"],
@@ -62,10 +62,32 @@ def test_shared_round_trip():
     tensors = move_tensordict_to_device(
         {k: torch.randn(2, 4, 4) + means[k] for k in means}
     )
-    result = transform.forward_transform(tensors, None)
-    restored = transform.inverse_transform(result)
+    result, state = transform.forward_transform(tensors, None)
+    restored = transform.inverse_transform(result, state)
     for k in means:
         torch.testing.assert_close(restored[k], tensors[k])
+
+
+def test_shared_state_independent_of_call_order():
+    """Regression for the previous cached-attribute design: two interleaved
+    forward/inverse pairs must each round-trip cleanly even when the
+    second forward overlaps the first inverse.
+    """
+    means = {"surface_temperature": 280.0}
+    stds = {"surface_temperature": 1.0}
+    transform = _make_shared(means, stds)
+    a = move_tensordict_to_device({"surface_temperature": torch.full((1, 4, 4), 285.0)})
+    b = move_tensordict_to_device({"surface_temperature": torch.full((1, 4, 4), 270.0)})
+    shifted_a, state_a = transform.forward_transform(a, None)
+    shifted_b, state_b = transform.forward_transform(b, None)  # interleaved
+    restored_a = transform.inverse_transform(shifted_a, state_a)
+    restored_b = transform.inverse_transform(shifted_b, state_b)
+    torch.testing.assert_close(
+        restored_a["surface_temperature"], a["surface_temperature"]
+    )
+    torch.testing.assert_close(
+        restored_b["surface_temperature"], b["surface_temperature"]
+    )
 
 
 def test_shared_preserves_horizontal_gradients():
@@ -75,7 +97,7 @@ def test_shared_preserves_horizontal_gradients():
     tensors = move_tensordict_to_device(
         {"surface_temperature": torch.tensor([[285.0, 290.0, 275.0]])}
     )
-    result = transform.forward_transform(tensors, None)
+    result, _ = transform.forward_transform(tensors, None)
     raw_grad = (
         tensors["surface_temperature"][0, 1] - tensors["surface_temperature"][0, 0]
     )
@@ -94,7 +116,7 @@ def test_shared_is_per_sample():
     tensors = move_tensordict_to_device(
         {"surface_temperature": surface_t, "air_temperature_0": air_t_0}
     )
-    result = transform.forward_transform(tensors, None)
+    result, _ = transform.forward_transform(tensors, None)
     # sample 0: offset = 280 - 285 = -5; sample 1: offset = 280 - 270 = +10
     expected = torch.tensor([[[230.0 + (-5.0)]], [[230.0 + 10.0]]])
     torch.testing.assert_close(result["air_temperature_0"].cpu(), expected)
@@ -109,8 +131,8 @@ def test_shared_no_extra_channels():
     tensors = move_tensordict_to_device(
         {"surface_temperature": torch.full((2, 4, 4), 285.0)}
     )
-    transform.forward_transform(tensors, None)
-    assert transform.extras_normalized() == {}
+    _, state = transform.forward_transform(tensors, None)
+    assert transform.extras_normalized(state) == {}
 
 
 def test_shared_extra_channels():
@@ -122,8 +144,8 @@ def test_shared_extra_channels():
     tensors = move_tensordict_to_device(
         {"surface_temperature": torch.full((2, 4, 4), 285.0)}
     )
-    transform.forward_transform(tensors, None)
-    extras = transform.extras_normalized()
+    _, state = transform.forward_transform(tensors, None)
+    extras = transform.extras_normalized(state)
     assert list(extras) == [extra_name]
     extra = extras[extra_name]
     assert extra.shape == (2, 4, 4)
@@ -154,14 +176,6 @@ def test_shared_raises_on_missing_reference():
         transform.forward_transform(tensors, None)
 
 
-def test_shared_inverse_before_forward_raises():
-    means = {"surface_temperature": 280.0}
-    stds = {"surface_temperature": 1.0}
-    transform = _make_shared(means, stds)
-    with pytest.raises(RuntimeError, match="forward_transform"):
-        transform.inverse_transform({"surface_temperature": torch.zeros(1, 4, 4)})
-
-
 # ── PerChannelGlobalMeanRemoval ─────────────────────────────────────────
 
 
@@ -184,7 +198,7 @@ def test_per_channel_removes_correct_means():
             "b": torch.tensor([[[22.0, 28.0]]]),  # mean = 25
         }
     )
-    result = transform.forward_transform(tensors, None)
+    result, _ = transform.forward_transform(tensors, None)
     # a: shift = 10 - 13 = -3; result = [12 - 3, 14 - 3] = [9, 11]
     torch.testing.assert_close(result["a"].cpu(), torch.tensor([[[9.0, 11.0]]]))
     # b: shift = 20 - 25 = -5; result = [22 - 5, 28 - 5] = [17, 23]
@@ -199,10 +213,25 @@ def test_per_channel_round_trip():
     tensors = move_tensordict_to_device(
         {k: torch.randn(3, 8, 8) + means[k] for k in means}
     )
-    result = transform.forward_transform(tensors, None)
-    restored = transform.inverse_transform(result)
+    result, state = transform.forward_transform(tensors, None)
+    restored = transform.inverse_transform(result, state)
     for k in means:
         torch.testing.assert_close(restored[k], tensors[k])
+
+
+def test_per_channel_state_independent_of_call_order():
+    """Two interleaved forward/inverse pairs must each round-trip cleanly."""
+    means = {"a": 0.0}
+    stds = {"a": 1.0}
+    transform = _make_per_channel(means, stds)
+    a = move_tensordict_to_device({"a": torch.tensor([[[10.0, 20.0]]])})
+    b = move_tensordict_to_device({"a": torch.tensor([[[100.0, 200.0]]])})
+    shifted_a, state_a = transform.forward_transform(a, None)
+    shifted_b, state_b = transform.forward_transform(b, None)
+    restored_a = transform.inverse_transform(shifted_a, state_a)
+    restored_b = transform.inverse_transform(shifted_b, state_b)
+    torch.testing.assert_close(restored_a["a"], a["a"])
+    torch.testing.assert_close(restored_b["a"], b["a"])
 
 
 def test_per_channel_is_per_sample():
@@ -212,7 +241,7 @@ def test_per_channel_is_per_sample():
     tensors = move_tensordict_to_device(
         {"a": torch.tensor([[[10.0, 20.0]], [[100.0, 200.0]]])}
     )
-    result = transform.forward_transform(tensors, None)
+    result, _ = transform.forward_transform(tensors, None)
     # clim_mean=0, so shift per sample is -sample_mean
     # sample 0: mean=15 → shift=-15 → [10-15, 20-15] = [-5, 5]
     # sample 1: mean=150 → shift=-150 → [100-150, 200-150] = [-50, 50]
@@ -228,8 +257,8 @@ def test_per_channel_no_extra_channels():
     assert transform.n_extra_input_channels == 0
     assert transform.extra_channel_names == []
     tensors = move_tensordict_to_device({"a": torch.full((2, 4, 4), 5.0)})
-    transform.forward_transform(tensors, None)
-    assert transform.extras_normalized() == {}
+    _, state = transform.forward_transform(tensors, None)
+    assert transform.extras_normalized(state) == {}
 
 
 def test_per_channel_extra_channels():
@@ -244,8 +273,8 @@ def test_per_channel_extra_channels():
             "b": torch.full((1, 4, 4), 25.0),  # mean=25
         }
     )
-    transform.forward_transform(tensors, None)
-    extras = transform.extras_normalized()
+    _, state = transform.forward_transform(tensors, None)
+    extras = transform.extras_normalized(state)
     assert list(extras) == [a_extra, b_extra]
     assert extras[a_extra].shape == (1, 4, 4)
     # a: (14 - 10) / 2 = 2.0
@@ -261,7 +290,7 @@ def test_per_channel_with_field_names_subset():
     tensors = move_tensordict_to_device(
         {"a": torch.full((1, 4, 4), 14.0), "b": torch.full((1, 4, 4), 25.0)}
     )
-    result = transform.forward_transform(tensors, None)
+    result, _ = transform.forward_transform(tensors, None)
     # a: shift = 10 - 14 = -4; result = 14 - 4 = 10 (== clim_mean)
     torch.testing.assert_close(result["a"].cpu(), torch.full((1, 4, 4), 10.0))
     # b was NOT shifted
@@ -277,25 +306,17 @@ def test_per_channel_masked_no_shift():
         {"a": torch.tensor([[[14.0, 14.0]], [[14.0, 14.0]]])}
     )
     data_mask = move_tensordict_to_device({"a": torch.tensor([True, False])})
-    result = transform.forward_transform(tensors, data_mask)
+    result, state = transform.forward_transform(tensors, data_mask)
     # sample 0 (unmasked): shift = 10 - 14 = -4; result = 14 - 4 = 10
     torch.testing.assert_close(result["a"][0].cpu(), torch.full((1, 2), 10.0))
     # sample 1 (masked): no shift, unchanged
     torch.testing.assert_close(result["a"][1].cpu(), torch.full((1, 2), 14.0))
 
-    extra = transform.extras_normalized()[extra_name]
+    extra = transform.extras_normalized(state)[extra_name]
     # sample 0: -shift/std = -(-4)/2 = 2.0
     assert extra[0, 0, 0].item() == pytest.approx(2.0)
     # sample 1 (masked): no shift, extra = 0
     assert extra[1, 0, 0].item() == pytest.approx(0.0)
-
-
-def test_per_channel_inverse_before_forward_raises():
-    means = {"a": 0.0}
-    stds = {"a": 1.0}
-    transform = _make_per_channel(means, stds)
-    with pytest.raises(RuntimeError, match="forward_transform"):
-        transform.inverse_transform({"a": torch.zeros(1, 4, 4)})
 
 
 def test_per_channel_post_normalization_mean_is_near_zero():
@@ -319,7 +340,7 @@ def test_per_channel_post_normalization_mean_is_near_zero():
             "air_temperature_0": torch.randn(2, 8, 16) * 8.0 + 215.0,
         }
     )
-    shifted = transform.forward_transform(tensors, None)
+    shifted, _ = transform.forward_transform(tensors, None)
     normalized = normalizer.normalize(shifted)
     for name in means:
         sample_means = normalized[name].mean(dim=tuple(range(1, normalized[name].ndim)))
@@ -342,7 +363,7 @@ def test_per_channel_post_normalization_mean_near_zero_when_masked():
     # Two samples, both with physical mean 110; one is masked.
     tensors = move_tensordict_to_device({"a": torch.full((2, 4, 4), 110.0)})
     data_mask = move_tensordict_to_device({"a": torch.tensor([True, False])})
-    shifted = transform.forward_transform(tensors, data_mask)
+    shifted, _ = transform.forward_transform(tensors, data_mask)
     normalized = normalizer.normalize(shifted)
     # Unmasked sample: spatial mean ≈ 0 in normalized space.
     assert normalized["a"][0].mean().abs().item() < 1e-5


### PR DESCRIPTION
Stacked on top of #1245.

`GlobalMeanRemoval` used to cache per-step state (offsets / shifts and the normalized extras dict) on the instance between `forward_transform` and `inverse_transform` / `extras_normalized`. Correctness then depended on call order — interleaved or skipped calls silently produced wrong outputs.

This PR makes the transform stateless: `forward_transform` returns an opaque `GlobalMeanRemovalState` that callers thread through to `inverse_transform` and `extras_normalized`. The instance carries no per-step state; the `RuntimeError("called before forward_transform")` guard is no longer needed because the contract is enforced by the type signature.

Changes:
- `fme.core.step.global_mean_removal`: add `GlobalMeanRemovalState` dataclass; `forward_transform` returns `(TensorDict, state)`; `inverse_transform` and `extras_normalized` take `state`. Remove the per-instance cached attributes.
- `fme.core.step.single_module.step_with_adjustments`: capture state from `forward_transform` and pass it back to `extras_normalized` and `inverse_transform`.

- [x] Tests added — interleaved forward/forward/inverse/inverse round-trips for both shared and per-channel variants verify state-threading is order-independent.
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated