### PR TITLE
Refactor step return to StepOutput carrying opaque StepMetrics

### DIFF
--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -14,6 +14,7 @@ from fme.core.dataset.dataset import DatasetItem
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.labels import BatchLabels, LabelEncoding
+from fme.core.step.metrics import StepperMetrics, null_stepper_metrics
 from fme.core.stepper_state import StepperState
 from fme.core.tensors import repeat_interleave_batch_dim, unfold_ensemble_dim
 from fme.core.typing_ import EnsembleTensorDict, TensorDict, TensorMapping
@@ -119,6 +120,10 @@ class BatchData:
             (today only the corrector). ``None`` when no state has been
             seeded; the data loader never sets this — it is populated only
             by ``Stepper.predict`` to thread state across prediction windows.
+        stepper_metrics: Opaque per-step metrics payload owned by the Step
+            implementation, stacked over the prediction window. Defaults to an
+            empty (Null) payload; the data loader never sets this — it is
+            populated only by ``Stepper.predict``.
     """
 
     data: TensorMapping
@@ -131,6 +136,9 @@ class BatchData:
     n_ensemble: int = 1
     data_mask: TensorMapping | None = None
     stepper_state: StepperState | None = None
+    stepper_metrics: StepperMetrics = dataclasses.field(
+        default_factory=null_stepper_metrics
+    )
 
     @classmethod
     def new_for_testing(
@@ -239,6 +247,7 @@ class BatchData:
                 if self.stepper_state is not None
                 else None
             ),
+            stepper_metrics=self.stepper_metrics.to_device(),
         )
 
     def scatter_spatial(self, global_img_shape: tuple[int, int]) -> "BatchData":
@@ -253,6 +262,7 @@ class BatchData:
             n_ensemble=self.n_ensemble,
             data_mask=self.data_mask,
             stepper_state=self.stepper_state,
+            stepper_metrics=self.stepper_metrics,
         )
 
     def to_cpu(self) -> "BatchData":
@@ -271,6 +281,7 @@ class BatchData:
             stepper_state=(
                 self.stepper_state.to_cpu() if self.stepper_state is not None else None
             ),
+            stepper_metrics=self.stepper_metrics.to_cpu(),
         )
 
     @classmethod
@@ -292,6 +303,7 @@ class BatchData:
         n_ensemble: int = 1,
         data_mask: TensorMapping | None = None,
         stepper_state: StepperState | None = None,
+        stepper_metrics: StepperMetrics | None = None,
     ) -> "BatchData":
         _check_device(data, torch.device("cpu"))
         if labels is not None:
@@ -314,6 +326,11 @@ class BatchData:
             n_ensemble=n_ensemble,
             data_mask=data_mask,
             stepper_state=stepper_state,
+            stepper_metrics=(
+                stepper_metrics
+                if stepper_metrics is not None
+                else null_stepper_metrics()
+            ),
             **kwargs,
         )
 
@@ -328,6 +345,7 @@ class BatchData:
         n_ensemble: int = 1,
         data_mask: TensorMapping | None = None,
         stepper_state: StepperState | None = None,
+        stepper_metrics: StepperMetrics | None = None,
     ) -> "BatchData":
         """
         Move the data to the current global device specified by get_device().
@@ -350,6 +368,11 @@ class BatchData:
             n_ensemble=n_ensemble,
             data_mask=data_mask,
             stepper_state=stepper_state,
+            stepper_metrics=(
+                stepper_metrics
+                if stepper_metrics is not None
+                else null_stepper_metrics()
+            ),
             **kwargs,
         )
 
@@ -461,6 +484,7 @@ class BatchData:
             n_ensemble=self.n_ensemble,
             data_mask=self.data_mask,
             stepper_state=self.stepper_state,
+            stepper_metrics=self.stepper_metrics,
         )
 
     def remove_initial_condition(self: SelfType, n_ic_timesteps: int) -> SelfType:
@@ -478,6 +502,7 @@ class BatchData:
             n_ensemble=self.n_ensemble,
             data_mask=self.data_mask,
             stepper_state=self.stepper_state,
+            stepper_metrics=self.stepper_metrics,
         )
 
     def subset_names(self: SelfType, names: Collection[str]) -> SelfType:
@@ -497,6 +522,7 @@ class BatchData:
             n_ensemble=self.n_ensemble,
             data_mask=data_mask,
             stepper_state=self.stepper_state,
+            stepper_metrics=self.stepper_metrics,
         )
 
     def get_start(
@@ -536,6 +562,7 @@ class BatchData:
             n_ensemble=self.n_ensemble,
             data_mask=self.data_mask,
             stepper_state=self.stepper_state,
+            stepper_metrics=self.stepper_metrics,
         )
 
     def prepend(self: SelfType, initial_condition: PrognosticState) -> SelfType:
@@ -561,6 +588,7 @@ class BatchData:
             n_ensemble=self.n_ensemble,
             data_mask=self.data_mask,
             stepper_state=self.stepper_state,
+            stepper_metrics=self.stepper_metrics,
         )
 
     def broadcast_ensemble(self: SelfType, n_ensemble: int) -> SelfType:
@@ -605,6 +633,7 @@ class BatchData:
                 if self.stepper_state is not None
                 else None
             ),
+            stepper_metrics=self.stepper_metrics.broadcast_ensemble(n_ensemble),
         )
 
     def pin_memory(self: SelfType) -> SelfType:
