### PR TITLE
Fix pin_memory crash for inference persistence_names variables

### DIFF
--- a/fme/ace/data_loading/inference.py
+++ b/fme/ace/data_loading/inference.py
@@ -341,7 +341,9 @@ class InferenceDataset(torch.utils.data.Dataset[BatchData]):
         if self._persistence_data is not None:
             updated_data = {}
             for key, value in self._persistence_data.data.items():
-                updated_data[key] = value.expand_as(result.data[key])
+                # contiguous: the DataLoader pin-memory thread cannot pin the
+                # overlapping-memory view produced by expand_as
+                updated_data[key] = value.expand_as(result.data[key]).contiguous()
             result.data = {**result.data, **updated_data}
         assert result.time.shape[0] == (
             self._n_initial_conditions // dist.total_data_parallel_ranks

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -983,7 +983,8 @@ def test_inference_persistence_names_tensors_support_pin_memory(tmp_path):
     )
     foo = dataset[0].data["foo"]
     # same layout-preserving copy that torch.utils.data pin_memory performs
-    torch.empty_strided(foo.size(), foo.stride()).copy_(foo)
+    result = torch.empty_strided(foo.size(), foo.stride()).copy_(foo)
+    torch.testing.assert_close(result, foo)
 
 
 def test_inference_dataset_label_override_without_dataset_labels(tmp_path):

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -957,6 +957,35 @@ def test_inference_persistence_names(tmp_path):
     assert not torch.all(first_item["bar"] == second_item["bar"])
 
 
+def test_inference_persistence_names_tensors_support_pin_memory(tmp_path):
+    """Persisted variables must not be stride-0 expanded views.
+
+    The DataLoader pin-memory thread allocates a pinned tensor with the same
+    strides and copies into it, which fails for tensors with overlapping
+    memory ("more than one element of the written-to tensor refers to a
+    single memory location").
+    """
+    _create_dataset_on_disk(tmp_path, n_times=14)
+
+    config = InferenceDataLoaderConfig(
+        dataset=XarrayDataConfig(data_path=tmp_path),
+        start_indices=ExplicitIndices([0, 3]),
+        persistence_names=["foo"],
+    )
+    window_requirements = DataRequirements(
+        names=["foo", "bar"],
+        n_timesteps=3,
+    )
+    dataset = InferenceDataset(
+        config,
+        9,
+        requirements=window_requirements,
+    )
+    foo = dataset[0].data["foo"]
+    # same layout-preserving copy that torch.utils.data pin_memory performs
+    torch.empty_strided(foo.size(), foo.stride()).copy_(foo)
+
+
 def test_inference_dataset_label_override_without_dataset_labels(tmp_path):
     _create_dataset_on_disk(tmp_path, n_times=14)
     config = InferenceDataLoaderConfig(


### PR DESCRIPTION
Inline inference runs configured with `persistence_names` (e.g. holding `global_mean_co2` constant at its initial-condition value) crash in the DataLoader pin-memory thread at the first inference epoch. `InferenceDataset.__getitem__` returns persisted variables as `expand_as` views with stride 0; pin_memory allocates a pinned tensor with the same strides and copies into it, which fails for overlapping memory with `RuntimeError: unsupported operation: more than one element of the written-to tensor refers to a single memory location.` This PR makes the expanded tensor contiguous before it is returned.

Changes:
- `fme.ace.data_loading.inference.InferenceDataset.__getitem__`: call `.contiguous()` on the `expand_as` view for persisted variables so the result can be memory-pinned
- `test_inference_persistence_names_tensors_support_pin_memory`: regression test performing the same layout-preserving copy as the pin-memory thread

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
