### PR TITLE
Refactor inference callback into per-task dispatch (2/3 of #1195 split)

### DIFF
--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -893,7 +893,14 @@ def build_inference_callback(
     inference_epochs: Sequence[int],
     stepper: TrainStepperABC[PS, BD, FD, SD, TO],
 ) -> InferenceCallback:
-    """Build an ``InferenceCallback`` shared between ACE and coupled training."""
+    """Build an ``InferenceCallback`` shared between ACE and coupled training.
+
+    Each active task is run through ``_run_inference_task_sequential`` into a
+    per-task summary, then the summaries are combined into the epoch's logs and
+    weighted checkpoint-selection error. This per-task dispatch is the structure
+    a later change extends to run tasks concurrently through a shared batched
+    forward pass; here every task runs on its own sequential path.
+    """
     inference_epochs_set = set(inference_epochs)
 
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
@@ -903,18 +910,16 @@ def build_inference_callback(
         if not active_tasks:
             return {}, None
 
+        per_task_summaries: dict[str, InferenceSummary] = {}
+        for task in active_tasks:
+            per_task_summaries[task.name] = _run_inference_task_sequential(
+                task=task, stepper=stepper, epoch=epoch
+            )
+
         all_logs: dict[str, Any] = {}
         weighted_error: float | None = None
         for task in active_tasks:
-            aggregator = task.aggregator_factory()
-            summary = inference_one_epoch(
-                stepper=stepper,
-                validation_context=contextlib.nullcontext,
-                dataset=task.data,
-                aggregator=aggregator,
-                label=task.name,
-                epoch=epoch,
-            )
+            summary = per_task_summaries[task.name]
             overlap = all_logs.keys() & summary.logs.keys()
             if overlap:
                 raise RuntimeError(
@@ -935,6 +940,22 @@ def build_inference_callback(
         return all_logs, weighted_error
 
     return inference_callback
+
+
+def _run_inference_task_sequential(
+    task: InferenceTask[PS, FD, SD],
+    stepper: TrainStepperABC[PS, BD, FD, SD, TO],
+    epoch: int,
+) -> InferenceSummary:
+    aggregator = task.aggregator_factory()
+    return inference_one_epoch(
+        stepper=stepper,
+        validation_context=contextlib.nullcontext,
+        dataset=task.data,
+        aggregator=aggregator,
+        label=task.name,
+        epoch=epoch,
+    )
 
 
 def _restore_checkpoint(trainer: Trainer, checkpoint_path):


### PR DESCRIPTION
**PR 2 of 3** splitting #1195. Targets PR 1 (`feature/cinf-1-cat-split-helpers`);
retarget to `main` once PR 1 merges.

Behavior-preserving refactor of the shared inference callback that reshapes it
into the per-task dispatch the concurrent change (PR 3) extends, while every
task still runs on its own sequential path.

Changes:
- `fme.core.generics.trainer.build_inference_callback` — run each active task through a new `_run_inference_task_sequential` helper into a per-task `InferenceSummary`, then combine the summaries into the epoch logs and the weighted checkpoint-selection error in a second pass. Identical runtime behavior to `main`.

- [x] Tests added — none new; behavior preservation is covered by the existing ACE/coupled `TestGetInferenceCallback` and `test_trainer` suites.
- [ ] If dependencies changed, "deps only" image rebuilt — n/a

Note: this chain reconciles #1195 against current `main`, which since #1195 was opened replaced the string-keyed error lookup with `InferenceSummary.loss` and added LR-tuning epoch threading. The original PR's `error_metric_template` and unused `aggregator_factory(epoch)` changes are therefore dropped as obsolete.