### PR TITLE
Add qsat_scaled_names to SharedGlobalMeanRemovalConfig

### DIFF
--- a/fme/core/humidity.py
+++ b/fme/core/humidity.py
@@ -1,0 +1,19 @@
+import torch
+
+from fme.core.constants import FREEZING_TEMPERATURE_KELVIN
+
+
+def bolton_saturation_vapor_pressure(temperature_kelvin: torch.Tensor) -> torch.Tensor:
+    """Saturation vapor pressure over liquid water from the Bolton (1980) formula.
+
+    Returns ``e_s = 6.112 * exp(17.67 * T_C / (T_C + 243.5))`` in hPa, where
+    ``T_C`` is temperature in degrees Celsius.
+
+    Args:
+        temperature_kelvin: Temperature in Kelvin.
+
+    Returns:
+        Saturation vapor pressure in hPa, same shape as input.
+    """
+    t_c = temperature_kelvin - FREEZING_TEMPERATURE_KELVIN
+    return 6.112 * torch.exp(17.67 * t_c / (t_c + 243.5))

--- a/fme/core/step/global_mean_removal.py
+++ b/fme/core/step/global_mean_removal.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 import torch
 
+from fme.core.humidity import bolton_saturation_vapor_pressure
 from fme.core.normalizer import StandardNormalizer
 from fme.core.typing_ import TensorDict, TensorMapping
 
@@ -120,13 +121,16 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         append_as_input: bool,
         reference_mean: torch.Tensor,
         reference_std: torch.Tensor,
+        qsat_scaled_names: frozenset[str] = frozenset(),
     ):
         self._reference_field = reference_field
         self._field_names = field_names
+        self._qsat_scaled_names = qsat_scaled_names
         self._append_as_input = append_as_input
         self._reference_mean = reference_mean
         self._reference_std = reference_std
         self._cached_offset: torch.Tensor | None = None
+        self._cached_qsat_factor: torch.Tensor | None = None
         self._cached_extra: torch.Tensor | None = None
 
     @property
@@ -154,6 +158,14 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
         offset = self._reference_mean - sample_mean
         self._cached_offset = offset
 
+        if self._qsat_scaled_names:
+            qsat_clim = bolton_saturation_vapor_pressure(self._reference_mean)
+            qsat_sample = bolton_saturation_vapor_pressure(sample_mean)
+            qsat_factor = qsat_clim / qsat_sample
+        else:
+            qsat_factor = None
+        self._cached_qsat_factor = qsat_factor
+
         if self._append_as_input:
             normalized_mean = -offset / self._reference_std
             spatial_shape = ref.shape[1:]
@@ -170,13 +182,28 @@ class SharedGlobalMeanRemoval(GlobalMeanRemoval):
             t = result[name]
             broadcast = offset.view(offset.shape[0], *(1,) * (t.ndim - 1))
             result[name] = t + broadcast
+        if qsat_factor is not None:
+            for name in self._qsat_scaled_names:
+                if name not in result:
+                    continue
+                t = result[name]
+                broadcast = qsat_factor.view(qsat_factor.shape[0], *(1,) * (t.ndim - 1))
+                result[name] = t * broadcast
         return result
 
     def inverse_transform(self, output: TensorDict) -> TensorDict:
         if self._cached_offset is None:
             raise RuntimeError("inverse_transform() called before forward_transform().")
         offset = self._cached_offset
+        qsat_factor = self._cached_qsat_factor
         result = dict(output)
+        if qsat_factor is not None:
+            for name in self._qsat_scaled_names:
+                if name not in result:
+                    continue
+                t = result[name]
+                broadcast = qsat_factor.view(qsat_factor.shape[0], *(1,) * (t.ndim - 1))
+                result[name] = t / broadcast
         for name in self._field_names:
             if name not in result:
                 continue
@@ -295,15 +322,26 @@ class SharedGlobalMeanRemovalConfig:
     appear in neither input nor output are silently ignored (a warning
     is logged).
 
+    Fields in ``qsat_scaled_names`` are multiplied by
+    ``qsat(reference_mean) / qsat(sample_mean_of_reference_field)`` in
+    ``forward_transform`` and divided back in ``inverse_transform``,
+    where ``qsat`` is the Bolton (1980) saturation vapor pressure as a
+    function of temperature in Kelvin.  This is intended for humidity-
+    like fields that scale with saturation vapor pressure; the reference
+    field is expected to be a temperature.
+
     Parameters:
         kind: Must be ``"shared"``.
         reference_field: Name of the field whose per-sample cellwise
             spatial mean determines the offset applied to all
