### PR TITLE
Trim slow test parametrizations and oversized test data

### DIFF
--- a/fme/ace/aggregator/inference/ipo/test_ipo_index.py
+++ b/fme/ace/aggregator/inference/ipo/test_ipo_index.py
@@ -9,8 +9,8 @@ from fme import get_device
 from fme.ace.aggregator.inference.data import InferenceBatchData
 
 from ..utils import LatLonRegion
+from . import ipo_index
 from .ipo_index import (
-    MIN_YEARS_FOR_FILTERED_TPI,
     PairedIPOIndexAggregator,
     _IPORegionalAccumulator,
     low_pass_filter,
@@ -174,17 +174,26 @@ class TestIPORegionalAccumulator:
 
 
 class TestPairedIPOIndexAggregator:
-    def test_get_logs_returns_expected_keys(self, very_fast_only: bool):
+    def test_get_logs_returns_expected_keys(
+        self, very_fast_only: bool, monkeypatch: pytest.MonkeyPatch
+    ):
         if very_fast_only:
             pytest.skip("Skipping non-fast tests")
         """Test that get_logs returns the expected metric keys for long runs."""
+        # Patch the minimum-length threshold so the "long run" behavior can be
+        # exercised with far less data than the production 80-year minimum.
+        min_years = 5
+        monkeypatch.setattr(ipo_index, "MIN_YEARS_FOR_FILTERED_TPI", min_years)
         lat = torch.linspace(-60.0, 60.0, 13)
         lon = torch.linspace(100.0, 300.0, 17)
         n_lat, n_lon = len(lat), len(lon)
         n_samples = 1
-        n_months = (MIN_YEARS_FOR_FILTERED_TPI + 5) * 12
+        n_months = (min_years + 5) * 12
 
-        agg = PairedIPOIndexAggregator(lat=lat, lon=lon)
+        # The cutoff period must be short relative to the (reduced) data
+        # length, since one cutoff period is trimmed from each end of the
+        # filtered series.
+        agg = PairedIPOIndexAggregator(lat=lat, lon=lon, cutoff_period_yrs=2.0)
 
         chunk_size = 60
         for i_start in range(0, n_months, chunk_size):
@@ -226,15 +235,21 @@ class TestPairedIPOIndexAggregator:
         assert any("ipo_tpi_power_spectrum" in k for k in logs)
         assert not any("ipo_tpi_std_ratio" in k for k in logs)
 
-    def test_get_logs_empty_for_short_rollout(self, very_fast_only: bool):
+    def test_get_logs_empty_for_short_rollout(
+        self, very_fast_only: bool, monkeypatch: pytest.MonkeyPatch
+    ):
         if very_fast_only:
             pytest.skip("Skipping non-fast tests")
         """Rollouts shorter than the minimum should not report IPO metrics."""
+        # Patch the minimum-length threshold so the "short run" behavior can be
+        # exercised with far less data than the production 80-year minimum.
+        min_years = 5
+        monkeypatch.setattr(ipo_index, "MIN_YEARS_FOR_FILTERED_TPI", min_years)
         lat = torch.linspace(-60.0, 60.0, 13)
         lon = torch.linspace(100.0, 300.0, 17)
         n_lat, n_lon = len(lat), len(lon)
         n_samples = 1
-        n_months = (MIN_YEARS_FOR_FILTERED_TPI // 2) * 12
+        n_months = (min_years // 2) * 12
 
         agg = PairedIPOIndexAggregator(lat=lat, lon=lon)
 

--- a/fme/ace/models/graphcast/test_graphcast.py
+++ b/fme/ace/models/graphcast/test_graphcast.py
@@ -44,7 +44,7 @@ def dummy_datasetinfo(height: int, width: int) -> DatasetInfo:
 
 
 @pytest.mark.skipif(not GRAPHCAST_AVAIL, reason="trimesh/rtree are not available")
-@pytest.mark.parametrize("activation", ["SiLU", "ReLU", "Mish", "GELU", "Tanh"])
+@pytest.mark.parametrize("activation", ["SiLU", "GELU"])
 def test_graphcast_normalization(activation):
     # Model parameters
     input_channels = 4

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -622,6 +622,7 @@ _TRAIN_AND_INFERENCE_CASES = [
             nettype="NoiseConditionedSFNO",
             crps_training=True,
             use_schedule=True,
+            validate_using_ema=True,
         ),
         id="SFNO-crps-schedule",
     ),
@@ -652,15 +653,6 @@ _TRAIN_AND_INFERENCE_CASES = [
         marks=pytest.mark.filterwarnings(
             "ignore:Metadata for each ensemble member:UserWarning"
         ),
-    ),
-    pytest.param(
-        TrainAndInferenceTestSettings(
-            nettype="NoiseConditionedSFNO",
-            crps_training=True,
-            use_schedule=True,
-            validate_using_ema=True,
-        ),
-        id="SFNO-crps-schedule-ema",
     ),
 ]
 

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -36,7 +36,7 @@ from fme.ace.registry.test_hpx import (
     up_sampling_block_config,
 )
 from fme.ace.stepper.derived_forcings import DerivedForcingsConfig
-from fme.ace.stepper.insolation.config import InsolationConfig, NameConfig, ValueConfig
+from fme.ace.stepper.insolation.config import InsolationConfig, NameConfig
 from fme.ace.stepper.single_module import (
     CheckpointStepperConfig,
     StepperConfig,
@@ -1085,28 +1085,17 @@ def test_train_without_inline_inference(tmp_path, very_fast_only: bool):
 
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="flaky on GPU")
-@pytest.mark.parametrize(
-    "insolation_config",
-    [
-        pytest.param(
-            InsolationConfig("DSWRFtoa", ValueConfig(1360.0)),
-            id="solar-constant-as-value",
-        ),
-        pytest.param(
-            InsolationConfig("DSWRFtoa", NameConfig("solar_constant")),
-            id="solar-constant-as-name",
-        ),
-    ],
-)
-def test_train_and_inference_with_derived_forcings(
-    tmp_path, insolation_config: InsolationConfig, very_fast_only: bool
-):
+def test_train_and_inference_with_derived_forcings(tmp_path, very_fast_only: bool):
     if very_fast_only:
         pytest.skip("Skipping non-fast tests")
 
     nettype = "SphericalFourierNeuralOperatorNet"
     crps_training = False
     log_validation_maps = False
+    # The solar-constant-as-name case exercises the more complex path (loading
+    # the solar constant from data on disk); the as-value alternative is
+    # covered by unit tests in test_insolation.py and test_derived_forcings.py.
+    insolation_config = InsolationConfig("DSWRFtoa", NameConfig("solar_constant"))
     derived_forcings = DerivedForcingsConfig(insolation_config)
     train_config, inference_config = _setup(
         tmp_path,


### PR DESCRIPTION
Several of the slowest tests in the suite spend their time on data volume or parametrized cases that add no coverage. This PR trims them while preserving the behaviors each test verifies, cutting several minutes of CI time without changing any production code.

Changes:
- `fme/ace/aggregator/inference/ipo/test_ipo_index.py::TestPairedIPOIndexAggregator`: monkeypatch `MIN_YEARS_FOR_FILTERED_TPI` to 5 years (and use a 2-year filter cutoff) so the long/short rollout behaviors of `get_logs` are exercised with ~10x less monthly data. Local timings: `test_get_logs_returns_expected_keys` 13.1s -> 1.7s, `test_get_logs_empty_for_short_rollout` 5.0s -> 0.3s (39s and 12s in CI before).
- `fme/ace/test_train.py::test_train_and_inference`: fold `validate_using_ema=True` into the `SFNO-crps-schedule` case and delete the otherwise-identical `SFNO-crps-schedule-ema` case, removing one full train+inference cycle (~27s locally, ~1 min in CI). Non-EMA validation remains covered by the `SFNO-val-maps-multi`, `SFNO-masking`, `Samudra`, and `HEALPix` cases.
- `fme/ace/test_train.py::test_train_and_inference_with_derived_forcings`: drop the `solar-constant-as-value` parametrization (~12s locally), keeping the more complex as-name path that loads the solar constant from disk. Value-vs-name resolution is already unit-tested by `fme/ace/stepper/insolation/test_insolation.py` (`test_update_requirements`, `test_insolation_compute`) and `fme/ace/stepper/test_derived_forcings.py::test_forcing_deriver`.
- `fme/ace/models/graphcast/test_graphcast.py::test_graphcast_normalization`: reduce the activation parametrization from 5 to `["SiLU", "GELU"]` (~4s per case locally, ~7s in CI); the test only asserts output shape and absence of NaN/Inf, which the activation choice does not affect.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
