### PR TITLE
Fix standalone-inference ensemble double-broadcast by mirroring the evaluator (alt to #1278)

### DIFF
--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -309,7 +309,6 @@ def run_inference_from_config(config: InferenceConfig):
             config.initial_condition.get_dataset(),
             stepper_config.prognostic_names,
             labels=config.labels,
-            n_ensemble=config.n_ensemble_per_ic,
         )
         stepper = config.load_stepper()
         stepper.set_eval()
@@ -323,6 +322,18 @@ def run_inference_from_config(config: InferenceConfig):
             ocean_fraction_name=stepper.ocean_fraction_name,
             label_override=config.labels,
         )
+        # Broadcast the initial condition across ensemble members only after the
+        # forcing loader is built, mirroring the evaluator path. The forcing then
+        # has one window per initial condition (n_ensemble=1) and predict_paired
+        # broadcasts it exactly once to match the ensemble-broadcast initial
+        # condition. Broadcasting before get_forcing_data would tile the forcing
+        # start times too, and predict_paired would broadcast the already-tiled
+        # forcing a second time (the standalone double-broadcast bug).
+        if config.n_ensemble_per_ic > 1:
+            ic = data.initial_condition.as_batch_data()
+            data._initial_condition = PrognosticState(
+                ic.broadcast_ensemble(config.n_ensemble_per_ic)
+            )
 
         if not config.allow_incompatible_dataset:
             try:

--- a/fme/ace/inference/test_inference.py
+++ b/fme/ace/inference/test_inference.py
@@ -110,7 +110,8 @@ def save_stepper(
     torch.save({"stepper": stepper.get_state()}, path)
 
 
-def test_inference_entrypoint(tmp_path: pathlib.Path):
+@pytest.mark.parametrize("n_ensemble_per_ic", [1, 2])
+def test_inference_entrypoint(tmp_path: pathlib.Path, n_ensemble_per_ic: int):
     forward_steps_in_memory = 2
     # NOTE: number of inputs and outputs has to be the same for the PlusOne
     # stepper module to work properly
@@ -189,8 +190,9 @@ def test_inference_entrypoint(tmp_path: pathlib.Path):
             files=[FileWriterConfig("autoregressive")],
         ),
         allow_incompatible_dataset=False,
-        n_ensemble_per_ic=1,
+        n_ensemble_per_ic=n_ensemble_per_ic,
     )
+    n_initial_conditions = initial_condition.sizes["sample"]
     config_filename = tmp_path / "config.yaml"
     with open(config_filename, "w") as f:
         yaml.dump(dataclasses.asdict(config), f)
@@ -241,10 +243,17 @@ def test_inference_entrypoint(tmp_path: pathlib.Path):
     # forcings not in
     assert "DSWRFtoa" not in ds
     assert "forcing_var" not in ds
-    assert ds["prog"].sizes == {"time": 4, "sample": 2, "lat": 16, "lon": 32}
-    np.testing.assert_allclose(
-        ds["prog"].isel(time=0).values, initial_condition["prog"].values + 1
-    )
+    n_samples = n_initial_conditions * n_ensemble_per_ic
+    assert ds["prog"].sizes == {
+        "time": 4,
+        "sample": n_samples,
+        "lat": 16,
+        "lon": 32,
+    }
+    # the initial condition is tiled across ensemble members (each repeated
+    # n_ensemble_per_ic times along the sample dimension)
+    expected_ic = np.repeat(initial_condition["prog"].values, n_ensemble_per_ic, axis=0)
+    np.testing.assert_allclose(ds["prog"].isel(time=0).values, expected_ic + 1)
     np.testing.assert_allclose(
         ds["prog"].isel(time=1).values, ds["prog"].isel(time=0).values + 1, rtol=1e-6
     )


### PR DESCRIPTION
Standalone inference (`run_inference_from_config`) crashes with `DataShapesNotUniform` when `n_ensemble_per_ic > 1`, because the forcing data is broadcast across ensemble members twice. This PR fixes it without teaching any data-loading API about `n_ensemble`: it defers the ensemble broadcast until after the forcing loader is built, exactly as the inline-training evaluator already does, so the forcing is broadcast exactly once. This is an alternative to #1278, which instead threads `n_ensemble` through four data-loading APIs. See the comment below for the detailed root cause and trade-off vs. #1278.

Changes:
- `fme.ace.inference.inference.run_inference_from_config` — stop tiling the initial condition before building forcing; call `get_initial_condition` with the default `n_ensemble=1` so `get_forcing_data` builds forcing with `n_ensemble=1`, then broadcast `data._initial_condition` to `n_ensemble_per_ic` after `get_forcing_data` returns. `get_initial_condition`'s `n_ensemble` parameter is now used only by the coupled caller.
- `test_inference_entrypoint` — parametrized over `n_ensemble_per_ic` in `[1, 2]`; the `2` case reproduces the crash without the fix.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
