### PR TITLE
Fail loud when a NaN reaches the network input

### DIFF
--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -2507,6 +2507,49 @@ def test_train_on_batch_masked_variable_has_zero_loss_count():
     assert stepped.per_channel_losses["a"].count == n_samples
 
 
+def test_train_on_batch_unmasked_nan_forcing_raises():
+    """A NaN forcing not covered by data_mask raises a located error.
+
+    Without the guard this silently propagates to a NaN loss with no
+    indication that an unmasked forcing variable was the cause (cf. PR #1262).
+    """
+    n_samples = 2
+    data: BatchData = get_data(["a", "b"], n_samples=n_samples, n_time=2).data
+    data.data["b"][1] = torch.nan  # NaN forcing, no data_mask to cover it
+    config = _get_stepper_config(["a", "b"], ["a"], module_name="ChannelSum")
+    stepper = _get_train_stepper(config, loss=StepLossConfig(type="MSE"))
+    with pytest.raises(ValueError, match=r"NaN found in network input.*\bb\b"):
+        stepper.train_on_batch(data=data, optimization=NullOptimization())
+
+
+def test_step_unmasked_nan_input_raises():
+    """A NaN input not covered by data_mask raises a located error in step()."""
+    stepper = _get_stepper(["a", "b"], ["a"], module_name="ChannelSum")
+    n_samples = 2
+    input_data = {x: torch.rand(n_samples, 5, 5).to(DEVICE) for x in ["a", "b"]}
+    input_data["b"][1] = torch.nan
+    with pytest.raises(ValueError, match=r"NaN found in network input.*\bb\b"):
+        stepper.step(StepArgs(input=input_data, next_step_input_data={}, labels=None))
+
+
+def test_step_masked_nan_input_does_not_raise():
+    """A NaN input covered by data_mask is zeroed, so the guard does not fire."""
+    stepper = _get_stepper(["a", "b"], ["a"], module_name="ChannelSum")
+    n_samples = 2
+    input_data = {x: torch.rand(n_samples, 5, 5).to(DEVICE) for x in ["a", "b"]}
+    input_data["b"][1] = torch.nan
+    data_mask = {"b": torch.tensor([True, False], dtype=torch.bool, device=DEVICE)}
+    output, _ = stepper.step(
+        StepArgs(
+            input=input_data,
+            next_step_input_data={},
+            labels=None,
+            data_mask=data_mask,
+        )
+    )
+    assert not torch.isnan(output["a"]).any()
+
+
 def test_predict_with_data_mask_zeros_masked_forcing():
     """Masked forcing variable is zeroed in normalized space before the forward pass."""
     n_steps = 1

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -383,6 +383,14 @@ class SingleModuleStep(StepABC):
             if args.data_mask is not None:
                 input_norm = _apply_input_mask(input_norm, args.data_mask)
             input_tensor = self.in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
+            # Fail loud if a NaN survives to the network input. This only happens
+            # when an input variable contains NaN that was neither covered by
+            # data_mask nor filled by fill_nans_on_normalize, which otherwise
+            # propagates silently to a NaN loss with no clue which variable (or
+            # that masking was the cause) -- see PR #1262. Gated on grad-enabled
+            # so the no_grad inference/eval rollout hot path pays no sync cost.
+            if torch.is_grad_enabled() and torch.isnan(input_tensor).any():
+                _raise_input_nan_error(input_norm)
             if self._config.include_channel_mask_inputs:
                 mask_dict = _build_channel_mask_dict(
                     self.in_packer.names, args.data_mask, input_tensor
@@ -445,6 +453,22 @@ class SingleModuleStep(StepABC):
         self.module.load_state(module)
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
+
+
+def _raise_input_nan_error(input_norm: TensorMapping) -> None:
+    """Raise a located error naming the input variable(s) that still hold NaN.
+
+    Called only once the cheap packed-tensor NaN check has fired, so the
+    per-variable scan here is off the hot path.
+    """
+    nan_names = sorted(k for k, v in input_norm.items() if torch.isnan(v).any())
+    raise ValueError(
+        "NaN found in network input for variable(s) "
+        f"{nan_names} after input masking and normalization. An input/forcing "
+        "variable likely contains NaN that is not covered by data_mask; ensure "
+        "the data_mask passed to the stepper includes every input variable that "
+        "may be masked (cf. PR #1262), or enable fill_nans_on_normalize."
+    )
 
 
 def _apply_input_mask(input_norm: TensorDict, data_mask: TensorMapping) -> TensorDict:


### PR DESCRIPTION
Masked-data handling currently fails silently: if an input/forcing variable contains a NaN that is neither covered by `data_mask` nor filled by `fill_nans_on_normalize`, the NaN propagates through the network and surfaces only as a NaN loss, with no indication of which variable caused it or that masking was the issue. This is exactly the failure mode fixed in #1262 (ensemble training reading `data_mask` from the wrong, prognostic-only source so masked forcing variables were never zeroed). The existing `Optimization._validate_loss` only catches the symptom — much later, training-only, and with an unhelpful "Loss is NaN-valued" message.

This PR adds a guard at the network-input boundary in `SingleModuleStep` that raises a `ValueError` naming the offending variable(s) the moment a NaN survives masking and normalization, so a mis-wired or missing mask is caught immediately and located rather than debugged backwards from a NaN loss.

The guard is gated on `torch.is_grad_enabled()` so the `no_grad` inference/eval rollout hot path pays no added device-sync cost; the cheap packed-tensor `.any()` check runs first, and the per-variable scan that builds the message only runs on the error path.

Changes:
- `fme.core.step.single_module.SingleModuleStep.step`: raise (via new `_raise_input_nan_error`) when a NaN survives `_apply_input_mask` to the packed network input, under `torch.is_grad_enabled()`.
- `fme.core.step.single_module._raise_input_nan_error`: helper that names the NaN-bearing input variable(s) in the error message.
- Tests: unmasked NaN forcing now raises in `train_on_batch`; `step()` raises on unmasked NaN input and stays silent on a properly masked NaN input.

Relationship to #1262: this guard is complementary. With #1262's fix, a properly masked forcing NaN is zeroed and the guard stays quiet; without a correct mask (the #1262 bug), training now raises a clear, located error instead of silently producing NaN loss. Note that #1262 adds `test_train_on_batch_unmasked_nan_forcing_produces_nan_loss_in_ensemble`, which asserts the old silent-NaN-loss behavior; once both land, that test should be updated to assert the raised error instead.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
