### PR TITLE
Add eval-only global mean relaxation to SingleModuleStep

### DIFF
--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1399,12 +1399,10 @@ class Stepper:
         return stepper
 
     def set_eval(self) -> None:
-        for module in self.modules:
-            module.eval()
+        self._step_obj.eval()
 
     def set_train(self) -> None:
-        for module in self.modules:
-            module.train()
+        self._step_obj.train()
 
 
 @dataclasses.dataclass

--- a/fme/core/step/global_mean_relaxation.py
+++ b/fme/core/step/global_mean_relaxation.py
@@ -1,0 +1,149 @@
+import dataclasses
+from typing import Literal
+
+import torch
+
+from fme.core.gridded_ops import GriddedOperations
+from fme.core.normalizer import StandardNormalizer
+from fme.core.typing_ import TensorDict, TensorMapping
+
+USE_NORMALIZATION_MEAN: Literal["mean"] = "mean"
+
+
+@dataclasses.dataclass
+class GlobalMeanRelaxationVariableConfig:
+    """
+    Per-variable target and timescale for global-mean Newtonian relaxation.
+
+    Parameters:
+        target: Target global mean. Either a float in the variable's
+            physical units, or the literal string ``"mean"`` to use the
+            variable's normalization mean as the target.
+        timescale_steps: Relaxation timescale in steps. Each step shifts the
+            field by ``-(area_weighted_mean(x) - target) / timescale_steps``,
+            i.e. an exponential approach to ``target`` with e-folding time of
+            ``timescale_steps`` steps. Must be positive.
+    """
+
+    target: float | Literal["mean"]
+    timescale_steps: float
+
+    def __post_init__(self):
+        if self.timescale_steps <= 0:
+            raise ValueError(
+                f"timescale_steps must be positive, got {self.timescale_steps}."
+            )
+        if isinstance(self.target, str) and self.target != USE_NORMALIZATION_MEAN:
+            raise ValueError(
+                f"target must be a number or '{USE_NORMALIZATION_MEAN}', got "
+                f"{self.target!r}."
+            )
+
+
+@dataclasses.dataclass
+class GlobalMeanRelaxationConfig:
+    """
+    Newtonian relaxation of the global mean of selected output variables
+    toward configured target values.
+
+    The relaxation is applied during ``.step`` in eval mode only, after
+    the network call (and any global-mean-removal inverse transform) and
+    before the corrector. For each named variable, the step subtracts a
+    uniform offset of ``(area_weighted_mean(x) - target) / timescale_steps``
+    from the field.
+
+    Names in ``variables`` must appear in ``out_names`` of the enclosing
+    step config. Variables whose ``target`` is ``"mean"`` must have a
+    normalization mean defined in the network normalizer.
+
+    Parameters:
+        variables: Mapping from output variable name to its per-variable
+            relaxation configuration.
+    """
+
+    variables: dict[str, GlobalMeanRelaxationVariableConfig]
+
+    def __post_init__(self):
+        if len(self.variables) == 0:
+            raise ValueError(
+                "global_mean_relaxation.variables must contain at least one entry; "
+                "use null/None to disable relaxation."
+            )
+
+    def validate_names(self, out_names: list[str]) -> None:
+        out_set = set(out_names)
+        missing = [name for name in self.variables if name not in out_set]
+        if missing:
+            raise ValueError(
+                "global_mean_relaxation variable names must be in out_names; "
+                f"missing: {missing}. out_names: {out_names}."
+            )
+
+    def build(
+        self,
+        gridded_operations: GriddedOperations,
+        normalizer: StandardNormalizer,
+    ) -> "GlobalMeanRelaxation":
+        targets: dict[str, float] = {}
+        timescales: dict[str, float] = {}
+        for name, var_config in self.variables.items():
+            if var_config.target == USE_NORMALIZATION_MEAN:
+                if name not in normalizer.means:
+                    raise ValueError(
+                        f"global_mean_relaxation target='{USE_NORMALIZATION_MEAN}' "
+                        f"requires '{name}' to have a normalization mean; "
+                        "none found in the network normalizer."
+                    )
+                targets[name] = float(normalizer.means[name].item())
+            else:
+                targets[name] = float(var_config.target)
+            timescales[name] = var_config.timescale_steps
+        return GlobalMeanRelaxation(
+            targets=targets,
+            timescales=timescales,
+            gridded_operations=gridded_operations,
+        )
+
+
+class GlobalMeanRelaxation:
+    """Apply Newtonian relaxation of the global mean toward target values.
+
+    For each configured variable, computes the area-weighted global mean
+    and subtracts a uniform offset that nudges the field's mean toward
+    the configured target on the configured timescale (in steps).
+    Variables not in the configuration are returned unchanged. Variables
+    in the configuration but absent from the input are skipped silently
+    so that the relaxation can be a no-op for steps that don't produce
+    that field on a given call.
+    """
+
+    def __init__(
+        self,
+        targets: dict[str, float],
+        timescales: dict[str, float],
+        gridded_operations: GriddedOperations,
+    ):
+        if set(targets) != set(timescales):
+            raise ValueError(
+                "targets and timescales must have the same keys: "
+                f"targets={list(targets)}, timescales={list(timescales)}."
+            )
+        self._targets = targets
+        self._timescales = timescales
+        self._gridded_operations = gridded_operations
+
+    def __call__(self, data: TensorMapping) -> TensorDict:
+        result: TensorDict = dict(data)
+        for name, target_value in self._targets.items():
+            if name not in result:
+                continue
+            field = result[name]
+            mean = self._gridded_operations.area_weighted_mean(
+                field, keepdim=True, name=name
+            )
+            target = torch.as_tensor(
+                target_value, dtype=field.dtype, device=field.device
+            )
+            offset = (mean - target) / self._timescales[name]
+            result[name] = field - offset
+        return result

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -422,12 +422,9 @@ class SingleModuleStep(StepABC):
             return output_dict
 
         # Newtonian relaxation toward configured target global means is an
