### PR TITLE
Add sample-dim cat/split helpers to batch data structures (1/3 of #1195 split)

### DIFF
--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -92,6 +92,15 @@ class PrognosticState:
     def as_batch_data(self) -> "BatchData":
         return self._data
 
+    @classmethod
+    def cat(cls, states: Sequence["PrognosticState"]) -> "PrognosticState":
+        """Concatenate prognostic states along the sample dimension."""
+        return cls(BatchData.cat([s._data for s in states]))
+
+    def split(self, sample_sizes: Sequence[int]) -> list["PrognosticState"]:
+        """Split along the sample dimension into the given sample sizes."""
+        return [PrognosticState(b) for b in self._data.split(sample_sizes)]
+
 
 @dataclasses.dataclass
 class BatchData:
@@ -563,6 +572,123 @@ class BatchData:
             stepper_state=self.stepper_state,
         )
 
+    @classmethod
+    def cat(cls, batches: Sequence["BatchData"]) -> "BatchData":
+        """Concatenate a sequence of BatchData along the sample dimension.
+
+        All inputs must share variable names, ``horizontal_dims``, ``epoch``,
+        ``n_ensemble``, ``n_timesteps``, and whether labels and data_mask are
+        present. Label names may differ across inputs: the result uses the
+        sorted union of all label names, with each input conformed to that
+        encoding before concatenation. Tensors must already be on the same
+        device.
+        """
+        if len(batches) == 0:
+            raise ValueError("Cannot cat an empty sequence of BatchData.")
+        if len(batches) == 1:
+            return batches[0]
+        first = batches[0]
+        first_names = set(first.data.keys())
+        for b in batches[1:]:
+            if b.horizontal_dims != first.horizontal_dims:
+                raise ValueError(
+                    "Cannot cat BatchData with different horizontal_dims: "
+                    f"{first.horizontal_dims} != {b.horizontal_dims}"
+                )
+            if b.epoch != first.epoch:
+                raise ValueError(
+                    "Cannot cat BatchData with different epochs: "
+                    f"{first.epoch} != {b.epoch}"
+                )
+            if b.n_ensemble != first.n_ensemble:
+                raise ValueError(
+                    "Cannot cat BatchData with different n_ensemble: "
+                    f"{first.n_ensemble} != {b.n_ensemble}"
+                )
+            if set(b.data.keys()) != first_names:
+                raise ValueError(
+                    "Cannot cat BatchData with different variable names: "
+                    f"{sorted(first_names)} != {sorted(b.data.keys())}"
+                )
+            if b.n_timesteps != first.n_timesteps:
+                raise ValueError(
+                    "Cannot cat BatchData with different n_timesteps: "
+                    f"{first.n_timesteps} != {b.n_timesteps}"
+                )
+            if (b.labels is None) != (first.labels is None):
+                raise ValueError(
+                    "Cannot cat BatchData with inconsistent labels presence."
+                )
+            if (b.data_mask is None) != (first.data_mask is None):
+                raise ValueError(
+                    "Cannot cat BatchData with inconsistent data_mask presence."
+                )
+        data = {k: torch.cat([b.data[k] for b in batches], dim=0) for k in first.data}
+        time = xr.concat([b.time for b in batches], dim="sample")
+        if first.labels is None:
+            labels = None
+        else:
+            labels = BatchLabels.cat(
+                [b.labels for b in batches if b.labels is not None]
+            )
+        if first.data_mask is None:
+            data_mask = None
+        else:
+            data_mask = {
+                k: torch.cat(
+                    [b.data_mask[k] for b in batches if b.data_mask is not None],
+                    dim=0,
+                )
+                for k in first.data_mask
+            }
+        return cls(
+            data=data,
+            time=time,
+            labels=labels,
+            horizontal_dims=first.horizontal_dims,
+            epoch=first.epoch,
+            n_ensemble=first.n_ensemble,
+            data_mask=data_mask,
+        )
+
+    def split(self: SelfType, sample_sizes: Sequence[int]) -> list[SelfType]:
+        """Split into pieces with the given sample sizes along the sample dim."""
+        n_samples = self.time.shape[0]
+        total = sum(sample_sizes)
+        if total != n_samples:
+            raise ValueError(
+                f"sample_sizes must sum to n_samples={n_samples}, got {total}"
+            )
+        if len(sample_sizes) == 1:
+            return [self]
+        out: list[SelfType] = []
+        start = 0
+        for size in sample_sizes:
+            end = start + size
+            data = {k: v[start:end] for k, v in self.data.items()}
+            time = self.time.isel(sample=slice(start, end))
+            if self.labels is None:
+                labels = None
+            else:
+                labels = BatchLabels(self.labels.tensor[start:end], self.labels.names)
+            if self.data_mask is None:
+                data_mask = None
+            else:
+                data_mask = {k: v[start:end] for k, v in self.data_mask.items()}
+            out.append(
+                self.__class__(
+                    data=data,
+                    time=time,
+                    labels=labels,
+                    horizontal_dims=self.horizontal_dims,
+                    epoch=self.epoch,
+                    n_ensemble=self.n_ensemble,
+                    data_mask=data_mask,
+                )
+            )
+            start = end
+        return out
+
     def broadcast_ensemble(self: SelfType, n_ensemble: int) -> SelfType:
         """
         Broadcast a singleton ensemble to a new BatchData obj with n_ensemble members
@@ -721,6 +847,93 @@ class PairedData:
             time=prediction.time,
             n_ensemble=prediction.n_ensemble,
         )
+
+    @classmethod
+    def cat(cls, batches: Sequence["PairedData"]) -> "PairedData":
+        """Concatenate a sequence of PairedData along the sample dimension.
+
+        Label names may differ across inputs: the result uses the sorted
+        union of all label names, with each input conformed to that encoding
+        before concatenation.
+        """
+        if len(batches) == 0:
+            raise ValueError("Cannot cat an empty sequence of PairedData.")
+        if len(batches) == 1:
+            return batches[0]
+        first = batches[0]
+        for b in batches[1:]:
+            if b.n_ensemble != first.n_ensemble:
+                raise ValueError(
+                    "Cannot cat PairedData with different n_ensemble: "
+                    f"{first.n_ensemble} != {b.n_ensemble}"
+                )
+            if set(b.prediction.keys()) != set(first.prediction.keys()):
+                raise ValueError(
+                    "Cannot cat PairedData with different prediction variables."
+                )
+            if set(b.reference.keys()) != set(first.reference.keys()):
+                raise ValueError(
+                    "Cannot cat PairedData with different reference variables."
+                )
+            if (b.labels is None) != (first.labels is None):
+                raise ValueError(
+                    "Cannot cat PairedData with inconsistent labels presence."
+                )
+        prediction = {
+            k: torch.cat([b.prediction[k] for b in batches], dim=0)
+            for k in first.prediction
+        }
+        reference = {
+            k: torch.cat([b.reference[k] for b in batches], dim=0)
+            for k in first.reference
+        }
+        time = xr.concat([b.time for b in batches], dim="sample")
+        if first.labels is None:
+            labels = None
+        else:
+            labels = BatchLabels.cat(
+                [b.labels for b in batches if b.labels is not None]
+            )
+        return cls(
+            prediction=prediction,
+            reference=reference,
+            time=time,
+            labels=labels,
+            n_ensemble=first.n_ensemble,
+        )
+
+    def split(self, sample_sizes: Sequence[int]) -> list["PairedData"]:
+        """Split into pieces with the given sample sizes along the sample dim."""
+        n_samples = self.time.shape[0]
+        total = sum(sample_sizes)
+        if total != n_samples:
+            raise ValueError(
+                f"sample_sizes must sum to n_samples={n_samples}, got {total}"
+            )
+        if len(sample_sizes) == 1:
+            return [self]
+        out: list[PairedData] = []
+        start = 0
+        for size in sample_sizes:
+            end = start + size
+            prediction = {k: v[start:end] for k, v in self.prediction.items()}
+            reference = {k: v[start:end] for k, v in self.reference.items()}
+            time = self.time.isel(sample=slice(start, end))
+            if self.labels is None:
+                labels = None
+            else:
+                labels = BatchLabels(self.labels.tensor[start:end], self.labels.names)
+            out.append(
+                PairedData(
+                    prediction=prediction,
+                    reference=reference,
+                    time=time,
+                    labels=labels,
+                    n_ensemble=self.n_ensemble,
+                )
+            )
+            start = end
+        return out
 
     @classmethod
     def new_on_device(

--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -577,11 +577,12 @@ class BatchData:
         """Concatenate a sequence of BatchData along the sample dimension.
 
         All inputs must share variable names, ``horizontal_dims``, ``epoch``,
