### PR TITLE
Fall back to static input coords when loading checkpoints without full_fine_coords

### DIFF
--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -818,6 +818,7 @@ class CheckpointModelConfig:
     def _get_coords_backwards_compatible(
         coords_from_state: dict | None,
         fine_coordinates_path: str | None,
+        static_inputs: StaticInputs | None,
     ) -> LatLonCoordinates:
         if coords_from_state and fine_coordinates_path:
             raise ValueError(
@@ -832,24 +833,27 @@ class CheckpointModelConfig:
             )
         elif fine_coordinates_path is not None:
             return load_coords_from_path(fine_coordinates_path).to(get_device())
+        elif static_inputs is not None:
+            return static_inputs.coords
         else:
             raise ValueError(
-                "No fine coordinates found in checkpoint state and no "
-                "fine_coordinates_path provided. One of these must be provided to "
-                "load the model using CheckpointModelConfig."
+                "No fine coordinates found in checkpoint state or static inputs, "
+                "and no fine_coordinates_path provided. One of these must be "
+                "provided to load the model using CheckpointModelConfig."
             )
 
     def build(
         self,
     ) -> DiffusionModel:
         checkpoint_model: dict = self._checkpoint["model"]
-        full_fine_coords = self._get_coords_backwards_compatible(
-            checkpoint_model.get("full_fine_coords"),
-            self.fine_coordinates_path,
-        )
         static_inputs = StaticInputs.from_state_backwards_compatible(
             state=checkpoint_model.get("static_inputs") or {},
             static_inputs_config=self.static_inputs or {},
+        )
+        full_fine_coords = self._get_coords_backwards_compatible(
+            checkpoint_model.get("full_fine_coords"),
+            self.fine_coordinates_path,
+            static_inputs,
         )
         model = _CheckpointModelConfigSelector.from_state(
             self._checkpoint["model"]["config"]

--- a/fme/downscaling/test_models.py
+++ b/fme/downscaling/test_models.py
@@ -603,6 +603,36 @@ def test_checkpoint_model_build_with_fine_coordinates_path(tmp_path):
     assert torch.equal(loaded_model.full_fine_coords.lon.cpu(), fine_coords.lon.cpu())
 
 
+def test_checkpoint_model_build_with_legacy_static_input_coords(tmp_path):
+    """In-between-format checkpoint (no full_fine_coords key, legacy per-field
+    coords in static_inputs) should load using the static input coordinates."""
+    coarse_shape = (8, 16)
+    fine_shape = (16, 32)
+    static_inputs = make_static_inputs(fine_shape)
+    fine_coords = static_inputs.coords
+    model = _get_diffusion_model(
+        coarse_shape=coarse_shape,
+        downscale_factor=2,
+        full_fine_coords=fine_coords,
+        use_fine_topography=True,
+        static_inputs=static_inputs,
+    )
+    state = model.get_state()
+    # Simulate in-between checkpoint: no full_fine_coords, coords stored
+    # per-field in static_inputs instead of at the top level
+    del state["full_fine_coords"]
+    coords_state = state["static_inputs"].pop("coords")
+    for field_state in state["static_inputs"]["fields"]:
+        field_state["coords"] = coords_state
+
+    checkpoint_path = tmp_path / "test.ckpt"
+    torch.save({"model": state}, checkpoint_path)
+
+    loaded_model = CheckpointModelConfig(checkpoint_path=str(checkpoint_path)).build()
+    assert torch.equal(loaded_model.full_fine_coords.lat.cpu(), fine_coords.lat.cpu())
+    assert torch.equal(loaded_model.full_fine_coords.lon.cpu(), fine_coords.lon.cpu())
+
+
 def test_checkpoint_model_build(tmp_path):
     """CheckpointModelConfig loads a modern checkpoint and restores the model."""
     coarse_shape = (8, 16)


### PR DESCRIPTION
## Description

Checkpoints saved during the window where coordinates were stored per-field in `StaticInputs` (but not yet as top-level `full_fine_coords`) previously could not be loaded without providing `fine_coordinates_path`. The publicly released HiRO v1 checkpoint on HuggingFace is in this in-between format, so loading it required a config workaround even though the coordinates are present in the checkpoint's static inputs.

`CheckpointModelConfig.build()` now loads static inputs first and falls back to their coordinates when resolving `full_fine_coords`. The fallback order is:

1. `full_fine_coords` in checkpoint state
2. `fine_coordinates_path` from config
3. Static input coordinates (new)

Existing behavior is unchanged, including configs that currently work around the issue via `fine_coordinates_path` — a mismatch between path coords and static input coords is still caught by the existing validation in `DiffusionModelConfig.build`.

## Testing

Added `test_checkpoint_model_build_with_legacy_static_input_coords`, which simulates the in-between checkpoint format (no `full_fine_coords` key, legacy per-field coords in static inputs) and verifies loading succeeds. Confirmed the test failed before the fix.