-        # eval-time-only adjustment; gating on the network module's training
-        # flag keeps it from contributing to the loss during training.
-        if (
-            self._global_mean_relaxation is not None
-            and not self.module.torch_module.training
-        ):
+        # eval-time-only adjustment; gating on the step's training flag
+        # keeps it from contributing to the loss during training.
+        if self._global_mean_relaxation is not None and not self._training:
             global_mean_relaxation: GlobalMeanRelaxation | None = (
                 self._global_mean_relaxation
             )

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -22,6 +22,10 @@ from fme.core.optimization import NullOptimization
 from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.step.args import StepArgs
+from fme.core.step.global_mean_relaxation import (
+    GlobalMeanRelaxation,
+    GlobalMeanRelaxationConfig,
+)
 from fme.core.step.global_mean_removal import (
     GlobalMeanRemoval,
     GlobalMeanRemovalConfigUnion,
@@ -70,6 +74,10 @@ class SingleModuleStepConfig(StepConfigABC):
             from fields before normalization and restoring them after
             denormalization. Supports shared (single reference field) or
             per-channel removal, with optional extra input channels.
+        global_mean_relaxation: Optional configuration for Newtonian
+            relaxation of the global mean of selected output variables
+            toward configured target values. Applied only in eval mode,
+            after the network call and before the corrector.
     """
 
     builder: ModuleSelector
@@ -86,11 +94,14 @@ class SingleModuleStepConfig(StepConfigABC):
     residual_prediction: bool = False
     include_channel_mask_inputs: bool = False
     global_mean_removal: GlobalMeanRemovalConfigUnion | None = None
+    global_mean_relaxation: GlobalMeanRelaxationConfig | None = None
 
     def __post_init__(self):
         self.crps_training = None  # unused, kept for backwards compatibility
         if self.global_mean_removal is not None:
             self.global_mean_removal.validate_names(self.in_names, self.out_names)
+        if self.global_mean_relaxation is not None:
+            self.global_mean_relaxation.validate_names(self.out_names)
         for name in self.prescribed_prognostic_names:
             if name not in self.out_names:
                 raise ValueError(
@@ -280,6 +291,15 @@ class SingleModuleStep(StepABC):
             )
         else:
             self._global_mean_removal = NoGlobalMeanRemoval()
+        if config.global_mean_relaxation is not None:
+            self._global_mean_relaxation: GlobalMeanRelaxation | None = (
+                config.global_mean_relaxation.build(
+                    gridded_operations=dataset_info.gridded_operations,
+                    normalizer=normalizer,
+                )
+            )
+        else:
+            self._global_mean_relaxation = None
         # Synthetic GMR channels are packed alongside real inputs so they
         # flow through the packer and channel-mask machinery uniformly.
         packed_in_names = (
@@ -401,6 +421,19 @@ class SingleModuleStep(StepABC):
             output_dict.update(secondary_output_dict)
             return output_dict
 
+        # Newtonian relaxation toward configured target global means is an
+        # eval-time-only adjustment; gating on the network module's training
+        # flag keeps it from contributing to the loss during training.
+        if (
+            self._global_mean_relaxation is not None
+            and not self.module.torch_module.training
+        ):
+            global_mean_relaxation: GlobalMeanRelaxation | None = (
+                self._global_mean_relaxation
+            )
+        else:
+            global_mean_relaxation = None
+
         return step_with_adjustments(
             input=args.input,
             next_step_input_data=args.next_step_input_data,
@@ -412,6 +445,7 @@ class SingleModuleStep(StepABC):
             prognostic_names=self.prognostic_names,
             prescribed_prognostic_names=self._config.prescribed_prognostic_names,
             global_mean_removal=self._global_mean_removal,
+            global_mean_relaxation=global_mean_relaxation,
             data_mask=args.data_mask,
             stepper_state=args.stepper_state,
         )
@@ -508,6 +542,7 @@ def step_with_adjustments(
     prognostic_names: list[str],
     prescribed_prognostic_names: list[str] | None = None,
     global_mean_removal: GlobalMeanRemoval | None = None,
+    global_mean_relaxation: GlobalMeanRelaxation | None = None,
     data_mask: TensorMapping | None = None,
     stepper_state: StepperState | None = None,
 ) -> tuple[TensorDict, StepperState | None]:
@@ -537,6 +572,11 @@ def step_with_adjustments(
             before the normalizer and ``inverse_transform`` after
             denormalization but before the corrector/ocean/prescribed steps,
             so those adjustments operate in physical space.
+        global_mean_relaxation: Optional Newtonian relaxation of the global
+            mean of selected output fields toward configured target values.
+            Applied after the network call (and any ``global_mean_removal``
+            inverse transform) and before the corrector. Pass ``None`` to
+            disable (e.g. during training).
         data_mask: Per-variable boolean masks passed to
             ``global_mean_removal.forward_transform``.
         stepper_state: Per-sample state carried across step calls. The
@@ -568,6 +608,8 @@ def step_with_adjustments(
     output = normalizer.denormalize(output_norm)
     if global_mean_removal is not None:
         output = global_mean_removal.inverse_transform(output)
+    if global_mean_relaxation is not None:
+        output = global_mean_relaxation(output)
     if corrector is not None:
         corrector_state: CorrectorState | None = (
             stepper_state.corrector_state if stepper_state is not None else None

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -235,10 +235,32 @@ class StepSelector(StepConfigABC):
 class StepABC(abc.ABC):
     SelfType = TypeVar("SelfType", bound="StepABC")
 
+    def __init__(self) -> None:
+        # Mirrors ``torch.nn.Module.training`` so that step-level eval/train
+        # state is observable without reaching into the underlying modules.
+        self._training: bool = True
+
     @property
     @abc.abstractmethod
     def config(self) -> StepConfigABC:
         pass
+
+    @final
+    def train(self, mode: bool = True) -> "StepABC":
+        """Set the step (and all submodules) to training mode.
+
+        Matches the ``torch.nn.Module.train`` signature so step instances
+        can be toggled with the same API as the modules they own.
+        """
+        self._training = mode
+        for module in self.modules:
+            module.train(mode)
+        return self
+
+    @final
+    def eval(self) -> "StepABC":
+        """Set the step (and all submodules) to evaluation mode."""
+        return self.train(False)
 
     @final
     def get_loss_normalizer(

--- a/fme/core/step/test_global_mean_relaxation.py
+++ b/fme/core/step/test_global_mean_relaxation.py
@@ -1,0 +1,165 @@
+import dataclasses
+
+import dacite
+import pytest
+import torch
+
+from fme.core.device import move_tensordict_to_device
+from fme.core.gridded_ops import LatLonOperations
+from fme.core.normalizer import NormalizationConfig
+from fme.core.step.global_mean_relaxation import (
+    GlobalMeanRelaxationConfig,
+    GlobalMeanRelaxationVariableConfig,
+)
+
+
+def _make_relaxation(
+    variables: dict[str, GlobalMeanRelaxationVariableConfig],
+    *,
+    means: dict[str, float] | None = None,
+    stds: dict[str, float] | None = None,
+    area_weights: torch.Tensor | None = None,
+):
+    if means is None:
+        means = {name: 0.0 for name in variables}
+    if stds is None:
+        stds = {name: 1.0 for name in variables}
+    if area_weights is None:
+        area_weights = torch.ones(4, 5)
+    normalizer = NormalizationConfig(means=means, stds=stds).build(list(means))
+    ops = LatLonOperations(area_weights=area_weights)
+    return GlobalMeanRelaxationConfig(variables=variables).build(
+        gridded_operations=ops, normalizer=normalizer
+    )
+
+
+def test_timescale_steps_must_be_positive():
+    with pytest.raises(ValueError, match="timescale_steps must be positive"):
+        GlobalMeanRelaxationVariableConfig(target=1.0, timescale_steps=0.0)
+    with pytest.raises(ValueError, match="timescale_steps must be positive"):
+        GlobalMeanRelaxationVariableConfig(target=1.0, timescale_steps=-1.0)
+
+
+def test_target_string_must_be_mean():
+    # The arg-type suppression below is intentional: this test exercises
+    # runtime validation against an invalid Literal value, which mypy
+    # correctly rejects at static-typing time.
+    with pytest.raises(ValueError, match="target must be a number or 'mean'"):
+        GlobalMeanRelaxationVariableConfig(target="median", timescale_steps=10.0)  # type: ignore[arg-type]
+
+
+def test_empty_variables_raises():
+    with pytest.raises(ValueError, match="at least one entry"):
+        GlobalMeanRelaxationConfig(variables={})
+
+
+def test_validate_names_missing_raises():
+    config = GlobalMeanRelaxationConfig(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target=0.0, timescale_steps=2.0)
+        }
+    )
+    with pytest.raises(ValueError, match="missing.*'a'"):
+        config.validate_names(out_names=["b"])
+
+
+def test_mean_target_requires_normalization_mean():
+    normalizer = NormalizationConfig(means={"other": 0.0}, stds={"other": 1.0}).build(
+        ["other"]
+    )
+    ops = LatLonOperations(area_weights=torch.ones(4, 5))
+    config = GlobalMeanRelaxationConfig(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target="mean", timescale_steps=2.0)
+        }
+    )
+    with pytest.raises(ValueError, match="requires 'a' to have a normalization mean"):
+        config.build(gridded_operations=ops, normalizer=normalizer)
+
+
+def test_worked_example_constant_field():
+    # mean=10, target=4, tau=2 -> offset = (10-4)/2 = 3, result = 10-3 = 7
+    relaxation = _make_relaxation(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target=4.0, timescale_steps=2.0)
+        }
+    )
+    data = move_tensordict_to_device({"a": torch.full((1, 4, 5), 10.0)})
+    out = relaxation(data)
+    torch.testing.assert_close(out["a"], torch.full_like(out["a"], 7.0))
+
+
+def test_uses_normalization_mean_when_target_is_mean():
+    relaxation = _make_relaxation(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target="mean", timescale_steps=2.0)
+        },
+        means={"a": 4.0},
+        stds={"a": 1.0},
+    )
+    data = move_tensordict_to_device({"a": torch.full((1, 4, 5), 10.0)})
+    out = relaxation(data)
+    # mean=10, target=4 (normalization mean), tau=2 -> result = 7
+    torch.testing.assert_close(out["a"], torch.full_like(out["a"], 7.0))
+
+
+def test_preserves_spatial_pattern():
+    # Relaxation only shifts the field uniformly, so all gradients survive.
+    relaxation = _make_relaxation(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target=0.0, timescale_steps=5.0)
+        }
+    )
+    field = torch.arange(20, dtype=torch.float32).reshape(1, 4, 5)
+    data = move_tensordict_to_device({"a": field.clone()})
+    out = relaxation(data)
+    diff = out["a"] - data["a"]
+    # The offset is constant across spatial dims for each sample.
+    torch.testing.assert_close(diff, torch.full_like(diff, diff.flatten()[0].item()))
+
+
+def test_unconfigured_variables_passthrough():
+    relaxation = _make_relaxation(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target=0.0, timescale_steps=2.0)
+        },
+        means={"a": 0.0, "b": 0.0},
+        stds={"a": 1.0, "b": 1.0},
+    )
+    a = torch.full((1, 4, 5), 10.0)
+    b = torch.full((1, 4, 5), 99.0)
+    data = move_tensordict_to_device({"a": a, "b": b})
+    out = relaxation(data)
+    torch.testing.assert_close(out["b"], b.to(out["b"].device))
+
+
+def test_per_sample_relaxation():
+    relaxation = _make_relaxation(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target=0.0, timescale_steps=4.0)
+        }
+    )
+    field = torch.stack(
+        [torch.full((4, 5), 8.0), torch.full((4, 5), 0.0)]
+    )  # shape [2, 4, 5]
+    data = move_tensordict_to_device({"a": field})
+    out = relaxation(data)
+    # sample 0: mean=8, offset=2 -> 6 everywhere; sample 1: mean=0 -> 0 everywhere
+    torch.testing.assert_close(out["a"][0], torch.full_like(out["a"][0], 6.0))
+    torch.testing.assert_close(out["a"][1], torch.full_like(out["a"][1], 0.0))
+
+
+def test_config_roundtrip_via_dacite():
+    config = GlobalMeanRelaxationConfig(
+        variables={
+            "a": GlobalMeanRelaxationVariableConfig(target=1.5, timescale_steps=10.0),
+            "b": GlobalMeanRelaxationVariableConfig(target="mean", timescale_steps=5.0),
+        }
+    )
+    data = dataclasses.asdict(config)
+    restored = dacite.from_dict(
+        data_class=GlobalMeanRelaxationConfig,
+        data=data,
+        config=dacite.Config(strict=True),
+    )
+    assert restored == config

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -24,6 +24,10 @@ from fme.core.labels import BatchLabels
 from fme.core.normalizer import NetworkAndLossNormalizationConfig, NormalizationConfig
 from fme.core.registry import ModuleSelector
 from fme.core.step.args import StepArgs
+from fme.core.step.global_mean_relaxation import (
+    GlobalMeanRelaxationConfig,
+    GlobalMeanRelaxationVariableConfig,
+)
 from fme.core.step.global_mean_removal import (
     PerChannelGlobalMeanRemovalConfig,
     SharedGlobalMeanRemovalConfig,
@@ -916,6 +920,121 @@ def test_secondary_module_full_field_and_residual():
     assert "diag" in output
     assert output["prog"].shape == (2, *img_shape)
     assert output["diag"].shape == (2, *img_shape)
+
+
+def _get_relaxation_single_module_selector(
+    relaxation: GlobalMeanRelaxationConfig | None,
+) -> StepSelector:
+    normalization = get_network_and_loss_normalization_config(
+        names=["forcing_shared", "forcing_rad", "diagnostic_main", "diagnostic_rad"]
+    )
+    return StepSelector(
+        type="single_module",
+        config=dataclasses.asdict(
+            SingleModuleStepConfig(
+                builder=ModuleSelector(
+                    type="SphericalFourierNeuralOperatorNet",
+                    config={"scale_factor": 1, "embed_dim": 4, "num_layers": 2},
+                ),
+                in_names=["forcing_shared", "forcing_rad"],
+                out_names=["diagnostic_main", "diagnostic_rad"],
+                normalization=normalization,
+                global_mean_relaxation=relaxation,
+            )
+        ),
+    )
+
+
+def test_global_mean_relaxation_name_not_in_out_names_raises():
+    normalization = get_network_and_loss_normalization_config(
+        names=["a", "b"],
+    )
+    with pytest.raises(ValueError, match="missing.*'c'"):
+        SingleModuleStepConfig(
+            builder=ModuleSelector(type="MLP", config={}),
+            in_names=["a"],
+            out_names=["b"],
+            normalization=normalization,
+            global_mean_relaxation=GlobalMeanRelaxationConfig(
+                variables={
+                    "c": GlobalMeanRelaxationVariableConfig(
+                        target=0.0, timescale_steps=2.0
+                    ),
+                }
+            ),
+        )
+
+
+@pytest.mark.parallel
+def test_global_mean_relaxation_only_applied_in_eval_mode():
+    torch.manual_seed(0)
+    relaxation = GlobalMeanRelaxationConfig(
+        variables={
+            "diagnostic_main": GlobalMeanRelaxationVariableConfig(
+                target=0.0, timescale_steps=2.0
+            ),
+        }
+    )
+    config = _get_relaxation_single_module_selector(relaxation)
+    img_shape = DEFAULT_IMG_SHAPE
+    step = get_step(config, img_shape)
+    input_data = get_tensor_dict(step.input_names, img_shape, n_samples=2)
+    next_step_input_data = get_tensor_dict(
+        step.next_step_input_names, img_shape, n_samples=2
+    )
+    args = StepArgs(
+        input=input_data, next_step_input_data=next_step_input_data, labels=None
+    )
+
+    for module in step.modules:
+        module.train()
+    train_output, _ = step.step(args=args)
+
+    for module in step.modules:
+        module.eval()
+    eval_output, _ = step.step(args=args)
+
+    # Other variables are untouched.
+    torch.testing.assert_close(
+        train_output["diagnostic_rad"], eval_output["diagnostic_rad"]
+    )
+    # The relaxation pushes diagnostic_main toward the target (0.0) by a
+    # constant per-sample offset, so eval and train differ by exactly that
+    # offset and the offset is spatially uniform.
+    delta = eval_output["diagnostic_main"] - train_output["diagnostic_main"]
+    per_sample = delta.flatten(start_dim=1)
+    torch.testing.assert_close(
+        per_sample, per_sample[:, :1].expand_as(per_sample), rtol=1e-5, atol=1e-6
+    )
+    # And shifts away from the train output (we cannot guarantee toward 0
+    # in a single step, but the offset should be nonzero).
+    assert not torch.allclose(delta, torch.zeros_like(delta))
+
+
+@pytest.mark.parallel
+def test_global_mean_relaxation_disabled_when_none():
+    torch.manual_seed(0)
+    config = _get_relaxation_single_module_selector(None)
+    img_shape = DEFAULT_IMG_SHAPE
+    step = get_step(config, img_shape)
+    input_data = get_tensor_dict(step.input_names, img_shape, n_samples=2)
+    next_step_input_data = get_tensor_dict(
+        step.next_step_input_names, img_shape, n_samples=2
+    )
+    args = StepArgs(
+        input=input_data, next_step_input_data=next_step_input_data, labels=None
+    )
+    for module in step.modules:
+        module.eval()
+    eval_output, _ = step.step(args=args)
+    for module in step.modules:
+        module.train()
+    train_output, _ = step.step(args=args)
+    # Without relaxation, eval and train produce identical outputs for SFNO
+    # (no dropout/batchnorm), since both go through step_with_adjustments
+    # with the same seed-free network call.
+    for name in eval_output:
+        torch.testing.assert_close(eval_output[name], train_output[name])
 
 
 @pytest.mark.parallel

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -945,6 +945,19 @@ def _get_relaxation_single_module_selector(
     )
 
 
+def test_step_train_eval_toggle_propagates_to_modules():
+    config = _get_relaxation_single_module_selector(None)
+    step = get_step(config, DEFAULT_IMG_SHAPE)
+    # Default is training mode (matches torch.nn.Module).
+    assert all(module.training for module in step.modules)
+    step.eval()
+    assert all(not module.training for module in step.modules)
+    step.train()
+    assert all(module.training for module in step.modules)
+    step.train(False)
+    assert all(not module.training for module in step.modules)
+
+
 def test_global_mean_relaxation_name_not_in_out_names_raises():
     normalization = get_network_and_loss_normalization_config(
         names=["a", "b"],
@@ -986,12 +999,10 @@ def test_global_mean_relaxation_only_applied_in_eval_mode():
         input=input_data, next_step_input_data=next_step_input_data, labels=None
     )
 
-    for module in step.modules:
-        module.train()
+    step.train()
     train_output, _ = step.step(args=args)
 
-    for module in step.modules:
-        module.eval()
+    step.eval()
     eval_output, _ = step.step(args=args)
 
     # Other variables are untouched.
@@ -1024,11 +1035,9 @@ def test_global_mean_relaxation_disabled_when_none():
     args = StepArgs(
         input=input_data, next_step_input_data=next_step_input_data, labels=None
     )
-    for module in step.modules:
-        module.eval()
+    step.eval()
     eval_output, _ = step.step(args=args)
-    for module in step.modules:
-        module.train()
+    step.train()
     train_output, _ = step.step(args=args)
     # Without relaxation, eval and train produce identical outputs for SFNO
     # (no dropout/batchnorm), since both go through step_with_adjustments


### PR DESCRIPTION
Adds an eval-only Newtonian relaxation of the global mean of selected output variables toward configured target values, applied between any global-mean-removal inverse transform and the corrector so the corrector operates on the relaxed field. Eval/train state on the step is made explicit via new `train()`/`eval()` methods on `StepABC`, matching the `torch.nn.Module` API.

Changes:
- `fme.core.step.global_mean_relaxation`: new `GlobalMeanRelaxationConfig`, `GlobalMeanRelaxationVariableConfig`, and `GlobalMeanRelaxation`; per variable, subtracts `(area_weighted_mean(x) - target) / timescale_steps`. `target` may be a float or `"mean"` (resolved to the network normalizer's mean at build time).
- `fme.core.step.single_module.SingleModuleStepConfig`: new optional `global_mean_relaxation` field, validated against `out_names`. Wired into `step_with_adjustments` via a new kwarg, gated on the step's training flag so it is inert during training.
- `fme.core.step.step.StepABC`: new `train(mode=True)`/`eval()` methods and a `_training` flag, mirroring `torch.nn.Module`. `fme.ace.stepper.single_module.SingleModuleStepper.set_eval`/`set_train` now delegate to the step's methods instead of iterating modules directly.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated