### PR TITLE
Add concurrent inline inference + sequential-equivalence test (cinf 3/3)

### DIFF
--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -315,6 +315,14 @@ class SingleModuleStepperConfig:
         )
 
 
+def _labels_semantically_equal(a: BatchLabels | None, b: BatchLabels | None) -> bool:
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    return a.semantically_equal(b)
+
+
 def _prepend_timesteps(
     data: EnsembleTensorDict, timesteps: TensorMapping, time_dim: int = 2
 ) -> EnsembleTensorDict:
@@ -1083,7 +1091,7 @@ class Stepper:
             Generator yielding (output, stepper_state) tuples at each timestep.
         """
         ic_batch_data = initial_condition.as_batch_data()
-        if ic_batch_data.labels != forcing_data.labels:
+        if not _labels_semantically_equal(ic_batch_data.labels, forcing_data.labels):
             raise ValueError(
                 "Initial condition and forcing data must have the same labels, "
                 f"got {ic_batch_data.labels} and {forcing_data.labels}."
@@ -1660,7 +1668,7 @@ class TrainStepper(
         input_data = data.get_start(self._prognostic_names, self.n_ic_timesteps)
         n_ensemble = self._config.n_ensemble
         input_batch_data = input_data.as_batch_data()
-        if input_batch_data.labels != data.labels:
+        if not _labels_semantically_equal(input_batch_data.labels, data.labels):
             raise ValueError(
                 "Initial condition and forcing data must have the same labels, "
                 f"got {input_batch_data.labels} and {data.labels}."

--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -361,11 +361,13 @@ class TestGetValidationCallback:
 
 class TestGetInferenceCallback:
     @staticmethod
-    def _make_entry(name, weight=1.0):
+    def _make_entry(name, weight=1.0, forward_steps_in_memory=None):
         config = MagicMock()
         config.weight = weight
         config.n_forward_steps = 1
         config.n_ensemble_per_ic = 1
+        if forward_steps_in_memory is not None:
+            config.forward_steps_in_memory = forward_steps_in_memory
         data = MagicMock()
         dataset_info = MagicMock()
         return (config, data, dataset_info, name)

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -59,6 +59,7 @@ import torch
 import fme
 from fme.ace.aggregator import TrainAggregator
 from fme.ace.aggregator.train import TrainAggregatorConfig
+from fme.ace.data_loading.batch_data import BatchData, PrognosticState
 from fme.ace.data_loading.gridded_data import InferenceGriddedData
 from fme.ace.stepper import TrainOutput, TrainStepper
 from fme.ace.train.train_config import (
@@ -73,6 +74,7 @@ from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
 from fme.core.ema import EMATracker
 from fme.core.generics.data import GriddedDataABC
+from fme.core.generics.inference import BatchedPredictor
 from fme.core.generics.lr_tuning import ValidateStepper
 from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import (
@@ -204,13 +206,29 @@ def get_inference_callback(
                 ),
                 epoch_set=frozenset(inference_epoch_sets[i]),
                 weight=entry_config.weight,
+                concurrent_group=(
+                    entry_config.forward_steps_in_memory,
+                    entry_config.n_ensemble_per_ic,
+                ),
             )
+        )
+
+    def build_predictor() -> BatchedPredictor:
+        return BatchedPredictor(
+            base_predict=stepper.predict_paired,
+            concat_ic=PrognosticState.cat,
+            concat_forcing=BatchData.cat,
+            split_output=lambda sd, sizes: sd.split(sizes),
+            split_state=lambda ps, sizes: ps.split(sizes),
+            sample_size_of_state=lambda ic: ic.as_batch_data().time.shape[0],
+            batch_key_of_forcing=lambda forcing: forcing.n_timesteps,
         )
 
     return build_inference_callback(
         tasks=tasks,
         inference_epochs=inference_epochs,
         stepper=stepper,
+        build_batched_predictor=build_predictor,
     )
 
 

--- a/fme/core/generics/inference.py
+++ b/fme/core/generics/inference.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Hashable, Iterator, Sequence
 from typing import Any, Generic, Protocol, TypeVar
 
 from fme.core.generics.aggregator import InferenceAggregatorABC, InferenceLogs
@@ -11,6 +11,11 @@ from fme.core.wandb import WandB
 PS = TypeVar("PS")  # prognostic state
 FD = TypeVar("FD", contravariant=True)  # forcing data
 SD = TypeVar("SD", covariant=True)  # stepped data
+
+# Invariant TypeVars used where Generic appears in both input and output position.
+PS_I = TypeVar("PS_I")
+FD_I = TypeVar("FD_I")
+SD_I = TypeVar("SD_I")
 
 
 class PredictFunction(Protocol, Generic[PS, FD, SD]):
@@ -69,6 +74,219 @@ class Looper(Generic[PS, FD, SD]):
         return self._prognostic_state
 
 
+class PredictionPromise(Generic[PS_I, SD_I]):
+    """Deferred handle for one slot of a batched ``BatchedPredictor`` call.
+
+    Created by ``BatchedPredictor.submit``. The first call to ``resolve()``
+    on any sibling promise triggers the single underlying forward pass; all
+    promises then return their own slice of the split outputs.
+    """
+
+    def __init__(self, predictor: "BatchedPredictor[PS_I, Any, SD_I]", slot_id: int):
+        self._predictor = predictor
+        self._slot_id = slot_id
+
+    def resolve(self) -> tuple[SD_I, PS_I]:
+        self._predictor._ensure_flushed()
+        return self._predictor._get_result(self._slot_id)
+
+
+class BatchedPredictor(Generic[PS_I, FD_I, SD_I]):
+    """Coordinates several ``PredictFunction`` calls into a single forward pass.
+
+    Submitters call ``submit(ic, forcing)`` and receive a ``PredictionPromise``.
+    The first ``promise.resolve()`` invokes the underlying predict function on
+    inputs concatenated along the sample dimension and splits the outputs back
+    into per-submission pieces. After all promises are resolved, call
+    ``reset()`` to clear the queue for the next step.
+
+    The concat / split callables make the abstraction independent of any
+    concrete batch container, so the same coordinator can drive ACE-style
+    ``BatchData`` runs and coupled-style ``CoupledBatchData`` runs.
+    """
+
+    def __init__(
+        self,
+        base_predict: "PredictFunction[PS_I, FD_I, SD_I]",
+        concat_ic: Callable[[Sequence[PS_I]], PS_I],
+        concat_forcing: Callable[[Sequence[FD_I]], FD_I],
+        split_output: Callable[[SD_I, Sequence[int]], list[SD_I]],
+        split_state: Callable[[PS_I, Sequence[int]], list[PS_I]],
+        sample_size_of_state: Callable[[PS_I], int],
+        batch_key_of_forcing: Callable[[FD_I], Hashable] = lambda _forcing: None,
+    ):
+        """``sample_size_of_state`` returns the per-call sample count from the
+        initial condition. Take it from the IC, not the forcing, because some
+        steppers broadcast a small forcing up to a larger IC (e.g. per-IC
+        ensemble members) before stepping, and the split must match the
+        post-broadcast output.
+
+        ``batch_key_of_forcing`` returns a key identifying which submissions can
+        share one forward pass: only forcing windows with equal keys are
+        concatenated together. Concurrent runs of different lengths reach their
+        short final window in different rounds, so a full window of one run and
+        the short final window of another can be submitted in the same round;
+        those windows have different shapes and cannot be concatenated. Keying
+        on the window shape (e.g. its number of timesteps) splits such a round
+        into one forward pass per distinct shape. The default keys everything
+        the same, preserving single-forward-pass behavior.
+        """
+        self._base_predict = base_predict
+        self._concat_ic = concat_ic
+        self._concat_forcing = concat_forcing
+        self._split_output = split_output
+        self._split_state = split_state
+        self._sample_size_of_state = sample_size_of_state
+        self._batch_key_of_forcing = batch_key_of_forcing
+        self._pending_ic: list[PS_I] = []
+        self._pending_forcing: list[FD_I] = []
+        self._sample_sizes: list[int] = []
+        self._batch_keys: list[Hashable] = []
+        self._compute_derived_variables: bool | None = None
+        self._results: list[tuple[SD_I, PS_I]] | None = None
+
+    @property
+    def num_pending(self) -> int:
+        return len(self._pending_ic)
+
+    def submit(
+        self,
+        initial_condition: PS_I,
+        forcing: FD_I,
+        compute_derived_variables: bool = True,
+    ) -> PredictionPromise[PS_I, SD_I]:
+        if self._results is not None:
+            raise RuntimeError(
+                "Cannot submit after flush. Call reset() before reusing the "
+                "predictor."
+            )
+        if (
+            self._compute_derived_variables is not None
+            and self._compute_derived_variables != compute_derived_variables
+        ):
+            raise ValueError(
+                "All submissions in a batched call must share "
+                "compute_derived_variables."
+            )
+        self._compute_derived_variables = compute_derived_variables
+        slot_id = len(self._pending_ic)
+        self._pending_ic.append(initial_condition)
+        self._pending_forcing.append(forcing)
+        self._sample_sizes.append(self._sample_size_of_state(initial_condition))
+        self._batch_keys.append(self._batch_key_of_forcing(forcing))
+        return PredictionPromise(self, slot_id)
+
+    def _ensure_flushed(self) -> None:
+        if self._results is not None:
+            return
+        if not self._pending_ic:
+            raise RuntimeError(
+                "Cannot flush BatchedPredictor with no pending submissions."
+            )
+        # Partition submissions into groups whose forcing windows share a batch
+        # key, so each forward pass only concatenates windows of the same shape.
+        # A single group (the common case, including all-equal keys) runs one
+        # forward pass; mismatched windows in a round (e.g. one run's short
+        # final window beside another's full window) each get their own pass.
+        groups: dict[Hashable, list[int]] = {}
+        for slot_id, key in enumerate(self._batch_keys):
+            groups.setdefault(key, []).append(slot_id)
+
+        result_by_slot: dict[int, tuple[SD_I, PS_I]] = {}
+        for slot_ids in groups.values():
+            if len(slot_ids) == 1:
+                (slot_id,) = slot_ids
+                sd, new_state = self._base_predict(
+                    self._pending_ic[slot_id],
+                    self._pending_forcing[slot_id],
+                    compute_derived_variables=bool(self._compute_derived_variables),
+                )
+                result_by_slot[slot_id] = (sd, new_state)
+                continue
+            merged_ic = self._concat_ic([self._pending_ic[i] for i in slot_ids])
+            merged_forcing = self._concat_forcing(
+                [self._pending_forcing[i] for i in slot_ids]
+            )
+            merged_sd, merged_state = self._base_predict(
+                merged_ic,
+                merged_forcing,
+                compute_derived_variables=bool(self._compute_derived_variables),
+            )
+            sizes = [self._sample_sizes[i] for i in slot_ids]
+            outputs = self._split_output(merged_sd, sizes)
+            states = self._split_state(merged_state, sizes)
+            for slot_id, sd, new_state in zip(slot_ids, outputs, states):
+                result_by_slot[slot_id] = (sd, new_state)
+        self._results = [result_by_slot[i] for i in range(len(self._pending_ic))]
+
+    def _get_result(self, slot_id: int) -> tuple[SD_I, PS_I]:
+        if self._results is None:
+            raise RuntimeError("Predictor has not been flushed.")
+        return self._results[slot_id]
+
+    def reset(self) -> None:
+        self._pending_ic = []
+        self._pending_forcing = []
+        self._sample_sizes = []
+        self._batch_keys = []
+        self._compute_derived_variables = None
+        self._results = None
+
+
+class LazyLooper(Generic[PS_I, FD_I, SD_I]):
+    """Same iteration contract as ``Looper`` but defers prediction to a shared
+    ``BatchedPredictor``.
+
+    A driver loops over several ``LazyLooper`` instances in lock-step: it calls
+    ``submit()`` on each (registering the next forcing window with the shared
+    predictor) and then ``commit()`` on each (resolving the promise and
+    updating internal prognostic state). One batched forward pass per round.
+    """
+
+    def __init__(
+        self,
+        predictor: BatchedPredictor[PS_I, FD_I, SD_I],
+        data: InferenceDataABC[PS_I, FD_I],
+    ):
+        self._predictor = predictor
+        self._prognostic_state = data.initial_condition
+        self._loader = iter(data.loader)
+        self._len = len(data.loader)
+        self._pending: PredictionPromise[PS_I, SD_I] | None = None
+
+    def __len__(self) -> int:
+        return self._len
+
+    def get_prognostic_state(self) -> PS_I:
+        return self._prognostic_state
+
+    def submit(self) -> PredictionPromise[PS_I, SD_I]:
+        """Load the next forcing batch and submit it to the predictor.
+
+        Raises ``StopIteration`` when the data loader is exhausted.
+        """
+        if self._pending is not None:
+            raise RuntimeError("commit() must be called before submit() again.")
+        timer = GlobalTimer.get_instance()
+        with timer.context("data_loading"):
+            forcing = next(self._loader)
+        self._pending = self._predictor.submit(
+            self._prognostic_state,
+            forcing,
+            compute_derived_variables=True,
+        )
+        return self._pending
+
+    def commit(self) -> SD_I:
+        """Resolve the pending promise, update internal state, return the output."""
+        if self._pending is None:
+            raise RuntimeError("submit() must be called before commit().")
+        sd, new_state = self._pending.resolve()
+        self._prognostic_state = new_state
+        self._pending = None
+        return sd
+
+
 class WandBStepLogger:
     """Logs inference metrics to wandb with step tracking and optional key prefixing.
 
@@ -112,6 +330,102 @@ class WandBStepLogger:
 
 def get_record_to_wandb(label: str = "") -> WandBStepLogger:
     return WandBStepLogger(label=label)
+
+
+class ConcurrentInferenceEntry(Generic[PS_I, FD_I, SD_I]):
+    """One inference run participating in a concurrent group.
+
+    Bundles the data, aggregator, writer, and log recorder for a single
+    inline-inference configuration so several can be passed to
+    ``run_concurrent_inference``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        data: InferenceDataABC[PS_I, FD_I],
+        aggregator: InferenceAggregatorABC[PS_I, SD_I],
+        writer: WriterABC[PS_I, SD_I] | None = None,
+        record_logs: Callable[[InferenceLogs], None] | None = None,
+    ):
+        self.name = name
+        self.data = data
+        self.aggregator = aggregator
+        self.writer: WriterABC[PS_I, SD_I] = (
+            writer if writer is not None else NullDataWriter()
+        )
+        self.record_logs: Callable[[InferenceLogs], None] = (
+            record_logs
+            if record_logs is not None
+            else get_record_to_wandb(label=name).log
+        )
+
+
+def run_concurrent_inference(
+    predictor: BatchedPredictor[PS_I, FD_I, SD_I],
+    entries: Sequence[ConcurrentInferenceEntry[PS_I, FD_I, SD_I]],
+):
+    """Run several inference data loaders concurrently through a shared predictor.
+
+    Each entry is independent in its data, aggregator, and writer, but they
+    share the predictor's underlying model. At each step, every still-active
+    entry submits its next forcing window and a single batched forward pass
+    produces all outputs. Entries whose loaders exhaust are dropped from
+    subsequent rounds, so this works for heterogeneous run lengths.
+    """
+    timer = GlobalTimer.get_instance()
+    loopers: dict[str, LazyLooper[PS_I, FD_I, SD_I]] = {}
+    n_windows: dict[str, int] = {}
+    windows_done: dict[str, int] = {}
+    entries_by_name: dict[str, ConcurrentInferenceEntry[PS_I, FD_I, SD_I]] = {}
+    for entry in entries:
+        entries_by_name[entry.name] = entry
+        looper = LazyLooper(predictor, entry.data)
+        loopers[entry.name] = looper
+        n_windows[entry.name] = len(looper)
+        windows_done[entry.name] = 0
+        with timer.context("aggregator"):
+            logs = entry.aggregator.record_initial_condition(
+                entry.data.initial_condition
+            )
+        with timer.context("wandb_logging"):
+            entry.record_logs(logs)
+        with timer.context("data_writer"):
+            entry.writer.write(entry.data.initial_condition, "initial_condition.nc")
+
+    active = dict(loopers)
+    while active:
+        submitted: list[str] = []
+        for name in list(active.keys()):
+            looper = active[name]
+            try:
+                looper.submit()
+            except StopIteration:
+                with timer.context("data_writer"):
+                    entries_by_name[name].writer.write(
+                        looper.get_prognostic_state(), "restart.nc"
+                    )
+                del active[name]
+                continue
+            submitted.append(name)
+        if not submitted:
+            break
+        for name in submitted:
+            looper = active[name]
+            sd = looper.commit()
+            windows_done[name] += 1
+            logging.info(
+                f"Concurrent inference {name!r}: processing output from "
+                f"window {windows_done[name]} of {n_windows[name]}."
+            )
+            entry = entries_by_name[name]
+            with timer.context("data_writer"):
+                entry.writer.append_batch(batch=sd)
+            with timer.context("aggregator"):
+                logs = entry.aggregator.record_batch(data=sd)
+            with timer.context("wandb_logging"):
+                entry.record_logs(logs)
+        predictor.reset()
 
 
 def run_inference(

--- a/fme/core/generics/test_batched_predictor.py
+++ b/fme/core/generics/test_batched_predictor.py
@@ -1,0 +1,479 @@
+"""Unit tests for BatchedPredictor, PredictionPromise, LazyLooper, and
+run_concurrent_inference using a fake predict function (no model needed)."""
+
+import unittest.mock
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import pytest
+
+from fme.core.generics.aggregator import InferenceAggregatorABC, InferenceSummary
+from fme.core.generics.data import SimpleInferenceData
+from fme.core.generics.inference import (
+    BatchedPredictor,
+    ConcurrentInferenceEntry,
+    LazyLooper,
+    PredictionPromise,
+    run_concurrent_inference,
+)
+from fme.core.generics.writer import NullDataWriter
+from fme.core.testing.wandb import mock_wandb
+from fme.core.timing import GlobalTimer
+
+
+@dataclass
+class FakeFD:
+    """Fake forcing-data batch: a list of integers, one per sample.
+
+    ``n_timesteps`` stands in for the window's time length: like the real
+    ``BatchData.cat``, ``_concat_fd`` refuses to concatenate windows whose
+    ``n_timesteps`` differ.
+    """
+
+    samples: list[int]
+    n_timesteps: int = 1
+
+
+@dataclass
+class FakePS:
+    """Fake prognostic state: a list of integers, one per sample."""
+
+    samples: list[int]
+
+
+@dataclass
+class FakeSD:
+    """Fake stepped-data batch: a list of integers, one per sample."""
+
+    samples: list[int]
+
+
+def _concat_fd(items: Sequence[FakeFD]) -> FakeFD:
+    out: list[int] = []
+    n_timesteps = items[0].n_timesteps
+    for item in items:
+        if item.n_timesteps != n_timesteps:
+            raise ValueError(
+                "Cannot cat FakeFD with different n_timesteps: "
+                f"{n_timesteps} != {item.n_timesteps}"
+            )
+        out.extend(item.samples)
+    return FakeFD(samples=out, n_timesteps=n_timesteps)
+
+
+def _concat_ps(items: Sequence[FakePS]) -> FakePS:
+    out: list[int] = []
+    for item in items:
+        out.extend(item.samples)
+    return FakePS(samples=out)
+
+
+def _split_sd(item: FakeSD, sample_sizes: Sequence[int]) -> list[FakeSD]:
+    out: list[FakeSD] = []
+    start = 0
+    for size in sample_sizes:
+        out.append(FakeSD(samples=list(item.samples[start : start + size])))
+        start += size
+    return out
+
+
+def _split_ps(item: FakePS, sample_sizes: Sequence[int]) -> list[FakePS]:
+    out: list[FakePS] = []
+    start = 0
+    for size in sample_sizes:
+        out.append(FakePS(samples=list(item.samples[start : start + size])))
+        start += size
+    return out
+
+
+def _sample_size_of_state(ps: FakePS) -> int:
+    return len(ps.samples)
+
+
+def _fake_predict(
+    initial_condition: FakePS,
+    forcing: FakeFD,
+    compute_derived_variables: bool = True,
+) -> tuple[FakeSD, FakePS]:
+    """Returns ic + forcing as next output; new state is the output."""
+    if len(initial_condition.samples) != len(forcing.samples):
+        raise AssertionError(
+            "Mismatched ic / forcing sample counts in fake predict: "
+            f"{len(initial_condition.samples)} vs {len(forcing.samples)}"
+        )
+    samples = [a + b for a, b in zip(initial_condition.samples, forcing.samples)]
+    return FakeSD(samples=samples), FakePS(samples=samples)
+
+
+def _make_predictor() -> BatchedPredictor[FakePS, FakeFD, FakeSD]:
+    return BatchedPredictor(
+        base_predict=_fake_predict,
+        concat_ic=_concat_ps,
+        concat_forcing=_concat_fd,
+        split_output=_split_sd,
+        split_state=_split_ps,
+        sample_size_of_state=_sample_size_of_state,
+    )
+
+
+def _make_keyed_predictor() -> BatchedPredictor[FakePS, FakeFD, FakeSD]:
+    """Like ``_make_predictor`` but keys forward passes on window length, so
+    only forcing windows of equal ``n_timesteps`` are batched together."""
+    return BatchedPredictor(
+        base_predict=_fake_predict,
+        concat_ic=_concat_ps,
+        concat_forcing=_concat_fd,
+        split_output=_split_sd,
+        split_state=_split_ps,
+        sample_size_of_state=_sample_size_of_state,
+        batch_key_of_forcing=lambda forcing: forcing.n_timesteps,
+    )
+
+
+def test_single_submission_resolves_to_underlying_predict():
+    predictor = _make_predictor()
+    promise = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1]))
+    sd, ps = promise.resolve()
+    assert sd.samples == [11]
+    assert ps.samples == [11]
+
+
+def test_two_submissions_share_one_forward_pass():
+    predictor = _make_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    p1 = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1]))
+    p2 = predictor.submit(FakePS(samples=[20, 30]), FakeFD(samples=[2, 3]))
+    sd1, ps1 = p1.resolve()
+    sd2, ps2 = p2.resolve()
+    assert mock_base.call_count == 1
+    merged_ic, merged_forcing, *_ = mock_base.call_args.args
+    assert merged_ic.samples == [10, 20, 30]
+    assert merged_forcing.samples == [1, 2, 3]
+    assert sd1.samples == [11]
+    assert sd2.samples == [22, 33]
+    assert ps1.samples == [11]
+    assert ps2.samples == [22, 33]
+
+
+def test_submissions_with_different_keys_use_separate_forward_passes():
+    """Windows whose batch keys differ cannot be concatenated, so each distinct
+    key gets its own forward pass; results stay aligned to their slots."""
+    predictor = _make_keyed_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    # Slots 0 and 2 share key (n_timesteps=74); slot 1 has key n_timesteps=3.
+    p0 = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1], n_timesteps=74))
+    p1 = predictor.submit(FakePS(samples=[20]), FakeFD(samples=[2], n_timesteps=3))
+    p2 = predictor.submit(FakePS(samples=[30]), FakeFD(samples=[3], n_timesteps=74))
+    sd0, _ = p0.resolve()
+    sd1, _ = p1.resolve()
+    sd2, _ = p2.resolve()
+    # One pass for the two n_timesteps=74 windows, one for the n_timesteps=3 one.
+    assert mock_base.call_count == 2
+    assert sd0.samples == [11]
+    assert sd1.samples == [22]
+    assert sd2.samples == [33]
+
+
+def test_resolve_is_idempotent():
+    predictor = _make_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    p = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1]))
+    r1 = p.resolve()
+    r2 = p.resolve()
+    assert r1 == r2
+    assert mock_base.call_count == 1
+
+
+def test_submit_after_flush_raises():
+    predictor = _make_predictor()
+    p = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1]))
+    p.resolve()
+    with pytest.raises(RuntimeError, match="Cannot submit after flush"):
+        predictor.submit(FakePS(samples=[20]), FakeFD(samples=[2]))
+
+
+def test_reset_allows_reuse():
+    predictor = _make_predictor()
+    p = predictor.submit(FakePS(samples=[10]), FakeFD(samples=[1]))
+    p.resolve()
+    predictor.reset()
+    p2 = predictor.submit(FakePS(samples=[20]), FakeFD(samples=[2]))
+    sd, _ = p2.resolve()
+    assert sd.samples == [22]
+
+
+def test_mismatched_compute_derived_variables_raises():
+    predictor = _make_predictor()
+    predictor.submit(
+        FakePS(samples=[1]), FakeFD(samples=[1]), compute_derived_variables=True
+    )
+    with pytest.raises(ValueError, match="compute_derived_variables"):
+        predictor.submit(
+            FakePS(samples=[2]),
+            FakeFD(samples=[2]),
+            compute_derived_variables=False,
+        )
+
+
+def test_flush_without_submissions_raises():
+    predictor = _make_predictor()
+    with pytest.raises(RuntimeError, match="no pending submissions"):
+        predictor._ensure_flushed()
+
+
+def test_lazy_looper_iterates_and_updates_state():
+    predictor = _make_predictor()
+    loader: list[FakeFD] = [FakeFD(samples=[1]), FakeFD(samples=[2])]
+    data = SimpleInferenceData(initial_condition=FakePS(samples=[0]), loader=loader)
+    looper = LazyLooper(predictor, data)
+    with GlobalTimer():
+        looper.submit()
+        sd = looper.commit()
+        assert sd.samples == [1]
+        assert looper.get_prognostic_state().samples == [1]
+        predictor.reset()
+        looper.submit()
+        sd = looper.commit()
+        assert sd.samples == [3]
+        assert looper.get_prognostic_state().samples == [3]
+        predictor.reset()
+        with pytest.raises(StopIteration):
+            looper.submit()
+
+
+def test_lazy_looper_double_submit_raises():
+    predictor = _make_predictor()
+    data = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[FakeFD(samples=[1])],
+    )
+    looper = LazyLooper(predictor, data)
+    with GlobalTimer():
+        looper.submit()
+        with pytest.raises(RuntimeError, match="commit"):
+            looper.submit()
+
+
+def test_lazy_looper_commit_without_submit_raises():
+    predictor = _make_predictor()
+    data = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[FakeFD(samples=[1])],
+    )
+    looper = LazyLooper(predictor, data)
+    with pytest.raises(RuntimeError, match="submit"):
+        looper.commit()
+
+
+class _FakeAggregator(InferenceAggregatorABC[FakePS, FakeSD]):
+    def __init__(self):
+        self.initial_conditions: list[FakePS] = []
+        self.batches: list[FakeSD] = []
+
+    def record_initial_condition(self, initial_condition: FakePS):
+        self.initial_conditions.append(initial_condition)
+        return []
+
+    def record_batch(self, data: FakeSD):
+        self.batches.append(data)
+        return []
+
+    def get_summary(self) -> InferenceSummary:
+        return InferenceSummary(logs={}, loss=None)
+
+    def flush_diagnostics(self, subdir):
+        pass
+
+
+def test_run_concurrent_inference_two_equal_length_runs():
+    predictor = _make_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    data_a = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[FakeFD(samples=[1]), FakeFD(samples=[1])],
+    )
+    data_b = SimpleInferenceData(
+        initial_condition=FakePS(samples=[100]),
+        loader=[FakeFD(samples=[10]), FakeFD(samples=[10])],
+    )
+    agg_a = _FakeAggregator()
+    agg_b = _FakeAggregator()
+    entries = [
+        ConcurrentInferenceEntry(
+            name="a",
+            data=data_a,
+            aggregator=agg_a,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+        ConcurrentInferenceEntry(
+            name="b",
+            data=data_b,
+            aggregator=agg_b,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+    ]
+    with GlobalTimer():
+        run_concurrent_inference(predictor, entries)
+    # One batched forward pass per window
+    assert mock_base.call_count == 2
+    assert [b.samples for b in agg_a.batches] == [[1], [2]]
+    assert [b.samples for b in agg_b.batches] == [[110], [120]]
+
+
+def test_run_concurrent_inference_heterogeneous_lengths():
+    """Loopers with shorter datasets drop out; remaining ones continue."""
+    predictor = _make_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    data_short = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[FakeFD(samples=[1])],
+    )
+    data_long = SimpleInferenceData(
+        initial_condition=FakePS(samples=[100]),
+        loader=[
+            FakeFD(samples=[10]),
+            FakeFD(samples=[10]),
+            FakeFD(samples=[10]),
+        ],
+    )
+    agg_short = _FakeAggregator()
+    agg_long = _FakeAggregator()
+    entries = [
+        ConcurrentInferenceEntry(
+            name="short",
+            data=data_short,
+            aggregator=agg_short,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+        ConcurrentInferenceEntry(
+            name="long",
+            data=data_long,
+            aggregator=agg_long,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+    ]
+    with GlobalTimer():
+        run_concurrent_inference(predictor, entries)
+    # 3 forward passes: first is batched (2 entries), next two are solo (long only)
+    assert mock_base.call_count == 3
+    assert [b.samples for b in agg_short.batches] == [[1]]
+    assert [b.samples for b in agg_long.batches] == [[110], [120], [130]]
+
+
+def test_run_concurrent_inference_mismatched_window_shapes():
+    """Regression: a shorter run reaches its short final window in the same
+    round a longer run still has a full window. Those windows
+    have different shapes (n_timesteps), so concatenating them must not be
+    attempted; each shape gets its own forward pass in that round."""
+    predictor = _make_keyed_predictor()
+    mock_base = unittest.mock.MagicMock(side_effect=_fake_predict)
+    predictor._base_predict = mock_base
+    # "short" runs two full windows then a short final window (n_timesteps 3).
+    data_short = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[
+            FakeFD(samples=[1], n_timesteps=74),
+            FakeFD(samples=[1], n_timesteps=74),
+            FakeFD(samples=[1], n_timesteps=3),
+        ],
+    )
+    # "long" runs four full windows; its window in round 3 is still full.
+    data_long = SimpleInferenceData(
+        initial_condition=FakePS(samples=[100]),
+        loader=[FakeFD(samples=[10], n_timesteps=74) for _ in range(4)],
+    )
+    agg_short = _FakeAggregator()
+    agg_long = _FakeAggregator()
+    entries = [
+        ConcurrentInferenceEntry(
+            name="short",
+            data=data_short,
+            aggregator=agg_short,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+        ConcurrentInferenceEntry(
+            name="long",
+            data=data_long,
+            aggregator=agg_long,
+            writer=NullDataWriter(),
+            record_logs=lambda logs: None,
+        ),
+    ]
+    with GlobalTimer():
+        run_concurrent_inference(predictor, entries)
+    # Rounds 1-2: one batched pass each (both full). Round 3: short's final
+    # window (n_timesteps=3) and long's full window split into two passes.
+    # Round 4: long alone. Total 1 + 1 + 2 + 1 = 5.
+    assert mock_base.call_count == 5
+    assert [b.samples for b in agg_short.batches] == [[1], [2], [3]]
+    assert [b.samples for b in agg_long.batches] == [[110], [120], [130], [140]]
+
+
+def test_run_concurrent_inference_writes_initial_and_restart():
+    predictor = _make_predictor()
+    data = SimpleInferenceData(
+        initial_condition=FakePS(samples=[5]),
+        loader=[FakeFD(samples=[1])],
+    )
+    agg = _FakeAggregator()
+    writer = unittest.mock.MagicMock(spec=NullDataWriter)
+    entry: ConcurrentInferenceEntry[FakePS, FakeFD, FakeSD] = ConcurrentInferenceEntry(
+        name="x",
+        data=data,
+        aggregator=agg,
+        writer=writer,
+        record_logs=lambda logs: None,
+    )
+    with GlobalTimer():
+        run_concurrent_inference(predictor, [entry])
+    write_calls = writer.write.call_args_list
+    filenames = [c.args[1] for c in write_calls]
+    assert filenames == ["initial_condition.nc", "restart.nc"]
+    assert agg.initial_conditions[0].samples == [5]
+
+
+def test_promise_resolve_returns_correct_slot():
+    predictor = _make_predictor()
+    p1 = predictor.submit(FakePS(samples=[0, 0]), FakeFD(samples=[1, 2]))
+    p2 = predictor.submit(FakePS(samples=[100]), FakeFD(samples=[3]))
+    p3 = predictor.submit(FakePS(samples=[0, 0, 0]), FakeFD(samples=[4, 5, 6]))
+    sd1, _ = p1.resolve()
+    sd3, _ = p3.resolve()
+    sd2, _ = p2.resolve()
+    assert sd1.samples == [1, 2]
+    assert sd2.samples == [103]
+    assert sd3.samples == [4, 5, 6]
+
+
+def test_isinstance_promise_type():
+    predictor = _make_predictor()
+    p = predictor.submit(FakePS(samples=[1]), FakeFD(samples=[1]))
+    assert isinstance(p, PredictionPromise)
+
+
+def test_concurrent_inference_default_record_logs_uses_wandb():
+    predictor = _make_predictor()
+    data = SimpleInferenceData(
+        initial_condition=FakePS(samples=[0]),
+        loader=[FakeFD(samples=[1])],
+    )
+    entry = ConcurrentInferenceEntry(
+        name="x",
+        data=data,
+        aggregator=_FakeAggregator(),
+    )
+    with mock_wandb() as wandb, GlobalTimer():
+        wandb.configure(log_to_wandb=True)
+        # Default record_logs comes from get_record_to_wandb; make sure the
+        # default path doesn't error even with empty logs.
+        run_concurrent_inference(predictor, [entry])

--- a/fme/core/generics/test_inference_callback.py
+++ b/fme/core/generics/test_inference_callback.py
@@ -1,15 +1,22 @@
-"""Unit tests for build_inference_callback's sequential dispatch (generic).
+"""Unit tests for build_inference_callback (generic, used by ACE and coupled).
 
-These cover the per-task sequential fan-out and the log/error aggregation
-shared by ACE and coupled training. (Concurrent grouping is added in a later
-change and tested alongside it.)"""
+Covers both the sequential per-task dispatch and the concurrent grouping that
+batches tasks sharing a ``concurrent_group`` through a single ``BatchedPredictor``."""
 
+from collections.abc import Sequence
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fme.core.generics.aggregator import InferenceSummary
+from fme.core.generics.aggregator import InferenceAggregatorABC, InferenceSummary
+from fme.core.generics.data import SimpleInferenceData
+from fme.core.generics.inference import BatchedPredictor
 from fme.core.generics.trainer import InferenceTask, build_inference_callback
+
+# ---------------------------------------------------------------------------
+# Sequential dispatch (no concurrent_group / build_batched_predictor)
+# ---------------------------------------------------------------------------
 
 
 def _make_task(name: str, weight: float = 0.0, epochs=(1,)) -> InferenceTask:
@@ -111,3 +118,267 @@ def test_weighted_task_without_loss_raises():
     )
     with mock, pytest.raises(RuntimeError, match="did not produce a loss"):
         callback(epoch=1)
+
+
+# ---------------------------------------------------------------------------
+# Concurrent grouping dispatch (build_batched_predictor + concurrent_group)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFD:
+    samples: list[int]
+
+
+@dataclass
+class _FakePS:
+    samples: list[int]
+
+
+@dataclass
+class _FakeSD:
+    samples: list[int]
+
+
+def _concat_fd(items: Sequence[_FakeFD]) -> _FakeFD:
+    out: list[int] = []
+    for item in items:
+        out.extend(item.samples)
+    return _FakeFD(samples=out)
+
+
+def _concat_ps(items: Sequence[_FakePS]) -> _FakePS:
+    out: list[int] = []
+    for item in items:
+        out.extend(item.samples)
+    return _FakePS(samples=out)
+
+
+def _split(item, sizes):
+    out = []
+    start = 0
+    for size in sizes:
+        out.append(type(item)(samples=list(item.samples[start : start + size])))
+        start += size
+    return out
+
+
+def _fake_predict(initial_condition, forcing, compute_derived_variables=True):
+    samples = [a + b for a, b in zip(initial_condition.samples, forcing.samples)]
+    return _FakeSD(samples=samples), _FakePS(samples=samples)
+
+
+class _CapturingAggregator(InferenceAggregatorABC):
+    """Fake inference aggregator returning a fixed summary (unprefixed logs)."""
+
+    def __init__(self, logs: dict[str, float], loss: float | None):
+        self._logs = logs
+        self._loss = loss
+        self.batches: list = []
+        self.flush_calls: list = []
+
+    def record_initial_condition(self, initial_condition):
+        return []
+
+    def record_batch(self, data):
+        self.batches.append(data)
+        return []
+
+    def get_summary(self) -> InferenceSummary:
+        return InferenceSummary(logs=dict(self._logs), loss=self._loss)
+
+    def flush_diagnostics(self, subdir):
+        self.flush_calls.append(subdir)
+
+
+def _make_stepper():
+    stepper = MagicMock()
+    stepper.set_eval = MagicMock()
+    stepper.predict_paired = MagicMock(side_effect=_fake_predict)
+    return stepper
+
+
+def _make_predictor(stepper) -> BatchedPredictor:
+    return BatchedPredictor(
+        base_predict=stepper.predict_paired,
+        concat_ic=_concat_ps,
+        concat_forcing=_concat_fd,
+        split_output=_split,
+        split_state=_split,
+        sample_size_of_state=lambda ps: len(ps.samples),
+    )
+
+
+def _make_grouped_task(
+    name: str,
+    logs: dict[str, float],
+    loss: float | None = None,
+    weight: float = 0.0,
+    concurrent_group=None,
+    n_windows: int = 2,
+):
+    data = SimpleInferenceData(
+        initial_condition=_FakePS(samples=[0]),
+        loader=[_FakeFD(samples=[i + 1]) for i in range(n_windows)],
+    )
+    aggregator = _CapturingAggregator(logs, loss)
+    return (
+        InferenceTask(
+            name=name,
+            data=data,
+            aggregator_factory=lambda: aggregator,
+            epoch_set=frozenset({1}),
+            weight=weight,
+            concurrent_group=concurrent_group,
+        ),
+        aggregator,
+    )
+
+
+def test_concurrent_group_batches_one_forward_per_window():
+    """Two tasks with same concurrent_group key share a single forward pass."""
+    stepper = _make_stepper()
+    task_a, agg_a = _make_grouped_task(
+        "a",
+        {"time_mean_norm/rmse/channel_mean": 0.1},
+        loss=0.1,
+        weight=1.0,
+        concurrent_group=(2,),
+    )
+    task_b, agg_b = _make_grouped_task(
+        "b",
+        {"time_mean_norm/rmse/channel_mean": 0.2},
+        loss=0.2,
+        weight=1.0,
+        concurrent_group=(2,),
+    )
+    callback = build_inference_callback(
+        tasks=[task_a, task_b],
+        inference_epochs=[1],
+        stepper=stepper,
+        build_batched_predictor=lambda: _make_predictor(stepper),
+    )
+    logs, error = callback(epoch=1)
+    # 2 windows shared across both tasks => 2 forward passes
+    assert stepper.predict_paired.call_count == 2
+    assert error == pytest.approx(0.1 + 0.2)
+    assert "a/time_mean_norm/rmse/channel_mean" in logs
+    assert "b/time_mean_norm/rmse/channel_mean" in logs
+    assert agg_a.flush_calls == ["epoch_0001"]
+    assert agg_b.flush_calls == ["epoch_0001"]
+
+
+def test_distinct_concurrent_groups_run_separately():
+    """Tasks with different concurrent_group keys do not share a forward pass."""
+    stepper = _make_stepper()
+    task_a, _ = _make_grouped_task(
+        "a",
+        {"time_mean_norm/rmse/channel_mean": 0.1},
+        loss=0.1,
+        weight=1.0,
+        concurrent_group=(2,),
+    )
+    task_b, _ = _make_grouped_task(
+        "b",
+        {"time_mean_norm/rmse/channel_mean": 0.2},
+        loss=0.2,
+        weight=1.0,
+        concurrent_group=(4,),
+    )
+    callback = build_inference_callback(
+        tasks=[task_a, task_b],
+        inference_epochs=[1],
+        stepper=stepper,
+        build_batched_predictor=lambda: _make_predictor(stepper),
+    )
+    # When groups differ, each task falls into its own group of size 1 — both
+    # use the sequential path, hitting inference_one_epoch.
+    with patch(
+        "fme.core.generics.trainer.inference_one_epoch",
+        side_effect=[
+            InferenceSummary(
+                logs={"a/time_mean_norm/rmse/channel_mean": 0.1}, loss=0.1
+            ),
+            InferenceSummary(
+                logs={"b/time_mean_norm/rmse/channel_mean": 0.2}, loss=0.2
+            ),
+        ],
+    ) as mock_inference:
+        logs, error = callback(epoch=1)
+    assert mock_inference.call_count == 2
+    assert error == pytest.approx(0.3)
+    assert {
+        "a/time_mean_norm/rmse/channel_mean",
+        "b/time_mean_norm/rmse/channel_mean",
+    } <= set(logs)
+
+
+def test_no_predictor_factory_runs_everything_sequentially():
+    """Without build_batched_predictor, concurrent_group is ignored."""
+    stepper = _make_stepper()
+    task_a, _ = _make_grouped_task(
+        "a",
+        {"time_mean_norm/rmse/channel_mean": 0.1},
+        loss=0.1,
+        weight=1.0,
+        concurrent_group=(2,),
+    )
+    task_b, _ = _make_grouped_task(
+        "b",
+        {"time_mean_norm/rmse/channel_mean": 0.2},
+        loss=0.2,
+        weight=1.0,
+        concurrent_group=(2,),
+    )
+    callback = build_inference_callback(
+        tasks=[task_a, task_b],
+        inference_epochs=[1],
+        stepper=stepper,
+    )
+    with patch(
+        "fme.core.generics.trainer.inference_one_epoch",
+        side_effect=[
+            InferenceSummary(
+                logs={"a/time_mean_norm/rmse/channel_mean": 0.1}, loss=0.1
+            ),
+            InferenceSummary(
+                logs={"b/time_mean_norm/rmse/channel_mean": 0.2}, loss=0.2
+            ),
+        ],
+    ) as mock_inference:
+        logs, error = callback(epoch=1)
+    assert mock_inference.call_count == 2
+    assert error == pytest.approx(0.3)
+
+
+def test_heterogeneous_lengths_in_concurrent_group():
+    """A short task can drop out mid-group while others continue."""
+    stepper = _make_stepper()
+    task_short, agg_short = _make_grouped_task(
+        "short",
+        {"time_mean_norm/rmse/channel_mean": 0.1},
+        loss=0.1,
+        weight=1.0,
+        concurrent_group=(2,),
+        n_windows=1,
+    )
+    task_long, agg_long = _make_grouped_task(
+        "long",
+        {"time_mean_norm/rmse/channel_mean": 0.2},
+        loss=0.2,
+        weight=1.0,
+        concurrent_group=(2,),
+        n_windows=3,
+    )
+    callback = build_inference_callback(
+        tasks=[task_short, task_long],
+        inference_epochs=[1],
+        stepper=stepper,
+        build_batched_predictor=lambda: _make_predictor(stepper),
+    )
+    logs, error = callback(epoch=1)
+    # First window batched (2), remaining 2 windows solo (long only)
+    assert stepper.predict_paired.call_count == 3
+    assert len(agg_short.batches) == 1
+    assert len(agg_long.batches) == 3
+    assert error == pytest.approx(0.3)

--- a/fme/core/generics/test_inference_concurrent_equivalence.py
+++ b/fme/core/generics/test_inference_concurrent_equivalence.py
@@ -14,8 +14,16 @@ effectively fully concurrent and so never exercise the sequential reference
 path. The two scenarios below cover exactly those cases:
 
 * a heterogeneous-length pair -- a short task reaching its final window in the
-  same round a longer task submits a full window, and
-* an ensemble task (``n_ensemble_per_ic > 1``) on distinct start dates.
+  same round a longer task submits a full window (#1279 window-shape
+  partitioning), and
+* two tasks on distinct per-sample start dates batched together in one
+  concurrent group, so the cat/split round trip must preserve each sample's
+  start date (the #1282 broadcast_ensemble fix was a time-coordinate ordering
+  bug of this kind).
+
+Both scenarios assert that the concurrent path really shared forward passes
+(fewer ``predict`` calls than sequential), so they cannot pass by silently
+falling back to per-task inference.
 """
 
 import dataclasses
@@ -48,7 +56,6 @@ from fme.core.timing import GlobalTimer
 IN_NAMES = ["forcing", "prognostic"]
 OUT_NAMES = ["prognostic", "diagnostic"]
 ALL_NAMES = list(set(IN_NAMES + OUT_NAMES))
-FORCING_NAMES = sorted(set(IN_NAMES) - set(OUT_NAMES))
 N_LAT, N_LON, NZ = 2, 4, 3
 
 
@@ -142,11 +149,9 @@ class _RecordingAggregator(InferenceAggregatorABC):
     """
 
     def __init__(self):
-        self.initial_condition: PrognosticState | None = None
         self.batches: list[PairedData] = []
 
     def record_initial_condition(self, initial_condition):
-        self.initial_condition = initial_condition
         return []
 
     def record_batch(self, data: PairedData):
@@ -279,25 +284,35 @@ def test_concurrent_equals_sequential_heterogeneous_lengths():
     assert con_calls == 4
 
 
-def test_concurrent_equals_sequential_ensemble_distinct_start_dates():
-    """A weather-like task with n_ensemble_per_ic > 1 on distinct start dates.
+def test_concurrent_equals_sequential_distinct_start_dates():
+    """Two tasks on distinct per-sample start dates, batched in one group.
 
-    Distinct per-sample start times exercise the broadcast_ensemble
-    time-coordinate ordering fixed in #1282, which the concurrent cat/split
-    must preserve.
+    Both tasks submit equal-shape windows every round, so the concurrent path
+    cats their samples into a single forward pass. The samples carry distinct
+    per-sample start dates (mirroring an ensemble laid out over multiple
+    initial-condition dates, e.g. n_ic dates x n_ensemble_per_ic members), so
+    the cat/split round trip must keep each sample paired with its own start
+    date -- exactly the time-coordinate ordering that #1282 got wrong.
     """
     stepper = _make_stepper()
-    # Two distinct initial-condition dates, each broadcast to two ensemble
-    # members (n_ic=2, n_ensemble_per_ic=2 => 4 samples). The per-sample start
-    # offsets mirror the broadcast_ensemble layout (repeat_interleave over the
-    # date dimension), so the cat/split round trip must preserve each sample's
-    # distinct start date.
-    ic, windows = _make_windows(
-        n_samples=4,
-        window_timesteps=[2, 2],
-        start_offsets=[0, 0, 7, 7],
+    # Two initial-condition dates, each with two members (4 samples), with
+    # distinct per-sample start offsets so a misordered cat/split would corrupt
+    # the per-sample time coordinate.
+    ic_a, windows_a = _make_windows(
+        n_samples=4, window_timesteps=[2, 2], start_offsets=[0, 0, 30, 30]
     )
-    tasks = {"weather": (ic, windows)}
-    seq_aggs, seq_summaries, _ = _run_sequential(stepper, tasks)
-    con_aggs, con_summaries, _ = _run_concurrent(stepper, tasks)
+    ic_b, windows_b = _make_windows(
+        n_samples=4, window_timesteps=[2, 2], start_offsets=[100, 100, 130, 130]
+    )
+    tasks = {
+        "weather_a": (ic_a, windows_a),
+        "weather_b": (ic_b, windows_b),
+    }
+    seq_aggs, seq_summaries, seq_calls = _run_sequential(stepper, tasks)
+    con_aggs, con_summaries, con_calls = _run_concurrent(stepper, tasks)
     _assert_tasks_equivalent(seq_aggs, seq_summaries, con_aggs, con_summaries)
+    # Sequential: 2 windows x 2 tasks = 4 forward passes. Concurrent cats the
+    # two tasks' equal-shape windows into one pass per round (2 total), so the
+    # distinct-start-date samples really went through the concurrent cat/split.
+    assert seq_calls == 4
+    assert con_calls == 2

--- a/fme/core/generics/test_inference_concurrent_equivalence.py
+++ b/fme/core/generics/test_inference_concurrent_equivalence.py
@@ -1,0 +1,303 @@
+"""End-to-end equivalence test: concurrent inline inference == sequential.
+
+Builds one small *real* ACE stepper and runs the same inference tasks through
+both the sequential path (``run_inference``) and the concurrent path
+(``run_concurrent_inference`` via ``BatchedPredictor``), then asserts the
+predicted fields, derived variables, and aggregator metric logs match up to
+rounding error.
+
+This locks in the concurrent==sequential invariant. The two concurrent-only
+divergences seen in production -- the #1279 window-shape (heterogeneous-length)
+cat crash and the #1282 broadcast_ensemble time-coordinate ordering -- were
+caught only empirically on beaker, because the production configs are
+effectively fully concurrent and so never exercise the sequential reference
+path. The two scenarios below cover exactly those cases:
+
+* a heterogeneous-length pair -- a short task reaching its final window in the
+  same round a longer task submits a full window, and
+* an ensemble task (``n_ensemble_per_ic > 1``) on distinct start dates.
+"""
+
+import dataclasses
+import datetime
+import unittest.mock
+
+import numpy as np
+import torch
+import xarray as xr
+
+import fme
+from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
+from fme.ace.stepper.single_module import StepperConfig
+from fme.core.coordinates import HybridSigmaPressureCoordinate, LatLonCoordinates
+from fme.core.dataset_info import DatasetInfo
+from fme.core.generics.aggregator import InferenceAggregatorABC, InferenceSummary
+from fme.core.generics.data import SimpleInferenceData
+from fme.core.generics.inference import (
+    BatchedPredictor,
+    ConcurrentInferenceEntry,
+    run_concurrent_inference,
+    run_inference,
+)
+from fme.core.registry.module import ModuleSelector
+from fme.core.step.single_module import SingleModuleStepConfig
+from fme.core.step.step import StepSelector
+from fme.core.testing import trivial_network_and_loss_normalization
+from fme.core.timing import GlobalTimer
+
+IN_NAMES = ["forcing", "prognostic"]
+OUT_NAMES = ["prognostic", "diagnostic"]
+ALL_NAMES = list(set(IN_NAMES + OUT_NAMES))
+FORCING_NAMES = sorted(set(IN_NAMES) - set(OUT_NAMES))
+N_LAT, N_LON, NZ = 2, 4, 3
+
+
+class _DeterministicStep(torch.nn.Module):
+    """Like the test_looper ChannelSum, but with a deterministic diagnostic."""
+
+    def forward(self, x):
+        summed = torch.sum(x, dim=-3, keepdim=True)
+        return torch.concat([x, summed], dim=-3)
+
+
+def _make_stepper():
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": _DeterministicStep()}
+                    ),
+                    in_names=IN_NAMES,
+                    out_names=OUT_NAMES,
+                    normalization=trivial_network_and_loss_normalization(ALL_NAMES),
+                ),
+            ),
+        ),
+    )
+    return config.get_stepper(
+        dataset_info=DatasetInfo(
+            horizontal_coordinates=LatLonCoordinates(
+                lat=torch.zeros(N_LAT), lon=torch.zeros(N_LON)
+            ),
+            vertical_coordinate=HybridSigmaPressureCoordinate(
+                ak=torch.arange(NZ), bk=torch.arange(NZ)
+            ),
+            timestep=datetime.timedelta(hours=6),
+        ),
+    )
+
+
+def _time_coord(n_samples: int, n_timesteps: int, start: int) -> xr.DataArray:
+    base = np.arange(start, start + n_timesteps)
+    return xr.DataArray(
+        np.repeat(base[None, :], n_samples, axis=0),
+        dims=["sample", "time"],
+    )
+
+
+def _make_windows(
+    n_samples: int,
+    window_timesteps: list[int],
+    start_offsets: list[int] | None = None,
+):
+    """Build a deterministic list of forcing windows + the initial condition.
+
+    ``window_timesteps`` gives the number of timesteps in each successive
+    window (allowing a short final window). Windows carry all variables
+    (prediction targets + forcing) so the paired output has reference data for
+    every channel. Consecutive windows advance the time coordinate by one step
+    of overlap. ``start_offsets`` (length ``n_samples``) gives a per-sample
+    additive time offset, used to place samples on distinct start dates.
+    """
+    device = fme.get_device()
+    windows: list[BatchData] = []
+    start = 0
+    for n_timesteps in window_timesteps:
+        if start_offsets is not None:
+            time = xr.concat(
+                [_time_coord(1, n_timesteps, start + off) for off in start_offsets],
+                dim="sample",
+            )
+        else:
+            time = _time_coord(n_samples, n_timesteps, start)
+        data = {
+            name: torch.rand(n_samples, n_timesteps, N_LAT, N_LON, device=device)
+            for name in ALL_NAMES
+        }
+        windows.append(BatchData.new_on_device(data=data, time=time, labels=None))
+        start += n_timesteps - 1
+    initial_condition = windows[0].get_start(
+        prognostic_names=["prognostic"], n_ic_timesteps=1
+    )
+    return initial_condition, windows
+
+
+class _RecordingAggregator(InferenceAggregatorABC):
+    """Captures the initial condition and every recorded PairedData batch.
+
+    ``get_summary`` returns a deterministic metric derived from the recorded
+    predictions, so that comparing summaries exercises the metric-log path too.
+    """
+
+    def __init__(self):
+        self.initial_condition: PrognosticState | None = None
+        self.batches: list[PairedData] = []
+
+    def record_initial_condition(self, initial_condition):
+        self.initial_condition = initial_condition
+        return []
+
+    def record_batch(self, data: PairedData):
+        self.batches.append(data)
+        return []
+
+    def get_summary(self) -> InferenceSummary:
+        logs: dict[str, float] = {}
+        for name in OUT_NAMES:
+            stacked = torch.cat([b.prediction[name] for b in self.batches], dim=1)
+            logs[f"time_mean/{name}"] = float(stacked.mean().item())
+        return InferenceSummary(logs=logs, loss=logs["time_mean/prognostic"])
+
+    def flush_diagnostics(self, subdir):
+        pass
+
+
+def _make_predictor(base_predict) -> BatchedPredictor:
+    return BatchedPredictor(
+        base_predict=base_predict,
+        concat_ic=PrognosticState.cat,
+        concat_forcing=BatchData.cat,
+        split_output=lambda sd, sizes: sd.split(sizes),
+        split_state=lambda ps, sizes: ps.split(sizes),
+        sample_size_of_state=lambda ic: ic.as_batch_data().time.shape[0],
+        batch_key_of_forcing=lambda forcing: forcing.n_timesteps,
+    )
+
+
+def _counting_predict(stepper):
+    """Wrap predict_paired in a Mock that delegates to the real method."""
+    return unittest.mock.MagicMock(side_effect=stepper.predict_paired)
+
+
+def _run_sequential(stepper, tasks):
+    summaries = {}
+    aggregators = {}
+    predict = _counting_predict(stepper)
+    for name, (ic, windows) in tasks.items():
+        agg = _RecordingAggregator()
+        aggregators[name] = agg
+        with torch.no_grad(), GlobalTimer():
+            run_inference(
+                predict=predict,
+                data=SimpleInferenceData(ic, list(windows)),
+                aggregator=agg,
+                record_logs=lambda logs: None,
+            )
+        summaries[name] = agg.get_summary()
+    return aggregators, summaries, predict.call_count
+
+
+def _run_concurrent(stepper, tasks):
+    aggregators = {name: _RecordingAggregator() for name in tasks}
+    entries = [
+        ConcurrentInferenceEntry(
+            name=name,
+            data=SimpleInferenceData(ic, list(windows)),
+            aggregator=aggregators[name],
+            record_logs=lambda logs: None,
+        )
+        for name, (ic, windows) in tasks.items()
+    ]
+    predict = _counting_predict(stepper)
+    predictor = _make_predictor(predict)
+    with torch.no_grad(), GlobalTimer():
+        run_concurrent_inference(predictor, entries)
+    summaries = {name: aggregators[name].get_summary() for name in tasks}
+    return aggregators, summaries, predict.call_count
+
+
+def _assert_paired_close(a: PairedData, b: PairedData):
+    assert set(a.prediction) == set(b.prediction)
+    assert set(a.reference) == set(b.reference)
+    for name in a.prediction:
+        torch.testing.assert_close(
+            a.prediction[name], b.prediction[name], rtol=1e-6, atol=1e-6
+        )
+    for name in a.reference:
+        torch.testing.assert_close(
+            a.reference[name], b.reference[name], rtol=1e-6, atol=1e-6
+        )
+    assert a.time.equals(b.time)
+
+
+def _assert_tasks_equivalent(seq_aggs, seq_summaries, con_aggs, con_summaries):
+    assert set(seq_aggs) == set(con_aggs)
+    for name in seq_aggs:
+        seq_batches = seq_aggs[name].batches
+        con_batches = con_aggs[name].batches
+        assert len(seq_batches) == len(con_batches), name
+        for sb, cb in zip(seq_batches, con_batches):
+            _assert_paired_close(sb, cb)
+        assert set(seq_summaries[name].logs) == set(con_summaries[name].logs)
+        for key in seq_summaries[name].logs:
+            np.testing.assert_allclose(
+                seq_summaries[name].logs[key],
+                con_summaries[name].logs[key],
+                rtol=1e-6,
+                atol=1e-6,
+            )
+        assert seq_summaries[name].loss == con_summaries[name].loss
+
+
+def test_concurrent_equals_sequential_heterogeneous_lengths():
+    """A short task and a long task share a group; the short one ends first.
+
+    With one step of overlap per window, the short task submits a single short
+    window while the long task submits full windows, reproducing the #1279
+    mismatched-window-shape situation the concurrent cat must tolerate.
+    """
+    stepper = _make_stepper()
+    # Both tasks submit a full 3-timestep window in round 1 (batched together),
+    # then the short task submits a 2-timestep final window in round 2 while the
+    # long task submits another full window (different shapes, same round), then
+    # the long task finishes alone in round 3.
+    short_ic, short_windows = _make_windows(n_samples=2, window_timesteps=[3, 2])
+    long_ic, long_windows = _make_windows(n_samples=2, window_timesteps=[3, 3, 3])
+    tasks = {
+        "short": (short_ic, short_windows),
+        "long": (long_ic, long_windows),
+    }
+    seq_aggs, seq_summaries, seq_calls = _run_sequential(stepper, tasks)
+    con_aggs, con_summaries, con_calls = _run_concurrent(stepper, tasks)
+    _assert_tasks_equivalent(seq_aggs, seq_summaries, con_aggs, con_summaries)
+    # Sequential: 2 + 3 = 5 forward passes. Concurrent batches the matching
+    # round-1 windows into one pass (4 total), proving the tasks really shared a
+    # forward pass rather than silently falling back to per-task inference.
+    assert seq_calls == 5
+    assert con_calls == 4
+
+
+def test_concurrent_equals_sequential_ensemble_distinct_start_dates():
+    """A weather-like task with n_ensemble_per_ic > 1 on distinct start dates.
+
+    Distinct per-sample start times exercise the broadcast_ensemble
+    time-coordinate ordering fixed in #1282, which the concurrent cat/split
+    must preserve.
+    """
+    stepper = _make_stepper()
+    # Two distinct initial-condition dates, each broadcast to two ensemble
+    # members (n_ic=2, n_ensemble_per_ic=2 => 4 samples). The per-sample start
+    # offsets mirror the broadcast_ensemble layout (repeat_interleave over the
+    # date dimension), so the cat/split round trip must preserve each sample's
+    # distinct start date.
+    ic, windows = _make_windows(
+        n_samples=4,
+        window_timesteps=[2, 2],
+        start_offsets=[0, 0, 7, 7],
+    )
+    tasks = {"weather": (ic, windows)}
+    seq_aggs, seq_summaries, _ = _run_sequential(stepper, tasks)
+    con_aggs, con_summaries, _ = _run_concurrent(stepper, tasks)
+    _assert_tasks_equivalent(seq_aggs, seq_summaries, con_aggs, con_summaries)

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -58,7 +58,7 @@ import signal
 import sys
 import time
 import uuid
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import Any, ClassVar, Generic, Protocol, TypeVar
 
 import torch
@@ -73,7 +73,12 @@ from fme.core.generics.aggregator import (
     InferenceSummary,
 )
 from fme.core.generics.data import GriddedDataABC, InferenceDataABC
-from fme.core.generics.inference import run_inference
+from fme.core.generics.inference import (
+    BatchedPredictor,
+    ConcurrentInferenceEntry,
+    run_concurrent_inference,
+    run_inference,
+)
 from fme.core.generics.lr_tuning import (
     LRTuningConfig,
     ValidateStepper,
@@ -876,6 +881,11 @@ class InferenceTask(Generic[PS, FD, SD]):
         epoch_set: Epochs on which this task should run.
         weight: Contribution weight for the combined checkpoint-selection error.
             Zero means the task runs but does not contribute to the metric.
+        concurrent_group: Tasks sharing this key are eligible to run together
+            through a single batched forward pass per step. ``None`` disables
+            concurrent batching for this task. Ignored when no
+            ``build_batched_predictor`` is supplied to
+            ``build_inference_callback``.
     """
 
     name: str
@@ -883,18 +893,22 @@ class InferenceTask(Generic[PS, FD, SD]):
     aggregator_factory: Callable[[], InferenceAggregatorABC[PS, SD]]
     epoch_set: frozenset[int]
     weight: float = 0.0
+    concurrent_group: Hashable | None = None
 
 
 def build_inference_callback(
     tasks: Sequence[InferenceTask[PS, FD, SD]],
     inference_epochs: Sequence[int],
     stepper: TrainStepperABC[PS, BD, FD, SD, TO],
+    build_batched_predictor: (Callable[[], BatchedPredictor[PS, FD, SD]] | None) = None,
 ) -> InferenceCallback:
     """Build an ``InferenceCallback`` shared between ACE and coupled training.
 
-    Each active task is run through the sequential ``inference_one_epoch`` path
-    and produces an ``InferenceSummary``; the per-task summaries are then
-    combined into the epoch's logs and weighted checkpoint-selection error.
+    When ``build_batched_predictor`` is supplied, tasks that share a non-None
+    ``concurrent_group`` are run together through a single ``BatchedPredictor``
+    so each forward pass covers all of them. Tasks with ``concurrent_group=None``
+    or in a singleton group fall back to the sequential ``inference_one_epoch``
+    path. Either path produces the same per-task ``InferenceSummary``.
     """
     inference_epochs_set = set(inference_epochs)
 
@@ -905,10 +919,37 @@ def build_inference_callback(
         if not active_tasks:
             return {}, None
 
+        groups: dict[Hashable, list[InferenceTask[PS, FD, SD]]] = {}
+        solo_tasks: list[InferenceTask[PS, FD, SD]] = []
+        if build_batched_predictor is None:
+            solo_tasks = list(active_tasks)
+        else:
+            for task in active_tasks:
+                if task.concurrent_group is None:
+                    solo_tasks.append(task)
+                else:
+                    groups.setdefault(task.concurrent_group, []).append(task)
+
         per_task_summaries: dict[str, InferenceSummary] = {}
-        for task in active_tasks:
+        for task in solo_tasks:
             per_task_summaries[task.name] = _run_inference_task_sequential(
                 task=task, stepper=stepper, epoch=epoch
+            )
+        for group_tasks in groups.values():
+            if len(group_tasks) == 1:
+                task = group_tasks[0]
+                per_task_summaries[task.name] = _run_inference_task_sequential(
+                    task=task, stepper=stepper, epoch=epoch
+                )
+                continue
+            assert build_batched_predictor is not None  # narrowed by branch above
+            per_task_summaries.update(
+                _run_inference_tasks_concurrent(
+                    tasks=group_tasks,
+                    stepper=stepper,
+                    epoch=epoch,
+                    predictor=build_batched_predictor(),
+                )
             )
 
         all_logs: dict[str, Any] = {}
@@ -952,6 +993,41 @@ def _run_inference_task_sequential(
         label=task.name,
         epoch=epoch,
     )
+
+
+def _run_inference_tasks_concurrent(
+    tasks: Sequence[InferenceTask[PS, FD, SD]],
+    stepper: TrainStepperABC[PS, BD, FD, SD, TO],
+    epoch: int,
+    predictor: BatchedPredictor[PS, FD, SD],
+) -> dict[str, InferenceSummary]:
+    """Run a group of inference tasks together through a single batched predictor.
+
+    Each task keeps its own aggregator, so the returned per-task summaries are
+    identical to what the sequential path would produce for the same tasks.
+    """
+    aggregators = {t.name: t.aggregator_factory() for t in tasks}
+    entries: list[ConcurrentInferenceEntry[PS, FD, SD]] = [
+        ConcurrentInferenceEntry(
+            name=t.name,
+            data=t.data,
+            aggregator=aggregators[t.name],
+        )
+        for t in tasks
+    ]
+    stepper.set_eval()
+    with torch.no_grad(), GlobalTimer():
+        run_concurrent_inference(predictor, entries)
+    out: dict[str, InferenceSummary] = {}
+    for task in tasks:
+        aggregator = aggregators[task.name]
+        logging.info(f"Starting flush of reduced diagnostics to disk for {task.name!r}")
+        aggregator.flush_diagnostics(subdir=f"epoch_{epoch:04d}")
+        logging.info(f"Getting inline inference aggregator summary for {task.name!r}")
+        summary = aggregator.get_summary()
+        prefixed_logs = {f"{task.name}/{k}": v for k, v in summary.logs.items()}
+        out[task.name] = InferenceSummary(logs=prefixed_logs, loss=summary.loss)
+    return out
 
 
 def _restore_checkpoint(trainer: Trainer, checkpoint_path):

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -12,6 +12,7 @@ from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.distributed import Distributed
 from fme.core.ema import EMATracker
 from fme.core.generics.data import GriddedDataABC
+from fme.core.generics.inference import BatchedPredictor
 from fme.core.generics.lr_tuning import ValidateStepper
 from fme.core.generics.train_stepper import TrainStepperABC
 from fme.core.generics.trainer import (
@@ -25,6 +26,7 @@ from fme.core.generics.trainer import (
 )
 from fme.core.generics.validation import run_validation_loop
 from fme.coupled.aggregator import OneStepAggregator, TrainAggregator
+from fme.coupled.data_loading.batch_data import CoupledBatchData, CoupledPrognosticState
 from fme.coupled.data_loading.gridded_data import InferenceGriddedData
 from fme.coupled.dataset_info import CoupledDatasetInfo
 from fme.coupled.stepper import CoupledTrainOutput, CoupledTrainStepper
@@ -143,13 +145,31 @@ def get_inference_callback(
                 ),
                 epoch_set=frozenset(inference_epoch_sets[i]),
                 weight=entry_config.weight,
+                concurrent_group=(entry_config.coupled_steps_in_memory,),
             )
+        )
+
+    def build_predictor() -> BatchedPredictor:
+        return BatchedPredictor(
+            base_predict=stepper.predict_paired,
+            concat_ic=CoupledPrognosticState.cat,
+            concat_forcing=CoupledBatchData.cat,
+            split_output=lambda sd, sizes: sd.split(sizes),
+            split_state=lambda ps, sizes: ps.split(sizes),
+            sample_size_of_state=lambda ic: (
+                ic.as_batch_data().ocean_data.time.shape[0]
+            ),
+            batch_key_of_forcing=lambda forcing: (
+                forcing.ocean_data.n_timesteps,
+                forcing.atmosphere_data.n_timesteps,
+            ),
         )
 
     return build_inference_callback(
         tasks=tasks,
         inference_epochs=inference_epochs,
         stepper=stepper,
+        build_batched_predictor=build_predictor,
     )
 
 


### PR DESCRIPTION
Splits the stuck concurrent-inline-inference PR #1195 into a reviewable 3-PR chain. This is **PR 3 of 3** (base: the PR 2 branch `cinf/pr2-callback-refactor`). Adds the concurrent inline-inference feature on top of the sequential callback refactor, **plus** the concurrent-vs-sequential equivalence test that #1195 was missing. Together PRs 1+2+3 reproduce #1195's content (reconciled with `main`) plus that test.

Changes:
- `fme.core.generics.inference` — `BatchedPredictor`, `PredictionPromise`, `ConcurrentInferenceEntry`, and `run_concurrent_inference`, including the window-shape partitioning (`batch_key_of_forcing`) that is the #1279 mismatched-window concurrent-cat fix.
- `fme.core.generics.trainer` — `concurrent_group` on `InferenceTask`, `_run_inference_tasks_concurrent`, and the grouping branch in `build_inference_callback` (group by `concurrent_group`; singleton / `None` groups fall back to the sequential helper), plus the `build_batched_predictor` parameter. Both paths return per-task `InferenceSummary`, so concurrent and sequential are interchangeable.
- `fme.ace.train.train` / `fme.coupled.train.train` — wire `build_predictor` and set `concurrent_group` (`(forward_steps_in_memory, n_ensemble_per_ic)` for ACE, `(coupled_steps_in_memory,)` for coupled).
- `fme.ace.stepper.single_module` — compare IC-vs-forcing labels with semantic equality so concurrently-cat'd labels (which may differ in encoding) still pass.

- [x] Tests added:
  - `fme/core/generics/test_batched_predictor.py` and the concurrent-grouping tests in `fme/core/generics/test_inference_callback.py`.
  - **New equivalence test** `fme/core/generics/test_inference_concurrent_equivalence.py`: builds one small real stepper and runs the same tasks through both `run_inference` (sequential) and `run_concurrent_inference` (concurrent), asserting equal predicted fields, derived variables, and aggregator metric logs (`torch.testing.assert_close`, tight rtol/atol). Covers the two production-divergent paths — a heterogeneous-length pair (a short task reaching its final window while a longer task submits a full window in the same round → #1279 partitioning, verified by a forward-pass count showing the tasks really shared a pass) and an ensemble task (`n_ensemble_per_ic > 1`) on distinct start dates (→ #1282 broadcast_ensemble time-coordinate ordering). These divergences were previously caught only empirically on beaker, because production configs are effectively fully concurrent and never run the sequential reference path.
- [ ] If dependencies changed, "deps only" image rebuilt — n/a.

---
**Stacked chain** (replaces #1195; review bottom-up):
1. `cat`/`split` helpers → `main`
2. callback refactor → PR 1 branch
3. **This PR** — concurrent inference + equivalence test → PR 2 branch

Supersedes #1195.