-        ``n_ensemble``, ``n_timesteps``, and whether labels and data_mask are
-        present. Label names may differ across inputs: the result uses the
-        sorted union of all label names, with each input conformed to that
-        encoding before concatenation. Tensors must already be on the same
-        device.
+        ``n_ensemble``, ``n_timesteps``, and whether labels, data_mask, and
+        stepper_state are present. Label names may differ across inputs: the
+        result uses the sorted union of all label names, with each input
+        conformed to that encoding before concatenation. Any per-sample
+        ``stepper_state`` is concatenated along the sample dim so it propagates
+        through batched prediction. Tensors must already be on the same device.
         """
         if len(batches) == 0:
             raise ValueError("Cannot cat an empty sequence of BatchData.")
@@ -623,6 +624,10 @@ class BatchData:
                 raise ValueError(
                     "Cannot cat BatchData with inconsistent data_mask presence."
                 )
+            if (b.stepper_state is None) != (first.stepper_state is None):
+                raise ValueError(
+                    "Cannot cat BatchData with inconsistent stepper_state presence."
+                )
         data = {k: torch.cat([b.data[k] for b in batches], dim=0) for k in first.data}
         time = xr.concat([b.time for b in batches], dim="sample")
         if first.labels is None:
@@ -641,6 +646,12 @@ class BatchData:
                 )
                 for k in first.data_mask
             }
+        if first.stepper_state is None:
+            stepper_state = None
+        else:
+            stepper_state = StepperState.cat(
+                [b.stepper_state for b in batches if b.stepper_state is not None]
+            )
         return cls(
             data=data,
             time=time,
@@ -649,6 +660,7 @@ class BatchData:
             epoch=first.epoch,
             n_ensemble=first.n_ensemble,
             data_mask=data_mask,
+            stepper_state=stepper_state,
         )
 
     def split(self: SelfType, sample_sizes: Sequence[int]) -> list[SelfType]:
@@ -661,9 +673,13 @@ class BatchData:
             )
         if len(sample_sizes) == 1:
             return [self]
+        if self.stepper_state is None:
+            stepper_states: list[StepperState | None] = [None] * len(sample_sizes)
+        else:
+            stepper_states = list(self.stepper_state.split(sample_sizes))
         out: list[SelfType] = []
         start = 0
-        for size in sample_sizes:
+        for size, stepper_state in zip(sample_sizes, stepper_states):
             end = start + size
             data = {k: v[start:end] for k, v in self.data.items()}
             time = self.time.isel(sample=slice(start, end))
@@ -684,6 +700,7 @@ class BatchData:
                     epoch=self.epoch,
                     n_ensemble=self.n_ensemble,
                     data_mask=data_mask,
+                    stepper_state=stepper_state,
                 )
             )
             start = end

--- a/fme/ace/data_loading/test_batch_data.py
+++ b/fme/ace/data_loading/test_batch_data.py
@@ -5,7 +5,12 @@ import pytest
 import torch
 import xarray as xr
 
-from fme.ace.data_loading.batch_data import BatchData, PairedData, _collate_with_masking
+from fme.ace.data_loading.batch_data import (
+    BatchData,
+    PairedData,
+    PrognosticState,
+    _collate_with_masking,
+)
 from fme.core.corrector.state import CorrectorState
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
@@ -1107,3 +1112,200 @@ def test_stepper_state_pin_memory():
     p = state.corrector_state.global_dry_air_mass
     assert p is not None
     assert p.is_pinned()
+
+
+@pytest.mark.parametrize("with_labels", [False, True])
+@pytest.mark.parametrize("with_data_mask", [False, True])
+def test_batchdata_cat_and_split_roundtrip(with_labels: bool, with_data_mask: bool):
+    names = ["foo", "bar"]
+    n_times = 4
+    horizontal_dims = ["lat", "lon"]
+    n_labels = 2 if with_labels else 0
+    a = get_batch_data(
+        names=names,
+        n_samples=2,
+        n_times=n_times,
+        horizontal_dims=horizontal_dims,
+        n_labels=n_labels,
+    )
+    b = get_batch_data(
+        names=names,
+        n_samples=3,
+        n_times=n_times,
+        horizontal_dims=horizontal_dims,
+        n_labels=n_labels,
+    )
+    # align time coords (cat does not require it, but split returns them so
+    # the explicit indexing is well-defined for the round trip test)
+    b.time = xr.DataArray(np.random.rand(3, n_times) + 100.0, dims=["sample", "time"])
+    if not with_data_mask:
+        a.data_mask = None
+        b.data_mask = None
+    cat = BatchData.cat([a, b])
+    assert cat.time.shape == (5, n_times)
+    for name in names:
+        torch.testing.assert_close(cat.data[name][:2].cpu(), a.data[name].cpu())
+        torch.testing.assert_close(cat.data[name][2:].cpu(), b.data[name].cpu())
+    if with_labels:
+        assert cat.labels is not None
+        assert cat.labels.tensor.shape == (5, n_labels)
+    if with_data_mask:
+        assert cat.data_mask is not None
+        for name in names:
+            assert cat.data_mask[name].shape == (5,)
+    pieces = cat.split([2, 3])
+    assert len(pieces) == 2
+    assert_batchdata_equal_up_to_device(pieces[0], a)
+    assert_batchdata_equal_up_to_device(pieces[1], b)
+
+
+def test_batchdata_cat_empty_raises():
+    with pytest.raises(ValueError, match="empty sequence"):
+        BatchData.cat([])
+
+
+def test_batchdata_cat_single_returns_input():
+    a = get_batch_data(
+        names=["foo"],
+        n_samples=2,
+        n_times=3,
+        horizontal_dims=["lat", "lon"],
+    )
+    assert BatchData.cat([a]) is a
+
+
+def test_batchdata_cat_mismatched_n_timesteps_raises():
+    a = get_batch_data(
+        names=["foo"], n_samples=2, n_times=3, horizontal_dims=["lat", "lon"]
+    )
+    b = get_batch_data(
+        names=["foo"], n_samples=2, n_times=4, horizontal_dims=["lat", "lon"]
+    )
+    with pytest.raises(ValueError, match="n_timesteps"):
+        BatchData.cat([a, b])
+
+
+def test_batchdata_cat_mismatched_n_ensemble_raises():
+    a = get_batch_data(
+        names=["foo"],
+        n_samples=2,
+        n_times=3,
+        horizontal_dims=["lat", "lon"],
+        n_ensemble=1,
+    )
+    b = get_batch_data(
+        names=["foo"],
+        n_samples=2,
+        n_times=3,
+        horizontal_dims=["lat", "lon"],
+        n_ensemble=2,
+    )
+    with pytest.raises(ValueError, match="n_ensemble"):
+        BatchData.cat([a, b])
+
+
+def test_batchdata_cat_unions_different_label_names():
+    """Cat is permitted across batches with different label encodings."""
+    device = get_device()
+    a = get_batch_data(
+        names=["foo"], n_samples=2, n_times=3, horizontal_dims=["lat", "lon"]
+    )
+    b = get_batch_data(
+        names=["foo"], n_samples=3, n_times=3, horizontal_dims=["lat", "lon"]
+    )
+    a.labels = BatchLabels(torch.ones(2, 2, device=device), ["x", "y"])
+    b.labels = BatchLabels(torch.ones(3, 2, device=device), ["y", "z"])
+    cat = BatchData.cat([a, b])
+    assert cat.labels is not None
+    assert cat.labels.names == ["x", "y", "z"]
+    # Sample 0 was originally "x"+"y" → ["x","y","z"] = [1,1,0]
+    # Sample 2 was originally "y"+"z" → ["x","y","z"] = [0,1,1]
+    expected = torch.tensor(
+        [
+            [1.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ],
+        device=device,
+    )
+    torch.testing.assert_close(cat.labels.tensor, expected)
+
+
+def test_batchdata_split_wrong_sum_raises():
+    a = get_batch_data(
+        names=["foo"], n_samples=2, n_times=3, horizontal_dims=["lat", "lon"]
+    )
+    with pytest.raises(ValueError, match="sample_sizes"):
+        a.split([1, 2])
+
+
+def test_prognostic_state_cat_and_split_roundtrip():
+    a = get_batch_data(
+        names=["foo"], n_samples=2, n_times=2, horizontal_dims=["lat", "lon"]
+    )
+    b = get_batch_data(
+        names=["foo"], n_samples=3, n_times=2, horizontal_dims=["lat", "lon"]
+    )
+    sa = PrognosticState(a)
+    sb = PrognosticState(b)
+    cat = PrognosticState.cat([sa, sb])
+    assert cat.as_batch_data().time.shape == (5, 2)
+    pieces = cat.split([2, 3])
+    assert len(pieces) == 2
+    assert_batchdata_equal_up_to_device(pieces[0].as_batch_data(), a)
+    assert_batchdata_equal_up_to_device(pieces[1].as_batch_data(), b)
+
+
+def _paired(
+    prediction_names: list[str],
+    reference_names: list[str],
+    n_samples: int,
+    n_times: int = 3,
+    n_labels: int = 0,
+) -> PairedData:
+    device = get_device()
+    if n_labels == 0:
+        labels = None
+    else:
+        labels = BatchLabels(
+            torch.zeros(n_samples, n_labels, device=device),
+            [f"label_{i}" for i in range(n_labels)],
+        )
+    return PairedData(
+        prediction={
+            k: torch.randn(n_samples, n_times, 4, 8, device=device)
+            for k in prediction_names
+        },
+        reference={
+            k: torch.randn(n_samples, n_times, 4, 8, device=device)
+            for k in reference_names
+        },
+        time=xr.DataArray(np.random.rand(n_samples, n_times), dims=["sample", "time"]),
+        labels=labels,
+    )
+
+
+@pytest.mark.parametrize("with_labels", [False, True])
+def test_paired_data_cat_and_split_roundtrip(with_labels: bool):
+    n_labels = 2 if with_labels else 0
+    a = _paired(["bar"], ["foo", "bar"], n_samples=2, n_labels=n_labels)
+    b = _paired(["bar"], ["foo", "bar"], n_samples=3, n_labels=n_labels)
+    cat = PairedData.cat([a, b])
+    assert cat.time.shape == (5, 3)
+    torch.testing.assert_close(
+        cat.prediction["bar"][:2].cpu(), a.prediction["bar"].cpu()
+    )
+    torch.testing.assert_close(cat.reference["foo"][2:].cpu(), b.reference["foo"].cpu())
+    pieces = cat.split([2, 3])
+    assert len(pieces) == 2
+    assert_paired_data_equal_up_to_device(pieces[0], a)
+    assert_paired_data_equal_up_to_device(pieces[1], b)
+
+
+def test_paired_data_cat_mismatched_prediction_names_raises():
+    a = _paired(["bar"], ["foo", "bar"], n_samples=2)
+    b = _paired(["foo"], ["foo", "bar"], n_samples=2)
+    with pytest.raises(ValueError, match="prediction variables"):
+        PairedData.cat([a, b])

--- a/fme/ace/data_loading/test_batch_data.py
+++ b/fme/ace/data_loading/test_batch_data.py
@@ -1241,6 +1241,30 @@ def test_batchdata_split_wrong_sum_raises():
         a.split([1, 2])
 
 
+def test_batchdata_cat_and_split_roundtrips_stepper_state():
+    """cat/split must carry per-sample stepper_state so corrector state
+    propagates through batched (concurrent) prediction exactly as in the
+    sequential path."""
+    a = _batch_data_with_stepper_state(n_samples=2)
+    b = _batch_data_with_stepper_state(n_samples=3)
+    cat = BatchData.cat([a, b])
+    assert cat.stepper_state is not None
+    assert cat.stepper_state.corrector_state is not None
+    mass = cat.stepper_state.corrector_state.global_dry_air_mass
+    assert mass is not None and mass.shape == (5, 1, 1)
+    pieces = cat.split([2, 3])
+    assert_batchdata_equal_up_to_device(pieces[0], a)
+    assert_batchdata_equal_up_to_device(pieces[1], b)
+
+
+def test_batchdata_cat_inconsistent_stepper_state_presence_raises():
+    a = _batch_data_with_stepper_state(n_samples=2)
+    b = _batch_data_with_stepper_state(n_samples=2)
+    b.stepper_state = None
+    with pytest.raises(ValueError, match="stepper_state"):
+        BatchData.cat([a, b])
+
+
 def test_prognostic_state_cat_and_split_roundtrip():
     a = get_batch_data(
         names=["foo"], n_samples=2, n_times=2, horizontal_dims=["lat", "lon"]

--- a/fme/core/corrector/state.py
+++ b/fme/core/corrector/state.py
@@ -6,6 +6,7 @@ window to the next.
 """
 
 import dataclasses
+from collections.abc import Sequence
 
 import torch
 
@@ -66,3 +67,29 @@ class CorrectorState:
         if self.global_dry_air_mass is not None:
             return self.global_dry_air_mass.shape[0]
         return None
+
+    @classmethod
+    def cat(cls, states: "Sequence[CorrectorState]") -> "CorrectorState":
+        """Concatenate corrector states along the sample dimension.
+
+        Inputs must agree on which fields are present (all ``None`` or all
+        not-``None`` for each field); a present field is concatenated along
+        dim 0.
+        """
+        masses = [s.global_dry_air_mass for s in states]
+        present = [m for m in masses if m is not None]
+        if not present:
+            return cls()
+        if len(present) != len(masses):
+            raise ValueError(
+                "Cannot cat CorrectorState with inconsistent global_dry_air_mass "
+                "presence."
+            )
+        return cls(global_dry_air_mass=torch.cat(present, dim=0))
+
+    def split(self, sample_sizes: "Sequence[int]") -> "list[CorrectorState]":
+        """Split along the sample dimension into the given sample sizes."""
+        if self.global_dry_air_mass is None:
+            return [CorrectorState() for _ in sample_sizes]
+        pieces = torch.split(self.global_dry_air_mass, list(sample_sizes), dim=0)
+        return [CorrectorState(global_dry_air_mass=p) for p in pieces]

