### PR TITLE
Fix standalone-inference ensemble double-broadcast

### DIFF
--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -399,6 +399,7 @@ class BatchData:
         horizontal_dims: list[str] | None = None,
         label_encoding: LabelEncoding | None = None,
         allow_missing_variables: bool = False,
+        n_ensemble: int = 1,
     ) -> "BatchData":
         (
             sample_data,
@@ -429,6 +430,7 @@ class BatchData:
             labels=labels,
             horizontal_dims=horizontal_dims,
             epoch=sample_epochs[0],
+            n_ensemble=n_ensemble,
             data_mask=data_mask,
         )
 

--- a/fme/ace/data_loading/getters.py
+++ b/fme/ace/data_loading/getters.py
@@ -171,6 +171,7 @@ def get_inference_data(
     label_override: list[str] | None = None,
     surface_temperature_name: str | None = None,
     ocean_fraction_name: str | None = None,
+    n_ensemble: int = 1,
     _force_forkserver: bool = False,
 ) -> InferenceGriddedData:
     """
@@ -188,6 +189,9 @@ def get_inference_data(
             set to None if no ocean temperature prescribing is being used.
         ocean_fraction_name: Name of the ocean fraction variable. Can be set to None
             if no ocean temperature prescribing is being used.
+        n_ensemble: Number of ensemble members the start indices enumerate. Used to
+            stamp the forcing batches so the stepper does not broadcast forcing that
+            is already tiled to match an ensemble-broadcast initial condition.
         _force_forkserver: Whether to force using forkserver multiprocessing context.
             This is useful for debugging or testing in cases where forkserver is not
             the default, but should generally be unused in production code.
@@ -202,6 +206,7 @@ def get_inference_data(
         surface_temperature_name=surface_temperature_name,
         ocean_fraction_name=ocean_fraction_name,
         label_override=label_override,
+        n_ensemble=n_ensemble,
     )
     properties = dataset.properties
 
@@ -267,7 +272,8 @@ def get_forcing_data(
     Returns:
         A data loader for forcing data with coordinates and metadata.
     """
-    initial_time = initial_condition.as_batch_data().time
+    initial_batch = initial_condition.as_batch_data()
+    initial_time = initial_batch.time
     if initial_time.shape[1] != 1:
         raise NotImplementedError("code assumes initial time only has 1 timestep")
     if isinstance(config.dataset, XarrayDataConfig):
@@ -302,4 +308,9 @@ def get_forcing_data(
         surface_temperature_name=surface_temperature_name,
         ocean_fraction_name=ocean_fraction_name,
         label_override=label_override,
+        # The initial condition is already tiled across ensemble members, so the
+        # start indices enumerate one forcing window per tiled sample. Stamp the
+        # forcing with the same n_ensemble so predict_paired does not broadcast it
+        # a second time (the standalone double-broadcast bug).
+        n_ensemble=initial_batch.n_ensemble,
     )

--- a/fme/ace/data_loading/inference.py
+++ b/fme/ace/data_loading/inference.py
@@ -210,6 +210,7 @@ class InferenceDataset(torch.utils.data.Dataset[BatchData]):
         surface_temperature_name: str | None = None,
         ocean_fraction_name: str | None = None,
         label_encoding: LabelEncoding | None = None,
+        n_ensemble: int = 1,
     ):
         """
         Parameters:
@@ -222,6 +223,10 @@ class InferenceDataset(torch.utils.data.Dataset[BatchData]):
             surface_temperature_name: Name of the surface temperature variable.
             ocean_fraction_name: Name of the ocean fraction variable.
             label_encoding: Label encoding to use for the labels.
+            n_ensemble: Number of ensemble members the batches represent. Used to
+                stamp the forcing batches when the start indices already enumerate
+                one window per ensemble-tiled initial condition, so that the
+                stepper does not broadcast the forcing a second time.
         """
         if label_encoding is None and config.available_labels is not None:
             label_encoding = LabelEncoding(labels=sorted(list(config.available_labels)))
@@ -255,6 +260,7 @@ class InferenceDataset(torch.utils.data.Dataset[BatchData]):
         self._surface_temperature_name = surface_temperature_name
         self._ocean_fraction_name = ocean_fraction_name
         self._n_initial_conditions = config.n_initial_conditions
+        self._n_ensemble = n_ensemble
         if isinstance(config.start_indices, TimestampList):
             self._start_indices = config.start_indices.as_indices(
                 self._dataset.all_times
@@ -333,6 +339,7 @@ class InferenceDataset(torch.utils.data.Dataset[BatchData]):
             horizontal_dims=list(self.properties.horizontal_coordinates.dims),
             label_encoding=self._label_encoding,
             allow_missing_variables=self._allow_missing_variables,
+            n_ensemble=self._n_ensemble,
         )
 
     def __getitem__(self, index) -> BatchData:

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -738,6 +738,48 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     )
 
 
+@pytest.mark.parametrize("n_ensemble", [1, 3])
+def test_get_forcing_data_broadcasts_ensemble_flag(tmp_path, n_ensemble):
+    """Forcing built from an ensemble-tiled initial condition must carry the
+    initial condition's ``n_ensemble``.
+
+    Standalone inference broadcasts the initial condition to ``n_ensemble``
+    members before building forcing, so ``get_forcing_data`` already produces
+    one forcing window per tiled sample. If the resulting forcing reported
+    ``n_ensemble == 1`` it would mismatch the initial condition, and
+    ``predict_paired`` would broadcast the already-tiled forcing a second time
+    (the standalone double-broadcast bug, an ``n_ensemble**2`` blowup).
+    """
+    calendar = "proleptic_gregorian"
+    total_forward_steps = 5
+    forward_steps_in_memory = 2
+    n_initial_conditions = 2
+    # forcing dataset starts 2 steps before initial condition time of 1970-01-01
+    _create_dataset_on_disk(tmp_path, calendar=calendar, n_times=10, timestep_start=-2)
+    config = ForcingDataLoaderConfig(dataset=XarrayDataConfig(data_path=tmp_path))
+    window_requirements = DataRequirements(
+        names=["foo"],
+        n_timesteps=forward_steps_in_memory + 1,
+    )
+    # mirror get_initial_condition: tile the IC across ensemble members
+    initial_condition = BatchData.new_for_testing(
+        names=["foo"],
+        n_samples=n_initial_conditions,
+        n_timesteps=1,
+        t_initial=cftime.datetime(1970, 1, 1),
+        calendar=calendar,
+    ).broadcast_ensemble(n_ensemble=n_ensemble)
+    data = get_forcing_data(
+        config,
+        total_forward_steps,
+        window_requirements=window_requirements,
+        initial_condition=PrognosticState(initial_condition),
+    )
+    batch_data = next(iter(data.loader))
+    assert batch_data.n_ensemble == n_ensemble
+    assert batch_data.data["foo"].shape[0] == n_initial_conditions * n_ensemble
+
+
 def test_inference_loader_raises_if_subset():
     with pytest.raises(ValueError):
         InferenceDataLoaderConfig(

--- a/fme/ace/inference/test_inference.py
+++ b/fme/ace/inference/test_inference.py
@@ -110,7 +110,8 @@ def save_stepper(
     torch.save({"stepper": stepper.get_state()}, path)
 
 
-def test_inference_entrypoint(tmp_path: pathlib.Path):
+@pytest.mark.parametrize("n_ensemble_per_ic", [1, 2])
+def test_inference_entrypoint(tmp_path: pathlib.Path, n_ensemble_per_ic: int):
     forward_steps_in_memory = 2
     # NOTE: number of inputs and outputs has to be the same for the PlusOne
     # stepper module to work properly
@@ -189,8 +190,9 @@ def test_inference_entrypoint(tmp_path: pathlib.Path):
             files=[FileWriterConfig("autoregressive")],
         ),
         allow_incompatible_dataset=False,
-        n_ensemble_per_ic=1,
+        n_ensemble_per_ic=n_ensemble_per_ic,
     )
+    n_initial_conditions = initial_condition.sizes["sample"]
     config_filename = tmp_path / "config.yaml"
     with open(config_filename, "w") as f:
         yaml.dump(dataclasses.asdict(config), f)
@@ -241,10 +243,17 @@ def test_inference_entrypoint(tmp_path: pathlib.Path):
     # forcings not in
     assert "DSWRFtoa" not in ds
     assert "forcing_var" not in ds
-    assert ds["prog"].sizes == {"time": 4, "sample": 2, "lat": 16, "lon": 32}
-    np.testing.assert_allclose(
-        ds["prog"].isel(time=0).values, initial_condition["prog"].values + 1
-    )
+    n_samples = n_initial_conditions * n_ensemble_per_ic
+    assert ds["prog"].sizes == {
+        "time": 4,
+        "sample": n_samples,
+        "lat": 16,
+        "lon": 32,
+    }
+    # the initial condition is tiled across ensemble members (each repeated
+    # n_ensemble_per_ic times along the sample dimension)
+    expected_ic = np.repeat(initial_condition["prog"].values, n_ensemble_per_ic, axis=0)
+    np.testing.assert_allclose(ds["prog"].isel(time=0).values, expected_ic + 1)
     np.testing.assert_allclose(
         ds["prog"].isel(time=1).values, ds["prog"].isel(time=0).values + 1, rtol=1e-6
     )


### PR DESCRIPTION
## Summary

Standalone inference (`run_inference_from_config`) crashes with `DataShapesNotUniform` when `n_ensemble_per_ic > 1`, because the forcing data is expanded across ensemble members twice.

## The bug

`get_initial_condition(n_ensemble=N)` tiles the initial condition to `N` members. `get_forcing_data` then reads those already-tiled times and builds one forcing window per member — but labels the forcing `n_ensemble=1`. Because of that stale label, `predict_paired` broadcasts the forcing a *second* time, inflating it from `N` to `N**2` members while the initial condition stays at `N`. The mismatched sample counts then fail in the packer.

The inline-training evaluator path is unaffected: it broadcasts the initial condition *after* building the forcing loader, so its forcing genuinely has `n_ensemble=1` and is broadcast exactly once.

## Impact

No reported numerical results are affected — the run fails fast rather than silently miscomputing. The second broadcast is also pure redundancy: it *copies* existing forcing windows, so the inflated members are exact duplicates. Even without the crash it would cost ~N× the inference compute for identical results.

## Fix

Thread the initial condition's `n_ensemble` through `get_forcing_data` -> `get_inference_data` -> `InferenceDataset` -> `BatchData.from_sample_tuples`, so the forcing reports the correct `n_ensemble` and `predict_paired` no longer re-broadcasts it. The parameter defaults to `1`, so the evaluator, training, and coupled callers are unchanged.

Changes:
- `fme.ace.data_loading.getters.get_forcing_data` — reads the initial condition's `n_ensemble` and passes it to `get_inference_data`.
- `fme.ace.data_loading.getters.get_inference_data` / `fme.ace.data_loading.inference.InferenceDataset` — new `n_ensemble` parameter (default `1`), used to stamp each forcing batch.
- `fme.ace.data_loading.batch_data.BatchData.from_sample_tuples` — new `n_ensemble` parameter (default `1`), forwarded to the constructed `BatchData`.
- `test_inference_entrypoint` — parametrized over `n_ensemble_per_ic` in `[1, 2]`; the `2` case reproduces the crash without the fix.
- `test_get_forcing_data_broadcasts_ensemble_flag` — focused regression: forcing built from an ensemble-tiled IC must carry the IC's `n_ensemble`.

## How it was found

Surfaced while setting up the blowup-investigation probes, which worked around it by building forcing from a single-sample initial condition. No production run is on record hitting it — standalone inference had not been exercised with `n_ensemble_per_ic > 1`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