@@ -623,6 +652,7 @@ class BatchData:
             }
         if self.stepper_state is not None:
             self.stepper_state.pin_memory()
+        self.stepper_metrics = self.stepper_metrics.pin_memory()
         return self
 
 

--- a/fme/ace/data_loading/test_batch_data.py
+++ b/fme/ace/data_loading/test_batch_data.py
@@ -20,6 +20,7 @@ _METADATA_FIELDS = {
     "labels",
     "data_mask",
     "stepper_state",
+    "stepper_metrics",
 }
 _NON_METADATA_FIELDS = {"data", "time"}
 
@@ -50,6 +51,7 @@ def assert_metadata_equal(
             dict(b.data_mask) if b.data_mask is not None else None,
         )
     _assert_stepper_state_equal_up_to_device(a.stepper_state, b.stepper_state)
+    assert a.stepper_metrics == b.stepper_metrics
 
 
 def _assert_stepper_state_equal_up_to_device(

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -24,8 +24,7 @@ from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.single_module import step_with_adjustments
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
-from fme.core.stepper_state import StepperState
+from fme.core.step.step import StepABC, StepConfigABC, StepOutput, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 DEFAULT_TIMESTEP = datetime.timedelta(hours=6)
@@ -444,7 +443,7 @@ class FCN3Step(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         if args.labels is not None:
             raise ValueError("Labels are not supported for FCN3")
 

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -51,13 +51,14 @@ from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.spatial_masking import NullSpatialMasking, StaticSpatialMaskingConfig
 from fme.core.step.args import StepArgs
 from fme.core.step.global_mean_removal import GlobalMeanRemovalConfigUnion
+from fme.core.step.metrics import StepperMetrics, null_stepper_metrics
 from fme.core.step.multi_call import (
     MultiCallConfig,
     MultiCallStepConfig,
     replace_multi_call,
 )
 from fme.core.step.single_module import SingleModuleStepConfig
-from fme.core.step.step import StepABC, StepSelector
+from fme.core.step.step import StepABC, StepOutput, StepSelector
 from fme.core.stepper_state import StepperState
 from fme.core.tensors import (
     add_ensemble_dim,
@@ -494,7 +495,7 @@ def process_ensemble_prediction_generator_list(
 
 
 def process_prediction_generator_list(
-    output_list: list[tuple[TensorDict, StepperState | None]],
+    output_list: list[StepOutput],
     time: xr.DataArray,
     n_ensemble: int,
     labels: BatchLabels | None = None,
@@ -504,10 +505,18 @@ def process_prediction_generator_list(
 
     Attaches the terminal stepper_state (from the last entry in
     ``output_list``) to the returned BatchData so it can propagate to the
-    next ``Stepper.predict`` call.
+    next ``Stepper.predict`` call, and the per-step metrics concatenated over
+    the time dimension into a single ``StepperMetrics``.
     """
-    output_dicts = [item[0] for item in output_list]
-    terminal_state = output_list[-1][1] if output_list else None
+    output_dicts = [item.output for item in output_list]
+    terminal_state = output_list[-1].stepper_state if output_list else None
+    stepper_metrics = (
+        StepperMetrics.cat(
+            [StepperMetrics(item.metrics) for item in output_list], dim=1
+        )
+        if output_list
+        else null_stepper_metrics()
+    )
     output_timeseries = stack_list_of_tensor_dicts(output_dicts, time_dim=1)
     return BatchData.new_on_device(
         data=output_timeseries,
@@ -516,6 +525,7 @@ def process_prediction_generator_list(
         labels=labels,
         n_ensemble=n_ensemble,
         stepper_state=terminal_state,
+        stepper_metrics=stepper_metrics,
     )
 
 
@@ -1040,7 +1050,7 @@ class Stepper:
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         """
         Step the model forward one timestep given input data.
 
@@ -1049,13 +1059,17 @@ class Stepper:
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            A tuple ``(output, stepper_state)`` where ``output`` is the
-            denormalized data at the next time step and ``stepper_state`` is
-            the per-sample state to thread into the next call (or ``None``).
+            A ``StepOutput`` carrying the denormalized output at the next time
+            step, the per-sample ``stepper_state`` to thread into the next call
+            (or ``None``), and the step's ``metrics`` payload.
         """
         args = args.apply_input_process_func(self._input_process_func)
-        output, stepper_state = self._step_obj.step(args=args, wrapper=wrapper)
-        return self._output_process_func(output), stepper_state
+        step_output = self._step_obj.step(args=args, wrapper=wrapper)
+        return StepOutput(
+            output=self._output_process_func(step_output.output),
+            stepper_state=step_output.stepper_state,
+            metrics=step_output.metrics,
+        )
 
     def get_prediction_generator(
         self,
@@ -1063,7 +1077,7 @@ class Stepper:
         forcing_data: BatchData,
         n_forward_steps: int,
         optimizer: OptimizationABC,
-    ) -> Generator[tuple[TensorDict, StepperState | None], None, None]:
+    ) -> Generator[StepOutput, None, None]:
         """
         Predict multiple steps forward given initial condition and forcing data.
 
@@ -1080,7 +1094,7 @@ class Stepper:
             optimizer: The optimizer to use for updating the module.
 
         Returns:
-            Generator yielding (output, stepper_state) tuples at each timestep.
+            Generator yielding a ``StepOutput`` at each timestep.
         """
         ic_batch_data = initial_condition.as_batch_data()
         if ic_batch_data.labels != forcing_data.labels:
@@ -1115,7 +1129,7 @@ class Stepper:
         labels: BatchLabels | None,
         data_mask: TensorMapping | None = None,
         stepper_state: StepperState | None = None,
-    ) -> Generator[tuple[TensorDict, StepperState | None], None, None]:
+    ) -> Generator[StepOutput, None, None]:
         state = {k: ic_dict[k].squeeze(self.TIME_DIM) for k in ic_dict}
         for step in range(n_forward_steps):
             input_forcing = {
@@ -1136,7 +1150,7 @@ class Stepper:
                 return optimizer.checkpoint(module, step=step)
 
             with optimizer.autocast():
-                state, stepper_state = self.step(
+                step_output = self.step(
                     StepArgs(
                         input=input_data,
                         next_step_input_data=next_step_input_dict,
@@ -1146,8 +1160,9 @@ class Stepper:
                     ),
                     wrapper=checkpoint,
                 )
-            yield state, stepper_state
-            state = optimizer.detach_if_using_gradient_accumulation(state)
+            stepper_state = step_output.stepper_state
+            yield step_output
+            state = optimizer.detach_if_using_gradient_accumulation(step_output.output)
 
     def predict(
         self,
@@ -1232,6 +1247,7 @@ class Stepper:
             labels=data.labels,
             n_ensemble=data.n_ensemble,
             stepper_state=data.stepper_state,
+            stepper_metrics=data.stepper_metrics,
         )
         return data, prognostic_state
 
@@ -1689,7 +1705,7 @@ class TrainStepper(
                 contextlib.nullcontext() if optimize_step else torch.no_grad()
             )
             with grad_context:
-                gen_step, _ = next(output_iterator)
+                gen_step = next(output_iterator).output
                 gen_step = unfold_ensemble_dim(gen_step, n_ensemble=n_ensemble)
                 output_list.append(gen_step)
                 target_step = add_ensemble_dim(

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -1080,9 +1080,9 @@ def test_step():
     n_samples = 3
     input_data = {x: torch.rand(n_samples, 5, 5).to(DEVICE) for x in ["a", "b"]}
 
-    output, _ = stepper.step(
+    output = stepper.step(
         StepArgs(input=input_data, next_step_input_data={}, labels=None)
-    )
+    ).output
 
     torch.testing.assert_close(output["a"], input_data["a"] + 1)
     torch.testing.assert_close(output["b"], input_data["b"] + 1)
@@ -1092,9 +1092,9 @@ def test_step_with_diagnostic():
     stepper = _get_stepper(["a"], ["a", "c"], module_name="RepeatChannel")
     n_samples = 3
     input_data = {"a": torch.rand(n_samples, 5, 5).to(DEVICE)}
-    output, _ = stepper.step(
+    output = stepper.step(
         StepArgs(input=input_data, next_step_input_data={}, labels=None)
-    )
+    ).output
     torch.testing.assert_close(output["a"], input_data["a"])
     torch.testing.assert_close(output["c"], input_data["a"])
 
@@ -1110,9 +1110,9 @@ def test_step_with_forcing_and_diagnostic(residual_prediction):
     )
     n_samples = 3
     input_data = {x: torch.rand(n_samples, 5, 5).to(DEVICE) for x in ["a", "b"]}
-    output, _ = stepper.step(
+    output = stepper.step(
         StepArgs(input=input_data, next_step_input_data={}, labels=None)
-    )
+    ).output
     if residual_prediction:
         expected_a_output = 2 * input_data["a"] + 1 - norm_mean
     else:
@@ -1128,9 +1128,9 @@ def test_step_with_prescribed_ocean():
     )
     input_data = {x: torch.rand(3, 5, 5).to(DEVICE) for x in ["a", "b"]}
     ocean_data = {x: torch.rand(3, 5, 5).to(DEVICE) for x in ["a", "mask"]}
-    output, _ = stepper.step(
+    output = stepper.step(
         StepArgs(input=input_data, next_step_input_data=ocean_data, labels=None)
-    )
+    ).output
     expected_a_output = torch.where(
         torch.round(ocean_data["mask"]).to(int) == 1,
         ocean_data["a"],

--- a/fme/core/distributed/parallel_tests/test_step.py
+++ b/fme/core/distributed/parallel_tests/test_step.py
@@ -452,12 +452,12 @@ def test_step_regression(
     input_data = dist.scatter_spatial(input_data, img_shape)
     next_step_input_data = dist.scatter_spatial(next_step_input_data, img_shape)
 
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(
             input=input_data, next_step_input_data=next_step_input_data, labels=labels
         ),
         wrapper=lambda x: x,
-    )
+    ).output
 
     # Gather local outputs back to global for comparison
     output = dist.gather_spatial(output, img_shape)

--- a/fme/core/step/_multi_call.py
+++ b/fme/core/step/_multi_call.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from torch import nn
 
 from fme.core.step.args import StepArgs
+from fme.core.step.step import StepOutput
 from fme.core.stepper_state import StepperState
 from fme.core.typing_ import TensorDict, TensorMapping
 
@@ -14,7 +15,7 @@ TEMPLATE = "{name}{suffix}"
 
 StepMethod = Callable[
     [StepArgs, Callable[[nn.Module], nn.Module]],
-    tuple[TensorDict, StepperState | None],
+    StepOutput,
 ]
 
 
@@ -164,7 +165,7 @@ class MultiCall:
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         predictions = {}
         if (
             self.forcing_name not in args.input
@@ -177,10 +178,12 @@ class MultiCall:
         for suffix, multiplier in self.forcing_multipliers.items():
             scale_forcing_func = self._get_scale_forcing_func(multiplier)
             scaled_args = args.apply_input_process_func(scale_forcing_func)
-            output, stepper_state = self._step(scaled_args, wrapper)
+            step_output = self._step(scaled_args, wrapper)
+            output = step_output.output
+            stepper_state = step_output.stepper_state
 
             for name in self.output_names:
                 new_name = get_multi_call_name(name, suffix)
                 predictions[new_name] = output[name]
 
-        return predictions, stepper_state
+        return StepOutput(output=predictions, stepper_state=stepper_state)

--- a/fme/core/step/metrics.py
+++ b/fme/core/step/metrics.py
@@ -1,0 +1,120 @@
+"""Per-step metrics payloads carried on prediction batches.
+
+A ``Step`` implementation that exposes extra training-time quantities
+(quantities that only exist inside that step, e.g. the pre-correction values at
+a corrector boundary) returns them as a :class:`StepMetrics` from ``.step``.
+
+Two layers, mirroring ``StepperState``:
+
+- :class:`StepMetrics` — the *step-focused*, polymorphic payload a step
+  produces. Concrete subclasses carry whatever that step's loss and aggregator
+  consume. Generic stepper / batch code only ever calls its tensor-container
+  lifecycle methods (``to_device`` / ``to_cpu`` / ``pin_memory`` /
+  ``broadcast_ensemble``) and :meth:`StepMetrics.cat` to assemble a rollout
+  window; only the step's own loss and aggregator introspect concrete fields.
+- :class:`StepperMetrics` — the concrete container riding on ``BatchData``
+  alongside ``StepperState``, holding the step-focused payload (and a home for
+  any future stepper-level metrics). Generic code moves it around via the same
+  lifecycle methods without inspecting the payload.
+
+A step that exposes nothing returns :class:`NullStepMetrics`, so generic call
+sites need no ``None`` / ``isinstance`` branches. The associated
+``StepMetricsLoss`` / ``StepMetricsAggregator`` classes (generic over the
+concrete ``StepMetrics`` type) are introduced alongside the first features that
+consume these payloads.
+"""
+
+import abc
+import dataclasses
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+
+class StepMetrics(abc.ABC):
+    """The step-focused, polymorphic payload a Step produces each step.
+
+    The abstract interface mirrors ``StepperState`` (the per-sample object this
+    rides beside on ``BatchData``): the tensor-container lifecycle methods plus
+    :meth:`cat` to assemble a per-step sequence into one rollout window.
+    """
+
+    @abc.abstractmethod
+    def to_device(self) -> "StepMetrics": ...
+
+    @abc.abstractmethod
+    def to_cpu(self) -> "StepMetrics": ...
+
+    @abc.abstractmethod
+    def pin_memory(self) -> "StepMetrics": ...
+
+    @abc.abstractmethod
+    def broadcast_ensemble(self, n_ensemble: int) -> "StepMetrics": ...
+
+    @classmethod
+    @abc.abstractmethod
+    def cat(cls, items: "Sequence[StepMetrics]", dim: int) -> "StepMetrics":
+        """Concatenate a per-step sequence along the time dim ``dim``.
+
+        Called by the rollout to assemble per-timestep payloads into one
+        window-aligned payload. Implementations may assume ``items`` are all of
+        this concrete type and non-empty.
+        """
+
+
+@dataclasses.dataclass(frozen=True)
+class NullStepMetrics(StepMetrics):
+    """Payload for a step that exposes no extra quantities."""
+
+    def to_device(self) -> "NullStepMetrics":
+        return self
+
+    def to_cpu(self) -> "NullStepMetrics":
+        return self
+
+    def pin_memory(self) -> "NullStepMetrics":
+        return self
+
+    def broadcast_ensemble(self, n_ensemble: int) -> "NullStepMetrics":
+        return self
+
+    @classmethod
+    def cat(cls, items: "Sequence[StepMetrics]", dim: int) -> "NullStepMetrics":
+        return cls()
+
+
+M = TypeVar("M", bound=StepMetrics)
+
+
+@dataclasses.dataclass
+class StepperMetrics(Generic[M]):
+    """Stepper-level metrics container carried on ``BatchData``.
+
+    Concrete and parallel to ``StepperState``; generic code moves it around via
+    the lifecycle methods without inspecting the step-focused ``step`` payload,
+    which is the part that varies by Step implementation. A home for any future
+    stepper-level (cross-step) metrics to live beside ``step``.
+    """
+
+    step: M
+
+    def to_device(self) -> "StepperMetrics[M]":
+        return StepperMetrics(self.step.to_device())  # type: ignore[arg-type]
+
+    def to_cpu(self) -> "StepperMetrics[M]":
+        return StepperMetrics(self.step.to_cpu())  # type: ignore[arg-type]
+
+    def pin_memory(self) -> "StepperMetrics[M]":
+        return StepperMetrics(self.step.pin_memory())  # type: ignore[arg-type]
+
+    def broadcast_ensemble(self, n_ensemble: int) -> "StepperMetrics[M]":
+        return StepperMetrics(self.step.broadcast_ensemble(n_ensemble))  # type: ignore[arg-type]
+
+    @classmethod
+    def cat(cls, items: "Sequence[StepperMetrics[M]]", dim: int) -> "StepperMetrics[M]":
+        step_type = type(items[0].step)
+        return cls(step_type.cat([item.step for item in items], dim))  # type: ignore[arg-type]
+
+
+def null_stepper_metrics() -> StepperMetrics[NullStepMetrics]:
+    """A :class:`StepperMetrics` carrying no step payload (the BatchData default)."""
+    return StepperMetrics(NullStepMetrics())

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -12,8 +12,7 @@ from fme.core.normalizer import StandardNormalizer
 from fme.core.ocean import OceanConfig
 from fme.core.step._multi_call import MultiCall, MultiCallConfig, StepMethod
 from fme.core.step.args import StepArgs
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
-from fme.core.stepper_state import StepperState
+from fme.core.step.step import StepABC, StepConfigABC, StepOutput, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -302,15 +301,22 @@ class MultiCallStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[torch.nn.Module], torch.nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
-        state, stepper_state = self._wrapped_step.step(
+    ) -> StepOutput:
+        step_output = self._wrapped_step.step(
             args=args,
             wrapper=wrapper,
         )
+        state = step_output.output
         if self._multi_call is not None:
-            multi_called_outputs, _ = self._multi_call.step(args=args, wrapper=wrapper)
+            multi_called_outputs = self._multi_call.step(
+                args=args, wrapper=wrapper
+            ).output
             state = {**multi_called_outputs, **state}
-        return state, stepper_state
+        return StepOutput(
+            output=state,
+            stepper_state=step_output.stepper_state,
+            metrics=step_output.metrics,
+        )
 
     def get_state(self) -> dict[str, Any]:
         """

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -20,8 +20,7 @@ from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.single_module import step_with_adjustments
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
-from fme.core.stepper_state import StepperState
+from fme.core.step.step import StepABC, StepConfigABC, StepOutput, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -352,7 +351,7 @@ class SeparateRadiationStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         def network_calls(input_norm: TensorDict) -> TensorDict:
             radiation_input_tensor = self.radiation_in_packer.pack(
                 input_norm, axis=self.CHANNEL_DIM

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -25,8 +25,7 @@ from fme.core.step.secondary_decoder import (
     SecondaryDecoderConfig,
 )
 from fme.core.step.single_module import step_with_adjustments
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
-from fme.core.stepper_state import StepperState
+from fme.core.step.step import StepABC, StepConfigABC, StepOutput, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -387,7 +386,7 @@ class SecondaryModuleStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         def network_call(input_norm: TensorDict) -> TensorDict:
             input_tensor = self.in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
             output_tensor = self.module.wrap_module(wrapper)(

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -34,7 +34,7 @@ from fme.core.step.secondary_decoder import (
     SecondaryDecoder,
     SecondaryDecoderConfig,
 )
-from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.step.step import StepABC, StepConfigABC, StepOutput, StepSelector
 from fme.core.stepper_state import StepperState
 from fme.core.typing_ import TensorDict, TensorMapping
 
@@ -378,7 +378,7 @@ class SingleModuleStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         def network_call(input_norm: TensorDict) -> TensorDict:
             if args.data_mask is not None:
                 input_norm = _apply_input_mask(input_norm, args.data_mask)
@@ -511,7 +511,7 @@ def step_with_adjustments(
     global_mean_removal: GlobalMeanRemoval | None = None,
     data_mask: TensorMapping | None = None,
     stepper_state: StepperState | None = None,
-) -> tuple[TensorDict, StepperState | None]:
+) -> StepOutput:
     """
     Step the model forward one timestep given input data.
 
@@ -546,8 +546,8 @@ def step_with_adjustments(
             ``StepperState``. Pass-through unchanged when no corrector is set.
 
     Returns:
-        A tuple ``(output, stepper_state)`` where ``output`` is the
-        denormalized data at the next time step.
+        A ``StepOutput`` whose ``output`` is the denormalized data at the next
+        time step. ``metrics`` defaults to ``NullStepMetrics``.
     """
     if prescribed_prognostic_names is None:
         prescribed_prognostic_names = []
@@ -588,4 +588,4 @@ def step_with_adjustments(
             raise ValueError(
                 f"prescribed_prognostic_name '{name}' not in next_step_input_data"
             )
-    return output, stepper_state
+    return StepOutput(output=output, stepper_state=stepper_state)

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -12,8 +12,30 @@ from fme.core.normalizer import StandardNormalizer
 from fme.core.ocean import OceanConfig
 from fme.core.registry.registry import Registry
 from fme.core.step.args import StepArgs
+from fme.core.step.metrics import NullStepMetrics, StepMetrics
 from fme.core.stepper_state import StepperState
 from fme.core.typing_ import TensorDict, TensorMapping
+
+
+@dataclasses.dataclass
+class StepOutput:
+    """The result of stepping a model forward one timestep.
+
+    Attributes:
+        output: The denormalized output data at the next timestep, after all
+            adjustments (corrector, ocean, prescribed prognostics) are applied.
+        stepper_state: The per-sample state to thread into the next step call,
+            or ``None``. Unchanged passthrough semantics relative to the prior
+            ``(output, stepper_state)`` tuple return.
+        metrics: An opaque, step-implementation-specific payload of extra
+            per-step quantities for that step's loss and aggregator to consume
+            (e.g. pre-correction values at a corrector boundary). Defaults to
+            ``NullStepMetrics`` so generic consumers need no branches.
+    """
+
+    output: TensorDict
+    stepper_state: StepperState | None
+    metrics: StepMetrics = dataclasses.field(default_factory=NullStepMetrics)
 
 
 # Children still need to decorate with @dataclass, otherwise
@@ -340,7 +362,7 @@ class StepABC(abc.ABC):
         self: SelfType,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         """
         Step the model forward one timestep given input data.
 
@@ -349,9 +371,9 @@ class StepABC(abc.ABC):
             wrapper: Wrapper to apply over each nn.Module before calling.
 
         Returns:
-            A tuple ``(output, stepper_state)`` where ``output`` is the
-            denormalized data at the next time step and ``stepper_state`` is
-            the per-sample state to thread into the next call (or ``None``).
+            A ``StepOutput`` carrying the denormalized output data at the next
+            timestep, the per-sample ``stepper_state`` to thread into the next
+            call (or ``None``), and an opaque ``metrics`` payload.
         """
         pass
 

--- a/fme/core/step/test__multi_call.py
+++ b/fme/core/step/test__multi_call.py
@@ -57,14 +57,14 @@ def test_multi_call():
     initial_condition = {"temperature": torch.ones(shape)}
     co2_data = {"CO2": torch.full(shape, co2_value)}
 
-    output, _ = multi_call.step(
+    output = multi_call.step(
         args=StepArgs(
             input=initial_condition | co2_data,
             next_step_input_data={},
             labels=None,
         ),
         wrapper=lambda x: x,
-    )
+    ).output
 
     assert set(output) == set(config.names)
     for name in config.output_names:

--- a/fme/core/step/test_multi_call.py
+++ b/fme/core/step/test_multi_call.py
@@ -53,14 +53,14 @@ def test_multi_call(include_multi_call_in_loss: bool):
             "b": torch.randn(1, 2, 3, 4),
             "CO2": torch.randn(1, 2, 3, 4),
         }
-        out, _ = step.step(
+        out = step.step(
             args=StepArgs(
                 input=input,
                 next_step_input_data={},
                 labels=None,
             ),
             wrapper=lambda x: x,
-        )
+        ).output
     torch.testing.assert_close(out["b"], input["CO2"])
     torch.testing.assert_close(out["c"], input["CO2"])
     torch.testing.assert_close(out["c_doubled_co2"], input["CO2"] * 2)

--- a/fme/core/step/test_radiation.py
+++ b/fme/core/step/test_radiation.py
@@ -131,10 +131,10 @@ def test_detach_radiation(detach_radiation: bool):
         n_samples=1,
     )
     input_data["forcing_rad"].requires_grad = True
-    output_data, _ = step.step(
+    output_data = step.step(
         args=StepArgs(input=input_data, next_step_input_data=input_data, labels=None),
         wrapper=lambda x: x,
-    )
+    ).output
     for name, value in output_data.items():
         assert value.requires_grad, f"{name} should require grad"
     grad = torch.autograd.grad(
@@ -144,10 +144,10 @@ def test_detach_radiation(detach_radiation: bool):
     )[0]
     assert grad is not None
     # have to call again as torch.autograd.grad frees the graph
-    output_data, _ = step.step(
+    output_data = step.step(
         args=StepArgs(input=input_data, next_step_input_data=input_data, labels=None),
         wrapper=lambda x: x,
-    )
+    ).output
     grad = torch.autograd.grad(
         outputs=output_data["diagnostic_main"].sum(),
         inputs=input_data["forcing_rad"],
@@ -173,14 +173,14 @@ def test_residual_prediction(residual_prediction: bool):
         img_shape=IMAGE_SHAPE,
         n_samples=1,
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data={},
             labels=None,
         ),
         wrapper=lambda x: x,
-    )
+    ).output
 
     for name in MAIN_PROGNOSTIC_NAMES:
         if residual_prediction:

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -514,7 +514,7 @@ def test_label_conditioned_step():
     )
     input_data = dist.scatter_spatial(input_data, DEFAULT_IMG_SHAPE)
     next_step_input_data = dist.scatter_spatial(next_step_input_data, DEFAULT_IMG_SHAPE)
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
@@ -523,7 +523,7 @@ def test_label_conditioned_step():
             ),
         ),
         wrapper=lambda x: x,
-    )
+    ).output
     h_sl, w_sl = dist.get_local_slices(DEFAULT_IMG_SHAPE)
     local_h = DEFAULT_IMG_SHAPE[0] if h_sl == slice(None) else h_sl.stop - h_sl.start
     local_w = DEFAULT_IMG_SHAPE[1] if w_sl == slice(None) else w_sl.stop - w_sl.start
@@ -730,14 +730,14 @@ def test_step_with_prescribed_prognostic_overwrites_output():
         (n_samples,) + img_shape, 42.0, device=fme.get_device()
     )
     next_step_input_data["diagnostic_main"] = prescribed_value
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
         ),
         wrapper=lambda x: x,
-    )
+    ).output
     torch.testing.assert_close(output["diagnostic_main"], prescribed_value)
 
 
@@ -890,11 +890,11 @@ def test_secondary_module_full_field_and_residual():
     next_step_input_data = get_tensor_dict(
         step.next_step_input_names, img_shape, n_samples=2
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(
             input=input_data, next_step_input_data=next_step_input_data, labels=None
         ),
-    )
+    ).output
     assert "prog" in output
     assert "diag" in output
     assert output["prog"].shape == (2, *img_shape)
@@ -945,8 +945,8 @@ def test_secondary_module_state_round_trip():
     args = StepArgs(
         input=input_data, next_step_input_data=next_step_input_data, labels=None
     )
-    out1, _ = step1.step(args=args)
-    out2, _ = step2.step(args=args)
+    out1 = step1.step(args=args).output
+    out2 = step2.step(args=args).output
     for name in out1:
         torch.testing.assert_close(out1[name], out2[name])
 
@@ -987,11 +987,11 @@ def test_secondary_module_residual_on_input_only_with_residual_prediction():
     next_step_input_data = get_tensor_dict(
         step.next_step_input_names, img_shape, n_samples=2
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(
             input=input_data, next_step_input_data=next_step_input_data, labels=None
         ),
-    )
+    ).output
     assert output["prog_a"].shape == (2, *img_shape)
     assert output["prog_b"].shape == (2, *img_shape)
 
@@ -1062,22 +1062,22 @@ def test_step_with_data_mask():
             [True, True, False, False], device=fme.get_device()
         ),
     }
-    output_no_mask, _ = step.step(
+    output_no_mask = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
             data_mask=None,
         ),
-    )
-    output_with_mask, _ = step.step(
+    ).output
+    output_with_mask = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
             data_mask=data_mask,
         ),
-    )
+    ).output
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_with_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_with_mask[name][:2], output_no_mask[name][:2])
@@ -1174,22 +1174,22 @@ def test_step_with_include_channel_mask_inputs():
             [True, True, False, False], device=fme.get_device()
         ),
     }
-    output_no_mask, _ = step.step(
+    output_no_mask = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
             data_mask=None,
         ),
-    )
-    output_with_mask, _ = step.step(
+    ).output
+    output_with_mask = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
             data_mask=data_mask,
         ),
-    )
+    ).output
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_with_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_with_mask[name][:2], output_no_mask[name][:2])
@@ -1226,26 +1226,26 @@ def test_step_with_include_channel_mask_inputs_no_data_mask():
     next_step_input_data = get_tensor_dict(
         step.next_step_input_names, img_shape, n_samples
     )
-    output_no_mask, _ = step.step(
+    output_no_mask = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
             data_mask=None,
         ),
-    )
+    ).output
     all_unmasked = {
         name: torch.ones(n_samples, dtype=torch.bool, device=fme.get_device())
         for name in step.input_names
     }
-    output_all_unmasked, _ = step.step(
+    output_all_unmasked = step.step(
         args=StepArgs(
             input=input_data,
             next_step_input_data=next_step_input_data,
             labels=None,
             data_mask=all_unmasked,
         ),
-    )
+    ).output
     for name in ["diagnostic_main", "diagnostic_rad"]:
         assert output_no_mask[name].shape == (n_samples, *img_shape)
         torch.testing.assert_close(output_no_mask[name], output_all_unmasked[name])
@@ -1305,9 +1305,9 @@ def test_step_shared_global_mean_removal():
     next_step = get_tensor_dict(
         step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in out_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1330,9 +1330,9 @@ def test_step_shared_global_mean_removal_with_extra_channels():
     next_step = get_tensor_dict(
         step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in out_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1345,9 +1345,9 @@ def test_step_per_channel_global_mean_removal():
     next_step = get_tensor_dict(
         step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in step.output_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1365,9 +1365,9 @@ def test_step_per_channel_global_mean_removal_with_extra_channels():
     next_step = get_tensor_dict(
         step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in step.output_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 
@@ -1392,12 +1392,12 @@ def _assert_global_mean_removal_affects_output(removal, in_names, out_names, mea
     next_step = get_tensor_dict(
         step_baseline.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
     )
-    baseline_output, _ = step_baseline.step(
+    baseline_output = step_baseline.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
-    removal_output, _ = step_with_removal.step(
+    ).output
+    removal_output = step_with_removal.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     differs = any(
         not torch.allclose(baseline_output[name], removal_output[name])
         for name in out_names
@@ -1484,9 +1484,9 @@ def test_step_per_channel_global_mean_removal_with_channel_masks():
     next_step = get_tensor_dict(
         step.next_step_input_names, DEFAULT_IMG_SHAPE, n_samples
     )
-    output, _ = step.step(
+    output = step.step(
         args=StepArgs(input=input_data, next_step_input_data=next_step, labels=None),
-    )
+    ).output
     for name in out_names:
         assert output[name].shape == (n_samples, *DEFAULT_IMG_SHAPE)
 

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -11,10 +11,9 @@ from fme.core.coordinates import HybridSigmaPressureCoordinate, LatLonCoordinate
 from fme.core.dataset_info import DatasetInfo
 from fme.core.ocean import OceanConfig
 from fme.core.step.args import StepArgs
-from fme.core.stepper_state import StepperState
 from fme.core.typing_ import TensorDict, TensorMapping
 
-from .step import StepABC, StepConfigABC, StepSelector
+from .step import StepABC, StepConfigABC, StepOutput, StepSelector
 
 
 class MockStep(StepABC):
@@ -63,7 +62,7 @@ class MockStep(StepABC):
         self,
         args: StepArgs,
         wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
-    ) -> tuple[TensorDict, StepperState | None]:
+    ) -> StepOutput:
         raise NotImplementedError()
 
     def get_state(self):

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -44,6 +44,7 @@ from fme.core.loss import StepLoss, StepLossConfig
 from fme.core.ocean import OceanConfig
 from fme.core.ocean_data import OCEAN_FIELD_NAME_PREFIXES, OceanData
 from fme.core.optimization import NullOptimization
+from fme.core.step.step import StepOutput
 from fme.core.tensors import add_ensemble_dim, unfold_ensemble_dim
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingHistory, TrainingJob
@@ -1114,7 +1115,7 @@ class CoupledStepper:
             # predict and yield atmosphere steps
             for i_inner in range(self.n_inner_steps):
                 atmos_step_num = i_outer * self.n_inner_steps + i_inner
-                atmos_step, _ = next(atmos_generator)
+                atmos_step = next(atmos_generator).output
                 yield ComponentStepPrediction(
                     realm="atmosphere",
                     data=atmos_step,
@@ -1145,7 +1146,7 @@ class CoupledStepper:
                 labels=ocean_window.labels,
             )
             # predict and yield a single ocean step
-            ocean_step, _ = next(
+            ocean_step = next(
                 iter(
                     self.ocean.get_prediction_generator(
                         ocean_ic_state,
@@ -1154,7 +1155,7 @@ class CoupledStepper:
                         optimizer=optimizer,
                     )
                 )
-            )
+            ).output
             yield ComponentStepPrediction(
                 realm="ocean",
                 data=ocean_step,
@@ -1192,14 +1193,22 @@ class CoupledStepper:
         forcing_data: CoupledBatchData,
     ) -> CoupledBatchData:
         atmos_data = process_prediction_generator_list(
-            [(x.data, None) for x in output_list if x.realm == "atmosphere"],
+            [
+                StepOutput(output=x.data, stepper_state=None)
+                for x in output_list
+                if x.realm == "atmosphere"
+            ],
             time=forcing_data.atmosphere_data.time[:, self.atmosphere.n_ic_timesteps :],
             horizontal_dims=forcing_data.atmosphere_data.horizontal_dims,
             labels=forcing_data.atmosphere_data.labels,
             n_ensemble=forcing_data.atmosphere_data.n_ensemble,
         )
         ocean_data = process_prediction_generator_list(
-            [(x.data, None) for x in output_list if x.realm == "ocean"],
+            [
+                StepOutput(output=x.data, stepper_state=None)
+                for x in output_list
+                if x.realm == "ocean"
+            ],
             time=forcing_data.ocean_data.time[:, self.ocean.n_ic_timesteps :],
             horizontal_dims=forcing_data.ocean_data.horizontal_dims,
             labels=forcing_data.ocean_data.labels,


### PR DESCRIPTION
Replaces the `StepABC.step` return type `tuple[TensorDict, StepperState | None]` with a `StepOutput` dataclass that additionally carries an opaque, step-implementation-specific `StepMetrics` payload, and threads a `StepperMetrics` container (parallel to `StepperState`) through `BatchData` and the prediction path. This is the foundation for surfacing per-step quantities that only exist inside a particular `Step` — e.g. the pre-correction values at a corrector boundary — to that step's loss and aggregator, without leaking step-specific fields (`corrections`, `uncorrected`) into the generic step return, into `BatchData`, or into generic loss/aggregator code. That leakage is the shared cost of #1218, #1283, and #1284; this PR is the seam those features will be re-homed onto.

It is pure plumbing with **no behavior change**: `metrics` defaults to `NullStepMetrics` and `stepper_metrics` to a Null payload everywhere, so generic consumers need no `None`/`isinstance` branches. The `StepMetricsLoss` / `StepMetricsAggregator` classes — and the builder-config that constructs them per step type — deliberately land later, with the features that consume them, to avoid merging unused code.

Changes:
- `fme.core.step.metrics` (new): `StepMetrics` ABC + `NullStepMetrics` (the step-focused payload; its lifecycle interface mirrors `StepperState`), and `StepperMetrics` + `null_stepper_metrics` (the concrete container that rides on `BatchData` beside `StepperState`).
- `fme.core.step.step.StepOutput`: new dataclass (`output`, `stepper_state`, `metrics`); `StepABC.step` and all implementations (`SingleModuleStep`, `SeparateRadiationStep`, `SecondaryModuleStep`, `FCN3Step`, `MultiCallStep`, `_multi_call.MultiCall`) return it.
- `fme.ace.stepper.single_module`: `Stepper.step` and `predict_generator` build/forward `StepOutput`; `process_prediction_generator_list` concatenates the per-step metrics into a windowed `StepperMetrics` on the returned `BatchData`.
- `fme.ace.data_loading.batch_data.BatchData`: new `stepper_metrics` field, threaded through every lifecycle method (`to_device`/`to_cpu`/`pin_memory`/`broadcast_ensemble`/`new_on_*`/derived/slicing) alongside `stepper_state`.
- `fme.coupled.stepper`: consume `StepOutput` from the component step generators.

- [x] Tests added — existing step / stepper / batch_data / coupled suites updated to the `StepOutput` return; no new behavior to cover (pure refactor). Verified green: `fme/core/step` (91), `test_batch_data` (48), `fme/ace/stepper` + `fme/coupled` non-parallel (387), inference smoke (35), parallel `test_step` under torchrun (15); ruff, ruff-format, and mypy clean.
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (n/a — no dependency changes)

Draft: foundation only. The corrector-regularization (#1218), pre-correction `uncorrected` (#1283), and correction-metrics (#1284) features will be ported on top of this seam as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