-            ``field_names``.
+            ``field_names`` and the qsat ratio applied to all
+            ``qsat_scaled_names``.
         field_names: Names of fields to shift by the shared offset.
             Fields may be inputs, outputs, or both.
         append_as_input: If true, the removed sample mean (normalized) is
             appended as an extra network input channel.
+        qsat_scaled_names: Names of fields to scale by the qsat ratio.
+            Fields may be inputs, outputs, or both.
     """
 
     kind: Literal["shared"] = "shared"
@@ -312,6 +350,7 @@ class SharedGlobalMeanRemovalConfig:
         default_factory=lambda: list(DEFAULT_TEMPERATURE_FIELD_NAMES)
     )
     append_as_input: bool = False
+    qsat_scaled_names: list[str] = dataclasses.field(default_factory=list)
 
     def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
         if self.reference_field not in in_names:
@@ -327,6 +366,13 @@ class SharedGlobalMeanRemovalConfig:
                     "in_names or out_names and will have no effect",
                     name,
                 )
+        for name in self.qsat_scaled_names:
+            if name not in all_names:
+                logger.warning(
+                    "global_mean_removal qsat_scaled_name '%s' is not in "
+                    "in_names or out_names and will have no effect",
+                    name,
+                )
 
     def build(
         self,
@@ -339,6 +385,7 @@ class SharedGlobalMeanRemovalConfig:
             append_as_input=self.append_as_input,
             reference_mean=normalizer.means[self.reference_field],
             reference_std=normalizer.stds[self.reference_field],
+            qsat_scaled_names=frozenset(self.qsat_scaled_names),
         )
 
 

--- a/fme/core/step/test_global_mean_removal.py
+++ b/fme/core/step/test_global_mean_removal.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from fme.core.device import move_tensordict_to_device
+from fme.core.humidity import bolton_saturation_vapor_pressure
 from fme.core.step.global_mean_removal import (
     GlobalMeanRemovalConfigUnion,
     PerChannelGlobalMeanRemovalConfig,
@@ -21,12 +22,15 @@ def _build_normalizer_for(means, stds):
 # ── SharedGlobalMeanRemoval ─────────────────────────────────────────────
 
 
-def _make_shared(means, stds, append_as_input=False):
+def _make_shared(
+    means, stds, append_as_input=False, qsat_scaled_names=None, field_names=None
+):
     normalizer = _build_normalizer_for(means, stds)
     config = SharedGlobalMeanRemovalConfig(
         reference_field="surface_temperature",
-        field_names=list(means.keys()),
+        field_names=list(means.keys()) if field_names is None else field_names,
         append_as_input=append_as_input,
+        qsat_scaled_names=qsat_scaled_names or [],
     )
     return config.build(normalizer, list(means.keys()))
 
@@ -157,6 +161,136 @@ def test_shared_inverse_before_forward_raises():
     transform = _make_shared(means, stds)
     with pytest.raises(RuntimeError, match="forward_transform"):
         transform.inverse_transform({"surface_temperature": torch.zeros(1, 4, 4)})
+
+
+# ── SharedGlobalMeanRemoval qsat_scaled_names ───────────────────────────
+
+
+def test_shared_qsat_scaled_worked_example():
+    means = {"surface_temperature": 280.0, "specific_humidity_4": 0.005}
+    stds = {"surface_temperature": 2.0, "specific_humidity_4": 0.001}
+    transform = _make_shared(
+        means, stds, field_names=[], qsat_scaled_names=["specific_humidity_4"]
+    )
+    tensors = move_tensordict_to_device(
+        {
+            "surface_temperature": torch.full((1, 4, 4), 290.0),
+            "specific_humidity_4": torch.full((1, 4, 4), 0.006),
+        }
+    )
+    result = transform.forward_transform(tensors, None)
+    expected_factor = (
+        bolton_saturation_vapor_pressure(torch.tensor(280.0))
+        / bolton_saturation_vapor_pressure(torch.tensor(290.0))
+    ).item()
+    # reference is unchanged (only listed in qsat_scaled_names? no, it's not listed)
+    torch.testing.assert_close(
+        result["surface_temperature"],
+        torch.full_like(result["surface_temperature"], 290.0),
+    )
+    torch.testing.assert_close(
+        result["specific_humidity_4"].cpu(),
+        torch.full((1, 4, 4), 0.006 * expected_factor),
+    )
+
+
+def test_shared_qsat_scaled_round_trip():
+    torch.manual_seed(0)
+    means = {"surface_temperature": 288.0, "specific_humidity_0": 0.01}
+    stds = {"surface_temperature": 5.0, "specific_humidity_0": 0.002}
+    transform = _make_shared(
+        means, stds, field_names=[], qsat_scaled_names=["specific_humidity_0"]
+    )
+    tensors = move_tensordict_to_device(
+        {
+            "surface_temperature": torch.randn(2, 4, 4) + 290.0,
+            "specific_humidity_0": torch.rand(2, 4, 4) * 0.01 + 0.005,
+        }
+    )
+    result = transform.forward_transform(tensors, None)
+    restored = transform.inverse_transform(result)
+    for k in tensors:
+        torch.testing.assert_close(restored[k], tensors[k])
+
+
+def test_shared_qsat_scaled_is_per_sample():
+    means = {"surface_temperature": 280.0, "q": 0.005}
+    stds = {"surface_temperature": 1.0, "q": 0.001}
+    transform = _make_shared(means, stds, field_names=[], qsat_scaled_names=["q"])
+    surface_t = torch.tensor([[[285.0]], [[270.0]]])
+    q = torch.tensor([[[0.01]], [[0.01]]])
+    tensors = move_tensordict_to_device({"surface_temperature": surface_t, "q": q})
+    result = transform.forward_transform(tensors, None)
+    factor_warm = (
+        bolton_saturation_vapor_pressure(torch.tensor(280.0))
+        / bolton_saturation_vapor_pressure(torch.tensor(285.0))
+    ).item()
+    factor_cold = (
+        bolton_saturation_vapor_pressure(torch.tensor(280.0))
+        / bolton_saturation_vapor_pressure(torch.tensor(270.0))
+    ).item()
+    expected = torch.tensor([[[0.01 * factor_warm]], [[0.01 * factor_cold]]])
+    torch.testing.assert_close(result["q"].cpu(), expected)
+
+
+def test_shared_qsat_scaled_does_not_apply_offset_to_humidity():
+    """Humidities listed only in qsat_scaled_names must not be shifted by
+    the temperature offset — only multiplicatively scaled."""
+    means = {"surface_temperature": 280.0, "q": 0.005}
+    stds = {"surface_temperature": 1.0, "q": 0.001}
+    # field_names is empty: no fields get the additive offset
+    transform = _make_shared(means, stds, field_names=[], qsat_scaled_names=["q"])
+    tensors = move_tensordict_to_device(
+        {
+            # sample_mean equals climatology, so factor = 1
+            "surface_temperature": torch.full((1, 4, 4), 280.0),
+            "q": torch.full((1, 4, 4), 0.01),
+        }
+    )
+    result = transform.forward_transform(tensors, None)
+    torch.testing.assert_close(result["q"].cpu(), torch.full((1, 4, 4), 0.01))
+
+
+def test_shared_qsat_scaled_output_only_field_unscaled_by_inverse():
+    """A field listed in qsat_scaled_names that only appears in the
+    output is not scaled by forward_transform (it isn't an input) but
+    *is* unscaled by inverse_transform, so the network learns to
+    produce it in the scaled space."""
+    means = {"surface_temperature": 280.0, "q_out": 0.005}
+    stds = {"surface_temperature": 1.0, "q_out": 0.001}
+    transform = _make_shared(means, stds, field_names=[], qsat_scaled_names=["q_out"])
+    inputs = move_tensordict_to_device(
+        {"surface_temperature": torch.full((1, 4, 4), 290.0)}
+    )
+    transform.forward_transform(inputs, None)
+    output = move_tensordict_to_device({"q_out": torch.full((1, 4, 4), 0.01)})
+    restored = transform.inverse_transform(output)
+    factor = (
+        bolton_saturation_vapor_pressure(torch.tensor(280.0))
+        / bolton_saturation_vapor_pressure(torch.tensor(290.0))
+    ).item()
+    torch.testing.assert_close(
+        restored["q_out"].cpu(), torch.full((1, 4, 4), 0.01 / factor)
+    )
+
+
+def test_shared_qsat_scaled_default_empty_is_noop():
+    """Default empty qsat_scaled_names must not change behavior vs. the
+    pre-existing shared transform."""
+    means = {"surface_temperature": 280.0, "q": 0.005}
+    stds = {"surface_temperature": 1.0, "q": 0.001}
+    transform = _make_shared(
+        means, stds, field_names=["surface_temperature"], qsat_scaled_names=[]
+    )
+    tensors = move_tensordict_to_device(
+        {
+            "surface_temperature": torch.full((1, 4, 4), 285.0),
+            "q": torch.full((1, 4, 4), 0.01),
+        }
+    )
+    result = transform.forward_transform(tensors, None)
+    # q is in neither field_names nor qsat_scaled_names — unchanged.
+    torch.testing.assert_close(result["q"].cpu(), torch.full((1, 4, 4), 0.01))
 
 
 # ── PerChannelGlobalMeanRemoval ─────────────────────────────────────────
@@ -363,6 +497,15 @@ def test_shared_config_warns_on_unknown_field_names(caplog):
     assert "will have no effect" in caplog.text
 
 
+def test_shared_config_warns_on_unknown_qsat_scaled_names(caplog):
+    config = SharedGlobalMeanRemovalConfig(
+        reference_field="a", field_names=["a"], qsat_scaled_names=["missing_q"]
+    )
+    config.validate_names(["a", "b"], ["a", "b"])
+    assert "missing_q" in caplog.text
+    assert "will have no effect" in caplog.text
+
+
 def test_per_channel_config_warns_on_unknown_field_names(caplog):
     config = PerChannelGlobalMeanRemovalConfig(field_names=["missing"])
     config.validate_names(["a", "b"], ["a", "b"])
@@ -396,6 +539,7 @@ def test_shared_config_round_trips_through_dacite():
         reference_field="surface_temperature",
         field_names=["surface_temperature", "air_temperature_0"],
         append_as_input=True,
+        qsat_scaled_names=["specific_humidity_0"],
     )
     data = dataclasses.asdict(config)
     restored = dacite.from_dict(

--- a/fme/core/test_humidity.py
+++ b/fme/core/test_humidity.py
@@ -1,0 +1,29 @@
+import torch
+
+from fme.core.humidity import bolton_saturation_vapor_pressure
+
+
+def test_bolton_at_freezing_point():
+    # Bolton (1980) yields exactly 6.112 hPa at T_C = 0.
+    result = bolton_saturation_vapor_pressure(torch.tensor(273.15))
+    torch.testing.assert_close(result, torch.tensor(6.112))
+
+
+def test_bolton_monotonic_in_temperature():
+    temps = torch.linspace(250.0, 320.0, 10)
+    es = bolton_saturation_vapor_pressure(temps)
+    diffs = es[1:] - es[:-1]
+    assert (diffs > 0).all()
+
+
+def test_bolton_reference_value_at_300k():
+    # Bolton (1980): T_C = 26.85; e_s ≈ 6.112 * exp(17.67 * 26.85 / 270.35)
+    # ≈ 35.30 hPa
+    result = bolton_saturation_vapor_pressure(torch.tensor(300.0))
+    torch.testing.assert_close(result, torch.tensor(35.345211), rtol=1e-5, atol=1e-4)
+
+
+def test_bolton_preserves_shape():
+    t = torch.full((2, 3, 4), 285.0)
+    es = bolton_saturation_vapor_pressure(t)
+    assert es.shape == t.shape


### PR DESCRIPTION
The shared global mean removal transform shifts temperature-like fields by a per-sample offset, but humidity-like fields scale multiplicatively with saturation vapor pressure rather than shifting additively with temperature. This PR adds a `qsat_scaled_names` option to `SharedGlobalMeanRemovalConfig` so humidity fields can be scaled by the ratio `qsat(reference_mean) / qsat(sample_mean)` in `forward_transform` and divided back in `inverse_transform`, using the Bolton (1980) saturation vapor pressure formula. The default (empty list) leaves existing behavior unchanged.

Changes:
- `fme.core.humidity.bolton_saturation_vapor_pressure`: new helper computing Bolton (1980) saturation vapor pressure over liquid water (hPa) from temperature in Kelvin
- `fme.core.step.global_mean_removal.SharedGlobalMeanRemovalConfig` / `SharedGlobalMeanRemoval`: new `qsat_scaled_names` field; listed fields are multiplied by the per-sample qsat ratio in `forward_transform` and unscaled in `inverse_transform`, with name validation warnings matching `field_names`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated