### PR TITLE
Add ensemble_metrics option to TrainAggregatorConfig

### DIFF
--- a/fme/ace/aggregator/test_train.py
+++ b/fme/ace/aggregator/test_train.py
@@ -221,3 +221,78 @@ def test_aggregator_per_channel_loss_disabled():
     logs = agg.get_logs(label="train")
     assert logs["train/mean/loss"] == 1.0
     assert "train/mean/loss/a" not in logs
+
+
+def test_aggregator_ensemble_metrics():
+    """When ensemble_metrics=True, logs include CRPS, SSR bias, and ensemble RMSE."""
+    batch_size = 10
+    n_ensemble = 2
+    n_time = 1
+    nx, ny = 2, 2
+    device = get_device()
+    gridded_operations = LatLonOperations(
+        area_weights=torch.ones(nx, ny, device=device)
+    )
+    config = TrainAggregatorConfig(
+        spherical_power_spectrum=False,
+        weighted_rmse=False,
+        ensemble_metrics=True,
+    )
+    agg = TrainAggregator(config=config, operations=gridded_operations)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="train")
+    assert "train/ensemble/crps/a" in logs
+    assert "train/ensemble/ssr_bias/a" in logs
+    assert "train/ensemble/ensemble_mean_rmse/a" in logs
+    for key in logs:
+        if key != "train/mean/loss":
+            assert not np.isnan(float(logs[key])), f"{key} is NaN"
+
+
+def test_aggregator_ensemble_metrics_disabled_by_default():
+    """Ensemble metrics are not present when ensemble_metrics=False (default)."""
+    batch_size = 10
+    n_ensemble = 2
+    n_time = 1
+    nx, ny = 2, 2
+    device = get_device()
+    gridded_operations = LatLonOperations(
+        area_weights=torch.ones(nx, ny, device=device)
+    )
+    config = TrainAggregatorConfig(
+        spherical_power_spectrum=False,
+        weighted_rmse=False,
+    )
+    agg = TrainAggregator(config=config, operations=gridded_operations)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="train")
+    assert "train/ensemble/crps/a" not in logs
+    assert "train/ensemble/ssr_bias/a" not in logs

--- a/fme/ace/aggregator/test_train.py
+++ b/fme/ace/aggregator/test_train.py
@@ -296,3 +296,41 @@ def test_aggregator_ensemble_metrics_disabled_by_default():
     logs = agg.get_logs(label="train")
     assert "train/ensemble/crps/a" not in logs
     assert "train/ensemble/ssr_bias/a" not in logs
+
+
+def test_aggregator_ensemble_metrics_skipped_with_single_member():
+    """Ensemble metrics are skipped when there is only one ensemble member,
+    even if ensemble_metrics=True."""
+    batch_size = 10
+    n_ensemble = 1
+    n_time = 1
+    nx, ny = 2, 2
+    device = get_device()
+    gridded_operations = LatLonOperations(
+        area_weights=torch.ones(nx, ny, device=device)
+    )
+    config = TrainAggregatorConfig(
+        spherical_power_spectrum=False,
+        weighted_rmse=False,
+        ensemble_metrics=True,
+    )
+    agg = TrainAggregator(config=config, operations=gridded_operations)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="train")
+    assert "train/ensemble/crps/a" not in logs
+    assert "train/ensemble/ssr_bias/a" not in logs
+    assert "train/ensemble/ensemble_mean_rmse/a" not in logs

--- a/fme/ace/aggregator/train.py
+++ b/fme/ace/aggregator/train.py
@@ -10,6 +10,7 @@ from fme.ace.aggregator.loss_metrics import (
     PerChannelLossAggregator,
     PerStepLossAggregator,
 )
+from fme.ace.aggregator.one_step.ensemble import _EnsembleAggregator
 from fme.ace.aggregator.one_step.reduced import MeanAggregator
 from fme.ace.stepper import TrainOutput
 from fme.core.device import get_device
@@ -31,11 +32,15 @@ class TrainAggregatorConfig:
         weighted_rmse: Whether to compute the weighted RMSE.
         per_channel_loss: Whether to accumulate and report per-variable (per-channel)
             loss in get_logs (e.g. train/mean/loss/<var_name>).
+        ensemble_metrics: Whether to compute ensemble metrics (CRPS, SSR bias, and
+            ensemble-mean RMSE) over the training batches. Disabled by default;
+            requires the batch to carry an ensemble dimension.
     """
 
     spherical_power_spectrum: bool = True
     weighted_rmse: bool = True
     per_channel_loss: bool = True
+    ensemble_metrics: bool = False
 
 
 class Aggregator(Protocol):
@@ -106,6 +111,12 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
                 include_bias=False,
                 include_grad_mag_percent_diff=False,
             )
+        self._ensemble_aggregator: _EnsembleAggregator | None = None
+        if config.ensemble_metrics:
+            self._ensemble_aggregator = _EnsembleAggregator(
+                gridded_operations=operations,
+                log_mean_maps=False,
+            )
 
     @torch.no_grad()
     def record_batch(self, batch: TrainOutput):
@@ -120,6 +131,12 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
             and batch.per_channel_losses is not None
         ):
             self._per_channel_losses.record(batch.per_channel_losses)
+
+        if self._ensemble_aggregator is not None:
+            self._ensemble_aggregator.record_batch(
+                target_data=batch.target_data,
+                gen_data=batch.gen_data,
+            )
 
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
@@ -136,6 +153,15 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
             for name, aggregator in self._paired_aggregators.items():
                 logs.update(
                     {f"{label}/{k}": v for k, v in aggregator.get_logs(name).items()}
+                )
+            if self._ensemble_aggregator is not None:
+                logs.update(
+                    {
+                        f"{label}/{k}": v
+                        for k, v in self._ensemble_aggregator.get_logs(
+                            "ensemble"
+                        ).items()
+                    }
                 )
         dist = Distributed.get_instance()
         loss = float(dist.reduce_mean(self._loss / self._n_loss_batches).cpu().numpy())

--- a/fme/ace/aggregator/train.py
+++ b/fme/ace/aggregator/train.py
@@ -112,6 +112,7 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
                 include_grad_mag_percent_diff=False,
             )
         self._ensemble_aggregator: _EnsembleAggregator | None = None
+        self._n_ensemble_batches = 0
         if config.ensemble_metrics:
             self._ensemble_aggregator = _EnsembleAggregator(
                 gridded_operations=operations,
@@ -132,11 +133,12 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
         ):
             self._per_channel_losses.record(batch.per_channel_losses)
 
-        if self._ensemble_aggregator is not None:
+        if self._ensemble_aggregator is not None and batch.n_ensemble > 1:
             self._ensemble_aggregator.record_batch(
                 target_data=batch.target_data,
                 gen_data=batch.gen_data,
             )
+            self._n_ensemble_batches += 1
 
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
@@ -154,7 +156,7 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
                 logs.update(
                     {f"{label}/{k}": v for k, v in aggregator.get_logs(name).items()}
                 )
-            if self._ensemble_aggregator is not None:
+            if self._ensemble_aggregator is not None and self._n_ensemble_batches > 0:
                 logs.update(
                     {
                         f"{label}/{k}": v

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -358,6 +358,13 @@ class TrainOutput(TrainOutputABC):
                     f"target_data can only have one ensemble member, got {v.shape[1]}"
                 )
 
+    @property
+    def n_ensemble(self) -> int:
+        """The number of ensemble members in the generated data."""
+        for v in self.gen_data.values():
+            return v.shape[1]
+        raise ValueError("gen_data is empty, ensemble member count is not defined")
+
     def ensemble_derive_func(
         self, data: EnsembleTensorDict, forcing_data: TensorMapping
     ) -> EnsembleTensorDict:


### PR DESCRIPTION
Ports the `ensemble_metrics` option for `TrainAggregatorConfig` from the `experiment/2026-06-05-aimip-like` branch back to `main`. When enabled, the training aggregator computes CRPS, SSR bias, and ensemble-mean RMSE over the training batches, so we can compare train vs. val SSR bias and diagnose whether ensemble overconfidence is caused by overfitting. Disabled by default, so existing configs are unaffected; enable with `train_aggregator.ensemble_metrics: true` in the training YAML.

Changes:
- `fme.ace.aggregator.train.TrainAggregatorConfig`: new `ensemble_metrics` flag (default `False`).
- `fme.ace.aggregator.train.TrainAggregator`: builds an `_EnsembleAggregator` (with `log_mean_maps=False`) when the flag is set, records each batch's native ensemble-dim target/gen data (i.e. the `EnsembleTensorDict`s as-is, with the ensemble dimension intact, rather than the folded data the paired aggregators receive), and merges its `ensemble/*` logs into the summary under `{label}/ensemble/...`.
- `fme.ace.aggregator.test_train`: tests that the metrics appear when enabled and are absent by default.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (no dependency changes)