### PR TITLE
Fix concurrent inference crash on mismatched window shapes

### DIFF
--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -223,6 +223,7 @@ def get_inference_callback(
             split_output=lambda sd, sizes: sd.split(sizes),
             split_state=lambda ps, sizes: ps.split(sizes),
             sample_size_of_state=lambda ic: ic.as_batch_data().time.shape[0],
+            batch_key_of_forcing=lambda forcing: forcing.n_timesteps,
         )
 
     return build_inference_callback(

--- a/fme/core/generics/inference.py
+++ b/fme/core/generics/inference.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Hashable, Iterator, Sequence
 from typing import Any, Generic, Protocol, TypeVar
 
 from fme.core.generics.aggregator import InferenceAggregatorABC, InferenceLogs
@@ -113,12 +113,23 @@ class BatchedPredictor(Generic[PS_I, FD_I, SD_I]):
         split_output: Callable[[SD_I, Sequence[int]], list[SD_I]],
         split_state: Callable[[PS_I, Sequence[int]], list[PS_I]],
         sample_size_of_state: Callable[[PS_I], int],
+        batch_key_of_forcing: Callable[[FD_I], Hashable] = lambda _forcing: None,
     ):
         """``sample_size_of_state`` returns the per-call sample count from the
         initial condition. Take it from the IC, not the forcing, because some
         steppers broadcast a small forcing up to a larger IC (e.g. per-IC
         ensemble members) before stepping, and the split must match the
         post-broadcast output.
+
+        ``batch_key_of_forcing`` returns a key identifying which submissions can
+        share one forward pass: only forcing windows with equal keys are
+        concatenated together. Concurrent runs of different lengths reach their
+        short final window in different rounds, so a full window of one run and
+        the short final window of another can be submitted in the same round;
+        those windows have different shapes and cannot be concatenated. Keying
+        on the window shape (e.g. its number of timesteps) splits such a round
+        into one forward pass per distinct shape. The default keys everything
+        the same, preserving single-forward-pass behavior.
         """
         self._base_predict = base_predict
         self._concat_ic = concat_ic
@@ -126,9 +137,11 @@ class BatchedPredictor(Generic[PS_I, FD_I, SD_I]):
         self._split_output = split_output
         self._split_state = split_state
         self._sample_size_of_state = sample_size_of_state
+        self._batch_key_of_forcing = batch_key_of_forcing
         self._pending_ic: list[PS_I] = []
         self._pending_forcing: list[FD_I] = []
         self._sample_sizes: list[int] = []
+        self._batch_keys: list[Hashable] = []
         self._compute_derived_variables: bool | None = None
         self._results: list[tuple[SD_I, PS_I]] | None = None
 
@@ -160,6 +173,7 @@ class BatchedPredictor(Generic[PS_I, FD_I, SD_I]):
         self._pending_ic.append(initial_condition)
         self._pending_forcing.append(forcing)
         self._sample_sizes.append(self._sample_size_of_state(initial_condition))
+        self._batch_keys.append(self._batch_key_of_forcing(forcing))
         return PredictionPromise(self, slot_id)
 
     def _ensure_flushed(self) -> None:
@@ -169,24 +183,41 @@ class BatchedPredictor(Generic[PS_I, FD_I, SD_I]):
             raise RuntimeError(
                 "Cannot flush BatchedPredictor with no pending submissions."
             )
-        if len(self._pending_ic) == 1:
-            sd, new_state = self._base_predict(
-                self._pending_ic[0],
-                self._pending_forcing[0],
+        # Partition submissions into groups whose forcing windows share a batch
+        # key, so each forward pass only concatenates windows of the same shape.
+        # A single group (the common case, including all-equal keys) runs one
+        # forward pass; mismatched windows in a round (e.g. one run's short
+        # final window beside another's full window) each get their own pass.
+        groups: dict[Hashable, list[int]] = {}
+        for slot_id, key in enumerate(self._batch_keys):
+            groups.setdefault(key, []).append(slot_id)
+
+        result_by_slot: dict[int, tuple[SD_I, PS_I]] = {}
+        for slot_ids in groups.values():
+            if len(slot_ids) == 1:
+                (slot_id,) = slot_ids
+                sd, new_state = self._base_predict(
+                    self._pending_ic[slot_id],
+                    self._pending_forcing[slot_id],
+                    compute_derived_variables=bool(self._compute_derived_variables),
+                )
+                result_by_slot[slot_id] = (sd, new_state)
+                continue
+            merged_ic = self._concat_ic([self._pending_ic[i] for i in slot_ids])
+            merged_forcing = self._concat_forcing(
+                [self._pending_forcing[i] for i in slot_ids]
+            )
+            merged_sd, merged_state = self._base_predict(
+                merged_ic,
+                merged_forcing,
                 compute_derived_variables=bool(self._compute_derived_variables),
             )
-            self._results = [(sd, new_state)]
-            return
-        merged_ic = self._concat_ic(self._pending_ic)
-        merged_forcing = self._concat_forcing(self._pending_forcing)
-        merged_sd, merged_state = self._base_predict(
-            merged_ic,
-            merged_forcing,
-            compute_derived_variables=bool(self._compute_derived_variables),
-        )
-        outputs = self._split_output(merged_sd, self._sample_sizes)
-        states = self._split_state(merged_state, self._sample_sizes)
-        self._results = list(zip(outputs, states))
+            sizes = [self._sample_sizes[i] for i in slot_ids]
+            outputs = self._split_output(merged_sd, sizes)
+            states = self._split_state(merged_state, sizes)
+            for slot_id, sd, new_state in zip(slot_ids, outputs, states):
+                result_by_slot[slot_id] = (sd, new_state)
+        self._results = [result_by_slot[i] for i in range(len(self._pending_ic))]
 
     def _get_result(self, slot_id: int) -> tuple[SD_I, PS_I]:
         if self._results is None:
@@ -197,6 +228,7 @@ class BatchedPredictor(Generic[PS_I, FD_I, SD_I]):
         self._pending_ic = []
         self._pending_forcing = []
         self._sample_sizes = []
+        self._batch_keys = []
         self._compute_derived_variables = None
         self._results = None
 

--- a/fme/core/generics/test_batched_predictor.py
+++ b/fme/core/generics/test_batched_predictor.py
@@ -23,9 +23,15 @@ from fme.core.timing import GlobalTimer
 
 @dataclass
 class FakeFD:
-    """Fake forcing-data batch: a list of integers, one per sample."""
+    """Fake forcing-data batch: a list of integers, one per sample.
+
+    ``n_timesteps`` stands in for the window's time length: like the real
+    ``BatchData.cat``, ``_concat_fd`` refuses to concatenate windows whose
+    ``n_timesteps`` differ.
+    """
 
     samples: list[int]
+    n_timesteps: int = 1
 
 
 @dataclass
@@ -44,9 +50,15 @@ class FakeSD:
 
 def _concat_fd(items: Sequence[FakeFD]) -> FakeFD:
     out: list[int] = []
+    n_timesteps = items[0].n_timesteps
     for item in items:
+        if item.n_timesteps != n_timesteps:
+            raise ValueError(
+                "Cannot cat FakeFD with different n_timesteps: "
+                f"{n_timesteps} != {item.n_timesteps}"
+            )
         out.extend(item.samples)
-    return FakeFD(samples=out)
+    return FakeFD(samples=out, n_timesteps=n_timesteps)
 
 
 def _concat_ps(items: Sequence[FakePS]) -> FakePS:
@@ -104,6 +116,20 @@ def _make_predictor() -> BatchedPredictor[FakePS, FakeFD, FakeSD]:
     )
 
 
+def _make_keyed_predictor() -> BatchedPredictor[FakePS, FakeFD, FakeSD]:
+    """Like ``_make_predictor`` but keys forward passes on window length, so
+    only forcing windows of equal ``n_timesteps`` are batched together."""
+    return BatchedPredictor(
+        base_predict=_fake_predict,
+        concat_ic=_concat_ps,
+        concat_forcing=_concat_fd,
+        split_output=_split_sd,
+        split_state=_split_ps,
+        sample_size_of_state=_sample_size_of_state,
+        batch_key_of_forcing=lambda forcing: forcing.n_timesteps,
+    )
+
+
 def test_single_submission_resolves_to_underlying_predict():
     predictor = _make_predictor()
     promise = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1]))
@@ -128,6 +154,26 @@ def test_two_submissions_share_one_forward_pass():
     assert sd2.samples == [22, 33]
     assert ps1.samples == [11]
     assert ps2.samples == [22, 33]
+
+
+def test_submissions_with_different_keys_use_separate_forward_passes():
+    """Windows whose batch keys differ cannot be concatenated, so each distinct
+    key gets its own forward pass; results stay aligned to their slots."""
+    predictor = _make_keyed_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    # Slots 0 and 2 share key (n_timesteps=74); slot 1 has key n_timesteps=3.
+    p0 = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1], n_timesteps=74))
+    p1 = predictor.submit(FakePS(samples=[20]), FakeFD(samples=[2], n_timesteps=3))
+    p2 = predictor.submit(FakePS(samples=[30]), FakeFD(samples=[3], n_timesteps=74))
+    sd0, _ = p0.resolve()
+    sd1, _ = p1.resolve()
+    sd2, _ = p2.resolve()
+    # One pass for the two n_timesteps=74 windows, one for the n_timesteps=3 one.
+    assert mock_base.call_count == 2
+    assert sd0.samples == [11]
+    assert sd1.samples == [22]
+    assert sd2.samples == [33]
 
 
 def test_resolve_is_idempotent():
@@ -321,6 +367,56 @@ def test_run_concurrent_inference_heterogeneous_lengths():
     assert mock_base.call_count == 3
     assert [b.samples for b in agg_short.batches] == [[1]]
     assert [b.samples for b in agg_long.batches] == [[110], [120], [130]]
+
+
+def test_run_concurrent_inference_mismatched_window_shapes():
+    """Regression for the rs1 crash: a shorter run reaches its short final
+    window in the same round a longer run still has a full window. Those windows
+    have different shapes (n_timesteps), so concatenating them must not be
+    attempted; each shape gets its own forward pass in that round."""
+    predictor = _make_keyed_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    # "short" runs two full windows then a short final window (n_timesteps 3).
+    data_short = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[
+            FakeFD(samples=[1], n_timesteps=74),
+            FakeFD(samples=[1], n_timesteps=74),
+            FakeFD(samples=[1], n_timesteps=3),
+        ],
+    )
+    # "long" runs four full windows; its window in round 3 is still full.
+    data_long = SimpleInferenceData(
+        initial_condition=FakePS(samples=[100]),
+        loader=[FakeFD(samples=[10], n_timesteps=74) for _ in range(4)],
+    )
+    agg_short = _FakeAggregator()
+    agg_long = _FakeAggregator()
+    entries = [
+        ConcurrentInferenceEntry(
+            name="short",
+            data=data_short,
+            aggregator=agg_short,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+        ConcurrentInferenceEntry(
+            name="long",
+            data=data_long,
+            aggregator=agg_long,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+    ]
+    with GlobalTimer():
+        run_concurrent_inference(predictor, entries)
+    # Rounds 1-2: one batched pass each (both full). Round 3: short's final
+    # window (n_timesteps=3) and long's full window split into two passes.
+    # Round 4: long alone. Total 1 + 1 + 2 + 1 = 5.
+    assert mock_base.call_count == 5
+    assert [b.samples for b in agg_short.batches] == [[1], [2], [3]]
+    assert [b.samples for b in agg_long.batches] == [[110], [120], [130], [140]]
 
 
 def test_run_concurrent_inference_writes_initial_and_restart():

--- a/fme/core/generics/test_batched_predictor.py
+++ b/fme/core/generics/test_batched_predictor.py
@@ -370,8 +370,8 @@ def test_run_concurrent_inference_heterogeneous_lengths():
 
 
 def test_run_concurrent_inference_mismatched_window_shapes():
-    """Regression for the rs1 crash: a shorter run reaches its short final
-    window in the same round a longer run still has a full window. Those windows
+    """Regression: a shorter run reaches its short final window in the same
+    round a longer run still has a full window. Those windows
     have different shapes (n_timesteps), so concatenating them must not be
     attempted; each shape gets its own forward pass in that round."""
     predictor = _make_keyed_predictor()

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -161,6 +161,10 @@ def get_inference_callback(
             sample_size_of_state=lambda ic: (
                 ic.as_batch_data().ocean_data.time.shape[0]
             ),
+            batch_key_of_forcing=lambda forcing: (
+                forcing.ocean_data.n_timesteps,
+                forcing.atmosphere_data.n_timesteps,
+            ),
         )
 
     return build_inference_callback(


### PR DESCRIPTION
Concurrent inline-inference runs of different lengths share one `BatchedPredictor`. A shorter run (e.g. `10year`, 3652 steps = 50×73 + 2) reaches its short final window in the same round a longer run (e.g. `long_46year`, 16794 steps) still has a full window. Those windows have different `n_timesteps` (3 vs 74), so concatenating them into one forward pass raised `ValueError: Cannot cat BatchData with different n_timesteps: 3 != 74`, crashing training before epoch 1 finished. This satisfies the requirement that concurrent inline inference run correctly for heterogeneous-length tasks that share a `concurrent_group`.

The fix partitions each `BatchedPredictor` flush into groups whose forcing windows share a batch key, running one forward pass per group and reassembling results per slot. The common all-equal-shape case still runs a single forward pass, so concurrency is preserved except in the rounds that genuinely mix window shapes (where the mismatched window simply gets its own pass that round).

Changes:
- `fme.core.generics.inference.BatchedPredictor`: new `batch_key_of_forcing` callable (default keys everything the same, preserving prior single-pass behavior); `_ensure_flushed` now partitions pending submissions by key and runs one forward pass per distinct window shape.
- `fme.ace.train.train.get_inference_callback` / `fme.coupled.train.train`: wire `batch_key_of_forcing` to the forcing window's `n_timesteps` (ACE) and ocean+atmosphere `n_timesteps` (coupled).
- `fme.core.generics.test_batched_predictor`: failing-first regression test reproducing the short-final-window vs full-window collision, plus a unit test of the partition logic.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated