### PR TITLE
Shrink synthetic data in end-to-end train tests

### DIFF
--- a/fme/ace/test_ice_train.py
+++ b/fme/ace/test_ice_train.py
@@ -336,7 +336,9 @@ def _setup(
     path,
     log_to_wandb=True,
     max_epochs=1,
-    n_time=60,
+    # inline inference uses two initial conditions at indices 0 and 1, so it
+    # needs inference_forward_steps + 2 timesteps of data on disk
+    n_time=12,
     timestep_days=2,
     inference_forward_steps=10,
     save_per_epoch_diagnostics=True,

--- a/fme/ace/test_ocean_train.py
+++ b/fme/ace/test_ocean_train.py
@@ -404,7 +404,9 @@ def _setup(
     path,
     log_to_wandb=True,
     max_epochs=1,
-    n_time=60,
+    # inline inference uses two initial conditions at indices 0 and 1, so it
+    # needs inference_forward_steps + 2 timesteps of data on disk
+    n_time=12,
     timestep_days=2,
     inference_forward_steps=10,
     save_per_epoch_diagnostics=True,

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -183,6 +183,11 @@ def _get_test_yaml_files(
             output_layer,
             n_channels=[4, 8, 16],
         )
+        # HEALPix conv padding equals the dilation, and padding cannot exceed
+        # the face size. The deepest UNet level has 2x2 faces for the 8x8
+        # test data, so dilations must be capped at 2.
+        encoder = dataclasses.replace(encoder, dilations=[1, 2, 2])
+        decoder = dataclasses.replace(decoder, dilations=[2, 2, 1])
         net_config = dict(
             encoder=encoder,
             decoder=decoder,
@@ -518,8 +523,8 @@ def _setup(
     if use_healpix:
         hpx_coords = HEALPixCoordinates(
             face=torch.Tensor(np.arange(12)),
-            width=torch.Tensor(np.arange(16)),
-            height=torch.Tensor(np.arange(16)),
+            width=torch.Tensor(np.arange(8)),
+            height=torch.Tensor(np.arange(8)),
         )
         dim_sizes = get_sizes(spatial_dims=hpx_coords, n_time=n_time)
     else:

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -679,14 +679,19 @@ def test_train_and_inference(
     """Ensure that training and standalone inference run without errors."""
     if very_fast_only:
         pytest.skip("Skipping non-fast tests")
-    # need multi-year to cover annual aggregator
+    # Inline inference must reach forward step 20 for the default step-20
+    # metrics, and the annual aggregator requires more than 730 days of
+    # inference data. 20 forward steps (even, as required by
+    # forward_steps_in_memory=2) at 40-day spacing gives 21 timesteps
+    # spanning 840 days and three calendar years. Two initial conditions at
+    # indices 0 and 1 require two extra timesteps of data on disk.
     train_config, inference_config = _setup(
         tmp_path,
         settings.nettype,
         log_to_wandb=True,
-        timestep_days=20,
-        n_time=int(366 * 3 / 20 + 1),
-        inference_forward_steps=int(366 * 3 / 20 / 2 - 1) * 2,  # must be even
+        timestep_days=40,
+        n_time=22,
+        inference_forward_steps=20,
         use_healpix=settings.use_healpix,
         crps_training=settings.crps_training,
         save_per_epoch_diagnostics=True,
@@ -1072,9 +1077,9 @@ def test_train_without_inline_inference(tmp_path, very_fast_only: bool):
         tmp_path,
         nettype,
         log_to_wandb=True,
-        timestep_days=20,
-        n_time=int(366 * 3 / 20 + 1),
-        inference_forward_steps=int(366 * 3 / 20 / 2 - 1) * 2,  # must be even
+        timestep_days=40,
+        n_time=22,
+        inference_forward_steps=20,  # must be even
         use_healpix=False,
         crps_training=crps_training,
         save_per_epoch_diagnostics=True,


### PR DESCRIPTION
The end-to-end train-and-inference tests generate far more synthetic data than their assertions require, dominating CI time. This PR derives the minimum data sizes that keep each test's coverage intact (annual/monthly aggregation, default step metrics, inline inference initial conditions) and shrinks the fixtures to those minimums, documenting the bound in a comment at each knob. No assertions are weakened and no production code changes.

Changes:
- `fme/ace/test_train.py::test_train_and_inference`, `test_train_without_inline_inference`: reduce `n_time` from 55 to 22 and `inference_forward_steps` from 52 to 20 at 40-day spacing — the minimum that still spans >730 days (annual aggregator) and reaches the asserted step-20 metrics
- `fme/ace/test_train.py` (HEALPix case): shrink faces from 16x16 to 8x8, capping the UNet test dilations at 2 so conv padding stays within the deepest level's 2x2 face size; this eliminates the ~28s fixture setup
- `fme/ace/test_ocean_train.py::_setup`, `fme/ace/test_ice_train.py::_setup`: reduce `n_time` from 60 to 12, the minimum for inline inference's two initial conditions plus `inference_forward_steps=10`

Local timings (FME_FORCE_CPU=1, `-n 4`; CI baseline in parentheses): ocean `test_train_and_inference` 12.5s (48.2s), ice 5.0s (35.0s), HEALPix setup negligible (27.6s). All 20 tests in the three files pass in 3:13.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