--- a/fme/core/labels.py
+++ b/fme/core/labels.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import torch
@@ -92,6 +93,50 @@ class BatchLabels:
         if self.names != other.names:
             return False
         return torch.equal(self.tensor, other.tensor)
+
+    def semantically_equal(self, other: "BatchLabels") -> bool:
+        """Equality after conforming both sides to a common encoding.
+
+        Returns True when the two label sets describe the same per-sample
+        memberships, even if encoded with different column orderings or
+        different name sets (extra columns are treated as zero).
+        """
+        if self.tensor.shape[0] != other.tensor.shape[0]:
+            return False
+        common = LabelEncoding(sorted(set(self.names) | set(other.names)))
+        return torch.equal(
+            self.conform_to_encoding(common).tensor,
+            other.conform_to_encoding(common).tensor,
+        )
+
+    @classmethod
+    def cat(cls, items: Sequence["BatchLabels"]) -> "BatchLabels":
+        """Concatenate a sequence of BatchLabels along the sample dimension.
+
+        Inputs may have differing ``names``. The result uses the sorted union
+        of all names, with each input conformed to that encoding before
+        concatenation. Missing-from-an-input names contribute zeros.
+        """
+        if len(items) == 0:
+            raise ValueError("Cannot cat an empty sequence of BatchLabels.")
+        if len(items) == 1:
+            return items[0]
+        all_names: set[str] = set()
+        for item in items:
+            all_names.update(item.names)
+        union_names = sorted(all_names)
+        if all(item.names == union_names for item in items):
+            return cls(
+                torch.cat([item.tensor for item in items], dim=0),
+                union_names,
+            )
+        encoding = LabelEncoding(union_names)
+        return cls(
+            torch.cat(
+                [item.conform_to_encoding(encoding).tensor for item in items], dim=0
+            ),
+            union_names,
+        )
 
     @classmethod
     def new_from_set(cls, label_set: set[str], n_samples: int, device) -> "BatchLabels":

--- a/fme/core/stepper_state.py
+++ b/fme/core/stepper_state.py
@@ -11,6 +11,7 @@ payloads owned by their respective components.
 """
 
 import dataclasses
+from collections.abc import Sequence
 
 from fme.core.corrector.state import CorrectorState
 
@@ -61,3 +62,29 @@ class StepperState:
         if self.corrector_state is not None:
             return self.corrector_state.sample_dim_size()
         return None
+
+    @classmethod
+    def cat(cls, states: "Sequence[StepperState]") -> "StepperState":
+        """Concatenate stepper states along the sample dimension.
+
+        Inputs must agree on which sub-states are present (all ``None`` or all
+        not-``None``); a present sub-state is concatenated along the sample dim.
+        """
+        corrector_states = [s.corrector_state for s in states]
+        present = [c for c in corrector_states if c is not None]
+        if not present:
+            return cls()
+        if len(present) != len(corrector_states):
+            raise ValueError(
+                "Cannot cat StepperState with inconsistent corrector_state presence."
+            )
+        return cls(corrector_state=CorrectorState.cat(present))
+
+    def split(self, sample_sizes: "Sequence[int]") -> "list[StepperState]":
+        """Split along the sample dimension into the given sample sizes."""
+        if self.corrector_state is None:
+            return [StepperState() for _ in sample_sizes]
+        return [
+            StepperState(corrector_state=c)
+            for c in self.corrector_state.split(sample_sizes)
+        ]

--- a/fme/core/test_labels.py
+++ b/fme/core/test_labels.py
@@ -103,3 +103,138 @@ def test_labels_equality(
     labels1: BatchLabels, labels2: BatchLabels | None, expected: bool
 ):
     assert (labels1 == labels2) == expected
+
+
+def test_semantically_equal_identical():
+    a = BatchLabels(torch.tensor([[1.0, 0.0], [0.0, 1.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[1.0, 0.0], [0.0, 1.0]]), ["a", "b"])
+    assert a.semantically_equal(b)
+
+
+def test_semantically_equal_reordered_names_same_meaning():
+    a = BatchLabels(torch.tensor([[1.0, 0.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[0.0, 1.0]]), ["b", "a"])
+    assert a.semantically_equal(b)
+
+
+def test_semantically_equal_disjoint_names_zero_padded():
+    # "a"-active on left vs "a"-active on right with extra zero col on the right
+    a = BatchLabels(torch.tensor([[1.0]]), ["a"])
+    b = BatchLabels(torch.tensor([[1.0, 0.0]]), ["a", "b"])
+    assert a.semantically_equal(b)
+
+
+def test_semantically_equal_different_meaning_returns_false():
+    a = BatchLabels(torch.tensor([[1.0]]), ["a"])
+    b = BatchLabels(torch.tensor([[1.0]]), ["b"])
+    assert not a.semantically_equal(b)
+
+
+def test_semantically_equal_different_n_samples_returns_false():
+    a = BatchLabels(torch.tensor([[1.0]]), ["a"])
+    b = BatchLabels(torch.tensor([[1.0], [1.0]]), ["a"])
+    assert not a.semantically_equal(b)
+
+
+def test_batchlabels_cat_empty_raises():
+    with pytest.raises(ValueError, match="empty sequence"):
+        BatchLabels.cat([])
+
+
+def test_batchlabels_cat_single_returns_input():
+    a = BatchLabels(torch.tensor([[1.0, 0.0]]), ["a", "b"])
+    assert BatchLabels.cat([a]) is a
+
+
+def test_batchlabels_cat_same_names_stacks_tensors():
+    a = BatchLabels(torch.tensor([[1.0, 0.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[0.0, 1.0], [1.0, 1.0]]), ["a", "b"])
+    out = BatchLabels.cat([a, b])
+    assert out.names == ["a", "b"]
+    assert out.tensor.tolist() == [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+
+def test_batchlabels_cat_disjoint_names_unions_with_zero_pad():
+    a = BatchLabels(torch.tensor([[1.0, 2.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[3.0, 4.0]]), ["c", "d"])
+    out = BatchLabels.cat([a, b])
+    assert out.names == ["a", "b", "c", "d"]
+    assert out.tensor.tolist() == [
+        [1.0, 2.0, 0.0, 0.0],
+        [0.0, 0.0, 3.0, 4.0],
+    ]
+
+
+def test_batchlabels_cat_overlapping_names_aligns_columns():
+    a = BatchLabels(torch.tensor([[1.0, 2.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[3.0, 4.0]]), ["b", "c"])
+    out = BatchLabels.cat([a, b])
+    assert out.names == ["a", "b", "c"]
+    assert out.tensor.tolist() == [
+        [1.0, 2.0, 0.0],
+        [0.0, 3.0, 4.0],
+    ]
+
+
+def test_batchlabels_cat_different_orderings_aligns_columns():
+    # Same name set but different orderings on inputs.
+    a = BatchLabels(torch.tensor([[1.0, 2.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[5.0, 4.0]]), ["b", "a"])
+    out = BatchLabels.cat([a, b])
+    assert out.names == ["a", "b"]
+    assert out.tensor.tolist() == [
+        [1.0, 2.0],
+        [4.0, 5.0],
+    ]
+
+
+def test_batchlabels_cat_three_inputs_with_partial_overlap():
+    a = BatchLabels(torch.tensor([[1.0, 0.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[1.0, 0.0]]), ["b", "c"])
+    c = BatchLabels(torch.tensor([[1.0]]), ["d"])
+    out = BatchLabels.cat([a, b, c])
+    assert out.names == ["a", "b", "c", "d"]
+    assert out.tensor.tolist() == [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+
+
+def test_batchlabels_cat_does_not_duplicate_names():
+    # Whether overlap is total, partial, or zero, the result has each name once.
+    a = BatchLabels(torch.tensor([[1.0, 1.0]]), ["a", "b"])
+    b = BatchLabels(torch.tensor([[1.0, 1.0]]), ["a", "b"])
+    c = BatchLabels(torch.tensor([[1.0, 1.0]]), ["b", "c"])
+    out = BatchLabels.cat([a, b, c])
+    assert out.names == ["a", "b", "c"]
+    assert len(set(out.names)) == len(out.names)
+
+
+def test_batchlabels_cat_preserves_device():
+    device = get_device()
+    a = BatchLabels(torch.tensor([[1.0, 0.0]]), ["a", "b"]).to(device)
+    b = BatchLabels(torch.tensor([[0.0, 1.0]]), ["b", "c"]).to(device)
+    out = BatchLabels.cat([a, b])
+    assert out.tensor.device == a.tensor.device
+
+
+def test_batchlabels_cat_empty_label_lists_combine_to_empty():
+    a = BatchLabels(torch.zeros(2, 0), [])
+    b = BatchLabels(torch.zeros(3, 0), [])
+    out = BatchLabels.cat([a, b])
+    assert out.names == []
+    assert out.tensor.shape == (5, 0)
+
+
+def test_batchlabels_cat_empty_with_non_empty_zero_pads():
+    a = BatchLabels(torch.zeros(2, 0), [])
+    b = BatchLabels(torch.tensor([[1.0, 1.0]]), ["a", "b"])
+    out = BatchLabels.cat([a, b])
+    assert out.names == ["a", "b"]
+    # The empty-labels rows get zeroed across the union.
+    assert out.tensor.tolist() == [
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [1.0, 1.0],
+    ]

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -34,6 +34,25 @@ class CoupledPrognosticState:
             self.ocean_data.as_batch_data(), self.atmosphere_data.as_batch_data()
         )
 
+    @classmethod
+    def cat(
+        cls, states: Sequence["CoupledPrognosticState"]
+    ) -> "CoupledPrognosticState":
+        """Concatenate coupled prognostic states along the sample dimension."""
+        return cls(
+            ocean_data=PrognosticState.cat([s.ocean_data for s in states]),
+            atmosphere_data=PrognosticState.cat([s.atmosphere_data for s in states]),
+        )
+
+    def split(self, sample_sizes: Sequence[int]) -> list["CoupledPrognosticState"]:
+        """Split along the sample dimension into the given sample sizes."""
+        ocean_split = self.ocean_data.split(sample_sizes)
+        atmos_split = self.atmosphere_data.split(sample_sizes)
+        return [
+            CoupledPrognosticState(ocean_data=o, atmosphere_data=a)
+            for o, a in zip(ocean_split, atmos_split)
+        ]
+
 
 @dataclasses.dataclass
 class CoupledBatchData:
@@ -154,6 +173,23 @@ class CoupledBatchData:
         self.atmosphere_data = self.atmosphere_data.pin_memory()
         return self
 
+    @classmethod
+    def cat(cls, batches: Sequence["CoupledBatchData"]) -> "CoupledBatchData":
+        """Concatenate along the sample dimension."""
+        return cls(
+            ocean_data=BatchData.cat([b.ocean_data for b in batches]),
+            atmosphere_data=BatchData.cat([b.atmosphere_data for b in batches]),
+        )
+
+    def split(self, sample_sizes: Sequence[int]) -> list["CoupledBatchData"]:
+        """Split along the sample dimension into the given sample sizes."""
+        ocean_split = self.ocean_data.split(sample_sizes)
+        atmos_split = self.atmosphere_data.split(sample_sizes)
+        return [
+            self.__class__(ocean_data=o, atmosphere_data=a)
+            for o, a in zip(ocean_split, atmos_split)
+        ]
+
 
 @dataclasses.dataclass
 class CoupledPairedData:
@@ -198,3 +234,20 @@ class CoupledPairedData:
                 labels=prediction.atmosphere_data.labels,
             ),
         )
+
+    @classmethod
+    def cat(cls, batches: Sequence["CoupledPairedData"]) -> "CoupledPairedData":
+        """Concatenate along the sample dimension."""
+        return cls(
+            ocean_data=PairedData.cat([b.ocean_data for b in batches]),
+            atmosphere_data=PairedData.cat([b.atmosphere_data for b in batches]),
+        )
+
+    def split(self, sample_sizes: Sequence[int]) -> list["CoupledPairedData"]:
+        """Split along the sample dimension into the given sample sizes."""
+        ocean_split = self.ocean_data.split(sample_sizes)
+        atmos_split = self.atmosphere_data.split(sample_sizes)
+        return [
+            CoupledPairedData(ocean_data=o, atmosphere_data=a)
+            for o, a in zip(ocean_split, atmos_split)
+        ]

--- a/fme/coupled/data_loading/test_batch_data.py
+++ b/fme/coupled/data_loading/test_batch_data.py
@@ -1,0 +1,77 @@
+import numpy as np
+import torch
+import xarray as xr
+
+from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
+from fme.coupled.data_loading.batch_data import (
+    CoupledBatchData,
+    CoupledPairedData,
+    CoupledPrognosticState,
+)
+
+
+def _batch(n_samples: int, n_times: int = 3) -> BatchData:
+    return BatchData(
+        data={"x": torch.randn(n_samples, n_times, 4, 8)},
+        time=xr.DataArray(np.random.rand(n_samples, n_times), dims=["sample", "time"]),
+        horizontal_dims=["lat", "lon"],
+    )
+
+
+def _paired(n_samples: int, n_times: int = 3) -> PairedData:
+    return PairedData(
+        prediction={"x": torch.randn(n_samples, n_times, 4, 8)},
+        reference={"x": torch.randn(n_samples, n_times, 4, 8)},
+        time=xr.DataArray(np.random.rand(n_samples, n_times), dims=["sample", "time"]),
+    )
+
+
+def test_coupled_batch_data_cat_and_split_roundtrip():
+    a = CoupledBatchData(ocean_data=_batch(2), atmosphere_data=_batch(2, n_times=5))
+    b = CoupledBatchData(ocean_data=_batch(3), atmosphere_data=_batch(3, n_times=5))
+    cat = CoupledBatchData.cat([a, b])
+    assert cat.ocean_data.time.shape == (5, 3)
+    assert cat.atmosphere_data.time.shape == (5, 5)
+    pieces = cat.split([2, 3])
+    assert len(pieces) == 2
+    torch.testing.assert_close(pieces[0].ocean_data.data["x"], a.ocean_data.data["x"])
+    torch.testing.assert_close(
+        pieces[1].atmosphere_data.data["x"], b.atmosphere_data.data["x"]
+    )
+
+
+def test_coupled_prognostic_state_cat_and_split_roundtrip():
+    a = CoupledPrognosticState(
+        ocean_data=PrognosticState(_batch(2)),
+        atmosphere_data=PrognosticState(_batch(2, n_times=5)),
+    )
+    b = CoupledPrognosticState(
+        ocean_data=PrognosticState(_batch(3)),
+        atmosphere_data=PrognosticState(_batch(3, n_times=5)),
+    )
+    cat = CoupledPrognosticState.cat([a, b])
+    pieces = cat.split([2, 3])
+    assert len(pieces) == 2
+    torch.testing.assert_close(
+        pieces[0].ocean_data.as_batch_data().data["x"],
+        a.ocean_data.as_batch_data().data["x"],
+    )
+    torch.testing.assert_close(
+        pieces[1].atmosphere_data.as_batch_data().data["x"],
+        b.atmosphere_data.as_batch_data().data["x"],
+    )
+
+
+def test_coupled_paired_data_cat_and_split_roundtrip():
+    a = CoupledPairedData(ocean_data=_paired(2), atmosphere_data=_paired(2, n_times=5))
+    b = CoupledPairedData(ocean_data=_paired(3), atmosphere_data=_paired(3, n_times=5))
+    cat = CoupledPairedData.cat([a, b])
+    assert cat.ocean_data.time.shape == (5, 3)
+    pieces = cat.split([2, 3])
+    assert len(pieces) == 2
+    torch.testing.assert_close(
+        pieces[0].ocean_data.prediction["x"], a.ocean_data.prediction["x"]
+    )
+    torch.testing.assert_close(
+        pieces[1].atmosphere_data.reference["x"], b.atmosphere_data.reference["x"]
+    )


### PR DESCRIPTION
Splits the stuck 1946-line PR #1195 (concurrent inline inference) into a
reviewable three-PR chain, smallest and most mechanical first. This is **PR 1
of 3**, targeting `main`.

Additive: new methods plus unit tests, no callers changed and zero behavior
change. These are the data-structure primitives the concurrent inline-inference
batching (PR 3) builds on.

Changes:
- `fme.core.labels.BatchLabels.cat` / `BatchLabels.semantically_equal` — concatenate label sets along the sample dim (sorted-union encoding, zero-padding for missing names) and compare two label sets for equality up to encoding.
- `fme.ace.data_loading.batch_data` — sample-dimension `cat`/`split` on `PrognosticState`, `BatchData`, and `PairedData`.
- `fme.coupled.data_loading.batch_data` — sample-dimension `cat`/`split` on `CoupledPrognosticState`, `CoupledBatchData`, and `CoupledPairedData`.
- `fme.core.stepper_state.StepperState` / `fme.core.corrector.state.CorrectorState` — `cat`/`split`, and propagation of per-sample `stepper_state` through `BatchData.cat`/`split`. Without this, the batched (concurrent) path would silently drop corrector state (e.g. the IC-pinned `global_dry_air_mass`) that the sequential path threads window-to-window, diverging for corrector-enabled steppers. (Surfaced in review of this chain.)

- [x] Tests added (`fme/core/test_labels.py`, `fme/ace/data_loading/test_batch_data.py`, `fme/coupled/data_loading/test_batch_data.py`)
- [ ] If dependencies changed, "deps only" image rebuilt — n/a

Part of the #1195 split: PR 2 refactors the inference callback; PR 3 adds the concurrent dispatch and a concurrent-vs-sequential equivalence test.