### PR TITLE
treat global mean removal extras as ordinary input channels

### DIFF
--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -33,6 +33,18 @@ def _extra_channel_name(field: str) -> str:
     return f"{_EXTRA_CHANNEL_PREFIX}{field}"
 
 
+def extra_channel_source_field(name: str) -> str | None:
+    """Return the source field for a GMR sentinel name, or None if not a sentinel.
+
+    GMR synthetic input channels are named ``__gmr_extra__<source_field>``;
+    they share their source field's data mask because their values are
+    derived from that field and are zeroed when it is masked.
+    """
+    if name.startswith(_EXTRA_CHANNEL_PREFIX):
+        return name[len(_EXTRA_CHANNEL_PREFIX) :]
+    return None
+
+
 class GlobalMeanRemoval(abc.ABC):
     """Removes global means from fields before normalization and restores
     them after denormalization.

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -26,6 +26,13 @@ DEFAULT_TEMPERATURE_FIELD_NAMES: list[str] = [
 logger = logging.getLogger(__name__)
 
 
+_EXTRA_CHANNEL_PREFIX = "__gmr_extra__"
+
+
+def _extra_channel_name(field: str) -> str:
+    return f"{_EXTRA_CHANNEL_PREFIX}{field}"
+
+
 class GlobalMeanRemoval(abc.ABC):
     """Removes global means from fields before normalization and restores
     them after denormalization.
@@ -39,6 +46,14 @@ class GlobalMeanRemoval(abc.ABC):
     so all listed fields — whether input, output, or both — share the
     same global-mean offset.
 
+    Optional synthetic input channels (when ``append_as_input=True``) are
+    produced by ``forward_transform`` already in *normalized* space and
+    exposed via ``extras_normalized()`` as a name -> tensor mapping
+    keyed by ``extra_channel_names``.  Callers append the sentinel names
+    to their input packer's name list and merge the dict into the
+    normalized-input dict, so the extras flow through packing and the
+    channel-mask machinery uniformly with real input channels.
+
     Note:
         "Global mean" here refers to a *cellwise* (unweighted) spatial
         mean of each sample, not the area-weighted global mean used
@@ -47,14 +62,24 @@ class GlobalMeanRemoval(abc.ABC):
         for simplicity, since the network learns to compensate during
         end-to-end training.
 
-    Call sequence per step: ``forward_transform`` -> ``get_extra_channels``
+    Call sequence per step: ``forward_transform`` -> ``extras_normalized``
     -> ``inverse_transform``.
     """
 
     @property
     @abc.abstractmethod
+    def extra_channel_names(self) -> list[str]:
+        """Sentinel names for the synthetic input channels this transform
+        contributes.  Empty if no extras are configured.
+
+        Names are prefixed with ``__gmr_extra__`` and are intended to be
+        appended to the stepper's input packer so the extras flow through
+        packing and channel-mask routines as ordinary inputs.
+        """
+
+    @property
     def n_extra_input_channels(self) -> int:
-        """Number of extra channels appended to the network input."""
+        return len(self.extra_channel_names)
 
     @abc.abstractmethod
     def forward_transform(
@@ -65,7 +90,7 @@ class GlobalMeanRemoval(abc.ABC):
         """Remove global means from denormalized input fields.
 
         Caches internal state needed by ``inverse_transform`` and
-        ``get_extra_channels``.
+        ``extras_normalized``.
         """
 
     @abc.abstractmethod
@@ -73,10 +98,12 @@ class GlobalMeanRemoval(abc.ABC):
         """Restore global means on denormalized output fields."""
 
     @abc.abstractmethod
-    def get_extra_channels(self) -> torch.Tensor | None:
-        """Return ``[batch, n_extra, *spatial]`` normalized extra channels.
+    def extras_normalized(self) -> TensorDict:
+        """Return the synthetic input channels in *normalized* space,
+        keyed by the names in ``extra_channel_names``.
 
-        Returns ``None`` when ``n_extra_input_channels == 0``.  Must be
+        Each value has shape ``[batch, *spatial]`` (no channel dim).
+        Returns an empty dict when no extras are configured.  Must be
         called after ``forward_transform``.
         """
 
