### PR TITLE
Refactor inline inference callback into per-task sequential dispatch (cinf 2/3)

### DIFF
--- a/fme/core/generics/test_inference_callback.py
+++ b/fme/core/generics/test_inference_callback.py
@@ -1,0 +1,113 @@
+"""Unit tests for build_inference_callback's sequential dispatch (generic).
+
+These cover the per-task sequential fan-out and the log/error aggregation
+shared by ACE and coupled training. (Concurrent grouping is added in a later
+change and tested alongside it.)"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fme.core.generics.aggregator import InferenceSummary
+from fme.core.generics.trainer import InferenceTask, build_inference_callback
+
+
+def _make_task(name: str, weight: float = 0.0, epochs=(1,)) -> InferenceTask:
+    return InferenceTask(
+        name=name,
+        data=MagicMock(),
+        aggregator_factory=MagicMock(),
+        epoch_set=frozenset(epochs),
+        weight=weight,
+    )
+
+
+def _build(tasks, side_effect, inference_epochs=(1,)):
+    stepper = MagicMock()
+    mock = patch(
+        "fme.core.generics.trainer.inference_one_epoch",
+        side_effect=side_effect,
+    )
+    callback = build_inference_callback(
+        tasks=tasks, inference_epochs=list(inference_epochs), stepper=stepper
+    )
+    return callback, mock
+
+
+def test_epoch_not_in_inference_epochs_returns_empty():
+    callback, mock = _build([_make_task("a", weight=1.0)], side_effect=[])
+    with mock as m:
+        logs, error = callback(epoch=2)
+    assert logs == {}
+    assert error is None
+    assert m.call_count == 0
+
+
+def test_runs_each_active_task_and_combines_weighted_error():
+    tasks = [_make_task("a", weight=2.0), _make_task("b", weight=3.0)]
+    callback, mock = _build(
+        tasks,
+        side_effect=[
+            InferenceSummary(logs={"a/loss": 0.1}, loss=0.1),
+            InferenceSummary(logs={"b/loss": 0.2}, loss=0.2),
+        ],
+    )
+    with mock as m:
+        logs, error = callback(epoch=1)
+    assert m.call_count == 2
+    assert error == pytest.approx(2.0 * 0.1 + 3.0 * 0.2)
+    assert logs == {"a/loss": 0.1, "b/loss": 0.2}
+
+
+def test_zero_weight_task_excluded_from_error():
+    tasks = [_make_task("a", weight=1.0), _make_task("b", weight=0.0)]
+    callback, mock = _build(
+        tasks,
+        side_effect=[
+            InferenceSummary(logs={"a/loss": 0.3}, loss=0.3),
+            InferenceSummary(logs={"b/loss": 9.0}, loss=9.0),
+        ],
+    )
+    with mock:
+        logs, error = callback(epoch=1)
+    assert error == pytest.approx(0.3)
+    assert "b/loss" in logs
+
+
+def test_inactive_task_skipped():
+    tasks = [
+        _make_task("a", weight=1.0, epochs=(1,)),
+        _make_task("b", weight=1.0, epochs=(2,)),
+    ]
+    callback, mock = _build(
+        tasks,
+        side_effect=[InferenceSummary(logs={"a/loss": 0.5}, loss=0.5)],
+    )
+    with mock as m:
+        logs, error = callback(epoch=1)
+    assert m.call_count == 1
+    assert error == pytest.approx(0.5)
+    assert "b/loss" not in logs
+
+
+def test_overlapping_log_keys_raise():
+    tasks = [_make_task("a", weight=0.0), _make_task("b", weight=0.0)]
+    callback, mock = _build(
+        tasks,
+        side_effect=[
+            InferenceSummary(logs={"shared": 0.1}, loss=None),
+            InferenceSummary(logs={"shared": 0.2}, loss=None),
+        ],
+    )
+    with mock, pytest.raises(RuntimeError, match="overlap"):
+        callback(epoch=1)
+
+
+def test_weighted_task_without_loss_raises():
+    tasks = [_make_task("a", weight=1.0)]
+    callback, mock = _build(
+        tasks,
+        side_effect=[InferenceSummary(logs={"a/x": 1.0}, loss=None)],
+    )
+    with mock, pytest.raises(RuntimeError, match="did not produce a loss"):
+        callback(epoch=1)

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -890,7 +890,12 @@ def build_inference_callback(
     inference_epochs: Sequence[int],
     stepper: TrainStepperABC[PS, BD, FD, SD, TO],
 ) -> InferenceCallback:
-    """Build an ``InferenceCallback`` shared between ACE and coupled training."""
+    """Build an ``InferenceCallback`` shared between ACE and coupled training.
+
+    Each active task is run through the sequential ``inference_one_epoch`` path
+    and produces an ``InferenceSummary``; the per-task summaries are then
+    combined into the epoch's logs and weighted checkpoint-selection error.
+    """
     inference_epochs_set = set(inference_epochs)
 
     def inference_callback(epoch: int) -> tuple[dict[str, Any], float | None]:
@@ -900,18 +905,16 @@ def build_inference_callback(
         if not active_tasks:
             return {}, None
 
+        per_task_summaries: dict[str, InferenceSummary] = {}
+        for task in active_tasks:
+            per_task_summaries[task.name] = _run_inference_task_sequential(
+                task=task, stepper=stepper, epoch=epoch
+            )
+
         all_logs: dict[str, Any] = {}
         weighted_error: float | None = None
         for task in active_tasks:
-            aggregator = task.aggregator_factory()
-            summary = inference_one_epoch(
-                stepper=stepper,
-                validation_context=contextlib.nullcontext,
-                dataset=task.data,
-                aggregator=aggregator,
-                label=task.name,
-                epoch=epoch,
-            )
+            summary = per_task_summaries[task.name]
             overlap = all_logs.keys() & summary.logs.keys()
             if overlap:
                 raise RuntimeError(
@@ -932,6 +935,23 @@ def build_inference_callback(
         return all_logs, weighted_error
 
     return inference_callback
+
+
+def _run_inference_task_sequential(
+    task: InferenceTask[PS, FD, SD],
+    stepper: TrainStepperABC[PS, BD, FD, SD, TO],
+    epoch: int,
+) -> InferenceSummary:
+    """Run a single inference task through the sequential ``run_inference`` path."""
+    aggregator = task.aggregator_factory()
+    return inference_one_epoch(
+        stepper=stepper,
+        validation_context=contextlib.nullcontext,
+        dataset=task.data,
+        aggregator=aggregator,
+        label=task.name,
+        epoch=epoch,
+    )
 
 
 def _restore_checkpoint(trainer: Trainer, checkpoint_path):

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -942,7 +942,7 @@ def _run_inference_task_sequential(
     stepper: TrainStepperABC[PS, BD, FD, SD, TO],
     epoch: int,
 ) -> InferenceSummary:
-    """Run a single inference task through the sequential ``run_inference`` path."""
+    """Run one inference task through the sequential ``inference_one_epoch`` path."""
     aggregator = task.aggregator_factory()
     return inference_one_epoch(
         stepper=stepper,


### PR DESCRIPTION
Splits the stuck concurrent-inline-inference PR #1195 into a reviewable 3-PR chain. This is **PR 2 of 3** (base: the PR 1 branch `cinf/pr1-cat-split-helpers`). Behavior-preserving refactor of the shared inline-inference callback that reduces the diff from `main` to the structural scaffolding PR 3 needs, while still running every task sequentially. **No runtime behavior change vs `main`.**

Changes:
- `fme.core.generics.trainer._run_inference_task_sequential` — extracted helper wrapping the existing `inference_one_epoch` call for a single task (returns its `InferenceSummary`).
- `fme.core.generics.trainer.build_inference_callback` — restructured into two phases: run each active task through the sequential helper into per-task `InferenceSummary` objects, then aggregate the combined logs and weighted checkpoint-selection error (same log-key overlap check and missing-loss error as `main`).

Note: `main` has since moved inline-inference checkpoint selection to an explicit `InferenceSummary.loss` (the #1285-era refactor), which supersedes #1195's original `error_metric_template` plan. This chain follows `main`: the weighted error is taken from `summary.loss`, and `InferenceTask.aggregator_factory` stays no-arg (it is already built once per epoch). No `BatchedPredictor` / `concurrent_group` / `run_concurrent_inference` appears here.

- [x] Tests added — `fme/core/generics/test_inference_callback.py` (sequential dispatch: per-task fan-out, weighted-error combination, zero-weight exclusion, inactive-task skip, log-key overlap, missing-loss). The ACE / coupled `TestGetInferenceCallback` tests continue to pass unchanged.
- [ ] If dependencies changed, "deps only" image rebuilt — n/a.

---
**Stacked chain** (replaces #1195; review bottom-up):
1. `cat`/`split` helpers → `main`
2. **This PR** — callback refactor → PR 1 branch
3. concurrent inference + equivalence test → this branch
