### PR TITLE
Move `corrector_disabled_epochs` scheduling into corrector

### DIFF
--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -507,5 +507,4 @@ class FCN3Step(StepABC):
             state: The state to load.
         """
         self.module.load_state_dict(state["module"])
-        if "corrector" in state:
-            self._load_corrector_state(state["corrector"])
+        self._load_corrector_state(state.get("corrector", {}))

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -486,6 +486,14 @@ class FCN3Step(StepABC):
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
 
+    def train(self, mode: bool = True) -> StepABC:
+        super().train(mode)
+        self._corrector.train(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self._corrector.set_epoch(epoch)
+
     def get_state(self):
         """
         Returns:
@@ -494,7 +502,7 @@ class FCN3Step(StepABC):
         state = {
             "module": self.module.state_dict(),
         }
-        corrector_state = self._get_corrector_state()
+        corrector_state = self._corrector.get_state()
         if len(corrector_state) > 0:
             state["corrector"] = corrector_state
         return state
@@ -507,4 +515,4 @@ class FCN3Step(StepABC):
             state: The state to load.
         """
         self.module.load_state_dict(state["module"])
-        self._load_corrector_state(state.get("corrector", {}))
+        self._corrector.load_state(state.get("corrector", {}))

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -491,9 +491,13 @@ class FCN3Step(StepABC):
         Returns:
             The state of the stepper.
         """
-        return {
+        state = {
             "module": self.module.state_dict(),
         }
+        corrector_state = self._get_corrector_state()
+        if len(corrector_state) > 0:
+            state["corrector"] = corrector_state
+        return state
 
     def load_state(self, state: dict[str, Any]) -> None:
         """
@@ -503,3 +507,5 @@ class FCN3Step(StepABC):
             state: The state to load.
         """
         self.module.load_state_dict(state["module"])
+        if "corrector" in state:
+            self._load_corrector_state(state["corrector"])

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -7,7 +7,7 @@ import unittest
 import unittest.mock
 from collections import namedtuple
 from collections.abc import Iterable, Mapping
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import patch
 
 import cftime
@@ -1293,6 +1293,18 @@ class _RecordingCorrector(CorrectorABC):
     def __init__(self):
         self.call_count = 0
         self.seen_states: list[CorrectorState | None] = []
+
+    def train(self, mode: bool = True) -> "_RecordingCorrector":
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        pass
+
+    def get_state(self) -> dict[str, Any]:
+        return {}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        pass
 
     def __call__(
         self,

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -2139,8 +2139,10 @@ def _get_force_positive_stepper(corrector_disabled_epochs: int) -> Stepper:
     return _get_stepper(
         ["a"],
         ["a"],
-        corrector=AtmosphereCorrectorConfig(force_positive_names=["a"]),
-        corrector_disabled_epochs=corrector_disabled_epochs,
+        corrector=AtmosphereCorrectorConfig(
+            force_positive_names=["a"],
+            corrector_disabled_epochs=corrector_disabled_epochs,
+        ),
     )
 
 

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 from collections.abc import Callable
-from typing import Literal, Protocol
+from typing import Any, Literal, Protocol
 
 import torch
 
@@ -170,6 +170,18 @@ class AtmosphereCorrector(CorrectorABC):
             self._dry_air_precision = torch.float32
         else:
             self._dry_air_precision = torch.float64
+
+    def train(self, mode: bool = True) -> "AtmosphereCorrector":
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        pass
+
+    def get_state(self) -> dict[str, Any]:
+        return {}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        pass
 
     def __call__(
         self,

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -12,7 +12,7 @@ from fme.core.atmosphere_data import (
     compute_layer_thickness,
 )
 from fme.core.constants import GRAVITY, SPECIFIC_HEAT_OF_DRY_AIR_CONST_VOLUME
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import CorrectorABC, EpochScheduledCorrectorConfigABC
 from fme.core.corrector.state import CorrectorState
 from fme.core.corrector.utils import force_positive
 from fme.core.dataset_info import DatasetInfo
@@ -41,7 +41,7 @@ class EnergyBudgetConfig:
 
 @CorrectorSelector.register("atmosphere_corrector")
 @dataclasses.dataclass
-class AtmosphereCorrectorConfig(CorrectorConfigABC):
+class AtmosphereCorrectorConfig(EpochScheduledCorrectorConfigABC):
     r"""
     Configuration for the post-step state corrector.
 

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -141,7 +141,7 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
     force_positive_names: list[str] = dataclasses.field(default_factory=list)
     total_energy_budget_correction: EnergyBudgetConfig | None = None
 
-    def get_corrector(
+    def _get_corrector(
         self,
         dataset_info: DatasetInfo,
     ) -> "AtmosphereCorrector":

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import torch
 
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import CorrectorABC, EpochScheduledCorrectorConfigABC
 from fme.core.corrector.state import CorrectorState
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
@@ -185,7 +185,7 @@ class IceBudgetCorrectionConfig:
 
 @CorrectorSelector.register("ice_corrector")
 @dataclasses.dataclass
-class IceCorrectorConfig(CorrectorConfigABC):
+class IceCorrectorConfig(EpochScheduledCorrectorConfigABC):
     budget_correction: IceBudgetCorrectionConfig | None = None
 
     def _get_corrector(

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -187,7 +187,7 @@ class IceBudgetCorrectionConfig:
 class IceCorrectorConfig(CorrectorConfigABC):
     budget_correction: IceBudgetCorrectionConfig | None = None
 
-    def get_corrector(
+    def _get_corrector(
         self,
         dataset_info: DatasetInfo,
     ) -> "IceCorrector":

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+from typing import Any
 
 import torch
 
@@ -212,6 +213,18 @@ class IceCorrector(CorrectorABC):
         self._config = config
         self._gridded_operations = gridded_operations
         self._timestep = timestep
+
+    def train(self, mode: bool = True) -> "IceCorrector":
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        pass
+
+    def get_state(self) -> dict[str, Any]:
+        return {}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        pass
 
     def __call__(
         self,

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -11,7 +11,7 @@ from fme.core.constants import (
     LATENT_HEAT_OF_VAPORIZATION,
     SPECIFIC_HEAT_OF_SEA_WATER_CM4,
 )
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import CorrectorABC, EpochScheduledCorrectorConfigABC
 from fme.core.corrector.state import CorrectorState
 from fme.core.corrector.utils import force_positive
 from fme.core.dataset_info import DatasetInfo
@@ -111,7 +111,7 @@ class SurfaceEnergyFluxCorrectionConfig:
 
 @CorrectorSelector.register("ocean_corrector")
 @dataclasses.dataclass
-class OceanCorrectorConfig(CorrectorConfigABC):
+class OceanCorrectorConfig(EpochScheduledCorrectorConfigABC):
     force_positive_names: list[str] = dataclasses.field(default_factory=list)
     sea_ice_fraction_correction: SeaIceFractionConfig | None = None
     surface_energy_flux_correction: SurfaceEnergyFluxCorrectionConfig | None = None

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -166,6 +166,18 @@ class OceanCorrector(CorrectorABC):
         self._vertical_coordinate = vertical_coordinate
         self._timestep = timestep
 
+    def train(self, mode: bool = True) -> "OceanCorrector":
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        pass
+
+    def get_state(self) -> dict[str, Any]:
+        return {}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        pass
+
     def __call__(
         self,
         input_data: TensorMapping,

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -141,7 +141,7 @@ class OceanCorrectorConfig(CorrectorConfigABC):
                     )
         return state_copy
 
-    def get_corrector(
+    def _get_corrector(
         self,
         dataset_info: DatasetInfo,
     ) -> "OceanCorrector":

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -12,15 +12,6 @@ from fme.core.typing_ import TensorDict, TensorMapping
 
 @dataclasses.dataclass
 class CorrectorConfigABC(abc.ABC):
-    corrector_disabled_epochs: int = dataclasses.field(default=0, kw_only=True)
-
-    def __post_init__(self):
-        if self.corrector_disabled_epochs < 0:
-            raise ValueError(
-                "corrector_disabled_epochs must be non-negative, got "
-                f"{self.corrector_disabled_epochs}"
-            )
-
     @classmethod
     @final
     def from_state(cls, state: Mapping[str, Any]) -> Self:
@@ -36,11 +27,26 @@ class CorrectorConfigABC(abc.ABC):
         """
         return dict(state)
 
-    @final
+    @abc.abstractmethod
     def get_corrector(
         self,
         dataset_info: DatasetInfo,
-    ) -> "CorrectorABC":
+    ) -> "CorrectorABC": ...
+
+
+@dataclasses.dataclass
+class EpochScheduledCorrectorConfigABC(CorrectorConfigABC):
+    corrector_disabled_epochs: int = dataclasses.field(default=0, kw_only=True)
+
+    def __post_init__(self):
+        if self.corrector_disabled_epochs < 0:
+            raise ValueError(
+                "corrector_disabled_epochs must be non-negative, got "
+                f"{self.corrector_disabled_epochs}"
+            )
+
+    @final
+    def get_corrector(self, dataset_info: DatasetInfo) -> "CorrectorABC":
         corrector = self._get_corrector(dataset_info)
         if self.corrector_disabled_epochs == 0:
             return corrector

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -36,12 +36,16 @@ class CorrectorConfigABC(abc.ABC):
         """
         return dict(state)
 
+    @final
     def get_corrector(
         self,
         dataset_info: DatasetInfo,
     ) -> "CorrectorABC":
+        corrector = self._get_corrector(dataset_info)
+        if self.corrector_disabled_epochs == 0:
+            return corrector
         return EpochScheduledCorrector(
-            wrapped=self._get_corrector(dataset_info),
+            wrapped=corrector,
             disabled_epochs=self.corrector_disabled_epochs,
         )
 
@@ -53,30 +57,34 @@ class CorrectorConfigABC(abc.ABC):
 
 
 class CorrectorABC(abc.ABC):
+    @abc.abstractmethod
     def train(self, mode: bool = True) -> "CorrectorABC":
         """Set the corrector to training or evaluation mode."""
-        self._training = mode
-        return self
+        ...
 
+    @final
     def eval(self) -> "CorrectorABC":
         """Set the corrector to evaluation mode."""
         return self.train(False)
 
+    @abc.abstractmethod
     def set_epoch(self, epoch: int) -> None:
         """Called by the stepper at the start of each training epoch."""
-        pass
+        ...
 
+    @abc.abstractmethod
     def get_state(self) -> dict[str, Any]:
         """
         Return corrector checkpoint state.
 
         Correctors without checkpointed state can return an empty dict.
         """
-        return {}
+        ...
 
+    @abc.abstractmethod
     def load_state(self, state: dict[str, Any]) -> None:
         """Load corrector checkpoint state."""
-        pass
+        ...
 
     @abc.abstractmethod
     def __call__(
@@ -132,10 +140,13 @@ class EpochScheduledCorrector(CorrectorABC):
         return state
 
     def load_state(self, state: dict[str, Any]) -> None:
+        if self._disabled_epochs > 0 and "corrector_disabled" not in state:
+            raise ValueError(
+                "EpochScheduledCorrector state is missing 'corrector_disabled'"
+            )
         if "corrector_disabled" in state:
             self._corrector_disabled = state["corrector_disabled"]
-        if "wrapped" in state:
-            self._wrapped.load_state(state["wrapped"])
+        self._wrapped.load_state(state.get("wrapped", {}))
 
     def __call__(
         self,

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -1,4 +1,5 @@
 import abc
+import dataclasses
 from collections.abc import Mapping
 from typing import Any, Self, final
 
@@ -9,7 +10,17 @@ from fme.core.dataset_info import DatasetInfo
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
+@dataclasses.dataclass
 class CorrectorConfigABC(abc.ABC):
+    corrector_disabled_epochs: int = dataclasses.field(default=0, kw_only=True)
+
+    def __post_init__(self):
+        if self.corrector_disabled_epochs < 0:
+            raise ValueError(
+                "corrector_disabled_epochs must be non-negative, got "
+                f"{self.corrector_disabled_epochs}"
+            )
+
     @classmethod
     @final
     def from_state(cls, state: Mapping[str, Any]) -> Self:
@@ -25,14 +36,48 @@ class CorrectorConfigABC(abc.ABC):
         """
         return dict(state)
 
-    @abc.abstractmethod
     def get_corrector(
+        self,
+        dataset_info: DatasetInfo,
+    ) -> "CorrectorABC":
+        return EpochScheduledCorrector(
+            wrapped=self._get_corrector(dataset_info),
+            disabled_epochs=self.corrector_disabled_epochs,
+        )
+
+    @abc.abstractmethod
+    def _get_corrector(
         self,
         dataset_info: DatasetInfo,
     ) -> "CorrectorABC": ...
 
 
 class CorrectorABC(abc.ABC):
+    def train(self, mode: bool = True) -> "CorrectorABC":
+        """Set the corrector to training or evaluation mode."""
+        self._training = mode
+        return self
+
+    def eval(self) -> "CorrectorABC":
+        """Set the corrector to evaluation mode."""
+        return self.train(False)
+
+    def set_epoch(self, epoch: int) -> None:
+        """Called by the stepper at the start of each training epoch."""
+        pass
+
+    def get_state(self) -> dict[str, Any]:
+        """
+        Return corrector checkpoint state.
+
+        Correctors without checkpointed state can return an empty dict.
+        """
+        return {}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        """Load corrector checkpoint state."""
+        pass
+
     @abc.abstractmethod
     def __call__(
         self,
@@ -55,3 +100,50 @@ class CorrectorABC(abc.ABC):
             A tuple ``(corrected_gen_data, corrector_state)``.
         """
         ...
+
+
+class EpochScheduledCorrector(CorrectorABC):
+    def __init__(self, wrapped: CorrectorABC, disabled_epochs: int):
+        if disabled_epochs < 0:
+            raise ValueError(
+                f"disabled_epochs must be non-negative, got {disabled_epochs}"
+            )
+        self._wrapped = wrapped
+        self._disabled_epochs = disabled_epochs
+        self._corrector_disabled = disabled_epochs > 0
+        self._training = True
+
+    def train(self, mode: bool = True) -> "EpochScheduledCorrector":
+        self._training = mode
+        self._wrapped.train(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self._corrector_disabled = epoch <= self._disabled_epochs
+        self._wrapped.set_epoch(epoch)
+
+    def get_state(self) -> dict[str, Any]:
+        state: dict[str, Any] = {}
+        if self._disabled_epochs > 0:
+            state["corrector_disabled"] = self._corrector_disabled
+        wrapped_state = self._wrapped.get_state()
+        if len(wrapped_state) > 0:
+            state["wrapped"] = wrapped_state
+        return state
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        if "corrector_disabled" in state:
+            self._corrector_disabled = state["corrector_disabled"]
+        if "wrapped" in state:
+            self._wrapped.load_state(state["wrapped"])
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self._corrector_disabled and self._training:
+            return dict(gen_data), corrector_state
+        return self._wrapped(input_data, gen_data, forcing_data, corrector_state)

--- a/fme/core/corrector/test_registry.py
+++ b/fme/core/corrector/test_registry.py
@@ -37,3 +37,12 @@ def test_corrector_configs_support_disabled_epochs(config):
     corrector = config.get_corrector(_get_dataset_info())
 
     assert isinstance(corrector, EpochScheduledCorrector)
+
+
+def test_scheduled_corrector_requires_state_when_disabled_epochs_configured():
+    corrector = AtmosphereCorrectorConfig(corrector_disabled_epochs=1).get_corrector(
+        _get_dataset_info()
+    )
+
+    with pytest.raises(ValueError, match="corrector_disabled"):
+        corrector.load_state({})

--- a/fme/core/corrector/test_registry.py
+++ b/fme/core/corrector/test_registry.py
@@ -7,9 +7,11 @@ from fme.core.coordinates import NullVerticalCoordinate
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.corrector.ice import IceCorrectorConfig
 from fme.core.corrector.ocean import OceanCorrectorConfig
-from fme.core.corrector.registry import EpochScheduledCorrector
+from fme.core.corrector.registry import CorrectorABC, EpochScheduledCorrector
+from fme.core.corrector.state import CorrectorState
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import LatLonOperations
+from fme.core.typing_ import TensorDict, TensorMapping
 
 
 def _get_dataset_info() -> DatasetInfo:
@@ -46,3 +48,50 @@ def test_scheduled_corrector_requires_state_when_disabled_epochs_configured():
 
     with pytest.raises(ValueError, match="corrector_disabled"):
         corrector.load_state({})
+
+
+class _LifecycleRecordingCorrector(CorrectorABC):
+    def __init__(self):
+        self.train_modes: list[bool] = []
+        self.epochs: list[int] = []
+        self.loaded_state: dict[str, object] | None = None
+
+    def train(self, mode: bool = True) -> "_LifecycleRecordingCorrector":
+        self.train_modes.append(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epochs.append(epoch)
+
+    def get_state(self) -> dict[str, object]:
+        return {"wrapped_value": 3}
+
+    def load_state(self, state: dict[str, object]) -> None:
+        self.loaded_state = state
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return dict(gen_data), corrector_state
+
+
+def test_scheduled_corrector_forwards_lifecycle_and_state():
+    wrapped = _LifecycleRecordingCorrector()
+    corrector = EpochScheduledCorrector(wrapped=wrapped, disabled_epochs=2)
+
+    assert corrector.train(False) is corrector
+    corrector.set_epoch(3)
+    state = corrector.get_state()
+    corrector.load_state(state)
+
+    assert wrapped.train_modes == [False]
+    assert wrapped.epochs == [3]
+    assert state == {
+        "corrector_disabled": False,
+        "wrapped": {"wrapped_value": 3},
+    }
+    assert wrapped.loaded_state == {"wrapped_value": 3}

--- a/fme/core/corrector/test_registry.py
+++ b/fme/core/corrector/test_registry.py
@@ -1,0 +1,39 @@
+import datetime
+
+import pytest
+import torch
+
+from fme.core.coordinates import NullVerticalCoordinate
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
+from fme.core.corrector.ice import IceCorrectorConfig
+from fme.core.corrector.ocean import OceanCorrectorConfig
+from fme.core.corrector.registry import EpochScheduledCorrector
+from fme.core.dataset_info import DatasetInfo
+from fme.core.gridded_ops import LatLonOperations
+
+
+def _get_dataset_info() -> DatasetInfo:
+    return DatasetInfo(
+        vertical_coordinate=NullVerticalCoordinate(),
+        gridded_operations=LatLonOperations(area_weights=torch.ones(2, 2)),
+        timestep=datetime.timedelta(hours=6),
+    )
+
+
+def test_corrector_disabled_epochs_must_be_non_negative():
+    with pytest.raises(ValueError, match="corrector_disabled_epochs"):
+        AtmosphereCorrectorConfig(corrector_disabled_epochs=-1)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        AtmosphereCorrectorConfig(corrector_disabled_epochs=1),
+        OceanCorrectorConfig(corrector_disabled_epochs=1),
+        IceCorrectorConfig(corrector_disabled_epochs=1),
+    ],
+)
+def test_corrector_configs_support_disabled_epochs(config):
+    corrector = config.get_corrector(_get_dataset_info())
+
+    assert isinstance(corrector, EpochScheduledCorrector)

--- a/fme/core/registry/corrector.py
+++ b/fme/core/registry/corrector.py
@@ -2,14 +2,18 @@ import dataclasses
 from collections.abc import Mapping
 from typing import Any, ClassVar  # noqa: UP035
 
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    CorrectorABC,
+    CorrectorConfigABC,
+    EpochScheduledCorrectorConfigABC,
+)
 from fme.core.dataset_info import DatasetInfo
 
 from .registry import Registry
 
 
 @dataclasses.dataclass
-class CorrectorSelector(CorrectorConfigABC):
+class CorrectorSelector(EpochScheduledCorrectorConfigABC):
     """
     A dataclass containing all the information needed to build a
     CorrectorConfigABC, including the type of the CorrectorConfigABC and the

--- a/fme/core/registry/corrector.py
+++ b/fme/core/registry/corrector.py
@@ -2,7 +2,11 @@ import dataclasses
 from collections.abc import Mapping
 from typing import Any, ClassVar  # noqa: UP035
 
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    CorrectorABC,
+    CorrectorConfigABC,
+    EpochScheduledCorrector,
+)
 from fme.core.dataset_info import DatasetInfo
 
 from .registry import Registry
@@ -34,6 +38,7 @@ class CorrectorSelector(CorrectorConfigABC):
     registry: ClassVar[Registry[CorrectorConfigABC]] = Registry[CorrectorConfigABC]()
 
     def __post_init__(self):
+        super().__post_init__()
         self._corrector_config_instance = self.registry.get(self.type, self.config)
 
     @classmethod
@@ -46,6 +51,18 @@ class CorrectorSelector(CorrectorConfigABC):
         return set(cls.registry._types.keys())
 
     def get_corrector(
+        self,
+        dataset_info: DatasetInfo,
+    ) -> CorrectorABC:
+        corrector = self._corrector_config_instance.get_corrector(dataset_info)
+        if self.corrector_disabled_epochs == 0:
+            return corrector
+        return EpochScheduledCorrector(
+            wrapped=corrector,
+            disabled_epochs=self.corrector_disabled_epochs,
+        )
+
+    def _get_corrector(
         self,
         dataset_info: DatasetInfo,
     ) -> CorrectorABC:

--- a/fme/core/registry/corrector.py
+++ b/fme/core/registry/corrector.py
@@ -2,11 +2,7 @@ import dataclasses
 from collections.abc import Mapping
 from typing import Any, ClassVar  # noqa: UP035
 
-from fme.core.corrector.registry import (
-    CorrectorABC,
-    CorrectorConfigABC,
-    EpochScheduledCorrector,
-)
+from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
 from fme.core.dataset_info import DatasetInfo
 
 from .registry import Registry
@@ -49,18 +45,6 @@ class CorrectorSelector(CorrectorConfigABC):
     def get_available_types(cls) -> set[str]:
         """This class method is used to expose all available types of Correctors."""
         return set(cls.registry._types.keys())
-
-    def get_corrector(
-        self,
-        dataset_info: DatasetInfo,
-    ) -> CorrectorABC:
-        corrector = self._corrector_config_instance.get_corrector(dataset_info)
-        if self.corrector_disabled_epochs == 0:
-            return corrector
-        return EpochScheduledCorrector(
-            wrapped=corrector,
-            disabled_epochs=self.corrector_disabled_epochs,
-        )
 
     def _get_corrector(
         self,

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -298,6 +298,9 @@ class MultiCallStep(StepABC):
     def get_regularizer_loss(self) -> torch.Tensor:
         return self._wrapped_step.get_regularizer_loss()
 
+    def _set_corrector_train_mode(self, mode: bool) -> None:
+        self._wrapped_step.train(mode)
+
     def set_epoch(self, epoch: int) -> None:
         self._wrapped_step.set_epoch(epoch)
 

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -298,8 +298,10 @@ class MultiCallStep(StepABC):
     def get_regularizer_loss(self) -> torch.Tensor:
         return self._wrapped_step.get_regularizer_loss()
 
-    def _set_corrector_train_mode(self, mode: bool) -> None:
+    def train(self, mode: bool = True) -> StepABC:
+        super().train(mode)
         self._wrapped_step.train(mode)
+        return self
 
     def set_epoch(self, epoch: int) -> None:
         self._wrapped_step.set_epoch(epoch)

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -422,5 +422,4 @@ class SeparateRadiationStep(StepABC):
         """
         self.module.load_state(state["module"])
         self.radiation_module.load_state(state["radiation_module"])
-        if "corrector" in state:
-            self._load_corrector_state(state["corrector"])
+        self._load_corrector_state(state.get("corrector", {}))

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -404,10 +404,14 @@ class SeparateRadiationStep(StepABC):
         Returns:
             The state of the ML modules.
         """
-        return {
+        state = {
             "module": self.module.get_state(),
             "radiation_module": self.radiation_module.get_state(),
         }
+        corrector_state = self._get_corrector_state()
+        if len(corrector_state) > 0:
+            state["corrector"] = corrector_state
+        return state
 
     def load_state(self, state: dict[str, Any]) -> None:
         """
@@ -418,3 +422,5 @@ class SeparateRadiationStep(StepABC):
         """
         self.module.load_state(state["module"])
         self.radiation_module.load_state(state["radiation_module"])
+        if "corrector" in state:
+            self._load_corrector_state(state["corrector"])

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -399,6 +399,14 @@ class SeparateRadiationStep(StepABC):
     def get_regularizer_loss(self) -> torch.Tensor:
         return torch.tensor(0.0)
 
+    def train(self, mode: bool = True) -> StepABC:
+        super().train(mode)
+        self._corrector.train(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self._corrector.set_epoch(epoch)
+
     def get_state(self):
         """
         Returns:
@@ -408,7 +416,7 @@ class SeparateRadiationStep(StepABC):
             "module": self.module.get_state(),
             "radiation_module": self.radiation_module.get_state(),
         }
-        corrector_state = self._get_corrector_state()
+        corrector_state = self._corrector.get_state()
         if len(corrector_state) > 0:
             state["corrector"] = corrector_state
         return state
@@ -422,4 +430,4 @@ class SeparateRadiationStep(StepABC):
         """
         self.module.load_state(state["module"])
         self.radiation_module.load_state(state["radiation_module"])
-        self._load_corrector_state(state.get("corrector", {}))
+        self._corrector.load_state(state.get("corrector", {}))

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -457,5 +457,4 @@ class SecondaryModuleStep(StepABC):
         self.secondary_module.load_state(state["secondary_module"])
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
-        if "corrector" in state:
-            self._load_corrector_state(state["corrector"])
+        self._load_corrector_state(state.get("corrector", {}))

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -431,6 +431,14 @@ class SecondaryModuleStep(StepABC):
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
 
+    def train(self, mode: bool = True) -> StepABC:
+        super().train(mode)
+        self._corrector.train(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self._corrector.set_epoch(epoch)
+
     def get_state(self):
         """
         Returns:
@@ -441,7 +449,7 @@ class SecondaryModuleStep(StepABC):
             "secondary_module": self.secondary_module.get_state(),
             "secondary_decoder": self.secondary_decoder.get_module_state(),
         }
-        corrector_state = self._get_corrector_state()
+        corrector_state = self._corrector.get_state()
         if len(corrector_state) > 0:
             state["corrector"] = corrector_state
         return state
@@ -457,4 +465,4 @@ class SecondaryModuleStep(StepABC):
         self.secondary_module.load_state(state["secondary_module"])
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
-        self._load_corrector_state(state.get("corrector", {}))
+        self._corrector.load_state(state.get("corrector", {}))

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -436,11 +436,15 @@ class SecondaryModuleStep(StepABC):
         Returns:
             The state of the stepper.
         """
-        return {
+        state = {
             "module": self.module.get_state(),
             "secondary_module": self.secondary_module.get_state(),
             "secondary_decoder": self.secondary_decoder.get_module_state(),
         }
+        corrector_state = self._get_corrector_state()
+        if len(corrector_state) > 0:
+            state["corrector"] = corrector_state
+        return state
 
     def load_state(self, state: dict[str, Any]) -> None:
         """
@@ -453,3 +457,5 @@ class SecondaryModuleStep(StepABC):
         self.secondary_module.load_state(state["secondary_module"])
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
+        if "corrector" in state:
+            self._load_corrector_state(state["corrector"])

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -420,6 +420,14 @@ class SingleModuleStep(StepABC):
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
 
+    def train(self, mode: bool = True) -> StepABC:
+        super().train(mode)
+        self._corrector.train(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self._corrector.set_epoch(epoch)
+
     def get_state(self):
         """
         Returns:
@@ -429,7 +437,7 @@ class SingleModuleStep(StepABC):
             "module": self.module.get_state(),
             "secondary_decoder": self.secondary_decoder.get_module_state(),
         }
-        corrector_state = self._get_corrector_state()
+        corrector_state = self._corrector.get_state()
         if len(corrector_state) > 0:
             state["corrector"] = corrector_state
         return state
@@ -448,7 +456,7 @@ class SingleModuleStep(StepABC):
         self.module.load_state(module)
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
-        self._load_corrector_state(state.get("corrector", {}))
+        self._corrector.load_state(state.get("corrector", {}))
 
 
 def _apply_input_mask(input_norm: TensorDict, data_mask: TensorMapping) -> TensorDict:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -448,8 +448,7 @@ class SingleModuleStep(StepABC):
         self.module.load_state(module)
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
-        if "corrector" in state:
-            self._load_corrector_state(state["corrector"])
+        self._load_corrector_state(state.get("corrector", {}))
 
 
 def _apply_input_mask(input_norm: TensorDict, data_mask: TensorMapping) -> TensorDict:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -71,10 +71,6 @@ class SingleModuleStepConfig(StepConfigABC):
             from fields before normalization and restoring them after
             denormalization. Supports shared (single reference field) or
             per-channel removal, with optional extra input channels.
-        corrector_disabled_epochs: Number of initial training epochs during
-            which the corrector is not applied to train-mode steps. The
-            corrector is always applied when the module is in eval mode
-            (validation, inline inference and standalone inference).
     """
 
     builder: ModuleSelector
@@ -91,15 +87,9 @@ class SingleModuleStepConfig(StepConfigABC):
     residual_prediction: bool = False
     include_channel_mask_inputs: bool = False
     global_mean_removal: GlobalMeanRemovalConfigUnion | None = None
-    corrector_disabled_epochs: int = 0
 
     def __post_init__(self):
         self.crps_training = None  # unused, kept for backwards compatibility
-        if self.corrector_disabled_epochs < 0:
-            raise ValueError(
-                "corrector_disabled_epochs must be non-negative, got "
-                f"{self.corrector_disabled_epochs}"
-            )
         if self.global_mean_removal is not None:
             self.global_mean_removal.validate_names(self.in_names, self.out_names)
         for name in self.prescribed_prognostic_names:
@@ -338,11 +328,6 @@ class SingleModuleStep(StepABC):
         self._timestep = dataset_info.timestep
 
         self._corrector = corrector
-        # Until set_epoch is called we assume we are in the first epoch, so
-        # that the corrector is disabled for train-mode steps taken before the
-        # trainer signals an epoch boundary. Eval-mode steps (validation and
-        # inference) always apply the corrector regardless of this flag.
-        self._corrector_disabled = config.corrector_disabled_epochs > 0
         self.in_names = config.in_names
         self.out_names = config.out_names
 
@@ -417,16 +402,12 @@ class SingleModuleStep(StepABC):
             output_dict.update(secondary_output_dict)
             return output_dict
 
-        corrector: CorrectorABC | None = self._corrector
-        if self._corrector_disabled and self._training:
-            corrector = None
-
         return step_with_adjustments(
             input=args.input,
             next_step_input_data=args.next_step_input_data,
             network_calls=network_call,
             normalizer=self.normalizer,
-            corrector=corrector,
+            corrector=self._corrector,
             ocean=self.ocean,
             residual_prediction=self._config.residual_prediction,
             prognostic_names=self.prognostic_names,
@@ -439,9 +420,6 @@ class SingleModuleStep(StepABC):
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
 
-    def set_epoch(self, epoch: int) -> None:
-        self._corrector_disabled = epoch <= self._config.corrector_disabled_epochs
-
     def get_state(self):
         """
         Returns:
@@ -451,11 +429,9 @@ class SingleModuleStep(StepABC):
             "module": self.module.get_state(),
             "secondary_decoder": self.secondary_decoder.get_module_state(),
         }
-        if self._config.corrector_disabled_epochs > 0:
-            # persisted so that mid-epoch resume, which does not signal an
-            # epoch boundary via set_epoch, keeps the corrector state of the
-            # interrupted epoch
-            state["corrector_disabled"] = self._corrector_disabled
+        corrector_state = self._get_corrector_state()
+        if len(corrector_state) > 0:
+            state["corrector"] = corrector_state
         return state
 
     def load_state(self, state: dict[str, Any]) -> None:
@@ -472,8 +448,8 @@ class SingleModuleStep(StepABC):
         self.module.load_state(module)
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
-        if "corrector_disabled" in state:
-            self._corrector_disabled = state["corrector_disabled"]
+        if "corrector" in state:
+            self._load_corrector_state(state["corrector"])
 
 
 def _apply_input_mask(input_norm: TensorDict, data_mask: TensorMapping) -> TensorDict:

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -255,12 +255,29 @@ class StepABC(abc.ABC):
         self._training = mode
         for module in self.modules:
             module.train(mode)
+        self._set_corrector_train_mode(mode)
         return self
 
     @final
     def eval(self) -> "StepABC":
         """Set the step (and all submodules) to evaluation mode."""
         return self.train(False)
+
+    def _set_corrector_train_mode(self, mode: bool) -> None:
+        corrector = getattr(self, "_corrector", None)
+        if corrector is not None:
+            corrector.train(mode)
+
+    def _get_corrector_state(self) -> dict[str, Any]:
+        corrector = getattr(self, "_corrector", None)
+        if corrector is None:
+            return {}
+        return corrector.get_state()
+
+    def _load_corrector_state(self, state: dict[str, Any]) -> None:
+        corrector = getattr(self, "_corrector", None)
+        if corrector is not None:
+            corrector.load_state(state)
 
     @final
     def get_loss_normalizer(
@@ -380,11 +397,12 @@ class StepABC(abc.ABC):
     def set_epoch(self, epoch: int) -> None:
         """Called by the stepper at the start of each training epoch.
 
-        Default implementation is a no-op. Override to update per-epoch
-        behavior, e.g. epoch-dependent corrector enablement. Steps which
-        wrap another step must forward the call to the wrapped step.
+        Default implementation forwards to the corrector, if present. Steps
+        which wrap another step must forward the call to the wrapped step.
         """
-        pass
+        corrector = getattr(self, "_corrector", None)
+        if corrector is not None:
+            corrector.set_epoch(epoch)
 
     @abc.abstractmethod
     def get_state(self) -> dict[str, Any]:

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -245,7 +245,6 @@ class StepABC(abc.ABC):
     def config(self) -> StepConfigABC:
         pass
 
-    @final
     def train(self, mode: bool = True) -> "StepABC":
         """Set the step (and all submodules) to training mode.
 
@@ -255,29 +254,12 @@ class StepABC(abc.ABC):
         self._training = mode
         for module in self.modules:
             module.train(mode)
-        self._set_corrector_train_mode(mode)
         return self
 
     @final
     def eval(self) -> "StepABC":
         """Set the step (and all submodules) to evaluation mode."""
         return self.train(False)
-
-    def _set_corrector_train_mode(self, mode: bool) -> None:
-        corrector = getattr(self, "_corrector", None)
-        if corrector is not None:
-            corrector.train(mode)
-
-    def _get_corrector_state(self) -> dict[str, Any]:
-        corrector = getattr(self, "_corrector", None)
-        if corrector is None:
-            return {}
-        return corrector.get_state()
-
-    def _load_corrector_state(self, state: dict[str, Any]) -> None:
-        corrector = getattr(self, "_corrector", None)
-        if corrector is not None:
-            corrector.load_state(state)
 
     @final
     def get_loss_normalizer(
@@ -397,12 +379,10 @@ class StepABC(abc.ABC):
     def set_epoch(self, epoch: int) -> None:
         """Called by the stepper at the start of each training epoch.
 
-        Default implementation forwards to the corrector, if present. Steps
-        which wrap another step must forward the call to the wrapped step.
+        Default implementation is a no-op. Steps which wrap another step must
+        forward the call to the wrapped step.
         """
-        corrector = getattr(self, "_corrector", None)
-        if corrector is not None:
-            corrector.set_epoch(epoch)
+        pass
 
     @abc.abstractmethod
     def get_state(self) -> dict[str, Any]:

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -1563,9 +1563,9 @@ def test_step_train_eval_toggle_propagates_to_modules():
     assert not step._training
 
 
-def test_corrector_disabled_not_in_state_by_default():
+def test_corrector_state_not_in_state_by_default():
     step = get_step(get_single_module_selector(), DEFAULT_IMG_SHAPE)
-    assert "corrector_disabled" not in step.get_state()
+    assert "corrector" not in step.get_state()
 
 
 def test_multi_call_step_forwards_set_epoch():
@@ -1578,3 +1578,21 @@ def test_multi_call_step_forwards_set_epoch():
     step = MultiCallStep(wrapped_step=wrapped_step, config=config)
     step.set_epoch(3)
     wrapped_step.set_epoch.assert_called_once_with(3)
+
+
+def test_multi_call_step_forwards_train_eval():
+    wrapped_step = unittest.mock.MagicMock(spec=StepABC)
+    wrapped_step.modules = nn.ModuleList()
+    config = MultiCallStepConfig(
+        wrapped_step=get_single_module_selector(),
+        config=None,
+        include_multi_call_in_loss=False,
+    )
+    step = MultiCallStep(wrapped_step=wrapped_step, config=config)
+
+    step.eval()
+    wrapped_step.train.assert_called_once_with(False)
+
+    wrapped_step.train.reset_mock()
+    step.train()
+    wrapped_step.train.assert_called_once_with(True)

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -1568,6 +1568,22 @@ def test_corrector_state_not_in_state_by_default():
     assert "corrector" not in step.get_state()
 
 
+def test_load_state_calls_corrector_with_empty_state_when_missing():
+    selector = get_single_module_selector()
+    config = dict(selector.config)
+    config["corrector"] = {
+        **config["corrector"],
+        "corrector_disabled_epochs": 1,
+    }
+    selector = StepSelector(type=selector.type, config=config)
+    step = get_step(selector, DEFAULT_IMG_SHAPE)
+    state = step.get_state()
+    del state["corrector"]
+
+    with pytest.raises(ValueError, match="corrector_disabled"):
+        step.load_state(state)
+
+
 def test_multi_call_step_forwards_set_epoch():
     wrapped_step = unittest.mock.MagicMock(spec=StepABC)
     config = MultiCallStepConfig(


### PR DESCRIPTION
These changes move `corrector_disabled_epochs` out of `SingleModuleStep` and into the shared corrector configuration layer. Correctors are now wrapped by `EpochScheduledCorrector`, which can disable any corrector during the first N training epochs while still applying it during eval/validation/inference.
This makes the behavior available to atmosphere, ocean, ice, and future correctors without copying logic into each Step. Step train/eval, epoch, and checkpoint state now forward through the corrector lifecycle so mid-epoch resume preserves the scheduler state.

Resolves #1261 