@@ -85,8 +112,8 @@ class NoGlobalMeanRemoval(GlobalMeanRemoval):
     """No-op implementation used when global mean removal is disabled."""
 
     @property
-    def n_extra_input_channels(self) -> int:
-        return 0
+    def extra_channel_names(self) -> list[str]:
+        return []
 
     def forward_transform(
         self,
@@ -98,8 +125,17 @@ class NoGlobalMeanRemoval(GlobalMeanRemoval):
     def inverse_transform(self, output: TensorDict) -> TensorDict:
         return output
 
-    def get_extra_channels(self) -> torch.Tensor | None:
-        return None
+    def extras_normalized(self) -> TensorDict:
+        return {}
+
+
+def _broadcast_to_spatial(
+    scalar_per_sample: torch.Tensor, spatial_shape: tuple[int, ...]
+) -> torch.Tensor:
+    """Broadcast a ``[batch]`` tensor to ``[batch, *spatial]``."""
+    return scalar_per_sample.view(-1, *(1,) * len(spatial_shape)).expand(
+        -1, *spatial_shape
+    )
 
 
 class SharedGlobalMeanRemoval(GlobalMeanRemoval):
@@ -127,11 +163,13 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         self._reference_mean = reference_mean
         self._reference_std = reference_std
         self._cached_offset: torch.Tensor | None = None
-        self._cached_extra: torch.Tensor | None = None
+        self._cached_extras: TensorDict = {}
 
     @property
-    def n_extra_input_channels(self) -> int:
-        return 1 if self._append_as_input else 0
+    def extra_channel_names(self) -> list[str]:
+        if not self._append_as_input:
+            return []
+        return [_extra_channel_name(self._reference_field)]
 
     def forward_transform(
         self,
@@ -153,15 +191,17 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         sample_mean = ref.mean(dim=tuple(range(1, ref.ndim)))
         offset = self._reference_mean - sample_mean
         self._cached_offset = offset
+        spatial_shape = tuple(ref.shape[1:])
 
         if self._append_as_input:
             normalized_mean = -offset / self._reference_std
-            spatial_shape = ref.shape[1:]
-            self._cached_extra = normalized_mean.view(
-                -1, 1, *(1,) * len(spatial_shape)
-            ).expand(-1, 1, *spatial_shape)
+            self._cached_extras = {
+                _extra_channel_name(ref_name): _broadcast_to_spatial(
+                    normalized_mean, spatial_shape
+                )
+            }
         else:
-            self._cached_extra = None
+            self._cached_extras = {}
 
         result = dict(input)
         for name in self._field_names:
@@ -185,8 +225,8 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
             result[name] = t - broadcast
         return result
 
-    def get_extra_channels(self) -> torch.Tensor | None:
-        return self._cached_extra
+    def extras_normalized(self) -> TensorDict:
+        return dict(self._cached_extras)
 
 
 class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
@@ -214,11 +254,13 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
         self._means = means
         self._stds = stds
         self._cached_shifts: dict[str, torch.Tensor] | None = None
-        self._cached_extra: torch.Tensor | None = None
+        self._cached_extras: TensorDict = {}
 
     @property
-    def n_extra_input_channels(self) -> int:
-        return len(self._field_names) if self._append_as_input else 0
+    def extra_channel_names(self) -> list[str]:
+        if not self._append_as_input:
+            return []
+        return [_extra_channel_name(name) for name in self._field_names]
 
     def forward_transform(
         self,
@@ -234,7 +276,7 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
                 continue
             t = result[name]
             if spatial_shape is None:
-                spatial_shape = t.shape[1:]
+                spatial_shape = tuple(t.shape[1:])
             sample_mean = t.mean(dim=tuple(range(1, t.ndim)))
             shift = self._means[name] - sample_mean
             if data_mask is not None and name in data_mask:
@@ -246,20 +288,16 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
 
         self._cached_shifts = shifts
 
+        extras: TensorDict = {}
         if self._append_as_input and spatial_shape is not None:
-            channels: list[torch.Tensor] = []
             for name in self._field_names:
                 if name not in shifts:
                     continue
-                sh = shifts[name]
-                normalized = -sh / self._stds[name]
-                ch = normalized.view(-1, 1, *(1,) * len(spatial_shape)).expand(
-                    -1, 1, *spatial_shape
+                normalized = -shifts[name] / self._stds[name]
+                extras[_extra_channel_name(name)] = _broadcast_to_spatial(
+                    normalized, spatial_shape
                 )
-                channels.append(ch)
-            self._cached_extra = torch.cat(channels, dim=1) if channels else None
-        else:
-            self._cached_extra = None
+        self._cached_extras = extras
 
         return result
 
@@ -276,8 +314,8 @@ class PerChannelGlobalMeanRemoval(GlobalMeanRemoval):
             result[name] = t - broadcast
         return result
 
-    def get_extra_channels(self) -> torch.Tensor | None:
-        return self._cached_extra
+    def extras_normalized(self) -> TensorDict:
+        return dict(self._cached_extras)
 
 
 @dataclasses.dataclass

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -271,20 +271,24 @@ class SingleModuleStep(StepABC):
             init_weights: Function to initialize the weights of the module.
         """
         super().__init__()
-        n_in_channels = len(config.in_names)
-        if config.include_channel_mask_inputs:
-            n_in_channels *= 2
         if config.global_mean_removal is not None:
             self._global_mean_removal: GlobalMeanRemoval = (
                 config.global_mean_removal.build(
                     normalizer=normalizer, in_names=config.in_names
                 )
             )
-            n_in_channels += self._global_mean_removal.n_extra_input_channels
         else:
             self._global_mean_removal = NoGlobalMeanRemoval()
+        # Synthetic GMR channels are packed alongside real inputs so they
+        # flow through the packer and channel-mask machinery uniformly.
+        packed_in_names = (
+            list(config.in_names) + self._global_mean_removal.extra_channel_names
+        )
+        n_in_channels = len(packed_in_names)
+        if config.include_channel_mask_inputs:
+            n_in_channels *= 2
         n_out_channels = len(config.out_names)
-        self.in_packer = Packer(config.in_names)
+        self.in_packer = Packer(packed_in_names)
         self.out_packer = Packer(config.out_names)
         self._normalizer = normalizer
         if config.ocean is not None:
@@ -379,15 +383,12 @@ class SingleModuleStep(StepABC):
             input_tensor = self.in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
             if self._config.include_channel_mask_inputs:
                 mask_dict = _build_channel_mask_dict(
-                    self.in_names, args.data_mask, input_tensor
+                    self.in_packer.names, args.data_mask, input_tensor
                 )
                 mask_tensor = self.in_packer.pack(mask_dict, axis=self.CHANNEL_DIM)
                 input_tensor = torch.cat(
                     [input_tensor, mask_tensor], dim=self.CHANNEL_DIM
                 )
-            extra = self._global_mean_removal.get_extra_channels()
-            if extra is not None:
-                input_tensor = torch.cat([input_tensor, extra], dim=self.CHANNEL_DIM)
             output_tensor = self.module.wrap_module(wrapper)(
                 input_tensor,
                 labels=args.labels,
@@ -550,6 +551,11 @@ def step_with_adjustments(
     else:
         network_input = input
     input_norm = normalizer.normalize(network_input)
+    if global_mean_removal is not None:
+        # Synthetic GMR channels are produced in normalized space; merge
+        # them in after normalization so the network sees a single uniform
+        # input dict.
+        input_norm = {**input_norm, **global_mean_removal.extras_normalized()}
     output_norm = network_calls(input_norm)
     if residual_prediction:
         output_norm = add_names(input_norm, output_norm, prognostic_names)

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -26,6 +26,7 @@ from fme.core.step.global_mean_removal import (
     GlobalMeanRemoval,
     GlobalMeanRemovalConfigUnion,
     NoGlobalMeanRemoval,
+    extra_channel_source_field,
 )
 from fme.core.step.secondary_decoder import (
     NoSecondaryDecoder,
@@ -483,8 +484,13 @@ def _build_channel_mask_dict(
     device = packed_input.device
     result: TensorDict = {}
     for name in in_names:
-        if data_mask is not None and name in data_mask:
-            mask_1d = data_mask[name].to(device=device, dtype=torch.float)
+        # GMR sentinel channels share their source field's mask: the extra
+        # value is already zeroed in forward_transform when the source is
+        # masked, so the mask channel must agree rather than default to 1.
+        source = extra_channel_source_field(name)
+        lookup_name = source if source is not None else name
+        if data_mask is not None and lookup_name in data_mask:
+            mask_1d = data_mask[lookup_name].to(device=device, dtype=torch.float)
             result[name] = mask_1d.view(batch, 1, 1).expand(batch, *spatial)
         else:
             result[name] = torch.ones(batch, *spatial, device=device)

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -105,11 +105,12 @@ def test_shared_no_extra_channels():
     stds = {"surface_temperature": 1.0}
     transform = _make_shared(means, stds)
     assert transform.n_extra_input_channels == 0
+    assert transform.extra_channel_names == []
     tensors = move_tensordict_to_device(
         {"surface_temperature": torch.full((2, 4, 4), 285.0)}
     )
     transform.forward_transform(tensors, None)
-    assert transform.get_extra_channels() is None
+    assert transform.extras_normalized() == {}
 
 
 def test_shared_extra_channels():
@@ -117,13 +118,15 @@ def test_shared_extra_channels():
     stds = {"surface_temperature": 5.0}
     transform = _make_shared(means, stds, append_as_input=True)
     assert transform.n_extra_input_channels == 1
+    [extra_name] = transform.extra_channel_names
     tensors = move_tensordict_to_device(
         {"surface_temperature": torch.full((2, 4, 4), 285.0)}
     )
     transform.forward_transform(tensors, None)
-    extra = transform.get_extra_channels()
-    assert extra is not None
-    assert extra.shape == (2, 1, 4, 4)
+    extras = transform.extras_normalized()
+    assert list(extras) == [extra_name]
+    extra = extras[extra_name]
+    assert extra.shape == (2, 4, 4)
     # sample_mean = 285, normalized = (285 - 280) / 5 = 1.0
     torch.testing.assert_close(extra, torch.full_like(extra, 1.0))
 
@@ -223,9 +226,10 @@ def test_per_channel_no_extra_channels():
     stds = {"a": 1.0}
     transform = _make_per_channel(means, stds)
     assert transform.n_extra_input_channels == 0
+    assert transform.extra_channel_names == []
     tensors = move_tensordict_to_device({"a": torch.full((2, 4, 4), 5.0)})
     transform.forward_transform(tensors, None)
-    assert transform.get_extra_channels() is None
+    assert transform.extras_normalized() == {}
 
 
 def test_per_channel_extra_channels():
@@ -233,6 +237,7 @@ def test_per_channel_extra_channels():
     stds = {"a": 2.0, "b": 5.0}
     transform = _make_per_channel(means, stds, append_as_input=True)
     assert transform.n_extra_input_channels == 2
+    a_extra, b_extra = transform.extra_channel_names
     tensors = move_tensordict_to_device(
         {
             "a": torch.full((1, 4, 4), 14.0),  # mean=14
@@ -240,13 +245,13 @@ def test_per_channel_extra_channels():
         }
     )
     transform.forward_transform(tensors, None)
-    extra = transform.get_extra_channels()
-    assert extra is not None
-    assert extra.shape == (1, 2, 4, 4)
+    extras = transform.extras_normalized()
+    assert list(extras) == [a_extra, b_extra]
+    assert extras[a_extra].shape == (1, 4, 4)
     # a: (14 - 10) / 2 = 2.0
-    torch.testing.assert_close(extra[:, 0].cpu(), torch.full((1, 4, 4), 2.0))
+    torch.testing.assert_close(extras[a_extra].cpu(), torch.full((1, 4, 4), 2.0))
     # b: (25 - 20) / 5 = 1.0
-    torch.testing.assert_close(extra[:, 1].cpu(), torch.full((1, 4, 4), 1.0))
+    torch.testing.assert_close(extras[b_extra].cpu(), torch.full((1, 4, 4), 1.0))
 
 
 def test_per_channel_with_field_names_subset():
@@ -267,6 +272,7 @@ def test_per_channel_masked_no_shift():
     means = {"a": 10.0}
     stds = {"a": 2.0}
     transform = _make_per_channel(means, stds, append_as_input=True)
+    [extra_name] = transform.extra_channel_names
     tensors = move_tensordict_to_device(
         {"a": torch.tensor([[[14.0, 14.0]], [[14.0, 14.0]]])}
     )
@@ -277,12 +283,11 @@ def test_per_channel_masked_no_shift():
     # sample 1 (masked): no shift, unchanged
     torch.testing.assert_close(result["a"][1].cpu(), torch.full((1, 2), 14.0))
 
-    extra = transform.get_extra_channels()
-    assert extra is not None
+    extra = transform.extras_normalized()[extra_name]
     # sample 0: -shift/std = -(-4)/2 = 2.0
-    assert extra[0, 0, 0, 0].item() == pytest.approx(2.0)
+    assert extra[0, 0, 0].item() == pytest.approx(2.0)
     # sample 1 (masked): no shift, extra = 0
-    assert extra[1, 0, 0, 0].item() == pytest.approx(0.0)
+    assert extra[1, 0, 0].item() == pytest.approx(0.0)
 
 
 def test_per_channel_inverse_before_forward_raises():

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -32,6 +32,7 @@ from fme.core.step.multi_call import MultiCallConfig, MultiCallStepConfig
 from fme.core.step.secondary_decoder import SecondaryDecoderConfig
 from fme.core.step.secondary_module import SecondaryModuleStepConfig
 from fme.core.step.single_module import (
+    SingleModuleStep,
     SingleModuleStepConfig,
     _apply_input_mask,
     _build_channel_mask_dict,
@@ -1440,6 +1441,58 @@ def test_step_shared_global_mean_removal_affects_output():
         out_names,
         means,
     )
+
+
+def test_step_per_channel_global_mean_removal_with_channel_masks():
+    """When both ``include_channel_mask_inputs`` and per-channel GMR extras
+    are enabled, the GMR extras should be packed as ordinary input
+    channels and receive their own mask channels.  Total network input
+    channels = ``2 * (n_in_names + n_extras)``.
+    """
+    in_names = ["forcing_shared", "forcing_rad"]
+    out_names = ["diagnostic_main", "diagnostic_rad"]
+    all_names = list(set(in_names + out_names))
+    normalization = NetworkAndLossNormalizationConfig(
+        network=NormalizationConfig(
+            means={name: 0.0 for name in all_names},
+            stds={name: 1.0 for name in all_names},
+        ),
+    )
+    removal = PerChannelGlobalMeanRemovalConfig(
+        field_names=in_names, append_as_input=True
+    )
+    config = StepSelector(
+        type="single_module",
+        config=dataclasses.asdict(
+            SingleModuleStepConfig(
+                builder=ModuleSelector(
+                    type="SphericalFourierNeuralOperatorNet",
+                    config={"scale_factor": 1, "embed_dim": 4, "num_layers": 2},
+                ),
+                in_names=in_names,
+                out_names=out_names,
+                normalization=normalization,
+                include_channel_mask_inputs=True,
+                global_mean_removal=removal,
+            ),
+        ),
+    )
+    step = get_step(config, DEFAULT_IMG_SHAPE)
+    assert isinstance(step, SingleModuleStep)
+    # 2 real inputs + 2 GMR extras → 4 packed input channels (doubled to 8
+    # by the channel-mask append in network_call).
+    assert len(step.in_packer.names) == 4
+
+    n_samples = 2
+    input_data = get_tensor_dict(step.input_names, DEFAULT_IMG_SHAPE, n_samples)
+    next_step = get_tensor_dict(
+        step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
+    )
+    output, _ = step.step(
+        args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
+    )
+    for name in out_names:
+        assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
 
 def test_step_shared_global_mean_removal_raises_on_masked_reference():

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -1138,6 +1138,24 @@ def test_build_channel_mask_dict_partial_mask():
     assert (result["b"] == 1.0).all()
 
 
+def test_build_channel_mask_dict_gmr_extra_inherits_source_mask():
+    # The GMR sentinel channel `__gmr_extra__a` must inherit `a`'s mask
+    # because its value is zeroed in forward_transform when `a` is masked;
+    # otherwise the network sees a 0-valued extra with a 1-valued mask
+    # (i.e. contradictory "present" signal on a masked sample).
+    packed = torch.zeros(2, 4, 4, 8)
+    data_mask = {"a": torch.tensor([True, False])}
+    result = _build_channel_mask_dict(
+        ["a", "b", "__gmr_extra__a", "__gmr_extra__b"], data_mask, packed
+    )
+    assert result["a"][0, 0, 0] == 1.0
+    assert result["a"][1, 0, 0] == 0.0
+    assert result["__gmr_extra__a"][0, 0, 0] == 1.0
+    assert result["__gmr_extra__a"][1, 0, 0] == 0.0
+    assert (result["b"] == 1.0).all()
+    assert (result["__gmr_extra__b"] == 1.0).all()
+
+
 def test_step_with_include_channel_mask_inputs():
     normalization = get_network_and_loss_normalization_config(
         names=["forcing_shared", "forcing_rad", "diagnostic_main", "diagnostic_rad"],


### PR DESCRIPTION
The synthetic input channels produced by `GlobalMeanRemoval` used to be concatenated separately in `network_call`, which meant the channel-mask machinery did not produce mask channels for them — when both `include_channel_mask_inputs` and `append_as_input` were enabled, the extras silently lacked their accompanying mask channels.

This PR makes each `GlobalMeanRemoval` expose the synthetic channels as named tensors in normalized space: `extra_channel_names` returns sentinel names (prefixed `__gmr_extra__`) and `extras_normalized()` returns `{name: tensor}` after `forward_transform`. The stepper extends its `in_packer` with the sentinel names, `step_with_adjustments` merges the extras into the normalized input dict, and `network_call` no longer mentions GMR. The channel-mask path produces mask channels for the extras: each sentinel inherits its source field's mask (resolved via the `__gmr_extra__` prefix), so a masked source field gets a 0-valued extra paired with a 0-valued mask channel rather than a contradictory 1.

The cached `forward_transform` / `inverse_transform` contract (state is stored on the instance) is unchanged in this PR. The follow-up PR #1244 makes that state explicit / order-independent.

**Backwards compatibility:** Checkpoints trained with **both** `include_channel_mask_inputs=True` and a GMR with `append_as_input=True` will no longer load — the network input channel count goes from `2*n_in + n_extra` to `2*(n_in + n_extra)` (each GMR extra now gets its own mask channel), and the channel ordering changes from `[in | mask(in) | extras]` to `[in | extras | mask(in) | mask(extras)]`. We are accepting this break because we haven't trained many models with this combination. Checkpoints that use only one of the two features are unaffected.

Changes:
- `fme.core.step.global_mean_removal`: add `extra_channel_names` and `extras_normalized()`; drop `get_extra_channels` (replaced by the named dict API). Expose `extra_channel_source_field` so callers can map a sentinel name back to its source field.
- `fme.core.step.single_module.SingleModuleStep.__init__`: extend the input packer with the GMR's `extra_channel_names` so packing and the channel-mask routines treat extras as ordinary input channels.
- `fme.core.step.single_module._build_channel_mask_dict`: resolve `__gmr_extra__<field>` sentinel names back to `<field>` for the `data_mask` lookup so the extra and its mask channel stay consistent on masked samples.
- `fme.core.step.single_module.step_with_adjustments`: merge normalized GMR extras into the input dict before `network_call`.

- [x] Tests added — combined `include_channel_mask_inputs` + GMR extras path, plus a unit test that the GMR extra mask channel inherits the source field's mask.
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated