### PR TITLE
Fix hard coded land fraction name in coupled stepper

### DIFF
--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -152,17 +152,20 @@ class CoupledOceanFractionConfig:
         # fill nans with 0s
         sea_ice_frac = torch.nan_to_num(forcings_from_ocean[sea_ice_frac_name])
         land_frac = atmos_forcing_data[land_frac_name]
-        ocean_field_name_prefixes = {
-            k: list(v) for k, v in OCEAN_FIELD_NAME_PREFIXES.items()
-        }
-        ocean_field_name_prefixes["land_fraction"] = [land_frac_name]
-        if sea_ice_frac_name == "sea_ice_fraction":
-            ocean_field_name_prefixes["sea_ice_fraction"] = [sea_ice_frac_name]
+        if sea_ice_frac_name in OCEAN_FIELD_NAME_PREFIXES["sea_ice_fraction"]:
+            canonical_sea_ice_frac_name = "sea_ice_fraction"
+        elif sea_ice_frac_name in OCEAN_FIELD_NAME_PREFIXES["ocean_sea_ice_fraction"]:
+            canonical_sea_ice_frac_name = "ocean_sea_ice_fraction"
         else:
-            ocean_field_name_prefixes["ocean_sea_ice_fraction"] = [sea_ice_frac_name]
+            raise ValueError(
+                f"CoupledOceanFractionConfig expected {sea_ice_frac_name} to be "
+                "registered in OCEAN_FIELD_NAME_PREFIXES as a sea ice fraction."
+            )
         return OceanData(
-            {land_frac_name: land_frac, sea_ice_frac_name: sea_ice_frac},
-            ocean_field_name_prefixes=ocean_field_name_prefixes,
+            {
+                "land_fraction": land_frac,
+                canonical_sea_ice_frac_name: sea_ice_frac,
+            }
         )
 
 

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -42,7 +42,7 @@ from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
 from fme.core.loss import StepLoss, StepLossConfig
 from fme.core.ocean import OceanConfig
-from fme.core.ocean_data import OceanData
+from fme.core.ocean_data import OCEAN_FIELD_NAME_PREFIXES, OceanData
 from fme.core.optimization import NullOptimization
 from fme.core.tensors import add_ensemble_dim, unfold_ensemble_dim
 from fme.core.timing import GlobalTimer
@@ -152,7 +152,18 @@ class CoupledOceanFractionConfig:
         # fill nans with 0s
         sea_ice_frac = torch.nan_to_num(forcings_from_ocean[sea_ice_frac_name])
         land_frac = atmos_forcing_data[land_frac_name]
-        return OceanData({land_frac_name: land_frac, sea_ice_frac_name: sea_ice_frac})
+        ocean_field_name_prefixes = {
+            k: list(v) for k, v in OCEAN_FIELD_NAME_PREFIXES.items()
+        }
+        ocean_field_name_prefixes["land_fraction"] = [land_frac_name]
+        if sea_ice_frac_name == "sea_ice_fraction":
+            ocean_field_name_prefixes["sea_ice_fraction"] = [sea_ice_frac_name]
+        else:
+            ocean_field_name_prefixes["ocean_sea_ice_fraction"] = [sea_ice_frac_name]
+        return OceanData(
+            {land_frac_name: land_frac, sea_ice_frac_name: sea_ice_frac},
+            ocean_field_name_prefixes=ocean_field_name_prefixes,
+        )
 
 
 def _load_stepper_weights_and_history_factory(

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -85,11 +85,18 @@ class CoupledOceanFractionConfig:
     Configuration for computing ocean fraction from the ocean-predicted sea ice
     fraction.
 
+    The configured land fraction name is used to read the atmosphere forcing,
+    then passed to OceanData as its canonical land_fraction field. The configured
+    sea ice fraction name must be registered in OCEAN_FIELD_NAME_PREFIXES as
+    either sea_ice_fraction or ocean_sea_ice_fraction.
+
     Parameters:
         sea_ice_fraction_name: Name of the sea ice fraction field in the ocean
-            data. Must be an ocean prognostic variable. If the atmosphere uses
-            the same name as an ML forcing then the generated sea ice fraction
-            is also passed as an input to the atmosphere.
+            data. Must be an ocean prognostic variable and must be registered in
+            OCEAN_FIELD_NAME_PREFIXES as either sea_ice_fraction or
+            ocean_sea_ice_fraction. If the atmosphere uses the same name as an
+            ML forcing then the generated sea ice fraction is also passed as an
+            input to the atmosphere.
         land_fraction_name: Name of the land fraction field in the atmosphere
             data. If needed, will be passed to the ocean stepper as a forcing.
         sea_ice_fraction_name_in_atmosphere: Name of the sea ice fraction field in
@@ -100,6 +107,21 @@ class CoupledOceanFractionConfig:
     sea_ice_fraction_name: str
     land_fraction_name: str
     sea_ice_fraction_name_in_atmosphere: str | None = None
+
+    def __post_init__(self):
+        self._get_canonical_sea_ice_fraction_name()
+
+    def _get_canonical_sea_ice_fraction_name(self) -> str:
+        sea_ice_frac_name = self.sea_ice_fraction_name
+        if sea_ice_frac_name in OCEAN_FIELD_NAME_PREFIXES["sea_ice_fraction"]:
+            return "sea_ice_fraction"
+        elif sea_ice_frac_name in OCEAN_FIELD_NAME_PREFIXES["ocean_sea_ice_fraction"]:
+            return "ocean_sea_ice_fraction"
+        else:
+            raise ValueError(
+                f"CoupledOceanFractionConfig expected {sea_ice_frac_name} to be "
+                "registered in OCEAN_FIELD_NAME_PREFIXES as a sea ice fraction."
+            )
 
     def validate_ocean_prognostic_names(self, prognostic_names: Iterable[str]):
         if self.sea_ice_fraction_name not in prognostic_names:
@@ -152,19 +174,10 @@ class CoupledOceanFractionConfig:
         # fill nans with 0s
         sea_ice_frac = torch.nan_to_num(forcings_from_ocean[sea_ice_frac_name])
         land_frac = atmos_forcing_data[land_frac_name]
-        if sea_ice_frac_name in OCEAN_FIELD_NAME_PREFIXES["sea_ice_fraction"]:
-            canonical_sea_ice_frac_name = "sea_ice_fraction"
-        elif sea_ice_frac_name in OCEAN_FIELD_NAME_PREFIXES["ocean_sea_ice_fraction"]:
-            canonical_sea_ice_frac_name = "ocean_sea_ice_fraction"
-        else:
-            raise ValueError(
-                f"CoupledOceanFractionConfig expected {sea_ice_frac_name} to be "
-                "registered in OCEAN_FIELD_NAME_PREFIXES as a sea ice fraction."
-            )
         return OceanData(
             {
                 "land_fraction": land_frac,
-                canonical_sea_ice_frac_name: sea_ice_frac,
+                self._get_canonical_sea_ice_fraction_name(): sea_ice_frac,
             }
         )
 

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -716,11 +716,6 @@ def test_coupled_ocean_fraction_config_uses_configured_land_fraction_name():
 
 
 def test_coupled_ocean_fraction_config_requires_registered_sea_ice_fraction_name():
-    config = CoupledOceanFractionConfig(
-        sea_ice_fraction_name="ICEFRAC",
-        land_fraction_name="LANDFRAC",
-    )
-
     with pytest.raises(
         ValueError,
         match=(
@@ -728,9 +723,9 @@ def test_coupled_ocean_fraction_config_requires_registered_sea_ice_fraction_name
             "in OCEAN_FIELD_NAME_PREFIXES"
         ),
     ):
-        config.build_ocean_data(
-            forcings_from_ocean={"ICEFRAC": torch.tensor([0.5])},
-            atmos_forcing_data={"LANDFRAC": torch.tensor([0.2])},
+        CoupledOceanFractionConfig(
+            sea_ice_fraction_name="ICEFRAC",
+            land_fraction_name="LANDFRAC",
         )
 
 

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -715,6 +715,25 @@ def test_coupled_ocean_fraction_config_uses_configured_land_fraction_name():
     )
 
 
+def test_coupled_ocean_fraction_config_requires_registered_sea_ice_fraction_name():
+    config = CoupledOceanFractionConfig(
+        sea_ice_fraction_name="ICEFRAC",
+        land_fraction_name="LANDFRAC",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "CoupledOceanFractionConfig expected ICEFRAC to be registered "
+            "in OCEAN_FIELD_NAME_PREFIXES"
+        ),
+    ):
+        config.build_ocean_data(
+            forcings_from_ocean={"ICEFRAC": torch.tensor([0.5])},
+            atmos_forcing_data={"LANDFRAC": torch.tensor([0.2])},
+        )
+
+
 # Shared parametrization data for testing various data requirements
 DATA_REQUIREMENTS_TEST_CASES = [
     pytest.param(

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -690,6 +690,31 @@ OCN_FRAC_OSIC = CoupledOceanFractionConfig(
 )
 
 
+def test_coupled_ocean_fraction_config_uses_configured_land_fraction_name():
+    config = CoupledOceanFractionConfig(
+        sea_ice_fraction_name="ocean_sea_ice_fraction",
+        land_fraction_name="LANDFRAC",
+        sea_ice_fraction_name_in_atmosphere="ICEFRAC",
+    )
+    land_fraction = torch.tensor([0.2])
+    ocean_sea_ice_fraction = torch.tensor([0.5])
+
+    ocean_data = config.build_ocean_data(
+        forcings_from_ocean={"ocean_sea_ice_fraction": ocean_sea_ice_fraction},
+        atmos_forcing_data={"LANDFRAC": land_fraction},
+    )
+
+    torch.testing.assert_close(ocean_data.land_fraction, land_fraction)
+    torch.testing.assert_close(
+        ocean_data.sea_ice_fraction,
+        ocean_sea_ice_fraction * (1 - land_fraction),
+    )
+    torch.testing.assert_close(
+        ocean_data.ocean_fraction,
+        1 - land_fraction - ocean_sea_ice_fraction * (1 - land_fraction),
+    )
+
+
 # Shared parametrization data for testing various data requirements
 DATA_REQUIREMENTS_TEST_CASES = [
     pytest.param(


### PR DESCRIPTION
Fix coupled ocean-fraction prediction when the configured atmosphere land-fraction field is not named `land_fraction`, for example `LANDFRAC`.

The coupled stepper already uses `stepper.ocean_fraction_prediction.land_fraction_name` to retrieve the land-fraction tensor from atmosphere forcing data. However, it then passed that tensor into `OceanData` under the configured data name. Since `OceanData` expects canonical semantic names, later `ocean_data.land_fraction` lookup could fail with `KeyError: 'land_fraction'`.

This change makes `CoupledOceanFractionConfig.build_ocean_data` act as the adapter between configured data names and `OceanData` names: it reads land fraction using the configured atmosphere field name, then passes it to `OceanData` as canonical `land_fraction`. It also validates during `__post_init__` that the configured ocean sea-ice field is registered in `OCEAN_FIELD_NAME_PREFIXES` as either `sea_ice_fraction` or `ocean_sea_ice_fraction`, so invalid sea-ice names fail early with a clearer error.

Changes:
- `fme.coupled.stepper.CoupledOceanFractionConfig`: document the naming contract for land fraction and sea ice fraction, and validate the configured sea-ice fraction name in `__post_init__`.
- `fme.coupled.stepper.CoupledOceanFractionConfig.build_ocean_data`: canonicalize the land-fraction tensor as `land_fraction` before constructing `OceanData`, while preserving `OceanData`’s registered sea-ice semantics.
- `fme.coupled.test_stepper`: add coverage for a non-default land-fraction name such as `LANDFRAC`, and for early validation of unregistered sea-ice fraction names.

- [x] Tests added

Resolved #1264 