### PR TITLE
Integrating sea ice into coupled data loaders

### DIFF
--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -124,6 +124,8 @@ class OneStepAggregator(AggregatorABC[CoupledTrainOutput]):
         self._loss_atmos = torch.tensor(0.0, device=get_device())
         self._n_batches = 0
         config = OneStepAggregatorConfig()
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         self._aggregators = {
             "ocean": config.build(
                 dataset_info=dataset_info.ocean,
@@ -329,6 +331,8 @@ class InferenceEvaluatorAggregatorConfig:
         else:
             log_zonal_mean_images = self.log_zonal_mean_images
 
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         ocean_metrics = self._build_metrics(
             include_nino34=True,
             n_timesteps=n_timesteps_ocean,
@@ -467,6 +471,12 @@ class InferenceEvaluatorAggregator(
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:
+        assert (
+            data.ocean_data is not None
+            and data.atmosphere_data is not None
+            and self.ocean is not None
+            and self.atmosphere is not None
+        )
         if self._num_channels_ocean is None:
             self._num_channels_ocean = len(data.ocean_data.prediction)
         if self._num_channels_atmos is None:
@@ -487,6 +497,12 @@ class InferenceEvaluatorAggregator(
 
         May only be recorded once, before any calls to record_batch.
         """
+        assert (
+            self.ocean is not None
+            and self.atmosphere is not None
+            and initial_condition.ocean_data is not None
+            and initial_condition.atmosphere_data is not None
+        )
         ocean_logs = self.ocean.record_initial_condition(initial_condition.ocean_data)
         atmos_logs = self.atmosphere.record_initial_condition(
             initial_condition.atmosphere_data
@@ -568,6 +584,8 @@ class InferenceAggregatorConfig:
         n_timesteps_atmosphere: int,
         output_dir: str,
     ) -> "InferenceAggregator":
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         ocean_ace_config = AceInferenceAggregatorConfig(
             time_mean_reference_data=self.ocean_time_mean_reference_data,
             log_global_mean_time_series=self.log_global_mean_time_series,
@@ -628,6 +646,12 @@ class InferenceAggregator(
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:
+        assert (
+            data.ocean_data is not None
+            and data.atmosphere_data is not None
+            and self.ocean is not None
+            and self.atmosphere is not None
+        )
         ocean_logs = self.ocean.record_batch(data.ocean_data)
         atmos_logs = self.atmosphere.record_batch(data.atmosphere_data)
         n_times_ocean = data.ocean_data.time["time"].size
@@ -644,6 +668,12 @@ class InferenceAggregator(
 
         May only be recorded once, before any calls to record_batch.
         """
+        assert (
+            self.ocean is not None
+            and self.atmosphere is not None
+            and initial_condition.ocean_data is not None
+            and initial_condition.atmosphere_data is not None
+        )
         ocean_logs = self.ocean.record_initial_condition(initial_condition.ocean_data)
         atmos_logs = self.atmosphere.record_initial_condition(
             initial_condition.atmosphere_data
@@ -652,6 +682,8 @@ class InferenceAggregator(
         return _combine_logs(ocean_logs, atmos_logs, n_atmos_steps_per_ocean_step=1)
 
     def get_summary(self) -> InferenceSummary:
+        assert self.ocean is not None
+        assert self.atmosphere is not None
         ocean_summary = self.ocean.get_summary()
         atmos_summary = self.atmosphere.get_summary()
         duplicates = set(ocean_summary.logs.keys()) & set(atmos_summary.logs.keys())

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -124,6 +124,8 @@ class OneStepAggregator(AggregatorABC[CoupledTrainOutput]):
         self._loss_atmos = torch.tensor(0.0, device=get_device())
         self._n_batches = 0
         config = OneStepAggregatorConfig()
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         self._aggregators = {
             "ocean": config.build(
                 dataset_info=dataset_info.ocean,
@@ -329,6 +331,8 @@ class InferenceEvaluatorAggregatorConfig:
         else:
             log_zonal_mean_images = self.log_zonal_mean_images
 
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         ocean_metrics = self._build_metrics(
             include_nino34=True,
             n_timesteps=n_timesteps_ocean,
@@ -467,6 +471,8 @@ class InferenceEvaluatorAggregator(
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:
+        assert data.ocean_data is not None
+        assert data.atmosphere_data is not None
         if self._num_channels_ocean is None:
             self._num_channels_ocean = len(data.ocean_data.prediction)
         if self._num_channels_atmos is None:
@@ -487,6 +493,8 @@ class InferenceEvaluatorAggregator(
 
         May only be recorded once, before any calls to record_batch.
         """
+        assert initial_condition.ocean_data is not None
+        assert initial_condition.atmosphere_data is not None
         ocean_logs = self.ocean.record_initial_condition(initial_condition.ocean_data)
         atmos_logs = self.atmosphere.record_initial_condition(
             initial_condition.atmosphere_data
@@ -576,6 +584,8 @@ class InferenceAggregatorConfig:
             time_mean_reference_data=self.atmosphere_time_mean_reference_data,
             log_global_mean_time_series=self.log_global_mean_time_series,
         )
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         ocean_agg = ocean_ace_config.build(
             dataset_info=dataset_info.ocean,
             n_timesteps=n_timesteps_ocean,
@@ -628,6 +638,8 @@ class InferenceAggregator(
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:
+        assert data.ocean_data is not None
+        assert data.atmosphere_data is not None
         ocean_logs = self.ocean.record_batch(data.ocean_data)
         atmos_logs = self.atmosphere.record_batch(data.atmosphere_data)
         n_times_ocean = data.ocean_data.time["time"].size
@@ -644,6 +656,8 @@ class InferenceAggregator(
 
         May only be recorded once, before any calls to record_batch.
         """
+        assert initial_condition.ocean_data is not None
+        assert initial_condition.atmosphere_data is not None
         ocean_logs = self.ocean.record_initial_condition(initial_condition.ocean_data)
         atmos_logs = self.atmosphere.record_initial_condition(
             initial_condition.atmosphere_data

--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -124,8 +124,6 @@ class OneStepAggregator(AggregatorABC[CoupledTrainOutput]):
         self._loss_atmos = torch.tensor(0.0, device=get_device())
         self._n_batches = 0
         config = OneStepAggregatorConfig()
-        assert dataset_info.ocean is not None
-        assert dataset_info.atmosphere is not None
         self._aggregators = {
             "ocean": config.build(
                 dataset_info=dataset_info.ocean,
@@ -331,8 +329,6 @@ class InferenceEvaluatorAggregatorConfig:
         else:
             log_zonal_mean_images = self.log_zonal_mean_images
 
-        assert dataset_info.ocean is not None
-        assert dataset_info.atmosphere is not None
         ocean_metrics = self._build_metrics(
             include_nino34=True,
             n_timesteps=n_timesteps_ocean,
@@ -471,8 +467,6 @@ class InferenceEvaluatorAggregator(
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:
-        assert data.ocean_data is not None
-        assert data.atmosphere_data is not None
         if self._num_channels_ocean is None:
             self._num_channels_ocean = len(data.ocean_data.prediction)
         if self._num_channels_atmos is None:
@@ -493,8 +487,6 @@ class InferenceEvaluatorAggregator(
 
         May only be recorded once, before any calls to record_batch.
         """
-        assert initial_condition.ocean_data is not None
-        assert initial_condition.atmosphere_data is not None
         ocean_logs = self.ocean.record_initial_condition(initial_condition.ocean_data)
         atmos_logs = self.atmosphere.record_initial_condition(
             initial_condition.atmosphere_data
@@ -584,8 +576,6 @@ class InferenceAggregatorConfig:
             time_mean_reference_data=self.atmosphere_time_mean_reference_data,
             log_global_mean_time_series=self.log_global_mean_time_series,
         )
-        assert dataset_info.ocean is not None
-        assert dataset_info.atmosphere is not None
         ocean_agg = ocean_ace_config.build(
             dataset_info=dataset_info.ocean,
             n_timesteps=n_timesteps_ocean,
@@ -638,8 +628,6 @@ class InferenceAggregator(
 
     @torch.no_grad()
     def record_batch(self, data: CoupledPairedData) -> InferenceLogs:
-        assert data.ocean_data is not None
-        assert data.atmosphere_data is not None
         ocean_logs = self.ocean.record_batch(data.ocean_data)
         atmos_logs = self.atmosphere.record_batch(data.atmosphere_data)
         n_times_ocean = data.ocean_data.time["time"].size
@@ -656,8 +644,6 @@ class InferenceAggregator(
 
         May only be recorded once, before any calls to record_batch.
         """
-        assert initial_condition.ocean_data is not None
-        assert initial_condition.atmosphere_data is not None
         ocean_logs = self.ocean.record_initial_condition(initial_condition.ocean_data)
         atmos_logs = self.atmosphere.record_initial_condition(
             initial_condition.atmosphere_data

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 import numpy as np
 
 from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
+from fme.core.coordinates import NullDeriveFn
 from fme.core.labels import LabelEncoding
 from fme.core.typing_ import TensorDict, TensorMapping
 from fme.coupled.data_loading.data_typing import CoupledDatasetItem
@@ -20,81 +21,146 @@ class CoupledPrognosticState:
     evolving forward in time.
     """
 
-    def __init__(self, ocean_data: PrognosticState, atmosphere_data: PrognosticState):
+    def __init__(
+        self,
+        ocean_data: PrognosticState | None = None,
+        ice_data: PrognosticState | None = None,
+        atmosphere_data: PrognosticState | None = None,
+    ):
         self.ocean_data = ocean_data
+        self.ice_data = ice_data
         self.atmosphere_data = atmosphere_data
 
     def to_device(self) -> "CoupledPrognosticState":
-        return CoupledPrognosticState(
-            self.ocean_data.to_device(), self.atmosphere_data.to_device()
-        )
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if self.ocean_data is not None:
+            ocean_device = self.ocean_data.to_device()
+        if self.ice_data is not None:
+            ice_device = self.ice_data.to_device()
+        if self.atmosphere_data is not None:
+            atmos_device = self.atmosphere_data.to_device()
+        return CoupledPrognosticState(ocean_device, ice_device, atmos_device)
 
     def as_batch_data(self) -> "CoupledBatchData":
-        return CoupledBatchData(
-            self.ocean_data.as_batch_data(), self.atmosphere_data.as_batch_data()
-        )
+        ocean_batch = None
+        ice_batch = None
+        atmos_batch = None
+        if self.ocean_data is not None:
+            ocean_batch = self.ocean_data.as_batch_data()
+        if self.ice_data is not None:
+            ice_batch = self.ice_data.as_batch_data()
+        if self.atmosphere_data is not None:
+            atmos_batch = self.atmosphere_data.as_batch_data()
+        return CoupledBatchData(ocean_batch, ice_batch, atmos_batch)
 
 
 @dataclasses.dataclass
 class CoupledBatchData:
-    ocean_data: BatchData
-    atmosphere_data: BatchData
+    ocean_data: BatchData | None = None
+    ice_data: BatchData | None = None
+    atmosphere_data: BatchData | None = None
 
     def to_device(self) -> "CoupledBatchData":
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if self.ocean_data is not None:
+            ocean_device = self.ocean_data.to_device()
+        if self.ice_data is not None:
+            ice_device = self.ice_data.to_device()
+        if self.atmosphere_data is not None:
+            atmos_device = self.atmosphere_data.to_device()
         return self.__class__(
-            ocean_data=self.ocean_data.to_device(),
-            atmosphere_data=self.atmosphere_data.to_device(),
+            ocean_data=ocean_device,
+            ice_data=ice_device,
+            atmosphere_data=atmos_device,
         )
 
     @classmethod
     def new_on_device(
         cls,
-        ocean_data: BatchData,
-        atmosphere_data: BatchData,
+        ocean_data: BatchData | None = None,
+        ice_data: BatchData | None = None,
+        atmosphere_data: BatchData | None = None,
     ) -> "CoupledBatchData":
-        ocean_batch = ocean_data.to_device()
-        atmos_batch = atmosphere_data.to_device()
-        return CoupledBatchData(ocean_data=ocean_batch, atmosphere_data=atmos_batch)
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if ocean_data is not None:
+            ocean_device = ocean_data.to_device()
+        if ice_data is not None:
+            ice_device = ice_data.to_device()
+        if atmosphere_data is not None:
+            atmos_device = atmosphere_data.to_device()
+        return CoupledBatchData(
+            ocean_data=ocean_device, ice_data=ice_device, atmosphere_data=atmos_device
+        )
 
     @classmethod
     def new_on_cpu(
         cls,
-        ocean_data: BatchData,
-        atmosphere_data: BatchData,
+        ocean_data: BatchData | None = None,
+        ice_data: BatchData | None = None,
+        atmosphere_data: BatchData | None = None,
     ) -> "CoupledBatchData":
-        ocean_batch = ocean_data.to_cpu()
-        atmos_batch = atmosphere_data.to_cpu()
-        return CoupledBatchData(ocean_data=ocean_batch, atmosphere_data=atmos_batch)
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if ocean_data is not None:
+            ocean_device = ocean_data.to_cpu()
+        if ice_data is not None:
+            ice_device = ice_data.to_cpu()
+        if atmosphere_data is not None:
+            atmos_device = atmosphere_data.to_cpu()
+        return CoupledBatchData(
+            ocean_data=ocean_device, ice_data=ice_device, atmosphere_data=atmos_device
+        )
 
     @classmethod
     def collate_fn(
         cls,
         samples: Sequence[CoupledDatasetItem],
-        ocean_horizontal_dims: list[str],
-        atmosphere_horizontal_dims: list[str],
         sample_dim_name: str = "sample",
+        ocean_horizontal_dims: list[str] | None = None,
+        ice_horizontal_dims: list[str] | None = None,
+        atmosphere_horizontal_dims: list[str] | None = None,
         ocean_label_encoding: LabelEncoding | None = None,
+        ice_label_encoding: LabelEncoding | None = None,
         atmosphere_label_encoding: LabelEncoding | None = None,
     ) -> "CoupledBatchData":
         """
-        Collate function for use with PyTorch DataLoader. Separates out ocean
-        and atmosphere sample tuples and constructs BatchData instances for
-        each of the two components.
+        Collate function for use with PyTorch DataLoader. Separates out ocean,
+        ice, and atmosphere sample tuples and constructs BatchData instances for
+        each component.
 
         """
-        ocean_data = BatchData.from_sample_tuples(
-            [x.ocean for x in samples],
-            horizontal_dims=ocean_horizontal_dims,
-            sample_dim_name=sample_dim_name,
-            label_encoding=ocean_label_encoding,
-        )
-        atmosphere_data = BatchData.from_sample_tuples(
-            [x.atmosphere for x in samples],
-            horizontal_dims=atmosphere_horizontal_dims,
-            sample_dim_name=sample_dim_name,
-            label_encoding=atmosphere_label_encoding,
-        )
-        return CoupledBatchData.new_on_cpu(ocean_data, atmosphere_data)
+        ocean_data = None
+        if ocean_horizontal_dims is not None:
+            ocean_data = BatchData.from_sample_tuples(
+                [x.ocean for x in samples],
+                horizontal_dims=ocean_horizontal_dims,
+                sample_dim_name=sample_dim_name,
+                label_encoding=ocean_label_encoding,
+            )
+        ice_data = None
+        if ice_horizontal_dims is not None:
+            ice_data = BatchData.from_sample_tuples(
+                [x.ice for x in samples],
+                horizontal_dims=ice_horizontal_dims,
+                sample_dim_name=sample_dim_name,
+                label_encoding=ice_label_encoding,
+            )
+        atmosphere_data = None
+        if atmosphere_horizontal_dims is not None:
+            atmosphere_data = BatchData.from_sample_tuples(
+                [x.atmosphere for x in samples],
+                horizontal_dims=atmosphere_horizontal_dims,
+                sample_dim_name=sample_dim_name,
+                label_encoding=atmosphere_label_encoding,
+            )
+        return CoupledBatchData.new_on_cpu(ocean_data, ice_data, atmosphere_data)
 
     def get_start(
         self: SelfType,
@@ -103,55 +169,104 @@ class CoupledBatchData:
         """
         Get the initial condition state.
         """
-        return CoupledPrognosticState(
-            ocean_data=self.ocean_data.get_start(
+        ocean_data = None
+        if self.ocean_data is not None:
+            ocean_data = self.ocean_data.get_start(
                 requirements.ocean.names,
                 requirements.ocean.n_timesteps,
-            ),
-            atmosphere_data=self.atmosphere_data.get_start(
+            )
+        ice_data = None
+        if self.ice_data is not None:
+            ice_data = self.ice_data.get_start(
+                requirements.ice.names,
+                requirements.ice.n_timesteps,
+            )
+        atmosphere_data = None
+        if self.atmosphere_data is not None:
+            atmosphere_data = self.atmosphere_data.get_start(
                 requirements.atmosphere.names,
                 requirements.atmosphere.n_timesteps,
-            ),
+            )
+        return CoupledPrognosticState(
+            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
         )
 
     def prepend(self: SelfType, initial_condition: CoupledPrognosticState) -> SelfType:
-        return self.__class__(
-            ocean_data=self.ocean_data.prepend(initial_condition.ocean_data),
-            atmosphere_data=self.atmosphere_data.prepend(
+        ocean_data = None
+        if self.ocean_data is not None:
+            ocean_data = self.ocean_data.prepend(initial_condition.ocean_data)
+        ice_data = None
+        if self.ice_data is not None:
+            ice_data = self.ice_data.prepend(initial_condition.ice_data)
+        atmosphere_data = None
+        if self.atmosphere_data is not None:
+            atmosphere_data = self.atmosphere_data.prepend(
                 initial_condition.atmosphere_data
-            ),
+            )
+        return self.__class__(
+            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
         )
 
     def remove_initial_condition(
         self: SelfType,
-        n_ic_timesteps_ocean: int,
-        n_ic_timesteps_atmosphere: int,
+        n_ic_timesteps_ocean: int | None = None,
+        n_ic_timesteps_ice: int | None = None,
+        n_ic_timesteps_atmosphere: int | None = None,
     ) -> SelfType:
-        return self.__class__(
-            ocean_data=self.ocean_data.remove_initial_condition(n_ic_timesteps_ocean),
-            atmosphere_data=self.atmosphere_data.remove_initial_condition(
+        ocean_data = None
+        if self.ocean_data is not None:
+            ocean_data = self.ocean_data.remove_initial_condition(n_ic_timesteps_ocean)
+        ice_data = None
+        if self.ice_data is not None:
+            ice_data = self.ice_data.remove_initial_condition(n_ic_timesteps_ice)
+        atmosphere_data = None
+        if self.atmosphere_data is not None:
+            atmosphere_data = self.atmosphere_data.remove_initial_condition(
                 n_ic_timesteps_atmosphere
-            ),
+            )
+        return self.__class__(
+            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
         )
 
     def compute_derived_variables(
         self: SelfType,
-        ocean_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict],
-        atmosphere_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict],
         forcing_data: SelfType,
+        ocean_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict]
+        | None = None,
+        ice_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict]
+        | None = None,
+        atmosphere_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict]
+        | None = None,
     ) -> SelfType:
-        return self.__class__(
-            ocean_data=self.ocean_data.compute_derived_variables(
+        ocean_data = None
+        if self.ocean_data is not None:
+            ocean_data = self.ocean_data.compute_derived_variables(
                 ocean_derive_func, forcing_data.ocean_data
-            ),
-            atmosphere_data=self.atmosphere_data.compute_derived_variables(
+            )
+        ice_data = None
+        if self.ice_data is not None:
+            if isinstance(ice_derive_func, NullDeriveFn):
+                ice_data = self.ice_data
+            else:
+                ice_data = self.ice_data.compute_derived_variables(
+                    ice_derive_func, forcing_data.ice_data
+                )
+        atmosphere_data = None
+        if self.atmosphere_data is not None:
+            atmosphere_data = self.atmosphere_data.compute_derived_variables(
                 atmosphere_derive_func, forcing_data.atmosphere_data
-            ),
+            )
+        return self.__class__(
+            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
         )
 
     def pin_memory(self: SelfType) -> SelfType:
-        self.ocean_data = self.ocean_data.pin_memory()
-        self.atmosphere_data = self.atmosphere_data.pin_memory()
+        if self.ocean_data is not None:
+            self.ocean_data = self.ocean_data.pin_memory()
+        if self.ice_data is not None:
+            self.ice_data = self.ice_data.pin_memory()
+        if self.atmosphere_data is not None:
+            self.atmosphere_data = self.atmosphere_data.pin_memory()
         return self
 
 
@@ -162,8 +277,9 @@ class CoupledPairedData:
     prediction and target data.
     """
 
-    ocean_data: PairedData
-    atmosphere_data: PairedData
+    ocean_data: PairedData | None = None
+    ice_data: PairedData | None = None
+    atmosphere_data: PairedData | None = None
 
     @classmethod
     def from_coupled_batch_data(
@@ -171,30 +287,51 @@ class CoupledPairedData:
         prediction: CoupledBatchData,
         reference: CoupledBatchData,
     ) -> "CoupledPairedData":
-        if not np.all(
-            prediction.ocean_data.time.values == reference.ocean_data.time.values
-        ):
-            raise ValueError(
-                "Prediction and target ocean time coordinate must be the same."
-            )
-        if not np.all(
-            prediction.atmosphere_data.time.values
-            == reference.atmosphere_data.time.values
-        ):
-            raise ValueError(
-                "Prediction and target atmosphere time coordinate must be the same."
-            )
-        return CoupledPairedData(
-            ocean_data=PairedData(
+        ocean_data = None
+        if prediction.ocean_data is not None:
+            if not np.all(
+                prediction.ocean_data.time.values == reference.ocean_data.time.values
+            ):
+                raise ValueError(
+                    "Prediction and target ocean time coordinate must be the same."
+                )
+            ocean_data = PairedData(
                 prediction=prediction.ocean_data.data,
                 reference=reference.ocean_data.data,
                 time=prediction.ocean_data.time,
                 labels=prediction.ocean_data.labels,
-            ),
-            atmosphere_data=PairedData(
+            )
+        ice_data = None
+        if prediction.ice_data is not None:
+            if not np.all(
+                prediction.ice_data.time.values == reference.ice_data.time.values
+            ):
+                raise ValueError(
+                    "Prediction and target ice time coordinate must be the same."
+                )
+            ice_data = PairedData(
+                prediction=prediction.ice_data.data,
+                reference=reference.ice_data.data,
+                time=prediction.ice_data.time,
+                labels=prediction.ice_data.labels,
+            )
+        atmosphere_data = None
+        if prediction.atmosphere_data is not None:
+            if not np.all(
+                prediction.atmosphere_data.time.values
+                == reference.atmosphere_data.time.values
+            ):
+                raise ValueError(
+                    "Prediction and target atmosphere time coordinate must be the same."
+                )
+            atmosphere_data = PairedData(
                 prediction=prediction.atmosphere_data.data,
                 reference=reference.atmosphere_data.data,
                 time=prediction.atmosphere_data.time,
                 labels=prediction.atmosphere_data.labels,
-            ),
+            )
+        return CoupledPairedData(
+            ocean_data=ocean_data,
+            ice_data=ice_data,
+            atmosphere_data=atmosphere_data,
         )

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -1,11 +1,12 @@
 import dataclasses
 from collections.abc import Callable, Sequence
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import numpy as np
 
 from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
 from fme.core.coordinates import NullDeriveFn
+from fme.core.dataset.dataset import DatasetItem
 from fme.core.labels import LabelEncoding
 from fme.core.typing_ import TensorDict, TensorMapping
 from fme.coupled.data_loading.data_typing import CoupledDatasetItem
@@ -139,7 +140,7 @@ class CoupledBatchData:
         ocean_data = None
         if ocean_horizontal_dims is not None:
             ocean_data = BatchData.from_sample_tuples(
-                [x.ocean for x in samples],
+                [cast(DatasetItem, x.ocean) for x in samples],
                 horizontal_dims=ocean_horizontal_dims,
                 sample_dim_name=sample_dim_name,
                 label_encoding=ocean_label_encoding,
@@ -147,7 +148,7 @@ class CoupledBatchData:
         ice_data = None
         if ice_horizontal_dims is not None:
             ice_data = BatchData.from_sample_tuples(
-                [x.ice for x in samples],
+                [cast(DatasetItem, x.ice) for x in samples],
                 horizontal_dims=ice_horizontal_dims,
                 sample_dim_name=sample_dim_name,
                 label_encoding=ice_label_encoding,
@@ -155,7 +156,7 @@ class CoupledBatchData:
         atmosphere_data = None
         if atmosphere_horizontal_dims is not None:
             atmosphere_data = BatchData.from_sample_tuples(
-                [x.atmosphere for x in samples],
+                [cast(DatasetItem, x.atmosphere) for x in samples],
                 horizontal_dims=atmosphere_horizontal_dims,
                 sample_dim_name=sample_dim_name,
                 label_encoding=atmosphere_label_encoding,
@@ -171,18 +172,21 @@ class CoupledBatchData:
         """
         ocean_data = None
         if self.ocean_data is not None:
+            assert requirements.ocean is not None
             ocean_data = self.ocean_data.get_start(
                 requirements.ocean.names,
                 requirements.ocean.n_timesteps,
             )
         ice_data = None
         if self.ice_data is not None:
+            assert requirements.ice is not None
             ice_data = self.ice_data.get_start(
                 requirements.ice.names,
                 requirements.ice.n_timesteps,
             )
         atmosphere_data = None
         if self.atmosphere_data is not None:
+            assert requirements.atmosphere is not None
             atmosphere_data = self.atmosphere_data.get_start(
                 requirements.atmosphere.names,
                 requirements.atmosphere.n_timesteps,
@@ -194,12 +198,15 @@ class CoupledBatchData:
     def prepend(self: SelfType, initial_condition: CoupledPrognosticState) -> SelfType:
         ocean_data = None
         if self.ocean_data is not None:
+            assert initial_condition.ocean_data is not None
             ocean_data = self.ocean_data.prepend(initial_condition.ocean_data)
         ice_data = None
         if self.ice_data is not None:
+            assert initial_condition.ice_data is not None
             ice_data = self.ice_data.prepend(initial_condition.ice_data)
         atmosphere_data = None
         if self.atmosphere_data is not None:
+            assert initial_condition.atmosphere_data is not None
             atmosphere_data = self.atmosphere_data.prepend(
                 initial_condition.atmosphere_data
             )
@@ -215,12 +222,15 @@ class CoupledBatchData:
     ) -> SelfType:
         ocean_data = None
         if self.ocean_data is not None:
+            assert n_ic_timesteps_ocean is not None
             ocean_data = self.ocean_data.remove_initial_condition(n_ic_timesteps_ocean)
         ice_data = None
         if self.ice_data is not None:
+            assert n_ic_timesteps_ice is not None
             ice_data = self.ice_data.remove_initial_condition(n_ic_timesteps_ice)
         atmosphere_data = None
         if self.atmosphere_data is not None:
+            assert n_ic_timesteps_atmosphere is not None
             atmosphere_data = self.atmosphere_data.remove_initial_condition(
                 n_ic_timesteps_atmosphere
             )
@@ -240,6 +250,8 @@ class CoupledBatchData:
     ) -> SelfType:
         ocean_data = None
         if self.ocean_data is not None:
+            assert ocean_derive_func is not None
+            assert forcing_data.ocean_data is not None
             ocean_data = self.ocean_data.compute_derived_variables(
                 ocean_derive_func, forcing_data.ocean_data
             )
@@ -248,11 +260,15 @@ class CoupledBatchData:
             if isinstance(ice_derive_func, NullDeriveFn):
                 ice_data = self.ice_data
             else:
+                assert ice_derive_func is not None
+                assert forcing_data.ice_data is not None
                 ice_data = self.ice_data.compute_derived_variables(
                     ice_derive_func, forcing_data.ice_data
                 )
         atmosphere_data = None
         if self.atmosphere_data is not None:
+            assert atmosphere_derive_func is not None
+            assert forcing_data.atmosphere_data is not None
             atmosphere_data = self.atmosphere_data.compute_derived_variables(
                 atmosphere_derive_func, forcing_data.atmosphere_data
             )
@@ -289,6 +305,7 @@ class CoupledPairedData:
     ) -> "CoupledPairedData":
         ocean_data = None
         if prediction.ocean_data is not None:
+            assert reference.ocean_data is not None
             if not np.all(
                 prediction.ocean_data.time.values == reference.ocean_data.time.values
             ):
@@ -303,6 +320,7 @@ class CoupledPairedData:
             )
         ice_data = None
         if prediction.ice_data is not None:
+            assert reference.ice_data is not None
             if not np.all(
                 prediction.ice_data.time.values == reference.ice_data.time.values
             ):
@@ -317,6 +335,7 @@ class CoupledPairedData:
             )
         atmosphere_data = None
         if prediction.atmosphere_data is not None:
+            assert reference.atmosphere_data is not None
             if not np.all(
                 prediction.atmosphere_data.time.values
                 == reference.atmosphere_data.time.values

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -1,4 +1,3 @@
-import dataclasses
 from collections.abc import Callable, Sequence
 from typing import TypeVar, cast
 
@@ -28,56 +27,72 @@ class CoupledPrognosticState:
         ice_data: PrognosticState | None = None,
         atmosphere_data: PrognosticState | None = None,
     ):
-        self.ocean_data = ocean_data
-        self.ice_data = ice_data
-        self.atmosphere_data = atmosphere_data
+        self._components: dict[str, PrognosticState] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean_data),
+                ("ice", ice_data),
+                ("atmosphere", atmosphere_data),
+            ]
+            if val is not None
+        }
+
+    @property
+    def ocean_data(self) -> PrognosticState | None:
+        return self._components.get("ocean")
+
+    @property
+    def ice_data(self) -> PrognosticState | None:
+        return self._components.get("ice")
+
+    @property
+    def atmosphere_data(self) -> PrognosticState | None:
+        return self._components.get("atmosphere")
 
     def to_device(self) -> "CoupledPrognosticState":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if self.ocean_data is not None:
-            ocean_device = self.ocean_data.to_device()
-        if self.ice_data is not None:
-            ice_device = self.ice_data.to_device()
-        if self.atmosphere_data is not None:
-            atmos_device = self.atmosphere_data.to_device()
-        return CoupledPrognosticState(ocean_device, ice_device, atmos_device)
+        result = CoupledPrognosticState.__new__(CoupledPrognosticState)
+        result._components = {k: v.to_device() for k, v in self._components.items()}
+        return result
 
     def as_batch_data(self) -> "CoupledBatchData":
-        ocean_batch = None
-        ice_batch = None
-        atmos_batch = None
-        if self.ocean_data is not None:
-            ocean_batch = self.ocean_data.as_batch_data()
-        if self.ice_data is not None:
-            ice_batch = self.ice_data.as_batch_data()
-        if self.atmosphere_data is not None:
-            atmos_batch = self.atmosphere_data.as_batch_data()
-        return CoupledBatchData(ocean_batch, ice_batch, atmos_batch)
+        result = CoupledBatchData.__new__(CoupledBatchData)
+        result._components = {k: v.as_batch_data() for k, v in self._components.items()}
+        return result
 
 
-@dataclasses.dataclass
 class CoupledBatchData:
-    ocean_data: BatchData | None = None
-    ice_data: BatchData | None = None
-    atmosphere_data: BatchData | None = None
+    def __init__(
+        self,
+        ocean_data: BatchData | None = None,
+        ice_data: BatchData | None = None,
+        atmosphere_data: BatchData | None = None,
+    ):
+        self._components: dict[str, BatchData] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean_data),
+                ("ice", ice_data),
+                ("atmosphere", atmosphere_data),
+            ]
+            if val is not None
+        }
+
+    @property
+    def ocean_data(self) -> BatchData | None:
+        return self._components.get("ocean")
+
+    @property
+    def ice_data(self) -> BatchData | None:
+        return self._components.get("ice")
+
+    @property
+    def atmosphere_data(self) -> BatchData | None:
+        return self._components.get("atmosphere")
 
     def to_device(self) -> "CoupledBatchData":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if self.ocean_data is not None:
-            ocean_device = self.ocean_data.to_device()
-        if self.ice_data is not None:
-            ice_device = self.ice_data.to_device()
-        if self.atmosphere_data is not None:
-            atmos_device = self.atmosphere_data.to_device()
-        return self.__class__(
-            ocean_data=ocean_device,
-            ice_data=ice_device,
-            atmosphere_data=atmos_device,
-        )
+        result = CoupledBatchData.__new__(CoupledBatchData)
+        result._components = {k: v.to_device() for k, v in self._components.items()}
+        return result
 
     @classmethod
     def new_on_device(
@@ -86,18 +101,12 @@ class CoupledBatchData:
         ice_data: BatchData | None = None,
         atmosphere_data: BatchData | None = None,
     ) -> "CoupledBatchData":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if ocean_data is not None:
-            ocean_device = ocean_data.to_device()
-        if ice_data is not None:
-            ice_device = ice_data.to_device()
-        if atmosphere_data is not None:
-            atmos_device = atmosphere_data.to_device()
-        return CoupledBatchData(
-            ocean_data=ocean_device, ice_data=ice_device, atmosphere_data=atmos_device
+        src = cls(
+            ocean_data=ocean_data,
+            ice_data=ice_data,
+            atmosphere_data=atmosphere_data,
         )
+        return src.to_device()
 
     @classmethod
     def new_on_cpu(
@@ -106,62 +115,41 @@ class CoupledBatchData:
         ice_data: BatchData | None = None,
         atmosphere_data: BatchData | None = None,
     ) -> "CoupledBatchData":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if ocean_data is not None:
-            ocean_device = ocean_data.to_cpu()
-        if ice_data is not None:
-            ice_device = ice_data.to_cpu()
-        if atmosphere_data is not None:
-            atmos_device = atmosphere_data.to_cpu()
-        return CoupledBatchData(
-            ocean_data=ocean_device, ice_data=ice_device, atmosphere_data=atmos_device
+        tmp = cls(
+            ocean_data=ocean_data,
+            ice_data=ice_data,
+            atmosphere_data=atmosphere_data,
         )
+        result = cls.__new__(cls)
+        result._components = {k: v.to_cpu() for k, v in tmp._components.items()}
+        return result
 
     @classmethod
     def collate_fn(
         cls,
         samples: Sequence[CoupledDatasetItem],
+        component_horizontal_dims: dict[str, list[str]],
         sample_dim_name: str = "sample",
-        ocean_horizontal_dims: list[str] | None = None,
-        ice_horizontal_dims: list[str] | None = None,
-        atmosphere_horizontal_dims: list[str] | None = None,
-        ocean_label_encoding: LabelEncoding | None = None,
-        ice_label_encoding: LabelEncoding | None = None,
-        atmosphere_label_encoding: LabelEncoding | None = None,
+        component_label_encodings: dict[str, LabelEncoding] | None = None,
     ) -> "CoupledBatchData":
         """
-        Collate function for use with PyTorch DataLoader. Separates out ocean,
-        ice, and atmosphere sample tuples and constructs BatchData instances for
-        each component.
-
+        Collate function for use with PyTorch DataLoader. Assembles per-component
+        BatchData from a sequence of CoupledDatasetItems.
         """
-        ocean_data = None
-        if ocean_horizontal_dims is not None:
-            ocean_data = BatchData.from_sample_tuples(
-                [cast(DatasetItem, x.ocean) for x in samples],
-                horizontal_dims=ocean_horizontal_dims,
+        if component_label_encodings is None:
+            component_label_encodings = {}
+        component_data: dict[str, BatchData] = {
+            name: BatchData.from_sample_tuples(
+                [cast(DatasetItem, getattr(sample, name)) for sample in samples],
+                horizontal_dims=horizontal_dims,
                 sample_dim_name=sample_dim_name,
-                label_encoding=ocean_label_encoding,
+                label_encoding=component_label_encodings.get(name),
             )
-        ice_data = None
-        if ice_horizontal_dims is not None:
-            ice_data = BatchData.from_sample_tuples(
-                [cast(DatasetItem, x.ice) for x in samples],
-                horizontal_dims=ice_horizontal_dims,
-                sample_dim_name=sample_dim_name,
-                label_encoding=ice_label_encoding,
-            )
-        atmosphere_data = None
-        if atmosphere_horizontal_dims is not None:
-            atmosphere_data = BatchData.from_sample_tuples(
-                [cast(DatasetItem, x.atmosphere) for x in samples],
-                horizontal_dims=atmosphere_horizontal_dims,
-                sample_dim_name=sample_dim_name,
-                label_encoding=atmosphere_label_encoding,
-            )
-        return CoupledBatchData.new_on_cpu(ocean_data, ice_data, atmosphere_data)
+            for name, horizontal_dims in component_horizontal_dims.items()
+        }
+        result = cls.__new__(cls)
+        result._components = {k: v.to_cpu() for k, v in component_data.items()}
+        return result
 
     def get_start(
         self: SelfType,
@@ -170,132 +158,93 @@ class CoupledBatchData:
         """
         Get the initial condition state.
         """
-        ocean_data = None
-        if self.ocean_data is not None:
-            assert requirements.ocean is not None
-            ocean_data = self.ocean_data.get_start(
-                requirements.ocean.names,
-                requirements.ocean.n_timesteps,
-            )
-        ice_data = None
-        if self.ice_data is not None:
-            assert requirements.ice is not None
-            ice_data = self.ice_data.get_start(
-                requirements.ice.names,
-                requirements.ice.n_timesteps,
-            )
-        atmosphere_data = None
-        if self.atmosphere_data is not None:
-            assert requirements.atmosphere is not None
-            atmosphere_data = self.atmosphere_data.get_start(
-                requirements.atmosphere.names,
-                requirements.atmosphere.n_timesteps,
-            )
-        return CoupledPrognosticState(
-            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
-        )
+        ic_components: dict[str, PrognosticState] = {}
+        for name, data in self._components.items():
+            req = getattr(requirements, name)
+            assert req is not None
+            ic_components[name] = data.get_start(req.names, req.n_timesteps)
+        result = CoupledPrognosticState.__new__(CoupledPrognosticState)
+        result._components = ic_components
+        return result
 
     def prepend(self: SelfType, initial_condition: CoupledPrognosticState) -> SelfType:
-        ocean_data = None
-        if self.ocean_data is not None:
-            assert initial_condition.ocean_data is not None
-            ocean_data = self.ocean_data.prepend(initial_condition.ocean_data)
-        ice_data = None
-        if self.ice_data is not None:
-            assert initial_condition.ice_data is not None
-            ice_data = self.ice_data.prepend(initial_condition.ice_data)
-        atmosphere_data = None
-        if self.atmosphere_data is not None:
-            assert initial_condition.atmosphere_data is not None
-            atmosphere_data = self.atmosphere_data.prepend(
-                initial_condition.atmosphere_data
-            )
-        return self.__class__(
-            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
-        )
+        result = self.__class__.__new__(self.__class__)
+        result._components = {
+            name: data.prepend(ic)
+            for name, data in self._components.items()
+            for ic in [initial_condition._components.get(name)]
+            if ic is not None
+        }
+        return result
 
     def remove_initial_condition(
         self: SelfType,
-        n_ic_timesteps_ocean: int | None = None,
-        n_ic_timesteps_ice: int | None = None,
-        n_ic_timesteps_atmosphere: int | None = None,
+        n_ic_timesteps: dict[str, int],
     ) -> SelfType:
-        ocean_data = None
-        if self.ocean_data is not None:
-            assert n_ic_timesteps_ocean is not None
-            ocean_data = self.ocean_data.remove_initial_condition(n_ic_timesteps_ocean)
-        ice_data = None
-        if self.ice_data is not None:
-            assert n_ic_timesteps_ice is not None
-            ice_data = self.ice_data.remove_initial_condition(n_ic_timesteps_ice)
-        atmosphere_data = None
-        if self.atmosphere_data is not None:
-            assert n_ic_timesteps_atmosphere is not None
-            atmosphere_data = self.atmosphere_data.remove_initial_condition(
-                n_ic_timesteps_atmosphere
-            )
-        return self.__class__(
-            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
-        )
+        result = self.__class__.__new__(self.__class__)
+        result._components = {
+            name: data.remove_initial_condition(n_ic_timesteps[name])
+            for name, data in self._components.items()
+        }
+        return result
 
     def compute_derived_variables(
         self: SelfType,
         forcing_data: SelfType,
-        ocean_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict]
-        | None = None,
-        ice_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict]
-        | None = None,
-        atmosphere_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict]
-        | None = None,
+        derive_funcs: dict[str, Callable[[TensorMapping, TensorMapping], TensorDict]],
     ) -> SelfType:
-        ocean_data = None
-        if self.ocean_data is not None:
-            assert ocean_derive_func is not None
-            assert forcing_data.ocean_data is not None
-            ocean_data = self.ocean_data.compute_derived_variables(
-                ocean_derive_func, forcing_data.ocean_data
-            )
-        ice_data = None
-        if self.ice_data is not None:
-            if isinstance(ice_derive_func, NullDeriveFn):
-                ice_data = self.ice_data
+        result_components: dict[str, BatchData] = {}
+        for name, data in self._components.items():
+            fn = derive_funcs.get(name)
+            if fn is None or isinstance(fn, NullDeriveFn):
+                result_components[name] = data
             else:
-                assert ice_derive_func is not None
-                assert forcing_data.ice_data is not None
-                ice_data = self.ice_data.compute_derived_variables(
-                    ice_derive_func, forcing_data.ice_data
-                )
-        atmosphere_data = None
-        if self.atmosphere_data is not None:
-            assert atmosphere_derive_func is not None
-            assert forcing_data.atmosphere_data is not None
-            atmosphere_data = self.atmosphere_data.compute_derived_variables(
-                atmosphere_derive_func, forcing_data.atmosphere_data
-            )
-        return self.__class__(
-            ocean_data=ocean_data, ice_data=ice_data, atmosphere_data=atmosphere_data
-        )
+                forcing = forcing_data._components.get(name)
+                assert forcing is not None
+                result_components[name] = data.compute_derived_variables(fn, forcing)
+        result = self.__class__.__new__(self.__class__)
+        result._components = result_components
+        return result
 
     def pin_memory(self: SelfType) -> SelfType:
-        if self.ocean_data is not None:
-            self.ocean_data = self.ocean_data.pin_memory()
-        if self.ice_data is not None:
-            self.ice_data = self.ice_data.pin_memory()
-        if self.atmosphere_data is not None:
-            self.atmosphere_data = self.atmosphere_data.pin_memory()
-        return self
+        result = self.__class__.__new__(self.__class__)
+        result._components = {k: v.pin_memory() for k, v in self._components.items()}
+        return result
 
 
-@dataclasses.dataclass
 class CoupledPairedData:
     """
     A container for the data and time coordinates of a batch, with paired
     prediction and target data.
     """
 
-    ocean_data: PairedData | None = None
-    ice_data: PairedData | None = None
-    atmosphere_data: PairedData | None = None
+    def __init__(
+        self,
+        ocean_data: PairedData | None = None,
+        ice_data: PairedData | None = None,
+        atmosphere_data: PairedData | None = None,
+    ):
+        self._components: dict[str, PairedData] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean_data),
+                ("ice", ice_data),
+                ("atmosphere", atmosphere_data),
+            ]
+            if val is not None
+        }
+
+    @property
+    def ocean_data(self) -> PairedData | None:
+        return self._components.get("ocean")
+
+    @property
+    def ice_data(self) -> PairedData | None:
+        return self._components.get("ice")
+
+    @property
+    def atmosphere_data(self) -> PairedData | None:
+        return self._components.get("atmosphere")
 
     @classmethod
     def from_coupled_batch_data(
@@ -303,54 +252,20 @@ class CoupledPairedData:
         prediction: CoupledBatchData,
         reference: CoupledBatchData,
     ) -> "CoupledPairedData":
-        ocean_data = None
-        if prediction.ocean_data is not None:
-            assert reference.ocean_data is not None
-            if not np.all(
-                prediction.ocean_data.time.values == reference.ocean_data.time.values
-            ):
+        paired: dict[str, PairedData] = {}
+        for name, pred_data in prediction._components.items():
+            ref_data = reference._components.get(name)
+            assert ref_data is not None
+            if not np.all(pred_data.time.values == ref_data.time.values):
                 raise ValueError(
-                    "Prediction and target ocean time coordinate must be the same."
+                    f"Prediction and target {name} time coordinate must be the same."
                 )
-            ocean_data = PairedData(
-                prediction=prediction.ocean_data.data,
-                reference=reference.ocean_data.data,
-                time=prediction.ocean_data.time,
-                labels=prediction.ocean_data.labels,
+            paired[name] = PairedData(
+                prediction=pred_data.data,
+                reference=ref_data.data,
+                time=pred_data.time,
+                labels=pred_data.labels,
             )
-        ice_data = None
-        if prediction.ice_data is not None:
-            assert reference.ice_data is not None
-            if not np.all(
-                prediction.ice_data.time.values == reference.ice_data.time.values
-            ):
-                raise ValueError(
-                    "Prediction and target ice time coordinate must be the same."
-                )
-            ice_data = PairedData(
-                prediction=prediction.ice_data.data,
-                reference=reference.ice_data.data,
-                time=prediction.ice_data.time,
-                labels=prediction.ice_data.labels,
-            )
-        atmosphere_data = None
-        if prediction.atmosphere_data is not None:
-            assert reference.atmosphere_data is not None
-            if not np.all(
-                prediction.atmosphere_data.time.values
-                == reference.atmosphere_data.time.values
-            ):
-                raise ValueError(
-                    "Prediction and target atmosphere time coordinate must be the same."
-                )
-            atmosphere_data = PairedData(
-                prediction=prediction.atmosphere_data.data,
-                reference=reference.atmosphere_data.data,
-                time=prediction.atmosphere_data.time,
-                labels=prediction.atmosphere_data.labels,
-            )
-        return CoupledPairedData(
-            ocean_data=ocean_data,
-            ice_data=ice_data,
-            atmosphere_data=atmosphere_data,
-        )
+        result = cls.__new__(cls)
+        result._components = paired
+        return result

--- a/fme/coupled/data_loading/config.py
+++ b/fme/coupled/data_loading/config.py
@@ -12,19 +12,25 @@ class CoupledDatasetConfig:
     """
     Parameters:
         ocean: Configuration for the ocean dataset.
-        ice: Configuration for the ocean dataset.
         atmosphere: Configuration for the atmosphere dataset.
     """
 
-    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
-    ice: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
-    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
+    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig
 
     @property
     def data_configs(
         self,
-    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig | None]:
-        return [self.ocean, self.ice, self.atmosphere]
+    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig]:
+        return [self.ocean, self.atmosphere]
+
+    @property
+    def ice(self) -> None:
+        return None
+
+    @property
+    def anchor_component_name(self) -> str:
+        return "ocean"
 
     @property
     def coupled_configs(self) -> Sequence["CoupledDatasetConfig"]:
@@ -32,23 +38,166 @@ class CoupledDatasetConfig:
 
 
 @dataclasses.dataclass
-class CoupledDatasetWithOptionalOceanConfig:
+class CoupledIceAtmosphereDatasetConfig:
     """
+    Configuration for a coupled dataset with atmosphere and ice components only
+    (no ocean).
+
     Parameters:
-        ocean: Optional configuration for the ocean dataset.
-        ice: Optional configuration for the ice dataset.
-        atmosphere: Optional Configuration for the atmosphere dataset.
+        ice: Configuration for the ice dataset.
+        atmosphere: Configuration for the atmosphere dataset.
     """
 
-    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
-    ice: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig
+
+    @property
+    def data_configs(
+        self,
+    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig]:
+        return [self.atmosphere, self.ice]
+
+    @property
+    def ocean(self) -> None:
+        return None
+
+    @property
+    def anchor_component_name(self) -> str:
+        return "ice"
+
+    @property
+    def coupled_configs(self) -> Sequence["CoupledIceAtmosphereDatasetConfig"]:
+        return [self]
+
+
+@dataclasses.dataclass
+class CoupledIceOceanDatasetConfig:
+    """
+    Configuration for a coupled dataset with ocean and ice components only
+    (no atmosphere).
+
+    Parameters:
+        ocean: Configuration for the ocean dataset.
+        ice: Configuration for the ice dataset.
+    """
+
+    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig
+
+    @property
+    def data_configs(
+        self,
+    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig]:
+        return [self.ocean, self.ice]
+
+    @property
+    def atmosphere(self) -> None:
+        return None
+
+    @property
+    def anchor_component_name(self) -> str:
+        return "ocean"
+
+    @property
+    def coupled_configs(self) -> Sequence["CoupledIceOceanDatasetConfig"]:
+        return [self]
+
+
+@dataclasses.dataclass
+class CoupledAtmosphereIceOceanDatasetConfig:
+    """
+    Parameters:
+        ocean: Configuration for the ocean dataset.
+        ice: Configuration for the ice dataset.
+        atmosphere: Configuration for the atmosphere dataset.
+    """
+
+    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig
+
+    @property
+    def data_configs(
+        self,
+    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig]:
+        return [self.ocean, self.ice, self.atmosphere]
+
+    @property
+    def anchor_component_name(self) -> str:
+        return "ocean"
+
+    @property
+    def coupled_configs(self) -> Sequence["CoupledAtmosphereIceOceanDatasetConfig"]:
+        return [self]
+
+
+@dataclasses.dataclass
+class CoupledDatasetWithOptionalOceanConfig:
+    """
+    Config where atmosphere is always present; ocean and ice are optional.
+    Ocean is always the anchor: if ocean is None, a dummy will be built
+    from the dataset_info during inference.
+
+    Parameters:
+        atmosphere: Configuration for the atmosphere dataset.
+        ocean: Optional configuration for the ocean dataset.
+        ice: Optional configuration for the ice dataset.
+    """
+
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig
     ocean: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
 
     @property
     def data_configs(
         self,
     ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig | None]:
         return [self.ocean, self.ice, self.atmosphere]
+
+    @property
+    def anchor_component_name(self) -> str:
+        # Ocean is always the anchor; when ocean is None a dummy is created
+        # from dataset_info during inference.
+        return "ocean"
+
+
+def build_coupled_dataset_config(
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None,
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None,
+    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None,
+) -> (
+    CoupledAtmosphereIceOceanDatasetConfig
+    | CoupledDatasetConfig
+    | CoupledIceAtmosphereDatasetConfig
+    | CoupledIceOceanDatasetConfig
+    | CoupledDatasetWithOptionalOceanConfig
+):
+    """
+    Returns the appropriate coupled dataset config for the combination of
+    components provided.  At least one component must be non-None.
+
+    Coupling priorities (for inference anchor selection):
+        ocean > ice > atmosphere
+    """
+    if atmosphere is not None and ice is not None and ocean is not None:
+        return CoupledAtmosphereIceOceanDatasetConfig(
+            ocean=ocean, ice=ice, atmosphere=atmosphere
+        )
+    if atmosphere is not None and ocean is not None:
+        return CoupledDatasetConfig(ocean=ocean, atmosphere=atmosphere)
+    if atmosphere is not None and ice is not None:
+        # ocean is not provided; use CoupledDatasetWithOptionalOceanConfig so that
+        # a dummy ocean (driven by dataset_info) is created as the anchor during
+        # inference, preserving the ocean-driven batch schedule.
+        return CoupledDatasetWithOptionalOceanConfig(
+            atmosphere=atmosphere, ice=ice, ocean=None
+        )
+    if ocean is not None and ice is not None:
+        return CoupledIceOceanDatasetConfig(ocean=ocean, ice=ice)
+    if atmosphere is not None:
+        # atmosphere only: ocean/ice anchor will be provided as a dummy
+        return CoupledDatasetWithOptionalOceanConfig(atmosphere=atmosphere, ocean=None)
+    raise ValueError("At least one of atmosphere, ice, or ocean must be provided.")
 
 
 @dataclasses.dataclass
@@ -59,23 +208,23 @@ class CoupledConcatDatasetConfig:
             to be loaded. This sequence of datasets will be concatenated.
     """
 
-    concat: Sequence[CoupledDatasetConfig]
+    concat: Sequence[
+        CoupledDatasetConfig
+        | CoupledIceOceanDatasetConfig
+        | CoupledIceAtmosphereDatasetConfig
+        | CoupledAtmosphereIceOceanDatasetConfig
+    ]
 
     @property
-    def coupled_configs(self) -> Sequence[CoupledDatasetConfig]:
+    def coupled_configs(
+        self,
+    ) -> Sequence[
+        CoupledDatasetConfig
+        | CoupledIceOceanDatasetConfig
+        | CoupledIceAtmosphereDatasetConfig
+        | CoupledAtmosphereIceOceanDatasetConfig
+    ]:
         return self.concat
-
-    @property
-    def atmosphere(self) -> XarrayDataConfig | MergeNoConcatDatasetConfig | None:
-        return self.concat[0].atmosphere if self.concat else None
-
-    @property
-    def ice(self) -> XarrayDataConfig | MergeNoConcatDatasetConfig | None:
-        return self.concat[0].ice if self.concat else None
-
-    @property
-    def ocean(self) -> XarrayDataConfig | MergeNoConcatDatasetConfig | None:
-        return self.concat[0].ocean if self.concat else None
 
 
 @dataclasses.dataclass
@@ -93,7 +242,13 @@ class CoupledDataLoaderConfig:
 
     """
 
-    dataset: CoupledConcatDatasetConfig | CoupledDatasetConfig
+    dataset: (
+        CoupledConcatDatasetConfig
+        | CoupledDatasetConfig
+        | CoupledIceOceanDatasetConfig
+        | CoupledIceAtmosphereDatasetConfig
+        | CoupledAtmosphereIceOceanDatasetConfig
+    )
     batch_size: int
     num_data_workers: int = 1
     prefetch_factor: int | None = None
@@ -118,8 +273,6 @@ class CoupledDataLoaderConfig:
         """
         Return the labels that are available in the atmosphere dataset.
         """
-        if self.dataset.atmosphere is None:
-            return None
         return accumulate_labels(
             [
                 ds.atmosphere.available_labels
@@ -133,8 +286,6 @@ class CoupledDataLoaderConfig:
         """
         Return the labels that are available in the ice dataset.
         """
-        if self.dataset.ice is None:
-            return None
         return accumulate_labels(
             [
                 ds.ice.available_labels
@@ -148,8 +299,6 @@ class CoupledDataLoaderConfig:
         """
         Return the labels that are available in the ocean dataset.
         """
-        if self.dataset.ocean is None:
-            return None
         return accumulate_labels(
             [
                 ds.ocean.available_labels

--- a/fme/coupled/data_loading/config.py
+++ b/fme/coupled/data_loading/config.py
@@ -65,6 +65,18 @@ class CoupledConcatDatasetConfig:
     def coupled_configs(self) -> Sequence[CoupledDatasetConfig]:
         return self.concat
 
+    @property
+    def atmosphere(self) -> XarrayDataConfig | MergeNoConcatDatasetConfig | None:
+        return self.concat[0].atmosphere if self.concat else None
+
+    @property
+    def ice(self) -> XarrayDataConfig | MergeNoConcatDatasetConfig | None:
+        return self.concat[0].ice if self.concat else None
+
+    @property
+    def ocean(self) -> XarrayDataConfig | MergeNoConcatDatasetConfig | None:
+        return self.concat[0].ocean if self.concat else None
+
 
 @dataclasses.dataclass
 class CoupledDataLoaderConfig:
@@ -109,7 +121,11 @@ class CoupledDataLoaderConfig:
         if self.dataset.atmosphere is None:
             return None
         return accumulate_labels(
-            [ds.atmosphere.available_labels for ds in self.dataset.coupled_configs]
+            [
+                ds.atmosphere.available_labels
+                for ds in self.dataset.coupled_configs
+                if ds.atmosphere is not None
+            ]
         )
 
     @property
@@ -120,7 +136,11 @@ class CoupledDataLoaderConfig:
         if self.dataset.ice is None:
             return None
         return accumulate_labels(
-            [ds.ice.available_labels for ds in self.dataset.coupled_configs]
+            [
+                ds.ice.available_labels
+                for ds in self.dataset.coupled_configs
+                if ds.ice is not None
+            ]
         )
 
     @property
@@ -131,7 +151,11 @@ class CoupledDataLoaderConfig:
         if self.dataset.ocean is None:
             return None
         return accumulate_labels(
-            [ds.ocean.available_labels for ds in self.dataset.coupled_configs]
+            [
+                ds.ocean.available_labels
+                for ds in self.dataset.coupled_configs
+                if ds.ocean is not None
+            ]
         )
 
     @property

--- a/fme/coupled/data_loading/config.py
+++ b/fme/coupled/data_loading/config.py
@@ -12,17 +12,19 @@ class CoupledDatasetConfig:
     """
     Parameters:
         ocean: Configuration for the ocean dataset.
+        ice: Configuration for the ocean dataset.
         atmosphere: Configuration for the atmosphere dataset.
     """
 
-    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig
-    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig
+    ocean: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
 
     @property
     def data_configs(
         self,
-    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig]:
-        return [self.ocean, self.atmosphere]
+    ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig | None]:
+        return [self.ocean, self.ice, self.atmosphere]
 
     @property
     def coupled_configs(self) -> Sequence["CoupledDatasetConfig"]:
@@ -34,17 +36,19 @@ class CoupledDatasetWithOptionalOceanConfig:
     """
     Parameters:
         ocean: Optional configuration for the ocean dataset.
-        atmosphere: Configuration for the atmosphere dataset.
+        ice: Optional configuration for the ice dataset.
+        atmosphere: Optional Configuration for the atmosphere dataset.
     """
 
-    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig
+    atmosphere: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
+    ice: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
     ocean: XarrayDataConfig | MergeNoConcatDatasetConfig | None = None
 
     @property
     def data_configs(
         self,
     ) -> Sequence[XarrayDataConfig | MergeNoConcatDatasetConfig | None]:
-        return [self.ocean, self.atmosphere]
+        return [self.ocean, self.ice, self.atmosphere]
 
 
 @dataclasses.dataclass
@@ -102,8 +106,21 @@ class CoupledDataLoaderConfig:
         """
         Return the labels that are available in the atmosphere dataset.
         """
+        if self.dataset.atmosphere is None:
+            return None
         return accumulate_labels(
             [ds.atmosphere.available_labels for ds in self.dataset.coupled_configs]
+        )
+
+    @property
+    def ice_available_labels(self) -> set[str] | None:
+        """
+        Return the labels that are available in the ice dataset.
+        """
+        if self.dataset.ice is None:
+            return None
+        return accumulate_labels(
+            [ds.ice.available_labels for ds in self.dataset.coupled_configs]
         )
 
     @property
@@ -111,6 +128,8 @@ class CoupledDataLoaderConfig:
         """
         Return the labels that are available in the ocean dataset.
         """
+        if self.dataset.ocean is None:
+            return None
         return accumulate_labels(
             [ds.ocean.available_labels for ds in self.dataset.coupled_configs]
         )

--- a/fme/coupled/data_loading/data_typing.py
+++ b/fme/coupled/data_loading/data_typing.py
@@ -21,76 +21,165 @@ class CoupledCoords:
     Convenience wrapper for the coords in dict format.
     """
 
-    ocean_vertical: dict[str, np.ndarray]
-    atmosphere_vertical: dict[str, np.ndarray]
-    ocean_horizontal: dict[str, np.ndarray]
-    atmosphere_horizontal: dict[str, np.ndarray]
+    ocean_vertical: dict[str, np.ndarray] | None = None
+    ice_vertical: dict[str, np.ndarray] | None = None
+    atmosphere_vertical: dict[str, np.ndarray] | None = None
+    ocean_horizontal: dict[str, np.ndarray] | None = None
+    ice_horizontal: dict[str, np.ndarray] | None = None
+    atmosphere_horizontal: dict[str, np.ndarray] | None = None
 
     @property
     def ocean(self) -> dict[str, np.ndarray]:
-        return {**self.ocean_vertical, **self.ocean_horizontal}
+        if self.ocean_horizontal is not None:
+            return {**self.ocean_vertical, **self.ocean_horizontal}
+        else:
+            raise AttributeError("Ocean component is None")
+
+    @property
+    def ice(self) -> dict[str, np.ndarray]:
+        if self.ice_horizontal is not None:
+            if self.ice_vertical is not None:
+                return {**self.ice_vertical, **self.ice_horizontal}
+            return {**self.ice_horizontal}
+        else:
+            raise AttributeError("Ice component is None")
 
     @property
     def atmosphere(self) -> dict[str, np.ndarray]:
-        return {**self.atmosphere_vertical, **self.atmosphere_horizontal}
+        if self.atmosphere_horizontal is not None:
+            return {**self.atmosphere_vertical, **self.atmosphere_horizontal}
+        else:
+            raise AttributeError("Atmosphere component is None")
 
 
 class CoupledVerticalCoordinate:
     def __init__(
         self,
-        ocean: OptionalDepthCoordinate,
-        atmosphere: OptionalHybridSigmaPressureCoordinate,
+        ocean: OptionalDepthCoordinate | None = None,
+        ice: OptionalDepthCoordinate | None = None,
+        atmosphere: OptionalHybridSigmaPressureCoordinate | None = None,
     ):
         self.ocean = ocean
+        self.ice = ice
         self.atmosphere = atmosphere
 
     def __eq__(self, other):
         if not isinstance(other, CoupledVerticalCoordinate):
             return False
-        return self.ocean == other.ocean and self.atmosphere == other.atmosphere
+        if self.atmosphere is None:
+            ocean_check = self.ocean == other.ocean
+            ice_check = self.ice == other.ice
+            return ocean_check and ice_check
+        elif self.ice is None:
+            ocean_check = self.ocean == other.ocean
+            atmos_check = self.atmosphere == other.atmosphere
+            return ocean_check and atmos_check
+        elif self.ocean is None:
+            ice_check = self.ice == other.ice
+            atmos_check = self.atmosphere == other.atmosphere
+            return ice_check and atmos_check
+        else:
+            ocean_check = self.ocean == other.ocean
+            ice_check = self.ice == other.ice
+            atmos_check = self.atmosphere == other.atmosphere
+            return ocean_check and ice_check and atmos_check
 
     def to(self, device: torch.device) -> "CoupledVerticalCoordinate":
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if self.ocean is not None:
+            ocean_device = self.ocean.to(device)
+        if self.ice is not None:
+            ice_device = self.ice.to(device)
+        if self.atmosphere is not None:
+            atmos_device = self.atmosphere.to(device)
         return CoupledVerticalCoordinate(
-            ocean=self.ocean.to(device), atmosphere=self.atmosphere.to(device)
+            ocean=ocean_device, ice=ice_device, atmosphere=atmos_device
         )
 
 
 class CoupledHorizontalCoordinates:
     def __init__(
         self,
-        ocean: HorizontalCoordinates,
-        atmosphere: HorizontalCoordinates,
+        ocean: HorizontalCoordinates | None = None,
+        ice: HorizontalCoordinates | None = None,
+        atmosphere: HorizontalCoordinates | None = None,
     ):
         self.ocean = ocean
+        self.ice = ice
         self.atmosphere = atmosphere
 
     def __eq__(self, other):
         if not isinstance(other, CoupledHorizontalCoordinates):
             return False
-        return self.ocean == other.ocean and self.atmosphere == other.atmosphere
+        if self.atmosphere is None:
+            ocean_check = self.ocean == other.ocean
+            ice_check = self.ice == other.ice
+            return ocean_check and ice_check
+        elif self.ice is None:
+            ocean_check = self.ocean == other.ocean
+            atmos_check = self.atmosphere == other.atmosphere
+            return ocean_check and atmos_check
+        elif self.ocean is None:
+            ice_check = self.ice == other.ice
+            atmos_check = self.atmosphere == other.atmosphere
+            return ice_check and atmos_check
+        else:
+            ocean_check = self.ocean == other.ocean
+            ice_check = self.ice == other.ice
+            atmos_check = self.atmosphere == other.atmosphere
+            return ocean_check and ice_check and atmos_check
 
     def to(self, device: torch.device) -> "CoupledHorizontalCoordinates":
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if self.ocean is not None:
+            ocean_device = self.ocean.to(device)
+        if self.ice is not None:
+            ice_device = self.ice.to(device)
+        if self.atmosphere is not None:
+            atmos_device = self.atmosphere.to(device)
         return CoupledHorizontalCoordinates(
-            ocean=self.ocean.to(device), atmosphere=self.atmosphere.to(device)
+            ocean=ocean_device, ice=ice_device, atmosphere=atmos_device
         )
 
 
 class CoupledDatasetProperties:
     def __init__(
         self,
-        ocean: DatasetProperties,
-        atmosphere: DatasetProperties,
+        ocean: DatasetProperties | None = None,
+        ice: DatasetProperties | None = None,
+        atmosphere: DatasetProperties | None = None,
     ):
         self.ocean = ocean
+        self.ice = ice
         self.atmosphere = atmosphere
-        ocean_coord = ocean.vertical_coordinate
-        atmos_coord = atmosphere.vertical_coordinate
-        assert isinstance(ocean_coord, OptionalDepthCoordinate)
-        assert isinstance(atmos_coord, OptionalHybridSigmaPressureCoordinate)
+        ocean_vcoord = None
+        ice_vcoord = None
+        atmos_vcoord = None
+        ocean_hcoord = None
+        ice_hcoord = None
+        atmos_hcoord = None
+        if self.ocean is not None:
+            ocean_vcoord = ocean.vertical_coordinate
+            ocean_hcoord = ocean.horizontal_coordinates
+            assert isinstance(ocean_vcoord, OptionalDepthCoordinate)
+        if self.ice is not None:
+            ice_vcoord = ice.vertical_coordinate
+            ice_hcoord = ice.horizontal_coordinates
+            assert isinstance(ice_vcoord, OptionalDepthCoordinate)
+        if self.atmosphere is not None:
+            atmos_vcoord = atmosphere.vertical_coordinate
+            atmos_hcoord = atmosphere.horizontal_coordinates
+            assert isinstance(atmos_vcoord, OptionalHybridSigmaPressureCoordinate)
 
-        self._vertical_coordinate = CoupledVerticalCoordinate(ocean_coord, atmos_coord)
+        self._vertical_coordinate = CoupledVerticalCoordinate(
+            ocean_vcoord, ice_vcoord, atmos_vcoord
+        )
         self._horizontal_coordinates = CoupledHorizontalCoordinates(
-            ocean.horizontal_coordinates, atmosphere.horizontal_coordinates
+            ocean_hcoord, ice_hcoord, atmos_hcoord
         )
 
     @property
@@ -104,6 +193,11 @@ class CoupledDatasetProperties:
         return self.ocean.timestep
 
     @property
+    def ice_timestep(self) -> datetime.timedelta:
+        assert self.ice.timestep is not None
+        return self.ice.timestep
+
+    @property
     def vertical_coordinate(self) -> CoupledVerticalCoordinate:
         return self._vertical_coordinate
 
@@ -114,35 +208,91 @@ class CoupledDatasetProperties:
     @property
     def variable_metadata(self) -> dict[str, VariableMetadata]:
         metadata: dict[str, VariableMetadata] = {}
-        metadata.update(self.ocean.variable_metadata)
-        metadata.update(self.atmosphere.variable_metadata)
+        if self.ocean is not None:
+            metadata.update(self.ocean.variable_metadata)
+        if self.ice is not None:
+            metadata.update(self.ice.variable_metadata)
+        if self.atmosphere is not None:
+            metadata.update(self.atmosphere.variable_metadata)
         return metadata
 
     @property
     def timestep(self) -> datetime.timedelta:
-        return self.ocean_timestep
+        if self.ocean is not None:
+            return self.ocean_timestep
+        else:
+            return self.ice_timestep
 
     @property
     def is_remote(self) -> bool:
-        return self.ocean.is_remote or self.atmosphere.is_remote
+        if self.atmosphere is None:
+            remote_ocean = self.ocean.is_remote
+            remote_ice = self.ice.is_remote
+            remote = remote_ocean or remote_ice
+        elif self.ice is None:
+            remote_atmos = self.atmosphere.is_remote
+            remote_ocean = self.ocean.is_remote
+            remote = remote_atmos or remote_ocean
+        elif self.ocean is None:
+            remote_ice = self.ice.is_remote
+            remote_atmos = self.atmosphere.is_remote
+            remote = remote_ice or remote_atmos
+        else:
+            remote_ice = self.ice.is_remote
+            remote_atmos = self.atmosphere.is_remote
+            remote_ocean = self.ocean.is_remote
+            remote = remote_ice or remote_atmos or remote_ocean
+        return remote
 
     @property
     def n_inner_steps(self) -> int:
-        return self.ocean_timestep // self.atmosphere_timestep
+        if self.atmosphere is None:
+            return self.ocean_timestep // self.ice_timestep
+        elif self.ice is None:
+            return self.ocean_timestep // self.atmosphere_timestep
+        elif self.ocean is None:
+            return self.ice_timestep // self.atmosphere_timestep
+        else:
+            return self.ocean_timestep // self.atmosphere_timestep
 
     @property
     def coords(self) -> CoupledCoords:
+        ocean_vcoord = None
+        ocean_hcoord = None
+        atmos_vcoord = None
+        atmos_hcoord = None
+        ice_hcoord = None
+        ice_vcoord = None
+        if self.ocean is not None:
+            ocean_vcoord = self.vertical_coordinate.ocean.coords
+            ocean_hcoord = dict(self.horizontal_coordinates.ocean.coords)
+        if self.ice is not None:
+            ice_vcoord = self.vertical_coordinate.ice.coords
+            ice_hcoord = dict(self.horizontal_coordinates.ice.coords)
+        if self.atmosphere is not None:
+            atmos_vcoord = self.vertical_coordinate.atmosphere.coords
+            atmos_hcoord = dict(self.horizontal_coordinates.atmosphere.coords)
         return CoupledCoords(
-            ocean_vertical=self.vertical_coordinate.ocean.coords,
-            atmosphere_vertical=self.vertical_coordinate.atmosphere.coords,
-            ocean_horizontal=dict(self.horizontal_coordinates.ocean.coords),
-            atmosphere_horizontal=dict(self.horizontal_coordinates.atmosphere.coords),
+            ocean_vertical=ocean_vcoord,
+            atmosphere_vertical=atmos_vcoord,
+            ice_vertical=ice_vcoord,
+            ocean_horizontal=ocean_hcoord,
+            ice_horizontal=ice_hcoord,
+            atmosphere_horizontal=atmos_hcoord,
         )
 
     def to_device(self) -> "CoupledDatasetProperties":
+        ocean_device = None
+        ice_device = None
+        atmos_device = None
+        if self.ocean is not None:
+            ocean_device = self.ocean.to_device()
+        if self.ice is not None:
+            ice_device = self.ice.to_device()
+        if self.atmosphere is not None:
+            atmos_device = self.atmosphere.to_device()
         return CoupledDatasetProperties(
-            ocean=self.ocean.to_device(),
-            atmosphere=self.atmosphere.to_device(),
+            ocean=ocean_device, ice=ice_device, atmosphere=atmos_device
         )
 
     def update(self, other: "CoupledDatasetProperties"):
@@ -152,48 +302,123 @@ class CoupledDatasetProperties:
             raise ValueError(
                 "Horizontal coordinates must be the same for both datasets."
             )
-        self.atmosphere.update(other.atmosphere)
-        self.ocean.update(other.ocean)
+        if self.atmosphere is not None:
+            self.atmosphere.update(other.atmosphere)
+        if self.ocean is not None:
+            self.ocean.update(other.ocean)
+        if self.ice is not None:
+            self.ice.update(other.ice)
 
 
 @dataclasses.dataclass
 class CoupledDatasetItem:
-    ocean: DatasetItem
-    atmosphere: DatasetItem
+    ocean: DatasetItem | None = None
+    ice: DatasetItem | None = None
+    atmosphere: DatasetItem | None = None
 
 
 class CoupledDataset:
     def __init__(
         self,
-        ocean: DatasetABC,
-        atmosphere: DatasetABC,
         properties: CoupledDatasetProperties,
         n_steps_fast: int,
+        ocean: DatasetABC | None = None,
+        ice: DatasetABC | None = None,
+        atmosphere: DatasetABC | None = None,
     ):
         """
         Args:
             ocean: ocean dataset.
+            ice: ice dataset.
             atmosphere: atmosphere dataset.
             properties: the coupled dataset properties.
             n_steps_fast: number of atmosphere timesteps per ocean timestep.
         """
         self._ocean = ocean
-        if properties.ocean_timestep != properties.atmosphere_timestep * n_steps_fast:
-            raise ValueError(
-                "Ocean and atmosphere timesteps must be consistent with "
-                f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
-                f"and atmosphere timestep {properties.atmosphere.timestep} "
-                f"with n_steps_fast={n_steps_fast}."
-            )
+        self._ice = ice
         self._atmosphere = atmosphere
-        ocean_time = ocean[0][1].isel(time=0).item()
-        atmos_time = atmosphere[0][1].isel(time=0).item()
-        if ocean_time != atmos_time:
-            raise ValueError(
-                f"First time of ocean dataset is {ocean_time} "
-                f"but the atmosphere's first time is {atmos_time}. "
-                "Maybe align the datasets using a subset?"
-            )
+        if self._atmosphere is None:
+            if properties.ocean_timestep != properties.ice_timestep * n_steps_fast:
+                raise ValueError(
+                    "Ocean and Ice timesteps must be consistent with "
+                    f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
+                    f"and ice timestep {properties.ice.timestep} "
+                    f"with n_steps_fast={n_steps_fast}."
+                )
+            ocean_time = self._ocean[0][1].isel(time=0).item()
+            ice_time = self._ice[0][1].isel(time=0).item()
+            if ocean_time != ice_time:
+                raise ValueError(
+                    f"First time of ocean dataset is {ocean_time} "
+                    f"but the ice's first time is {ice_time}. "
+                    "Maybe align the datasets using a subset?"
+                )
+        elif self._ice is None:
+            if (
+                properties.ocean_timestep
+                != properties.atmosphere_timestep * n_steps_fast
+            ):
+                raise ValueError(
+                    "Ocean and Atmosphere timesteps must be consistent with "
+                    f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
+                    f"and atmosphere timestep {properties.atmosphere.timestep} "
+                    f"with n_steps_fast={n_steps_fast}."
+                )
+            ocean_time = self._ocean[0][1].isel(time=0).item()
+            atmos_time = self._atmosphere[0][1].isel(time=0).item()
+            if ocean_time != atmos_time:
+                raise ValueError(
+                    f"First time of ocean dataset is {ocean_time} "
+                    f"but the atmosphere's first time is {atmos_time}. "
+                    "Maybe align the datasets using a subset?"
+                )
+        elif self._ocean is None:
+            if properties.ice_timestep != properties.atmosphere_timestep:
+                raise ValueError(
+                    "Ice and Atmosphere timesteps must be consistent, "
+                    f"got ice timestep {properties.ice.timestep} "
+                    f"and atmosphere timestep {properties.atmosphere.timestep}."
+                )
+            ice_time = self._ice[0][1].isel(time=0).item()
+            atmos_time = self._atmosphere[0][1].isel(time=0).item()
+            if ice_time != atmos_time:
+                raise ValueError(
+                    f"First time of ice dataset is {ice_time} "
+                    f"but the atmosphere's first time is {atmos_time}. "
+                    "Maybe align the datasets using a subset?"
+                )
+        else:
+            if properties.ice_timestep != properties.atmosphere_timestep:
+                raise ValueError(
+                    "Ice and Atmosphere timesteps must be consistent, "
+                    f"got ice timestep {properties.ice.timestep} "
+                    f"and atmosphere timestep {properties.atmosphere.timestep}."
+                )
+            if (
+                properties.ocean_timestep
+                != properties.atmosphere_timestep * n_steps_fast
+            ):
+                raise ValueError(
+                    "Ocean and Atmosphere timesteps must be consistent with "
+                    f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
+                    f"and atmosphere timestep {properties.atmosphere.timestep} "
+                    f"with n_steps_fast={n_steps_fast}."
+                )
+            ice_time = self._ice[0][1].isel(time=0).item()
+            ocean_time = self._ocean[0][1].isel(time=0).item()
+            atmos_time = self._atmosphere[0][1].isel(time=0).item()
+            if ice_time != atmos_time:
+                raise ValueError(
+                    f"First time of ice dataset is {ice_time} "
+                    f"but the atmosphere's first time is {atmos_time}. "
+                    "Maybe align the datasets using a subset?"
+                )
+            if ocean_time != atmos_time:
+                raise ValueError(
+                    f"First time of ocean dataset is {ocean_time} "
+                    f"but the atmosphere's first time is {atmos_time}. "
+                    "Maybe align the datasets using a subset?"
+                )
 
         self._properties = properties
         self._n_steps_fast = n_steps_fast
@@ -208,35 +433,133 @@ class CoupledDataset:
 
     @property
     def all_ic_times(self) -> xr.CFTimeIndex:
-        return self._ocean.sample_start_times
+        if self._atmosphere is None:
+            return self._ocean.sample_start_times
+        elif self._ice is None:
+            return self._ocean.sample_start_times
+        elif self._ocean is None:
+            return self._ice.sample_start_times
+        else:
+            return self._ocean.sample_start_times
 
     def __len__(self):
-        return min([len(self._ocean), len(self._atmosphere)])
+        if self._atmosphere is None:
+            return min([len(self._ocean), len(self._ice)])
+        elif self._ice is None:
+            return min([len(self._ocean), len(self._atmosphere)])
+        elif self._ocean is None:
+            return min([len(self._ice), len(self._atmosphere)])
+        else:
+            return min([len(self._ocean), len(self._ice), len(self._atmosphere)])
 
     def __getitem__(self, idx: int) -> CoupledDatasetItem:
         fast_idx = idx * self._n_steps_fast
-        ocean = self._ocean[idx]
-        atmosphere = self._atmosphere[fast_idx]
-        return CoupledDatasetItem(ocean=ocean, atmosphere=atmosphere)
+        ocean = None
+        ice = None
+        atmosphere = None
+        if self._ocean is not None:
+            ocean = self._ocean[idx]
+        if self._ice is not None:
+            ice = self._ice[fast_idx]
+        if self._atmosphere is not None:
+            atmosphere = self._atmosphere[fast_idx]
+        return CoupledDatasetItem(ocean=ocean, ice=ice, atmosphere=atmosphere)
 
     def validate_inference_length(self, max_start_index: int, max_window_len: int):
-        try:
-            self._ocean.validate_inference_length(max_start_index, max_window_len)
-        except ValueError as e:
-            raise ValueError(
-                "The ocean dataset has an insufficient number of timepoints."
-            ) from e
-        atmos_max_start_index = max_start_index * self.n_steps_fast
-        atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
-        try:
-            self._atmosphere.validate_inference_length(
-                atmos_max_start_index, atmos_max_window_len
-            )
-        except ValueError as e:
-            raise ValueError(
-                "The atmosphere dataset has an insufficient number of timepoints."
-            ) from e
+        if self._atmosphere is None:
+            try:
+                self._ocean.validate_inference_length(max_start_index, max_window_len)
+            except ValueError as e:
+                raise ValueError(
+                    "The ocean dataset has an insufficient number of timepoints."
+                ) from e
+            ice_max_start_index = max_start_index * self.n_steps_fast
+            ice_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
+            try:
+                self._ice.validate_inference_length(
+                    ice_max_start_index, ice_max_window_len
+                )
+            except ValueError as e:
+                raise ValueError(
+                    "The ice dataset has an insufficient number of timepoints."
+                ) from e
+        elif self._ice is None:
+            try:
+                self._ocean.validate_inference_length(max_start_index, max_window_len)
+            except ValueError as e:
+                raise ValueError(
+                    "The ocean dataset has an insufficient number of timepoints."
+                ) from e
+            atmos_max_start_index = max_start_index * self.n_steps_fast
+            atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
+            try:
+                self._atmosphere.validate_inference_length(
+                    atmos_max_start_index, atmos_max_window_len
+                )
+            except ValueError as e:
+                raise ValueError(
+                    "The atmosphere dataset has an insufficient number of timepoints."
+                ) from e
+        elif self._ocean is None:
+            try:
+                self._ice.validate_inference_length(max_start_index, max_window_len)
+            except ValueError as e:
+                raise ValueError(
+                    "The ice dataset has an insufficient number of timepoints."
+                ) from e
+            atmos_max_start_index = max_start_index * self.n_steps_fast
+            atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
+            try:
+                self._atmosphere.validate_inference_length(
+                    atmos_max_start_index, atmos_max_window_len
+                )
+            except ValueError as e:
+                raise ValueError(
+                    "The atmosphere dataset has an insufficient number of timepoints."
+                ) from e
+        else:
+            try:
+                self._ocean.validate_inference_length(max_start_index, max_window_len)
+            except ValueError as e:
+                raise ValueError(
+                    "The ocean dataset has an insufficient number of timepoints."
+                ) from e
+            ice_max_start_index = max_start_index * self.n_steps_fast
+            ice_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
+            atmos_max_start_index = max_start_index * self.n_steps_fast
+            atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
+            ice_ok = True
+            atmos_ok = True
+            try:
+                self._ice.validate_inference_length(
+                    ice_max_start_index, ice_max_window_len
+                )
+            except ValueError:
+                ice_ok = False
+            try:
+                self._atmosphere.validate_inference_length(
+                    atmos_max_start_index, atmos_max_window_len
+                )
+            except ValueError:
+                atmos_ok = False
+            if not ice_ok and not atmos_ok:
+                raise ValueError(
+                    f"The atmosphere/ice dataset has an insufficient number of "
+                    f"timepoints."
+                )
+            elif not ice_ok:
+                raise ValueError(
+                    "The ice dataset has an insufficient number of timepoints."
+                )
+            elif not atmos_ok:
+                raise ValueError(
+                    "The atmosphere dataset has an insufficient number of timepoints."
+                )
 
     def set_epoch(self, epoch: int):
-        self._ocean.set_epoch(epoch)
-        self._atmosphere.set_epoch(epoch)
+        if self._ocean is not None:
+            self._ocean.set_epoch(epoch)
+        if self._ice is not None:
+            self._ice.set_epoch(epoch)
+        if self._atmosphere is not None:
+            self._atmosphere.set_epoch(epoch)

--- a/fme/coupled/data_loading/data_typing.py
+++ b/fme/coupled/data_loading/data_typing.py
@@ -15,6 +15,8 @@ from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.dataset.dataset import DatasetABC, DatasetItem
 from fme.core.dataset.properties import DatasetProperties
 
+_VertCoordType = OptionalDepthCoordinate | OptionalHybridSigmaPressureCoordinate
+
 
 @dataclasses.dataclass
 class CoupledCoords:
@@ -32,27 +34,20 @@ class CoupledCoords:
     @property
     def ocean(self) -> dict[str, np.ndarray]:
         if self.ocean_horizontal is not None:
-            assert self.ocean_vertical is not None
-            return {**self.ocean_vertical, **self.ocean_horizontal}
-        else:
-            raise AttributeError("Ocean component is None")
+            return {**(self.ocean_vertical or {}), **self.ocean_horizontal}
+        raise AttributeError("Ocean component is None")
 
     @property
     def ice(self) -> dict[str, np.ndarray]:
         if self.ice_horizontal is not None:
-            if self.ice_vertical is not None:
-                return {**self.ice_vertical, **self.ice_horizontal}
-            return {**self.ice_horizontal}
-        else:
-            raise AttributeError("Ice component is None")
+            return {**(self.ice_vertical or {}), **self.ice_horizontal}
+        raise AttributeError("Ice component is None")
 
     @property
     def atmosphere(self) -> dict[str, np.ndarray]:
         if self.atmosphere_horizontal is not None:
-            assert self.atmosphere_vertical is not None
-            return {**self.atmosphere_vertical, **self.atmosphere_horizontal}
-        else:
-            raise AttributeError("Atmosphere component is None")
+            return {**(self.atmosphere_vertical or {}), **self.atmosphere_horizontal}
+        raise AttributeError("Atmosphere component is None")
 
 
 class CoupledVerticalCoordinate:
@@ -62,43 +57,50 @@ class CoupledVerticalCoordinate:
         ice: OptionalDepthCoordinate | None = None,
         atmosphere: OptionalHybridSigmaPressureCoordinate | None = None,
     ):
-        self.ocean = ocean
-        self.ice = ice
-        self.atmosphere = atmosphere
+        self._components: dict[str, _VertCoordType] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean),
+                ("ice", ice),
+                ("atmosphere", atmosphere),
+            ]
+            if val is not None
+        }
 
-    def __eq__(self, other):
+    @classmethod
+    def from_components(
+        cls,
+        components: dict[str, _VertCoordType],
+    ) -> "CoupledVerticalCoordinate":
+        obj = cls()
+        obj._components = components
+        return obj
+
+    @property
+    def ocean(self) -> OptionalDepthCoordinate | None:
+        return cast(OptionalDepthCoordinate | None, self._components.get("ocean"))
+
+    @property
+    def ice(self) -> OptionalDepthCoordinate | None:
+        return cast(OptionalDepthCoordinate | None, self._components.get("ice"))
+
+    @property
+    def atmosphere(self) -> OptionalHybridSigmaPressureCoordinate | None:
+        return cast(
+            OptionalHybridSigmaPressureCoordinate | None,
+            self._components.get("atmosphere"),
+        )
+
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, CoupledVerticalCoordinate):
             return False
-        if self.atmosphere is None:
-            ocean_check = self.ocean == other.ocean
-            ice_check = self.ice == other.ice
-            return ocean_check and ice_check
-        elif self.ice is None:
-            ocean_check = self.ocean == other.ocean
-            atmos_check = self.atmosphere == other.atmosphere
-            return ocean_check and atmos_check
-        elif self.ocean is None:
-            ice_check = self.ice == other.ice
-            atmos_check = self.atmosphere == other.atmosphere
-            return ice_check and atmos_check
-        else:
-            ocean_check = self.ocean == other.ocean
-            ice_check = self.ice == other.ice
-            atmos_check = self.atmosphere == other.atmosphere
-            return ocean_check and ice_check and atmos_check
+        return self._components.keys() == other._components.keys() and all(
+            self._components[k] == other._components[k] for k in self._components
+        )
 
     def to(self, device: torch.device) -> "CoupledVerticalCoordinate":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if self.ocean is not None:
-            ocean_device = self.ocean.to(device)
-        if self.ice is not None:
-            ice_device = self.ice.to(device)
-        if self.atmosphere is not None:
-            atmos_device = self.atmosphere.to(device)
-        return CoupledVerticalCoordinate(
-            ocean=ocean_device, ice=ice_device, atmosphere=atmos_device
+        return CoupledVerticalCoordinate.from_components(
+            {k: v.to(device) for k, v in self._components.items()}
         )
 
 
@@ -109,43 +111,38 @@ class CoupledHorizontalCoordinates:
         ice: HorizontalCoordinates | None = None,
         atmosphere: HorizontalCoordinates | None = None,
     ):
-        self.ocean = ocean
-        self.ice = ice
-        self.atmosphere = atmosphere
+        self._components: dict[str, HorizontalCoordinates] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean),
+                ("ice", ice),
+                ("atmosphere", atmosphere),
+            ]
+            if val is not None
+        }
 
-    def __eq__(self, other):
+    @property
+    def ocean(self) -> HorizontalCoordinates | None:
+        return self._components.get("ocean")
+
+    @property
+    def ice(self) -> HorizontalCoordinates | None:
+        return self._components.get("ice")
+
+    @property
+    def atmosphere(self) -> HorizontalCoordinates | None:
+        return self._components.get("atmosphere")
+
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, CoupledHorizontalCoordinates):
             return False
-        if self.atmosphere is None:
-            ocean_check = self.ocean == other.ocean
-            ice_check = self.ice == other.ice
-            return ocean_check and ice_check
-        elif self.ice is None:
-            ocean_check = self.ocean == other.ocean
-            atmos_check = self.atmosphere == other.atmosphere
-            return ocean_check and atmos_check
-        elif self.ocean is None:
-            ice_check = self.ice == other.ice
-            atmos_check = self.atmosphere == other.atmosphere
-            return ice_check and atmos_check
-        else:
-            ocean_check = self.ocean == other.ocean
-            ice_check = self.ice == other.ice
-            atmos_check = self.atmosphere == other.atmosphere
-            return ocean_check and ice_check and atmos_check
+        return self._components.keys() == other._components.keys() and all(
+            self._components[k] == other._components[k] for k in self._components
+        )
 
     def to(self, device: torch.device) -> "CoupledHorizontalCoordinates":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if self.ocean is not None:
-            ocean_device = self.ocean.to(device)
-        if self.ice is not None:
-            ice_device = self.ice.to(device)
-        if self.atmosphere is not None:
-            atmos_device = self.atmosphere.to(device)
         return CoupledHorizontalCoordinates(
-            ocean=ocean_device, ice=ice_device, atmosphere=atmos_device
+            **{k: v.to(device) for k, v in self._components.items()}
         )
 
 
@@ -156,52 +153,60 @@ class CoupledDatasetProperties:
         ice: DatasetProperties | None = None,
         atmosphere: DatasetProperties | None = None,
     ):
-        self.ocean = ocean
-        self.ice = ice
-        self.atmosphere = atmosphere
-        ocean_vcoord = None
-        ice_vcoord = None
-        atmos_vcoord = None
-        ocean_hcoord = None
-        ice_hcoord = None
-        atmos_hcoord = None
-        if self.ocean is not None:
-            ocean_vcoord = cast(OptionalDepthCoordinate, self.ocean.vertical_coordinate)
-            ocean_hcoord = self.ocean.horizontal_coordinates
-        if self.ice is not None:
-            ice_vcoord = cast(OptionalDepthCoordinate, self.ice.vertical_coordinate)
-            ice_hcoord = self.ice.horizontal_coordinates
-        if self.atmosphere is not None:
-            atmos_vcoord = cast(
-                OptionalHybridSigmaPressureCoordinate,
-                self.atmosphere.vertical_coordinate,
-            )
-            atmos_hcoord = self.atmosphere.horizontal_coordinates
-
-        self._vertical_coordinate = CoupledVerticalCoordinate(
-            ocean_vcoord, ice_vcoord, atmos_vcoord
-        )
+        self._components: dict[str, DatasetProperties] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean),
+                ("ice", ice),
+                ("atmosphere", atmosphere),
+            ]
+            if val is not None
+        }
+        vcoords: dict[str, _VertCoordType] = {}
+        for name, props in self._components.items():
+            if name == "atmosphere":
+                vcoords[name] = cast(
+                    OptionalHybridSigmaPressureCoordinate, props.vertical_coordinate
+                )
+            else:
+                vcoords[name] = cast(OptionalDepthCoordinate, props.vertical_coordinate)
+        self._vertical_coordinate = CoupledVerticalCoordinate.from_components(vcoords)
         self._horizontal_coordinates = CoupledHorizontalCoordinates(
-            ocean_hcoord, ice_hcoord, atmos_hcoord
+            **{
+                name: props.horizontal_coordinates
+                for name, props in self._components.items()
+            }
         )
+
+    @property
+    def ocean(self) -> DatasetProperties | None:
+        return self._components.get("ocean")
+
+    @property
+    def ice(self) -> DatasetProperties | None:
+        return self._components.get("ice")
+
+    @property
+    def atmosphere(self) -> DatasetProperties | None:
+        return self._components.get("atmosphere")
 
     @property
     def atmosphere_timestep(self) -> datetime.timedelta:
-        assert self.atmosphere is not None
-        assert self.atmosphere.timestep is not None
-        return self.atmosphere.timestep
+        props = self._components["atmosphere"]
+        assert props.timestep is not None
+        return props.timestep
 
     @property
     def ocean_timestep(self) -> datetime.timedelta:
-        assert self.ocean is not None
-        assert self.ocean.timestep is not None
-        return self.ocean.timestep
+        props = self._components["ocean"]
+        assert props.timestep is not None
+        return props.timestep
 
     @property
     def ice_timestep(self) -> datetime.timedelta:
-        assert self.ice is not None
-        assert self.ice.timestep is not None
-        return self.ice.timestep
+        props = self._components["ice"]
+        assert props.timestep is not None
+        return props.timestep
 
     @property
     def vertical_coordinate(self) -> CoupledVerticalCoordinate:
@@ -214,119 +219,61 @@ class CoupledDatasetProperties:
     @property
     def variable_metadata(self) -> dict[str, VariableMetadata]:
         metadata: dict[str, VariableMetadata] = {}
-        if self.ocean is not None:
-            metadata.update(self.ocean.variable_metadata)
-        if self.ice is not None:
-            metadata.update(self.ice.variable_metadata)
-        if self.atmosphere is not None:
-            metadata.update(self.atmosphere.variable_metadata)
+        for props in self._components.values():
+            metadata.update(props.variable_metadata)
         return metadata
 
     @property
     def timestep(self) -> datetime.timedelta:
-        if self.ocean is not None:
-            return self.ocean_timestep
-        else:
-            return self.ice_timestep
+        for name in ("ocean", "ice"):
+            if name in self._components:
+                props = self._components[name]
+                assert props.timestep is not None
+                return props.timestep
+        return self.atmosphere_timestep
 
     @property
     def is_remote(self) -> bool:
-        if self.atmosphere is None:
-            assert self.ocean is not None
-            assert self.ice is not None
-            remote_ocean = self.ocean.is_remote
-            remote_ice = self.ice.is_remote
-            remote = remote_ocean or remote_ice
-        elif self.ice is None:
-            assert self.ocean is not None
-            remote_atmos = self.atmosphere.is_remote
-            remote_ocean = self.ocean.is_remote
-            remote = remote_atmos or remote_ocean
-        elif self.ocean is None:
-            assert self.ice is not None
-            remote_ice = self.ice.is_remote
-            remote_atmos = self.atmosphere.is_remote
-            remote = remote_ice or remote_atmos
-        else:
-            remote_ice = self.ice.is_remote
-            remote_atmos = self.atmosphere.is_remote
-            remote_ocean = self.ocean.is_remote
-            remote = remote_ice or remote_atmos or remote_ocean
-        return remote
+        return any(props.is_remote for props in self._components.values())
 
     @property
     def n_inner_steps(self) -> int:
-        if self.atmosphere is None:
-            return self.ocean_timestep // self.ice_timestep
-        elif self.ice is None:
-            return self.ocean_timestep // self.atmosphere_timestep
-        elif self.ocean is None:
-            return self.ice_timestep // self.atmosphere_timestep
+        if self.ocean is not None:
+            if self.atmosphere is not None:
+                return self.ocean_timestep // self.atmosphere_timestep
+            else:
+                assert self.ice is not None
+                return self.ocean_timestep // self.ice_timestep
         else:
-            return self.ocean_timestep // self.atmosphere_timestep
+            assert self.ice is not None and self.atmosphere is not None
+            return self.ice_timestep // self.atmosphere_timestep
 
     @property
     def coords(self) -> CoupledCoords:
-        ocean_vcoord = None
-        ocean_hcoord = None
-        atmos_vcoord = None
-        atmos_hcoord = None
-        ice_hcoord = None
-        ice_vcoord = None
-        if self.ocean is not None:
-            assert self.vertical_coordinate.ocean is not None
-            assert self.horizontal_coordinates.ocean is not None
-            ocean_vcoord = self.vertical_coordinate.ocean.coords
-            ocean_hcoord = dict(self.horizontal_coordinates.ocean.coords)
-        if self.ice is not None:
-            assert self.vertical_coordinate.ice is not None
-            assert self.horizontal_coordinates.ice is not None
-            ice_vcoord = self.vertical_coordinate.ice.coords
-            ice_hcoord = dict(self.horizontal_coordinates.ice.coords)
-        if self.atmosphere is not None:
-            assert self.vertical_coordinate.atmosphere is not None
-            assert self.horizontal_coordinates.atmosphere is not None
-            atmos_vcoord = self.vertical_coordinate.atmosphere.coords
-            atmos_hcoord = dict(self.horizontal_coordinates.atmosphere.coords)
-        return CoupledCoords(
-            ocean_vertical=ocean_vcoord,
-            atmosphere_vertical=atmos_vcoord,
-            ice_vertical=ice_vcoord,
-            ocean_horizontal=ocean_hcoord,
-            ice_horizontal=ice_hcoord,
-            atmosphere_horizontal=atmos_hcoord,
-        )
+        kwargs: dict[str, dict[str, np.ndarray]] = {}
+        for name in self._components:
+            vcoord = self._vertical_coordinate._components.get(name)
+            hcoord = self._horizontal_coordinates._components.get(name)
+            assert vcoord is not None and hcoord is not None
+            kwargs[f"{name}_vertical"] = vcoord.coords
+            kwargs[f"{name}_horizontal"] = dict(hcoord.coords)
+        return CoupledCoords(**kwargs)
 
     def to_device(self) -> "CoupledDatasetProperties":
-        ocean_device = None
-        ice_device = None
-        atmos_device = None
-        if self.ocean is not None:
-            ocean_device = self.ocean.to_device()
-        if self.ice is not None:
-            ice_device = self.ice.to_device()
-        if self.atmosphere is not None:
-            atmos_device = self.atmosphere.to_device()
         return CoupledDatasetProperties(
-            ocean=ocean_device, ice=ice_device, atmosphere=atmos_device
+            **{name: props.to_device() for name, props in self._components.items()}
         )
 
     def update(self, other: "CoupledDatasetProperties"):
-        if self.vertical_coordinate != other.vertical_coordinate:
+        if self._vertical_coordinate != other._vertical_coordinate:
             raise ValueError("Vertical coordinates must be the same for both datasets.")
-        if self.horizontal_coordinates != other.horizontal_coordinates:
+        if self._horizontal_coordinates != other._horizontal_coordinates:
             raise ValueError(
                 "Horizontal coordinates must be the same for both datasets."
             )
-        if self.atmosphere is not None:
-            assert other.atmosphere is not None
-            self.atmosphere.update(other.atmosphere)
-        if self.ocean is not None:
-            assert other.ocean is not None
-            self.ocean.update(other.ocean)
-        if self.ice is not None:
-            assert other.ice is not None
-            self.ice.update(other.ice)
+        for name, props in self._components.items():
+            assert name in other._components
+            props.update(other._components[name])
 
 
 @dataclasses.dataclass
@@ -347,106 +294,78 @@ class CoupledDataset:
     ):
         """
         Args:
-            ocean: ocean dataset.
-            ice: ice dataset.
-            atmosphere: atmosphere dataset.
+            ocean: ocean dataset (slow component, idx at the coarse timestep).
+            ice: ice dataset (fast component, idx at the fine timestep).
+            atmosphere: atmosphere dataset (fast component, idx at the fine timestep).
             properties: the coupled dataset properties.
-            n_steps_fast: number of atmosphere timesteps per ocean timestep.
+            n_steps_fast: number of fast timesteps per slow (ocean) timestep.
         """
-        self._ocean = ocean
-        self._ice = ice
-        self._atmosphere = atmosphere
-        if self._atmosphere is None:
-            if properties.ocean_timestep != properties.ice_timestep * n_steps_fast:
-                raise ValueError(
-                    "Ocean and Ice timesteps must be consistent with "
-                    f"n_steps_fast, got ocean timestep {properties.ocean_timestep} "
-                    f"and ice timestep {properties.ice_timestep} "
-                    f"with n_steps_fast={n_steps_fast}."
-                )
-            assert self._ocean is not None
-            assert self._ice is not None
-            ocean_time = self._ocean[0][1].isel(time=0).item()
-            ice_time = self._ice[0][1].isel(time=0).item()
-            if ocean_time != ice_time:
-                raise ValueError(
-                    f"First time of ocean dataset is {ocean_time} "
-                    f"but the ice's first time is {ice_time}. "
-                    "Maybe align the datasets using a subset?"
-                )
-        elif self._ice is None:
-            if (
-                properties.ocean_timestep
-                != properties.atmosphere_timestep * n_steps_fast
-            ):
-                raise ValueError(
-                    "Ocean and Atmosphere timesteps must be consistent with "
-                    f"n_steps_fast, got ocean timestep {properties.ocean_timestep} "
-                    f"and atmosphere timestep {properties.atmosphere_timestep} "
-                    f"with n_steps_fast={n_steps_fast}."
-                )
-            assert self._ocean is not None
-            ocean_time = self._ocean[0][1].isel(time=0).item()
-            atmos_time = self._atmosphere[0][1].isel(time=0).item()
-            if ocean_time != atmos_time:
-                raise ValueError(
-                    f"First time of ocean dataset is {ocean_time} "
-                    f"but the atmosphere's first time is {atmos_time}. "
-                    "Maybe align the datasets using a subset?"
-                )
-        elif self._ocean is None:
-            if properties.ice_timestep != properties.atmosphere_timestep:
-                raise ValueError(
-                    "Ice and Atmosphere timesteps must be consistent, "
-                    f"got ice timestep {properties.ice_timestep} "
-                    f"and atmosphere timestep {properties.atmosphere_timestep}."
-                )
-            assert self._ice is not None
-            ice_time = self._ice[0][1].isel(time=0).item()
-            atmos_time = self._atmosphere[0][1].isel(time=0).item()
-            if ice_time != atmos_time:
-                raise ValueError(
-                    f"First time of ice dataset is {ice_time} "
-                    f"but the atmosphere's first time is {atmos_time}. "
-                    "Maybe align the datasets using a subset?"
-                )
-        else:
-            if properties.ice_timestep != properties.atmosphere_timestep:
-                raise ValueError(
-                    "Ice and Atmosphere timesteps must be consistent, "
-                    f"got ice timestep {properties.ice_timestep} "
-                    f"and atmosphere timestep {properties.atmosphere_timestep}."
-                )
-            if (
-                properties.ocean_timestep
-                != properties.atmosphere_timestep * n_steps_fast
-            ):
-                raise ValueError(
-                    "Ocean and Atmosphere timesteps must be consistent with "
-                    f"n_steps_fast, got ocean timestep {properties.ocean_timestep} "
-                    f"and atmosphere timestep {properties.atmosphere_timestep} "
-                    f"with n_steps_fast={n_steps_fast}."
-                )
-            assert self._ice is not None
-            assert self._ocean is not None
-            ice_time = self._ice[0][1].isel(time=0).item()
-            ocean_time = self._ocean[0][1].isel(time=0).item()
-            atmos_time = self._atmosphere[0][1].isel(time=0).item()
-            if ice_time != atmos_time:
-                raise ValueError(
-                    f"First time of ice dataset is {ice_time} "
-                    f"but the atmosphere's first time is {atmos_time}. "
-                    "Maybe align the datasets using a subset?"
-                )
-            if ocean_time != atmos_time:
-                raise ValueError(
-                    f"First time of ocean dataset is {ocean_time} "
-                    f"but the atmosphere's first time is {atmos_time}. "
-                    "Maybe align the datasets using a subset?"
-                )
-
+        self._slow_datasets: dict[str, DatasetABC] = {
+            name: ds for name, ds in [("ocean", ocean)] if ds is not None
+        }
+        self._fast_datasets: dict[str, DatasetABC] = {
+            name: ds
+            for name, ds in [("ice", ice), ("atmosphere", atmosphere)]
+            if ds is not None
+        }
+        self._validate_timesteps(properties, n_steps_fast)
+        self._validate_time_alignment()
         self._properties = properties
         self._n_steps_fast = n_steps_fast
+
+    def _validate_timesteps(
+        self, properties: CoupledDatasetProperties, n_steps_fast: int
+    ) -> None:
+        if not self._slow_datasets:
+            # No slow component: all fast components must share the same timestep.
+            fast_names = list(self._fast_datasets)
+            if len(fast_names) > 1:
+                fast_ts_0 = properties._components[fast_names[0]].timestep
+                for fast_name in fast_names[1:]:
+                    other_ts = properties._components[fast_name].timestep
+                    if other_ts != fast_ts_0:
+                        raise ValueError(
+                            f"{fast_names[0].capitalize()} and {fast_name} timesteps "
+                            f"must be consistent, got {fast_ts_0} and {other_ts}."
+                        )
+            return
+        if not self._fast_datasets:
+            return
+        slow_name = next(iter(self._slow_datasets))
+        slow_ts = properties._components[slow_name].timestep
+        fast_names = list(self._fast_datasets)
+        fast_ts = properties._components[fast_names[0]].timestep
+        for fast_name in fast_names[1:]:
+            other_ts = properties._components[fast_name].timestep
+            if other_ts != fast_ts:
+                raise ValueError(
+                    f"Fast components {fast_names[0]} and {fast_name} must have "
+                    f"the same timestep, got {fast_ts} and {other_ts}."
+                )
+        assert slow_ts is not None and fast_ts is not None
+        if slow_ts != fast_ts * n_steps_fast:
+            fast_names_str = " and ".join(fast_names)
+            raise ValueError(
+                f"{slow_name.capitalize()} and {fast_names_str} timesteps must be "
+                f"consistent with n_steps_fast, got {slow_name} timestep {slow_ts} "
+                f"and fast timestep {fast_ts} with n_steps_fast={n_steps_fast}."
+            )
+
+    def _validate_time_alignment(self) -> None:
+        all_datasets = {**self._slow_datasets, **self._fast_datasets}
+        if len(all_datasets) < 2:
+            return
+        times = {
+            name: ds[0][1].isel(time=0).item() for name, ds in all_datasets.items()
+        }
+        reference_name, reference_time = next(iter(times.items()))
+        for name, t in times.items():
+            if name != reference_name and t != reference_time:
+                raise ValueError(
+                    f"First time of {reference_name} dataset is {reference_time} "
+                    f"but the {name}'s first time is {t}. "
+                    "Maybe align the datasets using a subset?"
+                )
 
     @property
     def properties(self) -> CoupledDatasetProperties:
@@ -458,149 +377,42 @@ class CoupledDataset:
 
     @property
     def all_ic_times(self) -> xr.CFTimeIndex:
-        if self._atmosphere is None:
-            assert self._ocean is not None
-            return self._ocean.sample_start_times
-        elif self._ice is None:
-            assert self._ocean is not None
-            return self._ocean.sample_start_times
-        elif self._ocean is None:
-            assert self._ice is not None
-            return self._ice.sample_start_times
-        else:
-            assert self._ocean is not None
-            return self._ocean.sample_start_times
+        for ds in {**self._slow_datasets, **self._fast_datasets}.values():
+            return ds.sample_start_times
+        raise ValueError("No datasets available")
 
-    def __len__(self):
-        if self._atmosphere is None:
-            assert self._ocean is not None
-            assert self._ice is not None
-            return min([len(self._ocean), len(self._ice)])
-        elif self._ice is None:
-            assert self._ocean is not None
-            return min([len(self._ocean), len(self._atmosphere)])
-        elif self._ocean is None:
-            assert self._ice is not None
-            return min([len(self._ice), len(self._atmosphere)])
-        else:
-            assert self._ocean is not None
-            assert self._ice is not None
-            return min([len(self._ocean), len(self._ice), len(self._atmosphere)])
+    def __len__(self) -> int:
+        return min(
+            len(ds) for ds in {**self._slow_datasets, **self._fast_datasets}.values()
+        )
 
     def __getitem__(self, idx: int) -> CoupledDatasetItem:
         fast_idx = idx * self._n_steps_fast
-        ocean = None
-        ice = None
-        atmosphere = None
-        if self._ocean is not None:
-            ocean = self._ocean[idx]
-        if self._ice is not None:
-            ice = self._ice[fast_idx]
-        if self._atmosphere is not None:
-            atmosphere = self._atmosphere[fast_idx]
-        return CoupledDatasetItem(ocean=ocean, ice=ice, atmosphere=atmosphere)
+        components: dict[str, DatasetItem] = {}
+        for name, ds in self._slow_datasets.items():
+            components[name] = ds[idx]
+        for name, ds in self._fast_datasets.items():
+            components[name] = ds[fast_idx]
+        return CoupledDatasetItem(**components)
 
     def validate_inference_length(self, max_start_index: int, max_window_len: int):
-        if self._atmosphere is None:
-            assert self._ocean is not None
-            assert self._ice is not None
+        for name, ds in self._slow_datasets.items():
             try:
-                self._ocean.validate_inference_length(max_start_index, max_window_len)
+                ds.validate_inference_length(max_start_index, max_window_len)
             except ValueError as e:
                 raise ValueError(
-                    "The ocean dataset has an insufficient number of timepoints."
+                    f"The {name} dataset has an insufficient number of timepoints."
                 ) from e
-            ice_max_start_index = max_start_index * self.n_steps_fast
-            ice_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
+        fast_max_start = max_start_index * self._n_steps_fast
+        fast_max_window = (max_window_len - 1) * self._n_steps_fast + 1
+        for name, ds in self._fast_datasets.items():
             try:
-                self._ice.validate_inference_length(
-                    ice_max_start_index, ice_max_window_len
-                )
+                ds.validate_inference_length(fast_max_start, fast_max_window)
             except ValueError as e:
                 raise ValueError(
-                    "The ice dataset has an insufficient number of timepoints."
+                    f"The {name} dataset has an insufficient number of timepoints."
                 ) from e
-        elif self._ice is None:
-            assert self._ocean is not None
-            try:
-                self._ocean.validate_inference_length(max_start_index, max_window_len)
-            except ValueError as e:
-                raise ValueError(
-                    "The ocean dataset has an insufficient number of timepoints."
-                ) from e
-            atmos_max_start_index = max_start_index * self.n_steps_fast
-            atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
-            try:
-                self._atmosphere.validate_inference_length(
-                    atmos_max_start_index, atmos_max_window_len
-                )
-            except ValueError as e:
-                raise ValueError(
-                    "The atmosphere dataset has an insufficient number of timepoints."
-                ) from e
-        elif self._ocean is None:
-            assert self._ice is not None
-            try:
-                self._ice.validate_inference_length(max_start_index, max_window_len)
-            except ValueError as e:
-                raise ValueError(
-                    "The ice dataset has an insufficient number of timepoints."
-                ) from e
-            atmos_max_start_index = max_start_index * self.n_steps_fast
-            atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
-            try:
-                self._atmosphere.validate_inference_length(
-                    atmos_max_start_index, atmos_max_window_len
-                )
-            except ValueError as e:
-                raise ValueError(
-                    "The atmosphere dataset has an insufficient number of timepoints."
-                ) from e
-        else:
-            assert self._ocean is not None
-            assert self._ice is not None
-            try:
-                self._ocean.validate_inference_length(max_start_index, max_window_len)
-            except ValueError as e:
-                raise ValueError(
-                    "The ocean dataset has an insufficient number of timepoints."
-                ) from e
-            ice_max_start_index = max_start_index * self.n_steps_fast
-            ice_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
-            atmos_max_start_index = max_start_index * self.n_steps_fast
-            atmos_max_window_len = (max_window_len - 1) * self.n_steps_fast + 1
-            ice_ok = True
-            atmos_ok = True
-            try:
-                self._ice.validate_inference_length(
-                    ice_max_start_index, ice_max_window_len
-                )
-            except ValueError:
-                ice_ok = False
-            try:
-                self._atmosphere.validate_inference_length(
-                    atmos_max_start_index, atmos_max_window_len
-                )
-            except ValueError:
-                atmos_ok = False
-            if not ice_ok and not atmos_ok:
-                raise ValueError(
-                    f"The atmosphere/ice dataset has an insufficient number of "
-                    f"timepoints."
-                )
-            elif not ice_ok:
-                raise ValueError(
-                    "The ice dataset has an insufficient number of timepoints."
-                )
-            elif not atmos_ok:
-                raise ValueError(
-                    "The atmosphere dataset has an insufficient number of timepoints."
-                )
 
     def set_epoch(self, epoch: int):
-        if self._ocean is not None:
-            self._ocean.set_epoch(epoch)
-        if self._ice is not None:
-            self._ice.set_epoch(epoch)
-        if self._atmosphere is not None:
-            self._atmosphere.set_epoch(epoch)
+        for ds in {**self._slow_datasets, **self._fast_datasets}.values():
+            ds.set_epoch(epoch)

--- a/fme/coupled/data_loading/data_typing.py
+++ b/fme/coupled/data_loading/data_typing.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+from typing import cast
 
 import numpy as np
 import torch
@@ -31,6 +32,7 @@ class CoupledCoords:
     @property
     def ocean(self) -> dict[str, np.ndarray]:
         if self.ocean_horizontal is not None:
+            assert self.ocean_vertical is not None
             return {**self.ocean_vertical, **self.ocean_horizontal}
         else:
             raise AttributeError("Ocean component is None")
@@ -47,6 +49,7 @@ class CoupledCoords:
     @property
     def atmosphere(self) -> dict[str, np.ndarray]:
         if self.atmosphere_horizontal is not None:
+            assert self.atmosphere_vertical is not None
             return {**self.atmosphere_vertical, **self.atmosphere_horizontal}
         else:
             raise AttributeError("Atmosphere component is None")
@@ -163,17 +166,17 @@ class CoupledDatasetProperties:
         ice_hcoord = None
         atmos_hcoord = None
         if self.ocean is not None:
-            ocean_vcoord = ocean.vertical_coordinate
-            ocean_hcoord = ocean.horizontal_coordinates
-            assert isinstance(ocean_vcoord, OptionalDepthCoordinate)
+            ocean_vcoord = cast(OptionalDepthCoordinate, self.ocean.vertical_coordinate)
+            ocean_hcoord = self.ocean.horizontal_coordinates
         if self.ice is not None:
-            ice_vcoord = ice.vertical_coordinate
-            ice_hcoord = ice.horizontal_coordinates
-            assert isinstance(ice_vcoord, OptionalDepthCoordinate)
+            ice_vcoord = cast(OptionalDepthCoordinate, self.ice.vertical_coordinate)
+            ice_hcoord = self.ice.horizontal_coordinates
         if self.atmosphere is not None:
-            atmos_vcoord = atmosphere.vertical_coordinate
-            atmos_hcoord = atmosphere.horizontal_coordinates
-            assert isinstance(atmos_vcoord, OptionalHybridSigmaPressureCoordinate)
+            atmos_vcoord = cast(
+                OptionalHybridSigmaPressureCoordinate,
+                self.atmosphere.vertical_coordinate,
+            )
+            atmos_hcoord = self.atmosphere.horizontal_coordinates
 
         self._vertical_coordinate = CoupledVerticalCoordinate(
             ocean_vcoord, ice_vcoord, atmos_vcoord
@@ -184,16 +187,19 @@ class CoupledDatasetProperties:
 
     @property
     def atmosphere_timestep(self) -> datetime.timedelta:
+        assert self.atmosphere is not None
         assert self.atmosphere.timestep is not None
         return self.atmosphere.timestep
 
     @property
     def ocean_timestep(self) -> datetime.timedelta:
+        assert self.ocean is not None
         assert self.ocean.timestep is not None
         return self.ocean.timestep
 
     @property
     def ice_timestep(self) -> datetime.timedelta:
+        assert self.ice is not None
         assert self.ice.timestep is not None
         return self.ice.timestep
 
@@ -226,14 +232,18 @@ class CoupledDatasetProperties:
     @property
     def is_remote(self) -> bool:
         if self.atmosphere is None:
+            assert self.ocean is not None
+            assert self.ice is not None
             remote_ocean = self.ocean.is_remote
             remote_ice = self.ice.is_remote
             remote = remote_ocean or remote_ice
         elif self.ice is None:
+            assert self.ocean is not None
             remote_atmos = self.atmosphere.is_remote
             remote_ocean = self.ocean.is_remote
             remote = remote_atmos or remote_ocean
         elif self.ocean is None:
+            assert self.ice is not None
             remote_ice = self.ice.is_remote
             remote_atmos = self.atmosphere.is_remote
             remote = remote_ice or remote_atmos
@@ -264,12 +274,18 @@ class CoupledDatasetProperties:
         ice_hcoord = None
         ice_vcoord = None
         if self.ocean is not None:
+            assert self.vertical_coordinate.ocean is not None
+            assert self.horizontal_coordinates.ocean is not None
             ocean_vcoord = self.vertical_coordinate.ocean.coords
             ocean_hcoord = dict(self.horizontal_coordinates.ocean.coords)
         if self.ice is not None:
+            assert self.vertical_coordinate.ice is not None
+            assert self.horizontal_coordinates.ice is not None
             ice_vcoord = self.vertical_coordinate.ice.coords
             ice_hcoord = dict(self.horizontal_coordinates.ice.coords)
         if self.atmosphere is not None:
+            assert self.vertical_coordinate.atmosphere is not None
+            assert self.horizontal_coordinates.atmosphere is not None
             atmos_vcoord = self.vertical_coordinate.atmosphere.coords
             atmos_hcoord = dict(self.horizontal_coordinates.atmosphere.coords)
         return CoupledCoords(
@@ -303,10 +319,13 @@ class CoupledDatasetProperties:
                 "Horizontal coordinates must be the same for both datasets."
             )
         if self.atmosphere is not None:
+            assert other.atmosphere is not None
             self.atmosphere.update(other.atmosphere)
         if self.ocean is not None:
+            assert other.ocean is not None
             self.ocean.update(other.ocean)
         if self.ice is not None:
+            assert other.ice is not None
             self.ice.update(other.ice)
 
 
@@ -341,10 +360,12 @@ class CoupledDataset:
             if properties.ocean_timestep != properties.ice_timestep * n_steps_fast:
                 raise ValueError(
                     "Ocean and Ice timesteps must be consistent with "
-                    f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
-                    f"and ice timestep {properties.ice.timestep} "
+                    f"n_steps_fast, got ocean timestep {properties.ocean_timestep} "
+                    f"and ice timestep {properties.ice_timestep} "
                     f"with n_steps_fast={n_steps_fast}."
                 )
+            assert self._ocean is not None
+            assert self._ice is not None
             ocean_time = self._ocean[0][1].isel(time=0).item()
             ice_time = self._ice[0][1].isel(time=0).item()
             if ocean_time != ice_time:
@@ -360,10 +381,11 @@ class CoupledDataset:
             ):
                 raise ValueError(
                     "Ocean and Atmosphere timesteps must be consistent with "
-                    f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
-                    f"and atmosphere timestep {properties.atmosphere.timestep} "
+                    f"n_steps_fast, got ocean timestep {properties.ocean_timestep} "
+                    f"and atmosphere timestep {properties.atmosphere_timestep} "
                     f"with n_steps_fast={n_steps_fast}."
                 )
+            assert self._ocean is not None
             ocean_time = self._ocean[0][1].isel(time=0).item()
             atmos_time = self._atmosphere[0][1].isel(time=0).item()
             if ocean_time != atmos_time:
@@ -376,9 +398,10 @@ class CoupledDataset:
             if properties.ice_timestep != properties.atmosphere_timestep:
                 raise ValueError(
                     "Ice and Atmosphere timesteps must be consistent, "
-                    f"got ice timestep {properties.ice.timestep} "
-                    f"and atmosphere timestep {properties.atmosphere.timestep}."
+                    f"got ice timestep {properties.ice_timestep} "
+                    f"and atmosphere timestep {properties.atmosphere_timestep}."
                 )
+            assert self._ice is not None
             ice_time = self._ice[0][1].isel(time=0).item()
             atmos_time = self._atmosphere[0][1].isel(time=0).item()
             if ice_time != atmos_time:
@@ -391,8 +414,8 @@ class CoupledDataset:
             if properties.ice_timestep != properties.atmosphere_timestep:
                 raise ValueError(
                     "Ice and Atmosphere timesteps must be consistent, "
-                    f"got ice timestep {properties.ice.timestep} "
-                    f"and atmosphere timestep {properties.atmosphere.timestep}."
+                    f"got ice timestep {properties.ice_timestep} "
+                    f"and atmosphere timestep {properties.atmosphere_timestep}."
                 )
             if (
                 properties.ocean_timestep
@@ -400,10 +423,12 @@ class CoupledDataset:
             ):
                 raise ValueError(
                     "Ocean and Atmosphere timesteps must be consistent with "
-                    f"n_steps_fast, got ocean timestep {properties.ocean.timestep} "
-                    f"and atmosphere timestep {properties.atmosphere.timestep} "
+                    f"n_steps_fast, got ocean timestep {properties.ocean_timestep} "
+                    f"and atmosphere timestep {properties.atmosphere_timestep} "
                     f"with n_steps_fast={n_steps_fast}."
                 )
+            assert self._ice is not None
+            assert self._ocean is not None
             ice_time = self._ice[0][1].isel(time=0).item()
             ocean_time = self._ocean[0][1].isel(time=0).item()
             atmos_time = self._atmosphere[0][1].isel(time=0).item()
@@ -434,22 +459,32 @@ class CoupledDataset:
     @property
     def all_ic_times(self) -> xr.CFTimeIndex:
         if self._atmosphere is None:
+            assert self._ocean is not None
             return self._ocean.sample_start_times
         elif self._ice is None:
+            assert self._ocean is not None
             return self._ocean.sample_start_times
         elif self._ocean is None:
+            assert self._ice is not None
             return self._ice.sample_start_times
         else:
+            assert self._ocean is not None
             return self._ocean.sample_start_times
 
     def __len__(self):
         if self._atmosphere is None:
+            assert self._ocean is not None
+            assert self._ice is not None
             return min([len(self._ocean), len(self._ice)])
         elif self._ice is None:
+            assert self._ocean is not None
             return min([len(self._ocean), len(self._atmosphere)])
         elif self._ocean is None:
+            assert self._ice is not None
             return min([len(self._ice), len(self._atmosphere)])
         else:
+            assert self._ocean is not None
+            assert self._ice is not None
             return min([len(self._ocean), len(self._ice), len(self._atmosphere)])
 
     def __getitem__(self, idx: int) -> CoupledDatasetItem:
@@ -467,6 +502,8 @@ class CoupledDataset:
 
     def validate_inference_length(self, max_start_index: int, max_window_len: int):
         if self._atmosphere is None:
+            assert self._ocean is not None
+            assert self._ice is not None
             try:
                 self._ocean.validate_inference_length(max_start_index, max_window_len)
             except ValueError as e:
@@ -484,6 +521,7 @@ class CoupledDataset:
                     "The ice dataset has an insufficient number of timepoints."
                 ) from e
         elif self._ice is None:
+            assert self._ocean is not None
             try:
                 self._ocean.validate_inference_length(max_start_index, max_window_len)
             except ValueError as e:
@@ -501,6 +539,7 @@ class CoupledDataset:
                     "The atmosphere dataset has an insufficient number of timepoints."
                 ) from e
         elif self._ocean is None:
+            assert self._ice is not None
             try:
                 self._ice.validate_inference_length(max_start_index, max_window_len)
             except ValueError as e:
@@ -518,6 +557,8 @@ class CoupledDataset:
                     "The atmosphere dataset has an insufficient number of timepoints."
                 ) from e
         else:
+            assert self._ocean is not None
+            assert self._ice is not None
             try:
                 self._ocean.validate_inference_length(max_start_index, max_window_len)
             except ValueError as e:

--- a/fme/coupled/data_loading/getters.py
+++ b/fme/coupled/data_loading/getters.py
@@ -473,9 +473,13 @@ def get_forcing_data(
     if config.ocean is not None:
         assert initial_condition.ocean_data is not None
         initial_time = initial_condition.ocean_data.as_batch_data().time
-    elif (config.ocean is None) & (config.ice is not None):
+    elif config.ice is not None:
         assert initial_condition.ice_data is not None
         initial_time = initial_condition.ice_data.as_batch_data().time
+    else:
+        # atmosphere-only forcing: use ocean IC time to align the atmosphere dataset
+        assert initial_condition.ocean_data is not None
+        initial_time = initial_condition.ocean_data.as_batch_data().time
     if initial_time.shape[1] != 1:
         raise NotImplementedError("code assumes initial time only has 1 timestep")
     if config.ocean is None:

--- a/fme/coupled/data_loading/getters.py
+++ b/fme/coupled/data_loading/getters.py
@@ -17,9 +17,12 @@ from fme.core.labels import LabelEncoding
 from fme.coupled.data_loading.batch_data import CoupledBatchData, CoupledPrognosticState
 from fme.coupled.data_loading.concat import ConcatDataset
 from fme.coupled.data_loading.config import (
+    CoupledAtmosphereIceOceanDatasetConfig,
     CoupledConcatDatasetConfig,
     CoupledDataLoaderConfig,
     CoupledDatasetConfig,
+    CoupledIceAtmosphereDatasetConfig,
+    CoupledIceOceanDatasetConfig,
 )
 from fme.coupled.data_loading.data_typing import (
     CoupledDataset,
@@ -56,34 +59,26 @@ def _coupled_forkserver_worker_init_fn(worker_id: int) -> None:
 class CollateFn:
     def __init__(
         self,
-        ocean_horizontal_dims: list[str] | None = None,
-        ice_horizontal_dims: list[str] | None = None,
-        atmosphere_horizontal_dims: list[str] | None = None,
-        ocean_label_encoding: LabelEncoding | None = None,
-        ice_label_encoding: LabelEncoding | None = None,
-        atmosphere_label_encoding: LabelEncoding | None = None,
+        component_horizontal_dims: dict[str, list[str]],
+        component_label_encodings: dict[str, LabelEncoding] | None = None,
     ):
-        self.ocean_horizontal_dims = ocean_horizontal_dims
-        self.ice_horizontal_dims = ice_horizontal_dims
-        self.atmosphere_horizontal_dims = atmosphere_horizontal_dims
-        self.ocean_label_encoding = ocean_label_encoding
-        self.ice_label_encoding = ice_label_encoding
-        self.atmosphere_label_encoding = atmosphere_label_encoding
+        self.component_horizontal_dims = component_horizontal_dims
+        self.component_label_encodings = component_label_encodings
 
     def __call__(self, samples: list[CoupledDatasetItem]) -> CoupledBatchData:
         return CoupledBatchData.collate_fn(
             samples,
-            ocean_horizontal_dims=self.ocean_horizontal_dims,
-            ice_horizontal_dims=self.ice_horizontal_dims,
-            atmosphere_horizontal_dims=self.atmosphere_horizontal_dims,
-            ocean_label_encoding=self.ocean_label_encoding,
-            ice_label_encoding=self.ice_label_encoding,
-            atmosphere_label_encoding=self.atmosphere_label_encoding,
+            component_horizontal_dims=self.component_horizontal_dims,
+            component_label_encodings=self.component_label_encodings,
         )
 
 
 def get_dataset(
-    config: CoupledDatasetConfig, requirements: CoupledDataRequirements
+    config: CoupledDatasetConfig
+    | CoupledIceOceanDatasetConfig
+    | CoupledIceAtmosphereDatasetConfig
+    | CoupledAtmosphereIceOceanDatasetConfig,
+    requirements: CoupledDataRequirements,
 ) -> tuple[CoupledDataset, CoupledDatasetProperties]:
     ocean_reqs = requirements.ocean_requirements
     ice_reqs = requirements.ice_requirements
@@ -125,9 +120,19 @@ def get_dataset(
 
 
 def _combine_datasets(
-    configs: CoupledConcatDatasetConfig | CoupledDatasetConfig,
+    configs: CoupledConcatDatasetConfig
+    | CoupledDatasetConfig
+    | CoupledIceOceanDatasetConfig
+    | CoupledIceAtmosphereDatasetConfig
+    | CoupledAtmosphereIceOceanDatasetConfig,
     build_one: Callable[
-        [CoupledDatasetConfig], tuple[CoupledDataset, CoupledDatasetProperties]
+        [
+            CoupledDatasetConfig
+            | CoupledIceOceanDatasetConfig
+            | CoupledIceAtmosphereDatasetConfig
+            | CoupledAtmosphereIceOceanDatasetConfig
+        ],
+        tuple[CoupledDataset, CoupledDatasetProperties],
     ],
     strict: bool = True,
 ) -> tuple[ConcatDataset, CoupledDatasetProperties]:
@@ -159,7 +164,11 @@ def _combine_datasets(
 
 
 def get_datasets(
-    configs: CoupledConcatDatasetConfig | CoupledDatasetConfig,
+    configs: CoupledConcatDatasetConfig
+    | CoupledDatasetConfig
+    | CoupledIceOceanDatasetConfig
+    | CoupledIceAtmosphereDatasetConfig
+    | CoupledAtmosphereIceOceanDatasetConfig,
     requirements: CoupledDataRequirements,
     strict: bool = True,
 ) -> tuple[ConcatDataset, CoupledDatasetProperties]:
@@ -204,40 +213,26 @@ def _build_gridded_data(
     else:
         kwargs = {"prefetch_factor": config.prefetch_factor}
 
-    ocean_label_encoding = None
-    ocean_horiz_dim = None
-    if config.ocean_available_labels is not None:
-        ocean_label_encoding = LabelEncoding(
-            sorted(list(config.ocean_available_labels))
-        )
-    if properties.ocean is not None:
-        ocean_horiz_dim = list(properties.ocean.horizontal_coordinates.dims)
-
-    ice_label_encoding = None
-    ice_horiz_dim = None
-    if config.ice_available_labels is not None:
-        ice_label_encoding = LabelEncoding(sorted(list(config.ice_available_labels)))
-    if properties.ice is not None:
-        ice_horiz_dim = list(properties.ice.horizontal_coordinates.dims)
-
-    atmosphere_label_encoding = None
-    atmosphere_horiz_dim = None
-    if config.atmosphere_available_labels is not None:
-        atmosphere_label_encoding = LabelEncoding(
-            sorted(list(config.atmosphere_available_labels))
-        )
-    if properties.atmosphere is not None:
-        atmosphere_horiz_dim = list(properties.atmosphere.horizontal_coordinates.dims)
+    available_labels: dict[str, set[str] | None] = {
+        "ocean": config.ocean_available_labels,
+        "ice": config.ice_available_labels,
+        "atmosphere": config.atmosphere_available_labels,
+    }
+    component_horizontal_dims: dict[str, list[str]] = {
+        name: list(props.horizontal_coordinates.dims)
+        for name, props in properties._components.items()
+    }
+    component_label_encodings: dict[str, LabelEncoding] = {
+        name: LabelEncoding(sorted(list(labels)))
+        for name, labels in available_labels.items()
+        if labels is not None
+    }
 
     dataloader = CoupledDataLoader(
         dataset,
         CollateFn(
-            ocean_horizontal_dims=ocean_horiz_dim,
-            ocean_label_encoding=ocean_label_encoding,
-            ice_label_encoding=ice_label_encoding,
-            ice_horizontal_dims=ice_horiz_dim,
-            atmosphere_label_encoding=atmosphere_label_encoding,
-            atmosphere_horizontal_dims=atmosphere_horiz_dim,
+            component_horizontal_dims=component_horizontal_dims,
+            component_label_encodings=component_label_encodings or None,
         ),
         batch_size=batch_size,
         num_workers=config.num_data_workers,
@@ -281,7 +276,10 @@ def get_gridded_data(
 
 
 def get_train_dataset(
-    config: CoupledDatasetConfig,
+    config: CoupledDatasetConfig
+    | CoupledIceOceanDatasetConfig
+    | CoupledIceAtmosphereDatasetConfig
+    | CoupledAtmosphereIceOceanDatasetConfig,
     requirements: CoupledTrainDataRequirements,
 ) -> tuple[CoupledDataset, CoupledDatasetProperties]:
     """Build a CoupledDataset for training, where the atmosphere is split
@@ -347,7 +345,11 @@ def get_train_dataset(
 
 
 def get_train_datasets(
-    configs: CoupledConcatDatasetConfig | CoupledDatasetConfig,
+    configs: CoupledConcatDatasetConfig
+    | CoupledDatasetConfig
+    | CoupledIceOceanDatasetConfig
+    | CoupledIceAtmosphereDatasetConfig
+    | CoupledAtmosphereIceOceanDatasetConfig,
     requirements: CoupledTrainDataRequirements,
     strict: bool = True,
 ) -> tuple[ConcatDataset, CoupledDatasetProperties]:

--- a/fme/coupled/data_loading/getters.py
+++ b/fme/coupled/data_loading/getters.py
@@ -56,22 +56,28 @@ def _coupled_forkserver_worker_init_fn(worker_id: int) -> None:
 class CollateFn:
     def __init__(
         self,
-        ocean_horizontal_dims: list[str],
-        atmosphere_horizontal_dims: list[str],
+        ocean_horizontal_dims: list[str] | None = None,
+        ice_horizontal_dims: list[str] | None = None,
+        atmosphere_horizontal_dims: list[str] | None = None,
         ocean_label_encoding: LabelEncoding | None = None,
+        ice_label_encoding: LabelEncoding | None = None,
         atmosphere_label_encoding: LabelEncoding | None = None,
     ):
         self.ocean_horizontal_dims = ocean_horizontal_dims
+        self.ice_horizontal_dims = ice_horizontal_dims
         self.atmosphere_horizontal_dims = atmosphere_horizontal_dims
         self.ocean_label_encoding = ocean_label_encoding
+        self.ice_label_encoding = ice_label_encoding
         self.atmosphere_label_encoding = atmosphere_label_encoding
 
     def __call__(self, samples: list[CoupledDatasetItem]) -> CoupledBatchData:
         return CoupledBatchData.collate_fn(
             samples,
             ocean_horizontal_dims=self.ocean_horizontal_dims,
+            ice_horizontal_dims=self.ice_horizontal_dims,
             atmosphere_horizontal_dims=self.atmosphere_horizontal_dims,
             ocean_label_encoding=self.ocean_label_encoding,
+            ice_label_encoding=self.ice_label_encoding,
             atmosphere_label_encoding=self.atmosphere_label_encoding,
         )
 
@@ -80,18 +86,34 @@ def get_dataset(
     config: CoupledDatasetConfig, requirements: CoupledDataRequirements
 ) -> tuple[CoupledDataset, CoupledDatasetProperties]:
     ocean_reqs = requirements.ocean_requirements
+    ice_reqs = requirements.ice_requirements
     atmosphere_reqs = requirements.atmosphere_requirements
-    ocean: torch.utils.data.Dataset
-    atmosphere: torch.utils.data.Dataset
-    ocean, ocean_properties = config.ocean.build(
-        ocean_reqs.names, ocean_reqs.n_timesteps_schedule
+    ocean = None  #: torch.utils.data.Dataset
+    ice = None  #: torch.utils.data.Dataset
+    atmosphere = None  #: #torch.utils.data.Dataset
+    ocean_properties = None
+    ice_properties = None
+    atmosphere_properties = None
+    if ocean_reqs is not None:
+        ocean, ocean_properties = config.ocean.build(
+            ocean_reqs.names, ocean_reqs.n_timesteps_schedule
+        )
+    if ice_reqs is not None:
+        ice, ice_properties = config.ice.build(
+            ice_reqs.names, ice_reqs.n_timesteps_schedule
+        )
+    if atmosphere_reqs is not None:
+        atmosphere, atmosphere_properties = config.atmosphere.build(
+            atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
+        )
+    properties = CoupledDatasetProperties(
+        ocean=ocean_properties,
+        ice=ice_properties,
+        atmosphere=atmosphere_properties,
     )
-    atmosphere, atmosphere_properties = config.atmosphere.build(
-        atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
-    )
-    properties = CoupledDatasetProperties(ocean_properties, atmosphere_properties)
     dataset = CoupledDataset(
         ocean=ocean,
+        ice=ice,
         atmosphere=atmosphere,
         properties=properties,
         n_steps_fast=requirements.n_steps_fast,
@@ -179,28 +201,40 @@ def _build_gridded_data(
     else:
         kwargs = {"prefetch_factor": config.prefetch_factor}
 
+    ocean_label_encoding = None
+    ocean_horiz_dim = None
     if config.ocean_available_labels is not None:
         ocean_label_encoding = LabelEncoding(
             sorted(list(config.ocean_available_labels))
         )
-    else:
-        ocean_label_encoding = None
+    if properties.ocean is not None:
+        ocean_horiz_dim = list(properties.ocean.horizontal_coordinates.dims)
+
+    ice_label_encoding = None
+    ice_horiz_dim = None
+    if config.ice_available_labels is not None:
+        ice_label_encoding = LabelEncoding(sorted(list(config.ice_available_labels)))
+    if properties.ice is not None:
+        ice_horiz_dim = list(properties.ice.horizontal_coordinates.dims)
+
+    atmosphere_label_encoding = None
+    atmosphere_horiz_dim = None
     if config.atmosphere_available_labels is not None:
         atmosphere_label_encoding = LabelEncoding(
             sorted(list(config.atmosphere_available_labels))
         )
-    else:
-        atmosphere_label_encoding = None
+    if properties.atmosphere is not None:
+        atmosphere_horiz_dim = list(properties.atmosphere.horizontal_coordinates.dims)
 
     dataloader = CoupledDataLoader(
         dataset,
         CollateFn(
-            ocean_horizontal_dims=list(properties.ocean.horizontal_coordinates.dims),
+            ocean_horizontal_dims=ocean_horiz_dim,
             ocean_label_encoding=ocean_label_encoding,
+            ice_label_encoding=ice_label_encoding,
+            ice_horizontal_dims=ice_horiz_dim,
             atmosphere_label_encoding=atmosphere_label_encoding,
-            atmosphere_horizontal_dims=list(
-                properties.atmosphere.horizontal_coordinates.dims
-            ),
+            atmosphere_horizontal_dims=atmosphere_horiz_dim,
         ),
         batch_size=batch_size,
         num_workers=config.num_data_workers,
@@ -251,28 +285,54 @@ def get_train_dataset(
     into a short-horizon target dataset and a long-horizon forcing dataset
     that are merged via TimePaddedMergedDataset.
     """
-    ocean: torch.utils.data.Dataset
-    ocean, ocean_properties = config.ocean.build(
-        requirements.ocean_requirements.names,
-        requirements.ocean_requirements.n_timesteps_schedule,
+    ocean_properties = None
+    ocean = None
+    if config.ocean is not None:
+        ocean: torch.utils.data.Dataset
+        ocean, ocean_properties = config.ocean.build(
+            requirements.ocean_requirements.names,
+            requirements.ocean_requirements.n_timesteps_schedule,
+        )
+    atmosphere_properties = None
+    atmosphere = None
+    if config.atmosphere is not None:
+        atmos_target, atmos_target_properties = config.atmosphere.build(
+            requirements.atmosphere_target_requirements.names,
+            requirements.atmosphere_target_requirements.n_timesteps_schedule,
+        )
+        atmos_forcing, atmos_forcing_properties = config.atmosphere.build(
+            requirements.atmosphere_forcing_requirements.names,
+            requirements.atmosphere_forcing_requirements.n_timesteps_schedule,
+        )
+        # canonical = the long (forcing) horizon, since it provides the time
+        # coordinate that downstream code uses
+        atmosphere = TimePaddedMergedDataset([atmos_forcing, atmos_target])
+        atmosphere_properties = atmos_forcing_properties.copy()
+        atmosphere_properties.update_merged_dataset(atmos_target_properties)
+    ice_properties = None
+    ice = None
+    if config.ice is not None:
+        ice_target, ice_target_properties = config.ice.build(
+            requirements.ice_target_requirements.names,
+            requirements.ice_target_requirements.n_timesteps_schedule,
+        )
+        ice_forcing, ice_forcing_properties = config.ice.build(
+            requirements.ice_forcing_requirements.names,
+            requirements.ice_forcing_requirements.n_timesteps_schedule,
+        )
+        # canonical = the long (forcing) horizon, since it provides the time
+        # coordinate that downstream code uses
+        ice = TimePaddedMergedDataset([ice_forcing, ice_target])
+        ice_properties = ice_forcing_properties.copy()
+        ice_properties.update_merged_dataset(ice_target_properties)
+
+    properties = CoupledDatasetProperties(
+        ocean=ocean_properties, ice=ice_properties, atmosphere=atmosphere_properties
     )
-    atmos_target, atmos_target_properties = config.atmosphere.build(
-        requirements.atmosphere_target_requirements.names,
-        requirements.atmosphere_target_requirements.n_timesteps_schedule,
-    )
-    atmos_forcing, atmos_forcing_properties = config.atmosphere.build(
-        requirements.atmosphere_forcing_requirements.names,
-        requirements.atmosphere_forcing_requirements.n_timesteps_schedule,
-    )
-    # canonical = the long (forcing) horizon, since it provides the time
-    # coordinate that downstream code uses
-    atmosphere = TimePaddedMergedDataset([atmos_forcing, atmos_target])
-    atmosphere_properties = atmos_forcing_properties.copy()
-    atmosphere_properties.update_merged_dataset(atmos_target_properties)
-    properties = CoupledDatasetProperties(ocean_properties, atmosphere_properties)
     dataset = CoupledDataset(
         ocean=ocean,
         atmosphere=atmosphere,
+        ice=ice,
         properties=properties,
         n_steps_fast=requirements.n_steps_fast,
     )
@@ -402,7 +462,10 @@ def get_forcing_data(
     Returns:
         A data loader for forcing data with coordinates and metadata.
     """
-    initial_time = initial_condition.ocean_data.as_batch_data().time
+    if config.ocean is not None:
+        initial_time = initial_condition.ocean_data.as_batch_data().time
+    elif (config.ocean is None) & (config.ice is not None):
+        initial_time = initial_condition.ice_data.as_batch_data().time
     if initial_time.shape[1] != 1:
         raise NotImplementedError("code assumes initial time only has 1 timestep")
     if config.ocean is None:

--- a/fme/coupled/data_loading/getters.py
+++ b/fme/coupled/data_loading/getters.py
@@ -88,21 +88,24 @@ def get_dataset(
     ocean_reqs = requirements.ocean_requirements
     ice_reqs = requirements.ice_requirements
     atmosphere_reqs = requirements.atmosphere_requirements
-    ocean = None  #: torch.utils.data.Dataset
-    ice = None  #: torch.utils.data.Dataset
-    atmosphere = None  #: #torch.utils.data.Dataset
+    ocean: torch.utils.data.Dataset | None = None
+    ice: torch.utils.data.Dataset | None = None
+    atmosphere: torch.utils.data.Dataset | None = None
     ocean_properties = None
     ice_properties = None
     atmosphere_properties = None
     if ocean_reqs is not None:
+        assert config.ocean is not None
         ocean, ocean_properties = config.ocean.build(
             ocean_reqs.names, ocean_reqs.n_timesteps_schedule
         )
     if ice_reqs is not None:
+        assert config.ice is not None
         ice, ice_properties = config.ice.build(
             ice_reqs.names, ice_reqs.n_timesteps_schedule
         )
     if atmosphere_reqs is not None:
+        assert config.atmosphere is not None
         atmosphere, atmosphere_properties = config.atmosphere.build(
             atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
         )
@@ -286,9 +289,9 @@ def get_train_dataset(
     that are merged via TimePaddedMergedDataset.
     """
     ocean_properties = None
-    ocean = None
+    ocean: torch.utils.data.Dataset | None = None
     if config.ocean is not None:
-        ocean: torch.utils.data.Dataset
+        assert requirements.ocean_requirements is not None
         ocean, ocean_properties = config.ocean.build(
             requirements.ocean_requirements.names,
             requirements.ocean_requirements.n_timesteps_schedule,
@@ -296,6 +299,8 @@ def get_train_dataset(
     atmosphere_properties = None
     atmosphere = None
     if config.atmosphere is not None:
+        assert requirements.atmosphere_target_requirements is not None
+        assert requirements.atmosphere_forcing_requirements is not None
         atmos_target, atmos_target_properties = config.atmosphere.build(
             requirements.atmosphere_target_requirements.names,
             requirements.atmosphere_target_requirements.n_timesteps_schedule,
@@ -312,6 +317,8 @@ def get_train_dataset(
     ice_properties = None
     ice = None
     if config.ice is not None:
+        assert requirements.ice_target_requirements is not None
+        assert requirements.ice_forcing_requirements is not None
         ice_target, ice_target_properties = config.ice.build(
             requirements.ice_target_requirements.names,
             requirements.ice_target_requirements.n_timesteps_schedule,
@@ -378,6 +385,7 @@ def get_inference_data(
 ) -> InferenceGriddedData:
     initial_time = None
     if isinstance(initial_condition, CoupledPrognosticState):
+        assert initial_condition.ocean_data is not None
         initial_time = (
             initial_condition.ocean_data.as_batch_data().time
         )  # used only if no ocean forcing is specified
@@ -463,16 +471,20 @@ def get_forcing_data(
         A data loader for forcing data with coordinates and metadata.
     """
     if config.ocean is not None:
+        assert initial_condition.ocean_data is not None
         initial_time = initial_condition.ocean_data.as_batch_data().time
     elif (config.ocean is None) & (config.ice is not None):
+        assert initial_condition.ice_data is not None
         initial_time = initial_condition.ice_data.as_batch_data().time
     if initial_time.shape[1] != 1:
         raise NotImplementedError("code assumes initial time only has 1 timestep")
     if config.ocean is None:
+        assert window_requirements.ocean_timestep is not None
         available_times = _make_available_times_from_initial_time(
             initial_time, total_coupled_steps, window_requirements.ocean_timestep
         )
     else:
+        assert window_requirements.ocean_requirements is not None
         if isinstance(config.ocean.dataset, XarrayDataConfig):
             available_times = XarrayDataset(
                 config.ocean.dataset,

--- a/fme/coupled/data_loading/gridded_data.py
+++ b/fme/coupled/data_loading/gridded_data.py
@@ -128,6 +128,8 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
     @property
     def coords(self) -> CoupledCoords:
         if self._atmosphere is None:
+            assert self._ocean is not None
+            assert self._ice is not None
             return CoupledCoords(
                 ocean_vertical=self._ocean.vertical_coordinate.coords,
                 ice_vertical=self._ice.vertical_coordinate.coords,
@@ -135,6 +137,7 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
                 ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
             )
         elif self._ice is None:
+            assert self._ocean is not None
             return CoupledCoords(
                 ocean_vertical=self._ocean.vertical_coordinate.coords,
                 atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
@@ -144,6 +147,7 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
                 ),
             )
         elif self._ocean is None:
+            assert self._ice is not None
             return CoupledCoords(
                 ice_vertical=self._ice.vertical_coordinate.coords,
                 atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
@@ -153,6 +157,8 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
                 ),
             )
         else:
+            assert self._ocean is not None
+            assert self._ice is not None
             return CoupledCoords(
                 ocean_vertical=self._ocean.vertical_coordinate.coords,
                 ice_vertical=self._ice.vertical_coordinate.coords,
@@ -175,7 +181,10 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
     @property
     def batch_size(self) -> int:
         if self._batch_size is None:
-            example_data = next(iter(self.loader)).ocean_data.data
+            assert self._ocean is not None
+            _batch = next(iter(self.loader))
+            assert _batch.ocean_data is not None
+            example_data = _batch.ocean_data.data
             example_tensor = next(iter(example_data.values()))
             self._batch_size = example_tensor.shape[0]
         return self._batch_size
@@ -229,20 +238,25 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
 
     @property
     def atmosphere_properties(self) -> DatasetProperties:
+        assert self._properties.atmosphere is not None
         return self._properties.atmosphere
 
     @property
     def ice_properties(self) -> DatasetProperties:
+        assert self._properties.ice is not None
         return self._properties.ice
 
     @property
     def ocean_properties(self) -> DatasetProperties:
+        assert self._properties.ocean is not None
         return self._properties.ocean
 
     @property
     def n_initial_conditions(self) -> int:
         if self._n_initial_conditions is None:
-            example_data = self.initial_condition.as_batch_data().ocean_data.data
+            ocean_batch_data = self.initial_condition.as_batch_data().ocean_data
+            assert ocean_batch_data is not None
+            example_data = ocean_batch_data.data
             example_tensor = next(iter(example_data.values()))
             self._n_initial_conditions = example_tensor.shape[0]
         return self._n_initial_conditions
@@ -328,8 +342,10 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
     def initial_time(self) -> xr.DataArray:
         if self._properties.atmosphere is None:
             ocean_data = self.initial_condition.as_batch_data().ocean_data
+            assert ocean_data is not None
             ocean_initial_time = ocean_data.time.isel(time=0)
             ice_data = self.initial_condition.as_batch_data().ice_data
+            assert ice_data is not None
             ice_initial_time = ice_data.time.isel(time=0)
             np.testing.assert_array_equal(
                 ice_initial_time,
@@ -339,8 +355,10 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
             return ice_initial_time
         elif self._properties.ice is None:
             ocean_data = self.initial_condition.as_batch_data().ocean_data
+            assert ocean_data is not None
             ocean_initial_time = ocean_data.time.isel(time=0)
             atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+            assert atmosphere_data is not None
             atmosphere_initial_time = atmosphere_data.time.isel(time=0)
             np.testing.assert_array_equal(
                 atmosphere_initial_time,
@@ -350,8 +368,10 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
             return atmosphere_initial_time
         elif self._properties.ocean is None:
             ice_data = self.initial_condition.as_batch_data().ice_data
+            assert ice_data is not None
             ice_initial_time = ice_data.time.isel(time=0)
             atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+            assert atmosphere_data is not None
             atmosphere_initial_time = atmosphere_data.time.isel(time=0)
             np.testing.assert_array_equal(
                 atmosphere_initial_time,
@@ -361,10 +381,13 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
             return atmosphere_initial_time
         else:
             ocean_data = self.initial_condition.as_batch_data().ocean_data
+            assert ocean_data is not None
             ocean_initial_time = ocean_data.time.isel(time=0)
             ice_data = self.initial_condition.as_batch_data().ice_data
+            assert ice_data is not None
             ice_initial_time = ice_data.time.isel(time=0)
             atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+            assert atmosphere_data is not None
             atmosphere_initial_time = atmosphere_data.time.isel(time=0)
             np.testing.assert_array_equal(
                 atmosphere_initial_time,

--- a/fme/coupled/data_loading/gridded_data.py
+++ b/fme/coupled/data_loading/gridded_data.py
@@ -26,7 +26,7 @@ from fme.coupled.data_loading.dataloader import CoupledDataLoader
 from fme.coupled.dataset_info import CoupledDatasetInfo
 from fme.coupled.requirements import CoupledPrognosticStateDataRequirements
 
-CoupledImageShapes = namedtuple("CoupledImageShapes", ("ocean", "atmosphere"))
+CoupledImageShapes = namedtuple("CoupledImageShapes", ("ocean", "ice", "atmosphere"))
 
 
 class GriddedData(GriddedDataABC[CoupledBatchData]):
@@ -48,9 +48,6 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
         """
         self._loader = loader
         self._properties = properties.to_device()
-        self._ocean = self._properties.ocean
-        self._ice = self._properties.ice
-        self._atmosphere = self._properties.atmosphere
         self._sampler = sampler
         self._batch_size: int | None = None
 
@@ -79,38 +76,17 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
 
     @property
     def dataset_info(self) -> CoupledDatasetInfo:
-        ocean = None
-        ice = None
-        atmosphere = None
-        if self._ocean is not None:
-            ocean = DatasetInfo(
-                horizontal_coordinates=self._ocean.horizontal_coordinates,
-                vertical_coordinate=self._ocean.vertical_coordinate,
-                spatial_mask_provider=self._ocean.spatial_mask_provider,
-                timestep=self._ocean.timestep,
-                variable_metadata=self._properties.variable_metadata,
-            )
-        if self._atmosphere is not None:
-            atmosphere = DatasetInfo(
-                horizontal_coordinates=self._atmosphere.horizontal_coordinates,
-                vertical_coordinate=self._atmosphere.vertical_coordinate,
-                spatial_mask_provider=self._atmosphere.spatial_mask_provider,
-                timestep=self._atmosphere.timestep,
-                variable_metadata=self._properties.variable_metadata,
-            )
-        if self._ice is not None:
-            ice = DatasetInfo(
-                horizontal_coordinates=self._ice.horizontal_coordinates,
-                vertical_coordinate=self._ice.vertical_coordinate,
-                spatial_mask_provider=self._ice.spatial_mask_provider,
-                timestep=self._ice.timestep,
-                variable_metadata=self._properties.variable_metadata,
-            )
-
         return CoupledDatasetInfo(
-            ocean=ocean,
-            atmosphere=atmosphere,
-            ice=ice,
+            **{
+                name: DatasetInfo(
+                    horizontal_coordinates=props.horizontal_coordinates,
+                    vertical_coordinate=props.vertical_coordinate,
+                    spatial_mask_provider=props.spatial_mask_provider,
+                    timestep=props.timestep,
+                    variable_metadata=self._properties.variable_metadata,
+                )
+                for name, props in self._properties._components.items()
+            }
         )
 
     @property
@@ -127,48 +103,7 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
 
     @property
     def coords(self) -> CoupledCoords:
-        if self._atmosphere is None:
-            assert self._ocean is not None
-            assert self._ice is not None
-            return CoupledCoords(
-                ocean_vertical=self._ocean.vertical_coordinate.coords,
-                ice_vertical=self._ice.vertical_coordinate.coords,
-                ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
-                ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
-            )
-        elif self._ice is None:
-            assert self._ocean is not None
-            return CoupledCoords(
-                ocean_vertical=self._ocean.vertical_coordinate.coords,
-                atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
-                ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
-                atmosphere_horizontal=dict(
-                    self._atmosphere.horizontal_coordinates.coords
-                ),
-            )
-        elif self._ocean is None:
-            assert self._ice is not None
-            return CoupledCoords(
-                ice_vertical=self._ice.vertical_coordinate.coords,
-                atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
-                ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
-                atmosphere_horizontal=dict(
-                    self._atmosphere.horizontal_coordinates.coords
-                ),
-            )
-        else:
-            assert self._ocean is not None
-            assert self._ice is not None
-            return CoupledCoords(
-                ocean_vertical=self._ocean.vertical_coordinate.coords,
-                ice_vertical=self._ice.vertical_coordinate.coords,
-                atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
-                ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
-                ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
-                atmosphere_horizontal=dict(
-                    self._atmosphere.horizontal_coordinates.coords
-                ),
-            )
+        return self._properties.coords
 
     @property
     def n_samples(self) -> int:
@@ -181,12 +116,12 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
     @property
     def batch_size(self) -> int:
         if self._batch_size is None:
-            assert self._ocean is not None
             _batch = next(iter(self.loader))
-            assert _batch.ocean_data is not None
-            example_data = _batch.ocean_data.data
-            example_tensor = next(iter(example_data.values()))
-            self._batch_size = example_tensor.shape[0]
+            for component_data in _batch._components.values():
+                example_tensor = next(iter(component_data.data.values()))
+                self._batch_size = example_tensor.shape[0]
+                break
+        assert self._batch_size is not None
         return self._batch_size
 
     def set_epoch(self, epoch: int):
@@ -237,28 +172,32 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
             self._initial_condition = initial_condition.to_device()
 
     @property
-    def atmosphere_properties(self) -> DatasetProperties:
-        assert self._properties.atmosphere is not None
+    def atmosphere_properties(self) -> DatasetProperties | None:
         return self._properties.atmosphere
 
     @property
-    def ice_properties(self) -> DatasetProperties:
-        assert self._properties.ice is not None
+    def ice_properties(self) -> DatasetProperties | None:
         return self._properties.ice
 
     @property
-    def ocean_properties(self) -> DatasetProperties:
-        assert self._properties.ocean is not None
+    def ocean_properties(self) -> DatasetProperties | None:
         return self._properties.ocean
 
     @property
     def n_initial_conditions(self) -> int:
+        # check "slow" components: ocean always slowest
         if self._n_initial_conditions is None:
-            ocean_batch_data = self.initial_condition.as_batch_data().ocean_data
-            assert ocean_batch_data is not None
-            example_data = ocean_batch_data.data
-            example_tensor = next(iter(example_data.values()))
-            self._n_initial_conditions = example_tensor.shape[0]
+            for name in ("ocean", "ice"):
+                if name in self.initial_condition._components:
+                    batch_data = self.initial_condition.as_batch_data()._components[
+                        name
+                    ]
+                    example_data = batch_data.data
+                    example_tensor = next(iter(example_data.values()))
+                    self._n_initial_conditions = example_tensor.shape[0]
+                    break
+            else:
+                raise ValueError("Could not find ocean or ice components.")
         return self._n_initial_conditions
 
     @property
@@ -274,31 +213,18 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
 
     @property
     def dataset_info(self) -> CoupledDatasetInfo:
-        ocean = None
-        ice = None
-        atmosphere = None
-        if self._properties.ocean is not None:
-            ocean = DatasetInfo(
-                horizontal_coordinates=self._properties.ocean.horizontal_coordinates,
-                vertical_coordinate=self._properties.ocean.vertical_coordinate,
-                spatial_mask_provider=self._properties.ocean.spatial_mask_provider,
-                timestep=self.ocean_timestep,
-            )
-        if self._properties.atmosphere is not None:
-            atmosphere = DatasetInfo(
-                horizontal_coordinates=self._properties.atmosphere.horizontal_coordinates,
-                vertical_coordinate=self._properties.atmosphere.vertical_coordinate,
-                spatial_mask_provider=self._properties.atmosphere.spatial_mask_provider,
-                timestep=self.atmosphere_timestep,
-            )
-        if self._properties.ice is not None:
-            ice = DatasetInfo(
-                horizontal_coordinates=self._properties.ice.horizontal_coordinates,
-                vertical_coordinate=self._properties.ice.vertical_coordinate,
-                spatial_mask_provider=self._properties.ice.spatial_mask_provider,
-                timestep=self.ice_timestep,
-            )
-        return CoupledDatasetInfo(ocean=ocean, atmosphere=atmosphere, ice=ice)
+        return CoupledDatasetInfo(
+            **{
+                name: DatasetInfo(
+                    horizontal_coordinates=props.horizontal_coordinates,
+                    vertical_coordinate=props.vertical_coordinate,
+                    spatial_mask_provider=props.spatial_mask_provider,
+                    timestep=props.timestep,
+                    variable_metadata=self._properties.variable_metadata,
+                )
+                for name, props in self._properties._components.items()
+            }
+        )
 
     @property
     def variable_metadata(self) -> dict[str, VariableMetadata]:
@@ -306,21 +232,15 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
 
     @property
     def ocean_timestep(self) -> datetime.timedelta | None:
-        if self._properties.ocean is not None:
-            return self._properties.ocean_timestep
-        return None
+        return self._properties.ocean_timestep
 
     @property
     def ice_timestep(self) -> datetime.timedelta | None:
-        if self._properties.ice is not None:
-            return self._properties.ice_timestep
-        return None
+        return self._properties.ice_timestep
 
     @property
     def atmosphere_timestep(self) -> datetime.timedelta | None:
-        if self._properties.atmosphere is not None:
-            return self._properties.atmosphere_timestep
-        return None
+        return self._properties.atmosphere_timestep
 
     @property
     def n_inner_steps(self) -> int:
@@ -340,59 +260,28 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
 
     @property
     def initial_time(self) -> xr.DataArray:
-        if self._properties.atmosphere is None:
-            ocean_data = self.initial_condition.as_batch_data().ocean_data
-            assert ocean_data is not None
-            ocean_initial_time = ocean_data.time.isel(time=0)
-            ice_data = self.initial_condition.as_batch_data().ice_data
-            assert ice_data is not None
-            ice_initial_time = ice_data.time.isel(time=0)
+        """
+        Return the first initial-condition time, validating that every active
+        coupled component has the same initial time.
+        """
+        batch_data = self.initial_condition.as_batch_data()
+        initial_times: dict[str, xr.DataArray] = {
+            name: component_data.time.isel(time=0)
+            for name, component_data in batch_data._components.items()
+        }
+        if not initial_times:
+            raise ValueError("No initial-condition components were provided.")
+
+        reference_name, reference_time = next(iter(initial_times.items()))
+        for name, initial_time in initial_times.items():
+            if name == reference_name:
+                continue
             np.testing.assert_array_equal(
-                ice_initial_time,
-                ocean_initial_time,
-                err_msg="Ice and ocean initial times must be the same",
+                initial_time,
+                reference_time,
+                err_msg=(
+                    f"{name.capitalize()} and {reference_name} initial times "
+                    "must be the same"
+                ),
             )
-            return ice_initial_time
-        elif self._properties.ice is None:
-            ocean_data = self.initial_condition.as_batch_data().ocean_data
-            assert ocean_data is not None
-            ocean_initial_time = ocean_data.time.isel(time=0)
-            atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
-            assert atmosphere_data is not None
-            atmosphere_initial_time = atmosphere_data.time.isel(time=0)
-            np.testing.assert_array_equal(
-                atmosphere_initial_time,
-                ocean_initial_time,
-                err_msg="Atmosphere and ocean initial times must be the same",
-            )
-            return atmosphere_initial_time
-        elif self._properties.ocean is None:
-            ice_data = self.initial_condition.as_batch_data().ice_data
-            assert ice_data is not None
-            ice_initial_time = ice_data.time.isel(time=0)
-            atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
-            assert atmosphere_data is not None
-            atmosphere_initial_time = atmosphere_data.time.isel(time=0)
-            np.testing.assert_array_equal(
-                atmosphere_initial_time,
-                ice_initial_time,
-                err_msg="Atmosphere and ice initial times must be the same",
-            )
-            return atmosphere_initial_time
-        else:
-            ocean_data = self.initial_condition.as_batch_data().ocean_data
-            assert ocean_data is not None
-            ocean_initial_time = ocean_data.time.isel(time=0)
-            ice_data = self.initial_condition.as_batch_data().ice_data
-            assert ice_data is not None
-            ice_initial_time = ice_data.time.isel(time=0)
-            atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
-            assert atmosphere_data is not None
-            atmosphere_initial_time = atmosphere_data.time.isel(time=0)
-            np.testing.assert_array_equal(
-                atmosphere_initial_time,
-                ocean_initial_time,
-                ice_initial_time,
-                err_msg="Atmosphere, ice, and ocean initial times must be the same",
-            )
-            return atmosphere_initial_time
+        return reference_time

--- a/fme/coupled/data_loading/gridded_data.py
+++ b/fme/coupled/data_loading/gridded_data.py
@@ -49,6 +49,7 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
         self._loader = loader
         self._properties = properties.to_device()
         self._ocean = self._properties.ocean
+        self._ice = self._properties.ice
         self._atmosphere = self._properties.atmosphere
         self._sampler = sampler
         self._batch_size: int | None = None
@@ -78,21 +79,38 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
 
     @property
     def dataset_info(self) -> CoupledDatasetInfo:
-        return CoupledDatasetInfo(
-            ocean=DatasetInfo(
+        ocean = None
+        ice = None
+        atmosphere = None
+        if self._ocean is not None:
+            ocean = DatasetInfo(
                 horizontal_coordinates=self._ocean.horizontal_coordinates,
                 vertical_coordinate=self._ocean.vertical_coordinate,
                 spatial_mask_provider=self._ocean.spatial_mask_provider,
                 timestep=self._ocean.timestep,
                 variable_metadata=self._properties.variable_metadata,
-            ),
-            atmosphere=DatasetInfo(
+            )
+        if self._atmosphere is not None:
+            atmosphere = DatasetInfo(
                 horizontal_coordinates=self._atmosphere.horizontal_coordinates,
                 vertical_coordinate=self._atmosphere.vertical_coordinate,
                 spatial_mask_provider=self._atmosphere.spatial_mask_provider,
                 timestep=self._atmosphere.timestep,
                 variable_metadata=self._properties.variable_metadata,
-            ),
+            )
+        if self._ice is not None:
+            ice = DatasetInfo(
+                horizontal_coordinates=self._ice.horizontal_coordinates,
+                vertical_coordinate=self._ice.vertical_coordinate,
+                spatial_mask_provider=self._ice.spatial_mask_provider,
+                timestep=self._ice.timestep,
+                variable_metadata=self._properties.variable_metadata,
+            )
+
+        return CoupledDatasetInfo(
+            ocean=ocean,
+            atmosphere=atmosphere,
+            ice=ice,
         )
 
     @property
@@ -109,12 +127,42 @@ class GriddedData(GriddedDataABC[CoupledBatchData]):
 
     @property
     def coords(self) -> CoupledCoords:
-        return CoupledCoords(
-            ocean_vertical=self._ocean.vertical_coordinate.coords,
-            atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
-            ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
-            atmosphere_horizontal=dict(self._atmosphere.horizontal_coordinates.coords),
-        )
+        if self._atmosphere is None:
+            return CoupledCoords(
+                ocean_vertical=self._ocean.vertical_coordinate.coords,
+                ice_vertical=self._ice.vertical_coordinate.coords,
+                ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
+                ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
+            )
+        elif self._ice is None:
+            return CoupledCoords(
+                ocean_vertical=self._ocean.vertical_coordinate.coords,
+                atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
+                ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
+                atmosphere_horizontal=dict(
+                    self._atmosphere.horizontal_coordinates.coords
+                ),
+            )
+        elif self._ocean is None:
+            return CoupledCoords(
+                ice_vertical=self._ice.vertical_coordinate.coords,
+                atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
+                ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
+                atmosphere_horizontal=dict(
+                    self._atmosphere.horizontal_coordinates.coords
+                ),
+            )
+        else:
+            return CoupledCoords(
+                ocean_vertical=self._ocean.vertical_coordinate.coords,
+                ice_vertical=self._ice.vertical_coordinate.coords,
+                atmosphere_vertical=self._atmosphere.vertical_coordinate.coords,
+                ocean_horizontal=dict(self._ocean.horizontal_coordinates.coords),
+                ice_horizontal=dict(self._ice.horizontal_coordinates.coords),
+                atmosphere_horizontal=dict(
+                    self._atmosphere.horizontal_coordinates.coords
+                ),
+            )
 
     @property
     def n_samples(self) -> int:
@@ -184,6 +232,10 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
         return self._properties.atmosphere
 
     @property
+    def ice_properties(self) -> DatasetProperties:
+        return self._properties.ice
+
+    @property
     def ocean_properties(self) -> DatasetProperties:
         return self._properties.ocean
 
@@ -208,31 +260,53 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
 
     @property
     def dataset_info(self) -> CoupledDatasetInfo:
-        ocean = DatasetInfo(
-            horizontal_coordinates=self._properties.ocean.horizontal_coordinates,
-            vertical_coordinate=self._properties.ocean.vertical_coordinate,
-            spatial_mask_provider=self._properties.ocean.spatial_mask_provider,
-            timestep=self.ocean_timestep,
-        )
-        atmosphere = DatasetInfo(
-            horizontal_coordinates=self._properties.atmosphere.horizontal_coordinates,
-            vertical_coordinate=self._properties.atmosphere.vertical_coordinate,
-            spatial_mask_provider=self._properties.atmosphere.spatial_mask_provider,
-            timestep=self.atmosphere_timestep,
-        )
-        return CoupledDatasetInfo(ocean=ocean, atmosphere=atmosphere)
+        ocean = None
+        ice = None
+        atmosphere = None
+        if self._properties.ocean is not None:
+            ocean = DatasetInfo(
+                horizontal_coordinates=self._properties.ocean.horizontal_coordinates,
+                vertical_coordinate=self._properties.ocean.vertical_coordinate,
+                spatial_mask_provider=self._properties.ocean.spatial_mask_provider,
+                timestep=self.ocean_timestep,
+            )
+        if self._properties.atmosphere is not None:
+            atmosphere = DatasetInfo(
+                horizontal_coordinates=self._properties.atmosphere.horizontal_coordinates,
+                vertical_coordinate=self._properties.atmosphere.vertical_coordinate,
+                spatial_mask_provider=self._properties.atmosphere.spatial_mask_provider,
+                timestep=self.atmosphere_timestep,
+            )
+        if self._properties.ice is not None:
+            ice = DatasetInfo(
+                horizontal_coordinates=self._properties.ice.horizontal_coordinates,
+                vertical_coordinate=self._properties.ice.vertical_coordinate,
+                spatial_mask_provider=self._properties.ice.spatial_mask_provider,
+                timestep=self.ice_timestep,
+            )
+        return CoupledDatasetInfo(ocean=ocean, atmosphere=atmosphere, ice=ice)
 
     @property
     def variable_metadata(self) -> dict[str, VariableMetadata]:
         return self._properties.variable_metadata
 
     @property
-    def ocean_timestep(self) -> datetime.timedelta:
-        return self._properties.ocean_timestep
+    def ocean_timestep(self) -> datetime.timedelta | None:
+        if self._properties.ocean is not None:
+            return self._properties.ocean_timestep
+        return None
 
     @property
-    def atmosphere_timestep(self) -> datetime.timedelta:
-        return self._properties.atmosphere_timestep
+    def ice_timestep(self) -> datetime.timedelta | None:
+        if self._properties.ice is not None:
+            return self._properties.ice_timestep
+        return None
+
+    @property
+    def atmosphere_timestep(self) -> datetime.timedelta | None:
+        if self._properties.atmosphere is not None:
+            return self._properties.atmosphere_timestep
+        return None
 
     @property
     def n_inner_steps(self) -> int:
@@ -252,13 +326,50 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
 
     @property
     def initial_time(self) -> xr.DataArray:
-        atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
-        ocean_data = self.initial_condition.as_batch_data().ocean_data
-        atmosphere_initial_time = atmosphere_data.time.isel(time=0)
-        ocean_initial_time = ocean_data.time.isel(time=0)
-        np.testing.assert_array_equal(
-            atmosphere_initial_time,
-            ocean_initial_time,
-            err_msg="Atmosphere and ocean initial times must be the same",
-        )
-        return atmosphere_initial_time
+        if self._properties.atmosphere is None:
+            ocean_data = self.initial_condition.as_batch_data().ocean_data
+            ocean_initial_time = ocean_data.time.isel(time=0)
+            ice_data = self.initial_condition.as_batch_data().ice_data
+            ice_initial_time = ice_data.time.isel(time=0)
+            np.testing.assert_array_equal(
+                ice_initial_time,
+                ocean_initial_time,
+                err_msg="Ice and ocean initial times must be the same",
+            )
+            return ice_initial_time
+        elif self._properties.ice is None:
+            ocean_data = self.initial_condition.as_batch_data().ocean_data
+            ocean_initial_time = ocean_data.time.isel(time=0)
+            atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+            atmosphere_initial_time = atmosphere_data.time.isel(time=0)
+            np.testing.assert_array_equal(
+                atmosphere_initial_time,
+                ocean_initial_time,
+                err_msg="Atmosphere and ocean initial times must be the same",
+            )
+            return atmosphere_initial_time
+        elif self._properties.ocean is None:
+            ice_data = self.initial_condition.as_batch_data().ice_data
+            ice_initial_time = ice_data.time.isel(time=0)
+            atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+            atmosphere_initial_time = atmosphere_data.time.isel(time=0)
+            np.testing.assert_array_equal(
+                atmosphere_initial_time,
+                ice_initial_time,
+                err_msg="Atmosphere and ice initial times must be the same",
+            )
+            return atmosphere_initial_time
+        else:
+            ocean_data = self.initial_condition.as_batch_data().ocean_data
+            ocean_initial_time = ocean_data.time.isel(time=0)
+            ice_data = self.initial_condition.as_batch_data().ice_data
+            ice_initial_time = ice_data.time.isel(time=0)
+            atmosphere_data = self.initial_condition.as_batch_data().atmosphere_data
+            atmosphere_initial_time = atmosphere_data.time.isel(time=0)
+            np.testing.assert_array_equal(
+                atmosphere_initial_time,
+                ocean_initial_time,
+                ice_initial_time,
+                err_msg="Atmosphere, ice, and ocean initial times must be the same",
+            )
+            return atmosphere_initial_time

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -20,7 +20,14 @@ from fme.core.dataset.xarray import XarraySubset
 from fme.core.distributed import Distributed
 from fme.core.typing_ import Slice
 from fme.coupled.data_loading.batch_data import CoupledBatchData
-from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
+from fme.coupled.data_loading.config import (
+    CoupledAtmosphereIceOceanDatasetConfig,
+    CoupledDatasetConfig,
+    CoupledDatasetWithOptionalOceanConfig,
+    CoupledIceAtmosphereDatasetConfig,
+    CoupledIceOceanDatasetConfig,
+    build_coupled_dataset_config,
+)
 from fme.coupled.data_loading.data_typing import (
     CoupledDataset,
     CoupledDatasetProperties,
@@ -50,7 +57,13 @@ class InferenceDataLoaderConfig:
         num_data_workers: Number of parallel workers to use for data loading.
     """
 
-    dataset: CoupledDatasetWithOptionalOceanConfig
+    dataset: (
+        CoupledDatasetWithOptionalOceanConfig
+        | CoupledDatasetConfig
+        | CoupledIceOceanDatasetConfig
+        | CoupledIceAtmosphereDatasetConfig
+        | CoupledAtmosphereIceOceanDatasetConfig
+    )
     start_indices: InferenceInitialConditionIndices | ExplicitIndices | TimestampList
     num_data_workers: int = 0
 
@@ -58,26 +71,11 @@ class InferenceDataLoaderConfig:
         self._zarr_engine_used = any(
             ds.zarr_engine_used for ds in self.dataset.data_configs if ds is not None
         )
-        # issue warning if subset is used in the atmosphere dataset
-        if (
-            self.dataset.atmosphere is not None
-            and self.dataset.atmosphere.subset != Slice(None, None, None)
-        ):
-            raise ValueError(
-                "'subset' cannot be used in the atmosphere dataset during inference."
-            )
-        if self.dataset.ice is not None and self.dataset.ice.subset != Slice(
-            None, None, None
-        ):
-            raise ValueError(
-                "'subset' cannot be used in the ice dataset during inference."
-            )
-        if self.dataset.ocean is not None and self.dataset.ocean.subset != Slice(
-            None, None, None
-        ):
-            raise ValueError(
-                "'subset' cannot be used in the ocean dataset during inference."
-            )
+        for ds in self.dataset.data_configs:
+            if ds is not None and ds.subset != Slice(None, None, None):
+                raise ValueError(
+                    "'subset' cannot be used in dataset configs during inference."
+                )
 
     @property
     def zarr_engine_used(self) -> bool:
@@ -100,121 +98,69 @@ class InferenceDataset(torch.utils.data.Dataset):
         dataset_info: CoupledDatasetInfo | None = None,
         initial_time: xr.DataArray | None = None,
     ):
-        ocean_reqs = requirements.ocean_requirements
-        ice_reqs = requirements.ice_requirements
-        atmosphere_reqs = requirements.atmosphere_requirements
-        ocean: ComponentDatasetType | DummyDataset | None
-        ice: ComponentDatasetType | DummyDataset | None
-        atmosphere: ComponentDatasetType | DummyDataset | None
+        all_reqs = {
+            "ocean": requirements.ocean_requirements,
+            "ice": requirements.ice_requirements,
+            "atmosphere": requirements.atmosphere_requirements,
+        }
 
-        ocean = None
-        ocean_properties = None
-        ice = None
-        ice_properties = None
-        atmosphere = None
-        atmosphere_properties = None
-        if config.dataset.atmosphere is None:
-            if config.dataset.ocean is not None:
-                assert ocean_reqs is not None
-                ocean, ocean_properties = config.dataset.ocean.build(
-                    ocean_reqs.names, ocean_reqs.n_timesteps_schedule
-                )
-            else:
-                assert dataset_info is not None
-                assert ocean_reqs is not None
-                ocean, ocean_properties = _make_dummy_ocean_forcing(
-                    dataset_info=dataset_info,
-                    initial_time=initial_time,
-                    total_coupled_steps=total_coupled_steps,
-                    ocean_reqs=ocean_reqs,
-                )
-            ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
-            assert config.dataset.ice is not None
-            assert ice_reqs is not None
-            config.dataset.ice.update_subset(TimeSlice(start_time=ocean.first_time))
-            ice, ice_properties = config.dataset.ice.build(
-                ice_reqs.names, ice_reqs.n_timesteps_schedule
-            )
-        elif config.dataset.ice is None:
-            if config.dataset.ocean is not None:
-                assert ocean_reqs is not None
-                ocean, ocean_properties = config.dataset.ocean.build(
-                    ocean_reqs.names, ocean_reqs.n_timesteps_schedule
-                )
-            else:
-                assert dataset_info is not None
-                assert ocean_reqs is not None
-                ocean, ocean_properties = _make_dummy_ocean_forcing(
-                    dataset_info=dataset_info,
-                    initial_time=initial_time,
-                    total_coupled_steps=total_coupled_steps,
-                    ocean_reqs=ocean_reqs,
-                )
-            ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
-            assert atmosphere_reqs is not None
-            config.dataset.atmosphere.update_subset(
-                TimeSlice(start_time=ocean.first_time)
-            )
-            atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
-                atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
-            )
-        elif config.dataset.ocean is None:
-            if config.dataset.ice is not None:
-                assert ice_reqs is not None
-                if initial_time is not None:
-                    first_ic_time = sorted(initial_time)[0].values[0]
-                    config.dataset.ice.update_subset(
-                        TimeSlice(start_time=first_ic_time)
-                    )
-                ice, ice_properties = config.dataset.ice.build(
-                    ice_reqs.names, ice_reqs.n_timesteps_schedule
-                )
-            else:
-                assert dataset_info is not None
-                assert ice_reqs is not None
-                ice, ice_properties = _make_dummy_ice_forcing(
-                    dataset_info=dataset_info,
-                    initial_time=initial_time,
-                    total_coupled_steps=total_coupled_steps,
-                    ice_reqs=ice_reqs,
-                )
-            assert atmosphere_reqs is not None
-            config.dataset.atmosphere.update_subset(
-                TimeSlice(start_time=ice.first_time)
-            )
-            atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
-                atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
+        # The "anchor" is the slow/outer component that all others are aligned to.
+        # Each config class declares its anchor via anchor_component_name.
+        anchor_name = config.dataset.anchor_component_name
+        anchor_config = getattr(config.dataset, anchor_name)
+        anchor_reqs = all_reqs[anchor_name]
+
+        built: dict[
+            str, tuple[ComponentDatasetType | DummyDataset, DatasetProperties]
+        ] = {}
+
+        # Build anchor component (real dataset or dummy)
+        if anchor_config is not None:
+            assert anchor_reqs is not None
+            if anchor_name == "ice" and initial_time is not None:
+                first_ic_time = sorted(initial_time)[0].values[0]
+                anchor_config.update_subset(TimeSlice(start_time=first_ic_time))
+            built[anchor_name] = anchor_config.build(
+                anchor_reqs.names, anchor_reqs.n_timesteps_schedule
             )
         else:
-            if config.dataset.ocean is not None:
-                assert ocean_reqs is not None
-                ocean, ocean_properties = config.dataset.ocean.build(
-                    ocean_reqs.names, ocean_reqs.n_timesteps_schedule
-                )
-            else:
-                assert dataset_info is not None
-                assert ocean_reqs is not None
-                ocean, ocean_properties = _make_dummy_ocean_forcing(
-                    dataset_info=dataset_info,
-                    initial_time=initial_time,
-                    total_coupled_steps=total_coupled_steps,
-                    ocean_reqs=ocean_reqs,
-                )
-            ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
-            assert config.dataset.ice is not None
-            assert config.dataset.atmosphere is not None
-            assert ice_reqs is not None
-            assert atmosphere_reqs is not None
-            config.dataset.ice.update_subset(TimeSlice(start_time=ocean.first_time))
-            config.dataset.atmosphere.update_subset(
-                TimeSlice(start_time=ocean.first_time)
+            assert dataset_info is not None
+            assert anchor_reqs is not None
+            make_dummy = (
+                _make_dummy_ocean_forcing
+                if anchor_name == "ocean"
+                else _make_dummy_ice_forcing
             )
-            ice, ice_properties = config.dataset.ice.build(
-                ice_reqs.names, ice_reqs.n_timesteps_schedule
+            built[anchor_name] = make_dummy(
+                dataset_info, initial_time, total_coupled_steps, anchor_reqs
             )
-            atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
-                atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
+
+        anchor_ds, anchor_properties = built[anchor_name]
+
+        # Apply ocean-specific mask update
+        if anchor_name == "ocean":
+            anchor_properties = self._update_ocean_mask(anchor_properties, dataset_info)
+            built[anchor_name] = (anchor_ds, anchor_properties)
+
+        # Build remaining components, aligning each to the anchor's start time
+        for comp_name, comp_reqs in all_reqs.items():
+            if comp_name == anchor_name:
+                continue
+            comp_config = getattr(config.dataset, comp_name)
+            if comp_config is None:
+                continue
+            assert comp_reqs is not None
+            comp_config.update_subset(TimeSlice(start_time=anchor_ds.first_time))
+            built[comp_name] = comp_config.build(
+                comp_reqs.names, comp_reqs.n_timesteps_schedule
             )
+
+        ocean = built.get("ocean", (None, None))[0]
+        ocean_properties = built.get("ocean", (None, None))[1]
+        ice = built.get("ice", (None, None))[0]
+        ice_properties = built.get("ice", (None, None))[1]
+        atmosphere = built.get("atmosphere", (None, None))[0]
+        atmosphere_properties = built.get("atmosphere", (None, None))[1]
 
         properties = CoupledDatasetProperties(
             ocean=ocean_properties,
@@ -232,9 +178,9 @@ class InferenceDataset(torch.utils.data.Dataset):
 
         self._dataset = dataset
         self._properties = properties
-        assert requirements.ocean_requirements is not None
+        assert anchor_reqs is not None
         self._coupled_steps_in_memory = (
-            requirements.ocean_requirements.n_timesteps_schedule.get_value(0) - 1
+            anchor_reqs.n_timesteps_schedule.get_value(0) - 1
         )
         self._total_coupled_steps = total_coupled_steps
         self._n_initial_conditions = config.n_initial_conditions
@@ -287,39 +233,26 @@ class InferenceDataset(torch.utils.data.Dataset):
             i_window_start = i_start + self._start_indices[i_member]
             samples.append(self._dataset[i_window_start])
 
-        ocean_dims = None
-        ice_dims = None
-        atmosphere_dims = None
-        if self._dataset._ocean is not None:
-            assert self.properties.horizontal_coordinates.ocean is not None
-            ocean_dims = list(self.properties.horizontal_coordinates.ocean.dims)
-        if self._dataset._ice is not None:
-            assert self.properties.horizontal_coordinates.ice is not None
-            ice_dims = list(self.properties.horizontal_coordinates.ice.dims)
-        if self._dataset._atmosphere is not None:
-            assert self.properties.horizontal_coordinates.atmosphere is not None
-            atmosphere_dims = list(
-                self.properties.horizontal_coordinates.atmosphere.dims
+        component_horizontal_dims = {
+            name: list(hcoord.dims)
+            for name, hcoord in (
+                self.properties.horizontal_coordinates._components.items()
             )
-
+        }
         return CoupledBatchData.collate_fn(
             samples,
-            ocean_horizontal_dims=ocean_dims,
-            ice_horizontal_dims=ice_dims,
-            atmosphere_horizontal_dims=atmosphere_dims,
-            ocean_label_encoding=None,
-            ice_label_encoding=None,
-            atmosphere_label_encoding=None,
+            component_horizontal_dims=component_horizontal_dims,
         )
 
     def __getitem__(self, index) -> CoupledBatchData:
         dist = Distributed.get_instance()
         result = self._get_batch_data(index)
-        if result.ocean_data is not None:
+        # Validate batch dimension using the first available component
+        for comp_data in result._components.values():
             assert (
-                result.ocean_data.time.shape[0]
-                == self._n_initial_conditions // dist.world_size
+                comp_data.time.shape[0] == self._n_initial_conditions // dist.world_size
             )
+            break
         return result
 
     def __len__(self) -> int:
@@ -355,10 +288,10 @@ class CoupledForcingDataLoaderConfig:
             ocean = self.ocean.dataset
 
         return InferenceDataLoaderConfig(
-            dataset=CoupledDatasetWithOptionalOceanConfig(
+            dataset=build_coupled_dataset_config(
+                atmosphere=atmosphere,
                 ice=ice,
                 ocean=ocean,
-                atmosphere=atmosphere,
             ),
             start_indices=start_indices,
             num_data_workers=self.num_data_workers,

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -310,11 +310,11 @@ class InferenceDataset(torch.utils.data.Dataset):
     def __getitem__(self, index) -> CoupledBatchData:
         dist = Distributed.get_instance()
         result = self._get_batch_data(index)
-        assert result.ocean_data is not None
-        assert (
-            result.ocean_data.time.shape[0]
-            == self._n_initial_conditions // dist.world_size
-        )
+        if result.ocean_data is not None:
+            assert (
+                result.ocean_data.time.shape[0]
+                == self._n_initial_conditions // dist.world_size
+            )
         return result
 
     def __len__(self) -> int:

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -59,9 +59,18 @@ class InferenceDataLoaderConfig:
             ds.zarr_engine_used for ds in self.dataset.data_configs if ds is not None
         )
         # issue warning if subset is used in the atmosphere dataset
-        if self.dataset.atmosphere.subset != Slice(None, None, None):
+        if (
+            self.dataset.atmosphere is not None
+            and self.dataset.atmosphere.subset != Slice(None, None, None)
+        ):
             raise ValueError(
                 "'subset' cannot be used in the atmosphere dataset during inference."
+            )
+        if self.dataset.ice is not None and self.dataset.ice.subset != Slice(
+            None, None, None
+        ):
+            raise ValueError(
+                "'subset' cannot be used in the ice dataset during inference."
             )
         if self.dataset.ocean is not None and self.dataset.ocean.subset != Slice(
             None, None, None
@@ -92,34 +101,114 @@ class InferenceDataset(torch.utils.data.Dataset):
         initial_time: xr.DataArray | None = None,
     ):
         ocean_reqs = requirements.ocean_requirements
+        ice_reqs = requirements.ice_requirements
         atmosphere_reqs = requirements.atmosphere_requirements
         ocean: ComponentDatasetType | DummyDataset
-        atmosphere: ComponentDatasetType
+        ice: ComponentDatasetType | DummyDataset
+        atmosphere: ComponentDatasetType | DummyDataset
 
-        if config.dataset.ocean is not None:
-            ocean, ocean_properties = config.dataset.ocean.build(
-                ocean_reqs.names, ocean_reqs.n_timesteps_schedule
+        ocean = None
+        ocean_properties = None
+        ice = None
+        ice_properties = None
+        atmosphere = None
+        atmosphere_properties = None
+        if config.dataset.atmosphere is None:
+            if config.dataset.ocean is not None:
+                ocean, ocean_properties = config.dataset.ocean.build(
+                    ocean_reqs.names, ocean_reqs.n_timesteps_schedule
+                )
+            else:
+                assert dataset_info is not None
+                ocean, ocean_properties = _make_dummy_ocean_forcing(
+                    dataset_info=dataset_info,
+                    initial_time=initial_time,
+                    total_coupled_steps=total_coupled_steps,
+                    ocean_reqs=ocean_reqs,
+                )
+            ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
+            config.dataset.ice.update_subset(TimeSlice(start_time=ocean.first_time))
+            ice, ice_properties = config.dataset.ice.build(
+                ice_reqs.names, ice_reqs.n_timesteps_schedule
+            )
+        elif config.dataset.ice is None:
+            if config.dataset.ocean is not None:
+                ocean, ocean_properties = config.dataset.ocean.build(
+                    ocean_reqs.names, ocean_reqs.n_timesteps_schedule
+                )
+            else:
+                assert dataset_info is not None
+                ocean, ocean_properties = _make_dummy_ocean_forcing(
+                    dataset_info=dataset_info,
+                    initial_time=initial_time,
+                    total_coupled_steps=total_coupled_steps,
+                    ocean_reqs=ocean_reqs,
+                )
+            ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
+            config.dataset.atmosphere.update_subset(
+                TimeSlice(start_time=ocean.first_time)
+            )
+            atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
+                atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
+            )
+        elif config.dataset.ocean is None:
+            if config.dataset.ice is not None:
+                ice, ice_properties = config.dataset.ice.build(
+                    ice_reqs.names, ice_reqs.n_timesteps_schedule
+                )
+            else:
+                assert dataset_info is not None
+                ice, ice_properties = _make_dummy_ice_forcing(
+                    dataset_info=dataset_info,
+                    initial_time=initial_time,
+                    total_coupled_steps=total_coupled_steps,
+                    ice_reqs=ice_reqs,
+                )
+            config.dataset.atmosphere.update_subset(
+                TimeSlice(start_time=ice.first_time)
+            )
+            atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
+                atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
             )
         else:
-            assert dataset_info is not None
-            ocean, ocean_properties = _make_dummy_ocean_forcing(
-                dataset_info=dataset_info,
-                initial_time=initial_time,
-                total_coupled_steps=total_coupled_steps,
-                ocean_reqs=ocean_reqs,
+            if config.dataset.ocean is not None:
+                ocean, ocean_properties = config.dataset.ocean.build(
+                    ocean_reqs.names, ocean_reqs.n_timesteps_schedule
+                )
+            else:
+                assert dataset_info is not None
+                ocean, ocean_properties = _make_dummy_ocean_forcing(
+                    dataset_info=dataset_info,
+                    initial_time=initial_time,
+                    total_coupled_steps=total_coupled_steps,
+                    ocean_reqs=ocean_reqs,
+                )
+            ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
+            config.dataset.ice.update_subset(TimeSlice(start_time=ocean.first_time))
+            config.dataset.atmosphere.update_subset(
+                TimeSlice(start_time=ocean.first_time)
             )
-        ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
-        config.dataset.atmosphere.update_subset(TimeSlice(start_time=ocean.first_time))
-        atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
-            atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
+            ice, ice_properties = config.dataset.ice.build(
+                ice_reqs.names, ice_reqs.n_timesteps_schedule
+            )
+            atmosphere, atmosphere_properties = config.dataset.atmosphere.build(
+                atmosphere_reqs.names, atmosphere_reqs.n_timesteps_schedule
+            )
+
+        properties = CoupledDatasetProperties(
+            ocean=ocean_properties,
+            atmosphere=atmosphere_properties,
+            ice=ice_properties,
         )
-        properties = CoupledDatasetProperties(ocean_properties, atmosphere_properties)
+
         dataset = CoupledDataset(
             ocean=ocean,
             atmosphere=atmosphere,
+            ice=ice,
             properties=properties,
             n_steps_fast=requirements.n_steps_fast,
         )
+
         self._dataset = dataset
         self._properties = properties
         self._coupled_steps_in_memory = (
@@ -174,15 +263,26 @@ class InferenceDataset(torch.utils.data.Dataset):
                 continue
             i_window_start = i_start + self._start_indices[i_member]
             samples.append(self._dataset[i_window_start])
+
+        ocean_dims = None
+        ice_dims = None
+        atmosphere_dims = None
+        if self._dataset._ocean is not None:
+            ocean_dims = list(self.properties.horizontal_coordinates.ocean.dims)
+        if self._dataset._ice is not None:
+            ice_dims = list(self.properties.horizontal_coordinates.ice.dims)
+        if self._dataset._atmosphere is not None:
+            atmosphere_dims = list(
+                self.properties.horizontal_coordinates.atmosphere.dims
+            )
+
         return CoupledBatchData.collate_fn(
             samples,
-            ocean_horizontal_dims=list(
-                self.properties.horizontal_coordinates.ocean.dims
-            ),
-            atmosphere_horizontal_dims=list(
-                self.properties.horizontal_coordinates.atmosphere.dims
-            ),
+            ocean_horizontal_dims=ocean_dims,
+            ice_horizontal_dims=ice_dims,
+            atmosphere_horizontal_dims=atmosphere_dims,
             ocean_label_encoding=None,
+            ice_label_encoding=None,
             atmosphere_label_encoding=None,
         )
 
@@ -208,7 +308,8 @@ class InferenceDataset(torch.utils.data.Dataset):
 
 @dataclasses.dataclass
 class CoupledForcingDataLoaderConfig:
-    atmosphere: ForcingDataLoaderConfig
+    atmosphere: ForcingDataLoaderConfig | None = None
+    ice: ForcingDataLoaderConfig | None = None
     ocean: ForcingDataLoaderConfig | None = None
     num_data_workers: int = 0
 
@@ -216,18 +317,21 @@ class CoupledForcingDataLoaderConfig:
         self,
         start_indices: ExplicitIndices,
     ):
-        if self.ocean is None:
-            return InferenceDataLoaderConfig(
-                dataset=CoupledDatasetWithOptionalOceanConfig(
-                    atmosphere=self.atmosphere.dataset,
-                ),
-                start_indices=start_indices,
-                num_data_workers=self.num_data_workers,
-            )
+        ice = None
+        ocean = None
+        atmosphere = None
+        if self.atmosphere is not None:
+            atmosphere = self.atmosphere.dataset
+        if self.ice is not None:
+            ice = self.ice.dataset
+        if self.ocean is not None:
+            ocean = self.ocean.dataset
+
         return InferenceDataLoaderConfig(
             dataset=CoupledDatasetWithOptionalOceanConfig(
-                atmosphere=self.atmosphere.dataset,
-                ocean=self.ocean.dataset,
+                ice=ice,
+                ocean=ocean,
+                atmosphere=atmosphere,
             ),
             start_indices=start_indices,
             num_data_workers=self.num_data_workers,
@@ -259,3 +363,30 @@ def _make_dummy_ocean_forcing(
         labels=None,
     )
     return ocean, ocean_property
+
+
+def _make_dummy_ice_forcing(
+    dataset_info: CoupledDatasetInfo,
+    initial_time: xr.DataArray,
+    total_coupled_steps: int,
+    ice_reqs: DataRequirements,
+) -> tuple[DummyDataset, DatasetProperties]:
+    ice_property = DatasetProperties(
+        variable_metadata=dict(dataset_info.ice.variable_metadata),
+        vertical_coordinate=dataset_info.ice.vertical_coordinate,
+        horizontal_coordinates=dataset_info.ice.horizontal_coordinates,
+        mask_provider=dataset_info.ice.mask_provider,
+        timestep=dataset_info.ice.timestep,
+        is_remote=False,
+        all_labels=set(),
+    )
+    ts = dataset_info.ice.timestep
+    ice = DummyDataset(
+        start_time=initial_time.squeeze().values.flat[0],
+        end_time=initial_time.squeeze().values.flat[-1] + ts * total_coupled_steps,
+        timestep=ts,
+        n_timesteps=ice_reqs.n_timesteps_schedule,
+        horizontal_coordinates=dataset_info.ice.horizontal_coordinates,
+        labels=None,
+    )
+    return ice, ice_property

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -103,9 +103,9 @@ class InferenceDataset(torch.utils.data.Dataset):
         ocean_reqs = requirements.ocean_requirements
         ice_reqs = requirements.ice_requirements
         atmosphere_reqs = requirements.atmosphere_requirements
-        ocean: ComponentDatasetType | DummyDataset
-        ice: ComponentDatasetType | DummyDataset
-        atmosphere: ComponentDatasetType | DummyDataset
+        ocean: ComponentDatasetType | DummyDataset | None
+        ice: ComponentDatasetType | DummyDataset | None
+        atmosphere: ComponentDatasetType | DummyDataset | None
 
         ocean = None
         ocean_properties = None
@@ -115,11 +115,13 @@ class InferenceDataset(torch.utils.data.Dataset):
         atmosphere_properties = None
         if config.dataset.atmosphere is None:
             if config.dataset.ocean is not None:
+                assert ocean_reqs is not None
                 ocean, ocean_properties = config.dataset.ocean.build(
                     ocean_reqs.names, ocean_reqs.n_timesteps_schedule
                 )
             else:
                 assert dataset_info is not None
+                assert ocean_reqs is not None
                 ocean, ocean_properties = _make_dummy_ocean_forcing(
                     dataset_info=dataset_info,
                     initial_time=initial_time,
@@ -127,17 +129,21 @@ class InferenceDataset(torch.utils.data.Dataset):
                     ocean_reqs=ocean_reqs,
                 )
             ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
+            assert config.dataset.ice is not None
+            assert ice_reqs is not None
             config.dataset.ice.update_subset(TimeSlice(start_time=ocean.first_time))
             ice, ice_properties = config.dataset.ice.build(
                 ice_reqs.names, ice_reqs.n_timesteps_schedule
             )
         elif config.dataset.ice is None:
             if config.dataset.ocean is not None:
+                assert ocean_reqs is not None
                 ocean, ocean_properties = config.dataset.ocean.build(
                     ocean_reqs.names, ocean_reqs.n_timesteps_schedule
                 )
             else:
                 assert dataset_info is not None
+                assert ocean_reqs is not None
                 ocean, ocean_properties = _make_dummy_ocean_forcing(
                     dataset_info=dataset_info,
                     initial_time=initial_time,
@@ -145,6 +151,7 @@ class InferenceDataset(torch.utils.data.Dataset):
                     ocean_reqs=ocean_reqs,
                 )
             ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
+            assert atmosphere_reqs is not None
             config.dataset.atmosphere.update_subset(
                 TimeSlice(start_time=ocean.first_time)
             )
@@ -153,17 +160,20 @@ class InferenceDataset(torch.utils.data.Dataset):
             )
         elif config.dataset.ocean is None:
             if config.dataset.ice is not None:
+                assert ice_reqs is not None
                 ice, ice_properties = config.dataset.ice.build(
                     ice_reqs.names, ice_reqs.n_timesteps_schedule
                 )
             else:
                 assert dataset_info is not None
+                assert ice_reqs is not None
                 ice, ice_properties = _make_dummy_ice_forcing(
                     dataset_info=dataset_info,
                     initial_time=initial_time,
                     total_coupled_steps=total_coupled_steps,
                     ice_reqs=ice_reqs,
                 )
+            assert atmosphere_reqs is not None
             config.dataset.atmosphere.update_subset(
                 TimeSlice(start_time=ice.first_time)
             )
@@ -172,11 +182,13 @@ class InferenceDataset(torch.utils.data.Dataset):
             )
         else:
             if config.dataset.ocean is not None:
+                assert ocean_reqs is not None
                 ocean, ocean_properties = config.dataset.ocean.build(
                     ocean_reqs.names, ocean_reqs.n_timesteps_schedule
                 )
             else:
                 assert dataset_info is not None
+                assert ocean_reqs is not None
                 ocean, ocean_properties = _make_dummy_ocean_forcing(
                     dataset_info=dataset_info,
                     initial_time=initial_time,
@@ -184,6 +196,10 @@ class InferenceDataset(torch.utils.data.Dataset):
                     ocean_reqs=ocean_reqs,
                 )
             ocean_properties = self._update_ocean_mask(ocean_properties, dataset_info)
+            assert config.dataset.ice is not None
+            assert config.dataset.atmosphere is not None
+            assert ice_reqs is not None
+            assert atmosphere_reqs is not None
             config.dataset.ice.update_subset(TimeSlice(start_time=ocean.first_time))
             config.dataset.atmosphere.update_subset(
                 TimeSlice(start_time=ocean.first_time)
@@ -211,6 +227,7 @@ class InferenceDataset(torch.utils.data.Dataset):
 
         self._dataset = dataset
         self._properties = properties
+        assert requirements.ocean_requirements is not None
         self._coupled_steps_in_memory = (
             requirements.ocean_requirements.n_timesteps_schedule.get_value(0) - 1
         )
@@ -234,6 +251,7 @@ class InferenceDataset(torch.utils.data.Dataset):
     ) -> DatasetProperties:
         if dataset_info is None:
             return ocean_properties
+        assert dataset_info.ocean is not None
         ocean_mask_is_empty = not ocean_properties.spatial_mask_provider.masks
         identical_masks = (
             len(ocean_properties.spatial_mask_provider.masks) > 0
@@ -268,10 +286,13 @@ class InferenceDataset(torch.utils.data.Dataset):
         ice_dims = None
         atmosphere_dims = None
         if self._dataset._ocean is not None:
+            assert self.properties.horizontal_coordinates.ocean is not None
             ocean_dims = list(self.properties.horizontal_coordinates.ocean.dims)
         if self._dataset._ice is not None:
+            assert self.properties.horizontal_coordinates.ice is not None
             ice_dims = list(self.properties.horizontal_coordinates.ice.dims)
         if self._dataset._atmosphere is not None:
+            assert self.properties.horizontal_coordinates.atmosphere is not None
             atmosphere_dims = list(
                 self.properties.horizontal_coordinates.atmosphere.dims
             )
@@ -289,6 +310,7 @@ class InferenceDataset(torch.utils.data.Dataset):
     def __getitem__(self, index) -> CoupledBatchData:
         dist = Distributed.get_instance()
         result = self._get_batch_data(index)
+        assert result.ocean_data is not None
         assert (
             result.ocean_data.time.shape[0]
             == self._n_initial_conditions // dist.world_size
@@ -344,6 +366,7 @@ def _make_dummy_ocean_forcing(
     total_coupled_steps: int,
     ocean_reqs: DataRequirements,
 ) -> tuple[DummyDataset, DatasetProperties]:
+    assert dataset_info.ocean is not None
     ocean_property = DatasetProperties(
         variable_metadata=dict(dataset_info.ocean.variable_metadata),
         vertical_coordinate=dataset_info.ocean.vertical_coordinate,
@@ -371,11 +394,12 @@ def _make_dummy_ice_forcing(
     total_coupled_steps: int,
     ice_reqs: DataRequirements,
 ) -> tuple[DummyDataset, DatasetProperties]:
+    assert dataset_info.ice is not None
     ice_property = DatasetProperties(
         variable_metadata=dict(dataset_info.ice.variable_metadata),
         vertical_coordinate=dataset_info.ice.vertical_coordinate,
         horizontal_coordinates=dataset_info.ice.horizontal_coordinates,
-        mask_provider=dataset_info.ice.mask_provider,
+        spatial_mask_provider=dataset_info.ice.spatial_mask_provider,
         timestep=dataset_info.ice.timestep,
         is_remote=False,
         all_labels=set(),

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -161,6 +161,11 @@ class InferenceDataset(torch.utils.data.Dataset):
         elif config.dataset.ocean is None:
             if config.dataset.ice is not None:
                 assert ice_reqs is not None
+                if initial_time is not None:
+                    first_ic_time = sorted(initial_time)[0].values[0]
+                    config.dataset.ice.update_subset(
+                        TimeSlice(start_time=first_ic_time)
+                    )
                 ice, ice_properties = config.dataset.ice.build(
                     ice_reqs.names, ice_reqs.n_timesteps_schedule
                 )

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -486,7 +486,8 @@ def create_coupled_data_on_disk(
             ocean_timestep_size = ocean_timestep_size_in_days
         if ocean_timestep_size != int(ocean_timestep_size):
             raise ValueError(
-                "n_forward_times_atmosphere should be a multiple of n_forward_times_ocean."
+                f"n_forward_times_atmosphere should be a multiple of "
+                f"n_forward_times_ocean."
             )
         if atmosphere_start_time_offset_from_ocean < 0:
             raise ValueError("atmosphere_start_time_offset_from_ocean should be >= 0")
@@ -638,7 +639,8 @@ def create_coupled_data_on_disk(
             ocean_timestep_size = ocean_timestep_size_in_days
         if ocean_timestep_size != int(ocean_timestep_size):
             raise ValueError(
-                "n_forward_times_atmosphere should be a multiple of n_forward_times_ocean."
+                f"n_forward_times_atmosphere should be a multiple of "
+                f"n_forward_times_ocean."
             )
         if atmosphere_start_time_offset_from_ocean < 0:
             raise ValueError("atmosphere_start_time_offset_from_ocean should be >= 0")

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -275,16 +275,16 @@ class MockCoupledData:
 
 def create_coupled_data_on_disk(
     data_dir: pathlib.Path,
-    n_forward_times_ocean: int,
-    n_forward_times_ice: int,
-    n_forward_times_atmosphere: int,
-    ocean_names: list[str],
-    ice_names: list[str],
-    atmosphere_names: list[str],
-    atmosphere_start_time_offset_from_ocean: int = 0,
-    ice_start_time_offset_from_ocean: int = 0,
-    n_levels_ocean: int = 2,
-    n_levels_atmosphere: int = 2,
+    n_forward_times_ocean: int | None = None,
+    n_forward_times_ice: int | None = None,
+    n_forward_times_atmosphere: int | None = None,
+    ocean_names: list[str] | None = None,
+    ice_names: list[str] | None = None,
+    atmosphere_names: list[str] | None = None,
+    atmosphere_start_time_offset_from_ocean: int | None = 0,
+    ice_start_time_offset_from_ocean: int | None = 0,
+    n_levels_ocean: int | None = 2,
+    n_levels_atmosphere: int | None = 2,
     ocean_timestep_size_in_days: int | None = None,
     masked_fill_value: float = float("nan"),
 ) -> MockCoupledData:
@@ -341,115 +341,355 @@ def create_coupled_data_on_disk(
     """
     np.random.seed(0)
 
-    ocean_dir = data_dir / "ocean"
-    ocean_dir.mkdir()
-    ocean_dim_sizes = {"time": n_forward_times_ocean + 1, "lat": N_LAT, "lon": N_LON}
-    if ocean_timestep_size_in_days is None:
-        ocean_timestep_size = n_forward_times_atmosphere / n_forward_times_ocean
-    else:
-        ocean_timestep_size = ocean_timestep_size_in_days
-    if ocean_timestep_size != int(ocean_timestep_size):
-        raise ValueError(
-            "n_forward_times_atmosphere should be a multiple of n_forward_times_ocean."
+    if n_forward_times_atmosphere is None:
+        ocean_dir = data_dir / "ocean"
+        ocean_dir.mkdir()
+        ocean_dim_sizes = {
+            "time": n_forward_times_ocean + 1,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        if ocean_timestep_size_in_days is None:
+            assert n_forward_times_ocean is not None
+            assert n_forward_times_ice is not None
+            ocean_timestep_size = n_forward_times_ice / n_forward_times_ocean
+        else:
+            ocean_timestep_size = ocean_timestep_size_in_days
+        if ocean_timestep_size != int(ocean_timestep_size):
+            raise ValueError(
+                "n_forward_times_ice should be a multiple of n_forward_times_ocean."
+            )
+        if ice_start_time_offset_from_ocean < 0:
+            raise ValueError("ice_start_time_offset_from_ocean should be >= 0")
+        ocean_timestep_size = int(ocean_timestep_size)
+        ocean_ds = _save_netcdf(
+            filename=ocean_dir / "data.nc",
+            dim_sizes=ocean_dim_sizes,
+            variable_names=ocean_names,
+            calendar="proleptic_gregorian",
+            realm="ocean",
+            # _save_netcdf has a default timestep of 1 day which we interpret as the
+            # ice timestep, so the ocean data needs
+            timestep_size=ocean_timestep_size,
+            nz=n_levels_ocean + 1,
+            timestep_start=0,  # ocean start time fixed
+            masked_fill_value=masked_fill_value,
         )
-    if atmosphere_start_time_offset_from_ocean < 0:
-        raise ValueError("atmosphere_start_time_offset_from_ocean should be >= 0")
-    ocean_timestep_size = int(ocean_timestep_size)
-    ocean_ds = _save_netcdf(
-        filename=ocean_dir / "data.nc",
-        dim_sizes=ocean_dim_sizes,
-        variable_names=ocean_names,
-        calendar="proleptic_gregorian",
-        realm="ocean",
-        # _save_netcdf has a default timestep of 1 day which we interpret as the
-        # atmosphere timestep, so the ocean data needs
-        timestep_size=ocean_timestep_size,
-        nz=n_levels_ocean + 1,
-        timestep_start=0,  # ocean start time fixed
-        masked_fill_value=masked_fill_value,
-    )
+        ice_dir = data_dir / "ice"
+        ice_dir.mkdir()
+        n_times_ice = n_forward_times_ice + 1 + ice_start_time_offset_from_ocean
+        # ice initial time may be earlier than ocean's
+        timestep_start_ice = -ice_start_time_offset_from_ocean
+        ice_dim_sizes = {
+            "time": n_times_ice,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        ice_ds = _save_netcdf(
+            filename=ice_dir / "data.nc",
+            dim_sizes=ice_dim_sizes,
+            variable_names=ice_names,
+            calendar="proleptic_gregorian",
+            realm="ice",
+            timestep_size=1,
+            timestep_start=timestep_start_ice,
+            nz=1,
+            masked_fill_value=masked_fill_value,
+        )
+        timedelta_ice = "1D"
+        timedelta_ocean = f"{ocean_timestep_size}D"
 
-    ice_dir = data_dir / "ice"
-    ice_dir.mkdir()
-    n_times_ice = n_forward_times_ice + 1 + ice_start_time_offset_from_ocean
-    # ice initial time may be earlier than ocean's
-    timestep_start_ice = -ice_start_time_offset_from_ocean
-    ice_dim_sizes = {
-        "time": n_times_ice,
-        "lat": N_LAT,
-        "lon": N_LON,
-    }
-    ice_ds = _save_netcdf(
-        filename=ice_dir / "data.nc",
-        dim_sizes=ice_dim_sizes,
-        variable_names=ice_names,
-        calendar="proleptic_gregorian",
-        realm="ice",
-        timestep_size=1,
-        timestep_start=timestep_start_ice,
-        nz=1,
-        masked_fill_value=masked_fill_value,
-    )
+        stats_dir = data_dir / "stats"
+        stats_dir.mkdir()
+        all_names = list(set(ocean_names + ice_names))
+        save_stats_netcdfs(
+            stats_dir / "means.nc",
+            stats_dir / "stds.nc",
+            variable_names=all_names,
+        )
+        return MockCoupledData(
+            ocean=MockComponentData(
+                ds=ocean_ds,
+                data_dir=str(ocean_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_ocean,
+            ),
+            ice=MockComponentData(
+                ds=ice_ds,
+                data_dir=str(ice_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_ice,
+            ),
+        )
+    elif n_forward_times_ice is None:
+        ocean_dir = data_dir / "ocean"
+        ocean_dir.mkdir()
+        ocean_dim_sizes = {
+            "time": n_forward_times_ocean + 1,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        if ocean_timestep_size_in_days is None:
+            assert n_forward_times_ocean is not None
+            assert n_forward_times_atmosphere is not None
+            ocean_timestep_size = n_forward_times_atmosphere / n_forward_times_ocean
+        else:
+            ocean_timestep_size = ocean_timestep_size_in_days
+        if ocean_timestep_size != int(ocean_timestep_size):
+            raise ValueError(
+                "n_forward_times_atmosphere should be a multiple of n_forward_times_ocean."
+            )
+        if atmosphere_start_time_offset_from_ocean < 0:
+            raise ValueError("atmosphere_start_time_offset_from_ocean should be >= 0")
+        ocean_timestep_size = int(ocean_timestep_size)
+        ocean_ds = _save_netcdf(
+            filename=ocean_dir / "data.nc",
+            dim_sizes=ocean_dim_sizes,
+            variable_names=ocean_names,
+            calendar="proleptic_gregorian",
+            realm="ocean",
+            # _save_netcdf has a default timestep of 1 day which we interpret as the
+            # ice timestep, so the ocean data needs
+            timestep_size=ocean_timestep_size,
+            nz=n_levels_ocean + 1,
+            timestep_start=0,  # ocean start time fixed
+            masked_fill_value=masked_fill_value,
+        )
+        atmos_dir = data_dir / "atmos"
+        atmos_dir.mkdir()
+        n_times_atmos = (
+            n_forward_times_atmosphere + 1 + atmosphere_start_time_offset_from_ocean
+        )
+        # atmosphere initial time may be earlier than ocean's
+        timestep_start_atmosphere = -atmosphere_start_time_offset_from_ocean
+        atmos_dim_sizes = {
+            "time": n_times_atmos,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        atmos_ds = _save_netcdf(
+            filename=atmos_dir / "data.nc",
+            dim_sizes=atmos_dim_sizes,
+            variable_names=atmosphere_names,
+            calendar="proleptic_gregorian",
+            realm="atmosphere",
+            timestep_size=1,
+            timestep_start=timestep_start_atmosphere,
+            nz=n_levels_atmosphere + 1,
+            masked_fill_value=masked_fill_value,
+        )
+        timedelta_atmos = "1D"
+        timedelta_ocean = f"{ocean_timestep_size}D"
 
-    atmos_dir = data_dir / "atmos"
-    atmos_dir.mkdir()
-    n_times_atmos = (
-        n_forward_times_atmosphere + 1 + atmosphere_start_time_offset_from_ocean
-    )
-    # atmosphere initial time may be earlier than ocean's
-    timestep_start_atmosphere = -atmosphere_start_time_offset_from_ocean
-    atmos_dim_sizes = {
-        "time": n_times_atmos,
-        "lat": N_LAT,
-        "lon": N_LON,
-    }
-    atmos_ds = _save_netcdf(
-        filename=atmos_dir / "data.nc",
-        dim_sizes=atmos_dim_sizes,
-        variable_names=atmosphere_names,
-        calendar="proleptic_gregorian",
-        realm="atmosphere",
-        timestep_size=1,
-        timestep_start=timestep_start_atmosphere,
-        nz=n_levels_atmosphere + 1,
-        masked_fill_value=masked_fill_value,
-    )
-    # _save_netcdf creates integer times in units of "days since 1970-01-01"
-    timedelta_atmos = "1D"
-    timedelta_ice = "1D"
-    timedelta_ocean = f"{ocean_timestep_size}D"
+        stats_dir = data_dir / "stats"
+        stats_dir.mkdir()
+        all_names = list(set(ocean_names + atmosphere_names))
+        save_stats_netcdfs(
+            stats_dir / "means.nc",
+            stats_dir / "stds.nc",
+            variable_names=all_names,
+        )
+        return MockCoupledData(
+            ocean=MockComponentData(
+                ds=ocean_ds,
+                data_dir=str(ocean_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_ocean,
+            ),
+            atmosphere=MockComponentData(
+                ds=atmos_ds,
+                data_dir=str(atmos_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_atmos,
+            ),
+        )
+    elif n_forward_times_ocean is None:
+        ice_dir = data_dir / "ice"
+        ice_dir.mkdir()
+        n_times_ice = n_forward_times_ice + 1
+        timestep_start_ice = 0
+        ice_dim_sizes = {
+            "time": n_times_ice,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        ice_ds = _save_netcdf(
+            filename=ice_dir / "data.nc",
+            dim_sizes=ice_dim_sizes,
+            variable_names=ice_names,
+            calendar="proleptic_gregorian",
+            realm="ice",
+            timestep_size=1,
+            timestep_start=timestep_start_ice,
+            nz=1,
+            masked_fill_value=masked_fill_value,
+        )
+        atmos_dir = data_dir / "atmos"
+        atmos_dir.mkdir()
+        n_times_atmos = n_forward_times_atmosphere + 1
+        timestep_start_atmosphere = 0
+        atmos_dim_sizes = {
+            "time": n_times_atmos,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        atmos_ds = _save_netcdf(
+            filename=atmos_dir / "data.nc",
+            dim_sizes=atmos_dim_sizes,
+            variable_names=atmosphere_names,
+            calendar="proleptic_gregorian",
+            realm="atmosphere",
+            timestep_size=1,
+            timestep_start=timestep_start_atmosphere,
+            nz=n_levels_atmosphere + 1,
+            masked_fill_value=masked_fill_value,
+        )
+        timedelta_atmos = "1D"
+        timedelta_ice = "1D"
 
-    stats_dir = data_dir / "stats"
-    stats_dir.mkdir()
-    all_names = list(set(ocean_names + atmosphere_names + ice_names))
-    save_stats_netcdfs(
-        stats_dir / "means.nc",
-        stats_dir / "stds.nc",
-        variable_names=all_names,
-    )
-    return MockCoupledData(
-        ocean=MockComponentData(
-            ds=ocean_ds,
-            data_dir=str(ocean_dir),
-            means_path=str(stats_dir / "means.nc"),
-            stds_path=str(stats_dir / "stds.nc"),
-            timedelta=timedelta_ocean,
-        ),
-        ice=MockComponentData(
-            ds=ice_ds,
-            data_dir=str(ice_dir),
-            means_path=str(stats_dir / "means.nc"),
-            stds_path=str(stats_dir / "stds.nc"),
-            timedelta=timedelta_ice,
-        ),
-        atmosphere=MockComponentData(
-            ds=atmos_ds,
-            data_dir=str(atmos_dir),
-            means_path=str(stats_dir / "means.nc"),
-            stds_path=str(stats_dir / "stds.nc"),
-            timedelta=timedelta_atmos,
-        ),
-    )
+        stats_dir = data_dir / "stats"
+        stats_dir.mkdir()
+        all_names = list(set(ice_names + atmosphere_names))
+        save_stats_netcdfs(
+            stats_dir / "means.nc",
+            stats_dir / "stds.nc",
+            variable_names=all_names,
+        )
+        return MockCoupledData(
+            ice=MockComponentData(
+                ds=ice_ds,
+                data_dir=str(ice_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_ice,
+            ),
+            atmosphere=MockComponentData(
+                ds=atmos_ds,
+                data_dir=str(atmos_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_atmos,
+            ),
+        )
+    else:
+        ocean_dir = data_dir / "ocean"
+        ocean_dir.mkdir()
+        ocean_dim_sizes = {
+            "time": n_forward_times_ocean + 1,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        if ocean_timestep_size_in_days is None:
+            assert n_forward_times_ocean is not None
+            assert n_forward_times_atmosphere is not None
+            ocean_timestep_size = n_forward_times_atmosphere / n_forward_times_ocean
+        else:
+            ocean_timestep_size = ocean_timestep_size_in_days
+        if ocean_timestep_size != int(ocean_timestep_size):
+            raise ValueError(
+                "n_forward_times_atmosphere should be a multiple of n_forward_times_ocean."
+            )
+        if atmosphere_start_time_offset_from_ocean < 0:
+            raise ValueError("atmosphere_start_time_offset_from_ocean should be >= 0")
+        ocean_timestep_size = int(ocean_timestep_size)
+        ocean_ds = _save_netcdf(
+            filename=ocean_dir / "data.nc",
+            dim_sizes=ocean_dim_sizes,
+            variable_names=ocean_names,
+            calendar="proleptic_gregorian",
+            realm="ocean",
+            # _save_netcdf has a default timestep of 1 day which we interpret as the
+            # atmosphere timestep, so the ocean data needs
+            timestep_size=ocean_timestep_size,
+            nz=n_levels_ocean + 1,
+            timestep_start=0,  # ocean start time fixed
+            masked_fill_value=masked_fill_value,
+        )
+        assert n_forward_times_ice is not None
+        ice_dir = data_dir / "ice"
+        ice_dir.mkdir()
+        n_times_ice = n_forward_times_ice + 1 + ice_start_time_offset_from_ocean
+        # ice initial time may be earlier than ocean's
+        timestep_start_ice = -ice_start_time_offset_from_ocean
+        ice_dim_sizes = {
+            "time": n_times_ice,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        ice_ds = _save_netcdf(
+            filename=ice_dir / "data.nc",
+            dim_sizes=ice_dim_sizes,
+            variable_names=ice_names,
+            calendar="proleptic_gregorian",
+            realm="ice",
+            timestep_size=1,
+            timestep_start=timestep_start_ice,
+            nz=1,
+            masked_fill_value=masked_fill_value,
+        )
+        atmos_dir = data_dir / "atmos"
+        atmos_dir.mkdir()
+        n_times_atmos = (
+            n_forward_times_atmosphere + 1 + atmosphere_start_time_offset_from_ocean
+        )
+        # atmosphere initial time may be earlier than ocean's
+        timestep_start_atmosphere = -atmosphere_start_time_offset_from_ocean
+        atmos_dim_sizes = {
+            "time": n_times_atmos,
+            "lat": N_LAT,
+            "lon": N_LON,
+        }
+        atmos_ds = _save_netcdf(
+            filename=atmos_dir / "data.nc",
+            dim_sizes=atmos_dim_sizes,
+            variable_names=atmosphere_names,
+            calendar="proleptic_gregorian",
+            realm="atmosphere",
+            timestep_size=1,
+            timestep_start=timestep_start_atmosphere,
+            nz=n_levels_atmosphere + 1,
+            masked_fill_value=masked_fill_value,
+        )
+        # _save_netcdf creates integer times in units of "days since 1970-01-01"
+        timedelta_atmos = "1D"
+        timedelta_ice = "1D"
+        timedelta_ocean = f"{ocean_timestep_size}D"
+
+        stats_dir = data_dir / "stats"
+        stats_dir.mkdir()
+        all_names = list(set(ocean_names + atmosphere_names + ice_names))
+        save_stats_netcdfs(
+            stats_dir / "means.nc",
+            stats_dir / "stds.nc",
+            variable_names=all_names,
+        )
+        return MockCoupledData(
+            ocean=MockComponentData(
+                ds=ocean_ds,
+                data_dir=str(ocean_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_ocean,
+            ),
+            ice=MockComponentData(
+                ds=ice_ds,
+                data_dir=str(ice_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_ice,
+            ),
+            atmosphere=MockComponentData(
+                ds=atmos_ds,
+                data_dir=str(atmos_dir),
+                means_path=str(stats_dir / "means.nc"),
+                stds_path=str(stats_dir / "stds.nc"),
+                timedelta=timedelta_atmos,
+            ),
+        )
 
 
 @pytest.mark.parametrize("atmosphere_times_offset", [0, 1])
@@ -587,9 +827,13 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
         .values
     )
     # check that
-    assert np.allclose(sample.ocean[0]["bar"].cpu().numpy(), expected_ocean)
-    assert np.allclose(sample.atmosphere[0]["foo"].cpu().numpy(), expected_atmos)
-    assert np.allclose(sample.ice[0]["baz"].cpu().numpy(), expected_ice)
+    assert np.allclose(
+        sample.ocean[0]["bar"].cpu().numpy(), expected_ocean, equal_nan=True
+    )
+    assert np.allclose(
+        sample.atmosphere[0]["foo"].cpu().numpy(), expected_atmos, equal_nan=True
+    )
+    assert np.allclose(sample.ice[0]["baz"].cpu().numpy(), expected_ice, equal_nan=True)
 
 
 def test_zarr_engine_used_true():

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -556,6 +556,9 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
     atmos_ds = ics[ic_idx].atmosphere.ds
     sample = data._loader._dataset[sample_idx]  # type: ignore
     assert isinstance(sample, CoupledDatasetItem)
+    assert sample.ocean is not None
+    assert sample.ice is not None
+    assert sample.atmosphere is not None
     ocean_sample_init_time = sample.ocean[1].isel(time=0).item()
     ice_sample_init_time = sample.ice[1].isel(time=0).item()
     atmos_sample_init_time = sample.atmosphere[1].isel(time=0).item()
@@ -755,6 +758,9 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
 
     data = get_gridded_data(config, False, coupled_requirements)
     batch = next(iter(data.loader))
+    assert batch.ocean_data is not None
+    assert batch.ice_data is not None
+    assert batch.atmosphere_data is not None
     assert set(batch.ocean_data.data.keys()) == set(ocean_names)
     assert set(batch.ice_data.data.keys()) == set(ice_names)
     assert set(batch.atmosphere_data.data.keys()) == set(atmos_names)
@@ -864,6 +870,9 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     )
     batch_data = next(iter(data.loader))
     assert isinstance(batch_data, CoupledBatchData)
+    assert batch_data.ocean_data is not None
+    assert batch_data.atmosphere_data is not None
+    assert batch_data.ice_data is not None
     assert isinstance(batch_data.ocean_data.data["bar"], torch.Tensor)
     assert isinstance(batch_data.atmosphere_data.data["foo"], torch.Tensor)
     assert isinstance(batch_data.ice_data.data["baz"], torch.Tensor)
@@ -894,6 +903,9 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     assert batch_data.ocean_data.time.dt.calendar == calendar
     assert batch_data.ice_data.time.dt.calendar == calendar
     assert batch_data.atmosphere_data.time.dt.calendar == calendar
+    assert data.initial_condition.ocean_data is not None
+    assert data.initial_condition.ice_data is not None
+    assert data.initial_condition.atmosphere_data is not None
     xr.testing.assert_equal(
         data.initial_condition.ocean_data.as_batch_data().time,
         ocean_initial_condition.time,

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -32,7 +32,6 @@ from fme.core.dataset.xarray import (
 from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.typing_ import Slice
 from fme.coupled.data_loading.batch_data import CoupledBatchData, CoupledPrognosticState
-from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
 from fme.coupled.data_loading.data_typing import (
     CoupledDatasetItem,
     CoupledHorizontalCoordinates,
@@ -42,9 +41,10 @@ from fme.coupled.dataset_info import CoupledDatasetInfo
 from fme.coupled.requirements import CoupledDataRequirements
 
 from .config import (
+    CoupledAtmosphereIceOceanDatasetConfig,
     CoupledConcatDatasetConfig,
     CoupledDataLoaderConfig,
-    CoupledDatasetConfig,
+    build_coupled_dataset_config,
 )
 from .getters import get_forcing_data, get_gridded_data
 from .inference import (
@@ -237,7 +237,7 @@ class MockCoupledData:
         )
 
     @property
-    def dataset_config(self) -> CoupledDatasetConfig:
+    def dataset_config(self):
         ocean_dir = None
         ice_dir = None
         atmos_dir = None
@@ -247,7 +247,7 @@ class MockCoupledData:
             ice_dir = XarrayDataConfig(str(self.ice.data_dir))
         if self.atmosphere is not None:
             atmos_dir = XarrayDataConfig(str(self.atmosphere.data_dir))
-        return CoupledDatasetConfig(
+        return build_coupled_dataset_config(
             ocean=ocean_dir,
             ice=ice_dir,
             atmosphere=atmos_dir,
@@ -258,7 +258,7 @@ class MockCoupledData:
         ocean_kwargs: dict[str, Any] | None = None,
         ice_kwargs: dict[str, Any] | None = None,
         atmos_kwargs: dict[str, Any] | None = None,
-    ) -> CoupledDatasetConfig:
+    ):
         ocean_dir = None
         ice_dir = None
         atmos_dir = None
@@ -283,7 +283,7 @@ class MockCoupledData:
                 str(self.atmosphere.data_dir),
                 **atmos_kwargs,
             )
-        return CoupledDatasetConfig(
+        return build_coupled_dataset_config(
             ocean=ocean_dir,
             ice=ice_dir,
             atmosphere=atmos_dir,
@@ -824,7 +824,7 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
         assert ice_ic is not None
         assert atmos_ic is not None
         coupled_configs.append(
-            CoupledDatasetConfig(
+            CoupledAtmosphereIceOceanDatasetConfig(
                 ocean=XarrayDataConfig(
                     data_path=ocean_ic.data_dir,
                 ),
@@ -938,7 +938,7 @@ def test_zarr_engine_used_true():
     config = CoupledDataLoaderConfig(
         dataset=CoupledConcatDatasetConfig(
             concat=[
-                CoupledDatasetConfig(
+                CoupledAtmosphereIceOceanDatasetConfig(
                     ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
                     ice=XarrayDataConfig(
                         data_path="ice", file_pattern="data.zarr", engine="zarr"
@@ -947,7 +947,7 @@ def test_zarr_engine_used_true():
                         data_path="atmos", file_pattern="data.zarr", engine="zarr"
                     ),
                 ),
-                CoupledDatasetConfig(
+                CoupledAtmosphereIceOceanDatasetConfig(
                     ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
                     ice=XarrayDataConfig(data_path="ice", engine="netcdf4"),
                     atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
@@ -961,7 +961,7 @@ def test_zarr_engine_used_true():
 
 def test_zarr_engine_used_false():
     config = CoupledDataLoaderConfig(
-        dataset=CoupledDatasetConfig(
+        dataset=CoupledAtmosphereIceOceanDatasetConfig(
             ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
             ice=XarrayDataConfig(data_path="ice", engine="netcdf4"),
             atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
@@ -973,7 +973,7 @@ def test_zarr_engine_used_false():
 
 def test_zarr_engine_used_true_inference():
     config = InferenceDataLoaderConfig(
-        dataset=CoupledDatasetWithOptionalOceanConfig(
+        dataset=CoupledAtmosphereIceOceanDatasetConfig(
             ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
             ice=XarrayDataConfig(
                 data_path="ice", file_pattern="data.zarr", engine="zarr"
@@ -989,7 +989,7 @@ def test_zarr_engine_used_true_inference():
 
 def test_zarr_engine_used_false_inference():
     config = InferenceDataLoaderConfig(
-        dataset=CoupledDatasetWithOptionalOceanConfig(
+        dataset=CoupledAtmosphereIceOceanDatasetConfig(
             ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
             ice=XarrayDataConfig(data_path="ice", engine="netcdf4"),
             atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
@@ -1081,7 +1081,7 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
 
     # test CoupledDataLoaderConfig
     config = CoupledDataLoaderConfig(
-        dataset=CoupledDatasetConfig(
+        dataset=CoupledAtmosphereIceOceanDatasetConfig(
             ocean=ocean_config,
             ice=ice_config,
             atmosphere=atmos_config,
@@ -1109,7 +1109,7 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
 
     # test InferenceDataLoaderConfig
     inference_config = InferenceDataLoaderConfig(
-        dataset=CoupledDatasetWithOptionalOceanConfig(
+        dataset=CoupledAtmosphereIceOceanDatasetConfig(
             ocean=ocean_config,
             ice=ice_config,
             atmosphere=atmos_config,

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -62,7 +62,7 @@ def _save_netcdf(
     dim_sizes,
     variable_names,
     calendar,
-    realm: Literal["ocean", "atmosphere"],
+    realm: Literal["ocean", "ice", "atmosphere"],
     timestep_size=1,
     timestep_start=0,
     nz=3,
@@ -120,6 +120,13 @@ def _save_netcdf(
                         mask == 1, masked_fill_value
                     )
             data_vars[f"idepth_{i}"] = float(i)
+    if realm == "ice":
+        dim_sizes_to_use = dim_sizes_without_time
+        data = np.ones(tuple(dim_sizes_to_use.values()))
+        data[0, 0] = 0.0
+        names = [name for name in data_vars if name != "mask_2d"]
+        for name in names:
+            data_vars[name] = data_vars[name].where(data == 1, masked_fill_value)
     ds = xr.Dataset(data_vars=data_vars, coords=coords)
     ds.to_netcdf(filename, unlimited_dims=["time"], format="NETCDF4_CLASSIC")
     return ds
@@ -164,6 +171,7 @@ class MockComponentData:
 @dataclasses.dataclass
 class MockCoupledData:
     ocean: MockComponentData
+    ice: MockComponentData
     atmosphere: MockComponentData
 
     @property
@@ -171,18 +179,23 @@ class MockCoupledData:
         return len(self.ocean.ds["time"])
 
     @property
+    def n_times_ice(self):
+        return len(self.ice.ds["time"])
+
+    @property
     def n_times_atmosphere(self):
         return len(self.atmosphere.ds["time"])
 
     @property
     def img_shape(self) -> tuple[int, int]:
-        # NOTE: assumes atmosphere has same img_shape
+        # NOTE: assumes atmosphere and ice have same img_shape
         return self.ocean.ds[next(iter(self.ocean.ds.data_vars))].shape[-2:]
 
     @property
     def hcoord(self) -> CoupledHorizontalCoordinates:
         return CoupledHorizontalCoordinates(
             ocean=self.ocean.hcoord,
+            ice=self.ice.hcoord,
             atmosphere=self.atmosphere.hcoord,
         )
 
@@ -190,6 +203,7 @@ class MockCoupledData:
     def vcoord(self) -> CoupledVerticalCoordinate:
         return CoupledVerticalCoordinate(
             ocean=cast(OptionalDepthCoordinate, self.ocean.vcoord),
+            ice=cast(OptionalDepthCoordinate, self.ice.vcoord),
             atmosphere=cast(
                 OptionalHybridSigmaPressureCoordinate, self.atmosphere.vcoord
             ),
@@ -199,22 +213,30 @@ class MockCoupledData:
     def dataset_config(self) -> CoupledDatasetConfig:
         return CoupledDatasetConfig(
             ocean=XarrayDataConfig(str(self.ocean.data_dir)),
+            ice=XarrayDataConfig(str(self.ice.data_dir)),
             atmosphere=XarrayDataConfig(str(self.atmosphere.data_dir)),
         )
 
     def get_dataset_config_with_kwargs(
         self,
         ocean_kwargs: dict[str, Any] | None = None,
+        ice_kwargs: dict[str, Any] | None = None,
         atmos_kwargs: dict[str, Any] | None = None,
     ) -> CoupledDatasetConfig:
         if ocean_kwargs is None:
             ocean_kwargs = {}
+        if ice_kwargs is None:
+            ice_kwargs = {}
         if atmos_kwargs is None:
             atmos_kwargs = {}
         return CoupledDatasetConfig(
             ocean=XarrayDataConfig(
                 data_path=str(self.ocean.data_dir),
                 **ocean_kwargs,
+            ),
+            ice=XarrayDataConfig(
+                data_path=str(self.ice.data_dir),
+                **ice_kwargs,
             ),
             atmosphere=XarrayDataConfig(
                 data_path=str(self.atmosphere.data_dir),
@@ -236,48 +258,67 @@ class MockCoupledData:
             spatial_mask_provider=self.ocean.spatial_mask_provider,
             timestep=self.ocean.timestep,
         )
+        ice_info = DatasetInfo(
+            horizontal_coordinates=self.ice.hcoord,
+            vertical_coordinate=self.ice.vcoord,
+            spatial_mask_provider=self.ice.spatial_mask_provider,
+            timestep=self.ice.timestep,
+        )
         atmos_info = DatasetInfo(
             horizontal_coordinates=self.atmosphere.hcoord,
             vertical_coordinate=self.atmosphere.vcoord,
             spatial_mask_provider=self.atmosphere.spatial_mask_provider,
             timestep=self.atmosphere.timestep,
         )
-        return CoupledDatasetInfo(ocean=ocean_info, atmosphere=atmos_info)
+        return CoupledDatasetInfo(ocean=ocean_info, atmosphere=atmos_info, ice=ice_info)
 
 
 def create_coupled_data_on_disk(
     data_dir: pathlib.Path,
     n_forward_times_ocean: int,
+    n_forward_times_ice: int,
     n_forward_times_atmosphere: int,
     ocean_names: list[str],
+    ice_names: list[str],
     atmosphere_names: list[str],
     atmosphere_start_time_offset_from_ocean: int = 0,
+    ice_start_time_offset_from_ocean: int = 0,
     n_levels_ocean: int = 2,
     n_levels_atmosphere: int = 2,
     ocean_timestep_size_in_days: int | None = None,
     masked_fill_value: float = float("nan"),
 ) -> MockCoupledData:
-    """Create synthetic coupled ocean-atmosphere data on disk for testing.
+    """Create synthetic coupled ocean-ice-atmosphere data on disk for testing.
 
-    Creates netCDF files with random data for ocean and atmosphere components,
-    along with statistics files. The ocean and atmosphere can have different
-    timesteps, and the atmosphere can optionally start earlier than the ocean.
+    Creates netCDF files with random data for ocean, ice, and atmosphere components,
+    along with statistics files. The ocean, ice and atmosphere can have different
+    timesteps, and the atmosphere and ice can optionally start earlier than the ocean.
 
     Args:
         data_dir: Directory where data will be written. Will create subdirectories
-            ocean/, atmos/, and stats/.
+            ocean/, ice/, atmos/, and stats/.
         n_forward_times_ocean: Number of forward timesteps for ocean data.
             Total ocean timesteps will be n_forward_times_ocean + 1 (including IC).
+        n_forward_times_ice: Number of forward timesteps for ice
+            data. Must be a multiple of n_forward_times_ocean. Total ice
+            timesteps will be n_forward_times_ice + 1 +
+            ice_start_time_offset_from_ocean.
         n_forward_times_atmosphere: Number of forward timesteps for atmosphere
             data. Must be a multiple of n_forward_times_ocean. Total atmosphere
             timesteps will be n_forward_times_atmosphere + 1 +
             atmosphere_start_time_offset_from_ocean.
         ocean_names: List of variable names to create in the ocean dataset.
+        ice_names: List of variable names to create in the ice dataset.
         atmosphere_names: List of variable names to create in the atmosphere dataset.
         atmosphere_start_time_offset_from_ocean: Non-negative integer offset in
             atmosphere timesteps. When 0, ocean and atmosphere start at the same time
             (1970-01-01). When positive, atmosphere starts earlier by this many
             atmosphere timesteps. For example, with offset=1, atmosphere starts at
+            1969-12-31 while ocean starts at 1970-01-01. Default is 0.
+        ice_start_time_offset_from_ocean: Non-negative integer offset in
+            ice timesteps. When 0, ocean and ice start at the same time
+            (1970-01-01). When positive, ice starts earlier by this many
+            ice timesteps. For example, with offset=1, ice starts at
             1969-12-31 while ocean starts at 1970-01-01. Default is 0.
         n_levels_ocean: Number of ocean depth levels. Default is 2.
         n_levels_atmosphere: Number of atmosphere vertical levels. Default is 2.
@@ -288,11 +329,11 @@ def create_coupled_data_on_disk(
             target comparison tests).
 
     Returns:
-        MockCoupledData containing the created ocean and atmosphere datasets,
+        MockCoupledData containing the created ocean, ice, and atmosphere datasets,
         along with paths to data and statistics files.
 
     Note:
-        The atmosphere timestep is fixed at 1 day. If not provided, the ocean
+        The atmosphere and ice timesteps are fixed at 1 day. If not provided, the ocean
         timestep is automatically calculated as
         (n_forward_times_atmosphere / n_forward_times_ocean) days to ensure the
         datasets span the same total time period.
@@ -328,6 +369,28 @@ def create_coupled_data_on_disk(
         masked_fill_value=masked_fill_value,
     )
 
+    ice_dir = data_dir / "ice"
+    ice_dir.mkdir()
+    n_times_ice = n_forward_times_ice + 1 + ice_start_time_offset_from_ocean
+    # ice initial time may be earlier than ocean's
+    timestep_start_ice = -ice_start_time_offset_from_ocean
+    ice_dim_sizes = {
+        "time": n_times_ice,
+        "lat": N_LAT,
+        "lon": N_LON,
+    }
+    ice_ds = _save_netcdf(
+        filename=ice_dir / "data.nc",
+        dim_sizes=ice_dim_sizes,
+        variable_names=ice_names,
+        calendar="proleptic_gregorian",
+        realm="ice",
+        timestep_size=1,
+        timestep_start=timestep_start_ice,
+        nz=1,
+        masked_fill_value=masked_fill_value,
+    )
+
     atmos_dir = data_dir / "atmos"
     atmos_dir.mkdir()
     n_times_atmos = (
@@ -353,11 +416,12 @@ def create_coupled_data_on_disk(
     )
     # _save_netcdf creates integer times in units of "days since 1970-01-01"
     timedelta_atmos = "1D"
+    timedelta_ice = "1D"
     timedelta_ocean = f"{ocean_timestep_size}D"
 
     stats_dir = data_dir / "stats"
     stats_dir.mkdir()
-    all_names = list(set(ocean_names + atmosphere_names))
+    all_names = list(set(ocean_names + atmosphere_names + ice_names))
     save_stats_netcdfs(
         stats_dir / "means.nc",
         stats_dir / "stds.nc",
@@ -370,6 +434,13 @@ def create_coupled_data_on_disk(
             means_path=str(stats_dir / "means.nc"),
             stds_path=str(stats_dir / "stds.nc"),
             timedelta=timedelta_ocean,
+        ),
+        ice=MockComponentData(
+            ds=ice_ds,
+            data_dir=str(ice_dir),
+            means_path=str(stats_dir / "means.nc"),
+            stds_path=str(stats_dir / "stds.nc"),
+            timedelta=timedelta_ice,
         ),
         atmosphere=MockComponentData(
             ds=atmos_ds,
@@ -388,6 +459,7 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
     # Create datasets with fast and slow timesteps.
     ocean_names = ["bar"]
     atmos_names = ["foo"]
+    ice_names = ["baz"]
 
     n_ics = 2
     ics = []
@@ -398,18 +470,24 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
         ic = create_coupled_data_on_disk(
             ic_path,
             n_forward_times_ocean=2,
+            n_forward_times_ice=4,
             n_forward_times_atmosphere=4,
             ocean_names=ocean_names,
             atmosphere_names=atmos_names,
+            ice_names=ice_names,
             atmosphere_start_time_offset_from_ocean=atmosphere_times_offset,
+            ice_start_time_offset_from_ocean=atmosphere_times_offset,
         )
         ics.append(ic)
 
     # subset atmosphere data to align with beginning of ocean data
+    # keep ice aligned with atmosphere for simplicity
     if atmosphere_times_offset > 0:
         atmos_data_subset = Slice(start=atmosphere_times_offset)
+        ice_data_subset = Slice(start=atmosphere_times_offset)
     else:
         atmos_data_subset = Slice()
+        ice_data_subset = Slice()
 
     config = CoupledDataLoaderConfig(
         dataset=CoupledConcatDatasetConfig(
@@ -417,6 +495,10 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
                 CoupledDatasetConfig(
                     ocean=XarrayDataConfig(
                         data_path=ics[i].ocean.data_dir,
+                    ),
+                    ice=XarrayDataConfig(
+                        data_path=ics[i].ice.data_dir,
+                        subset=ice_data_subset,
                     ),
                     atmosphere=XarrayDataConfig(
                         data_path=ics[i].atmosphere.data_dir,
@@ -433,6 +515,8 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
     coupled_requirements = CoupledDataRequirements(
         ocean_timestep=datetime.timedelta(days=2),
         ocean_requirements=DataRequirements(ocean_names, n_timesteps=2),
+        ice_timestep=datetime.timedelta(days=1),
+        ice_requirements=DataRequirements(ice_names, n_timesteps=3),
         atmosphere_timestep=datetime.timedelta(days=1),
         atmosphere_requirements=DataRequirements(atmos_names, n_timesteps=3),
     )
@@ -442,14 +526,18 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
     assert data.n_batches == 2 * n_ics  # 2 samples per IC
     for batch in data.loader:
         ocean_data = batch.ocean_data
+        ice_data = batch.ice_data
         atmosphere_data = batch.atmosphere_data
         assert isinstance(ocean_data, BatchData)
+        assert isinstance(ice_data, BatchData)
         assert isinstance(atmosphere_data, BatchData)
         assert len(ocean_data.time.isel(sample=0).values) == 2  # IC + 1 forward step
+        assert len(ice_data.time.isel(sample=0).values) == 3  # IC + 2 forward steps
         assert (
             len(atmosphere_data.time.isel(sample=0).values) == 3
         )  # IC + 2 forward steps
         assert set(ocean_data.data.keys()) == set(ocean_names)
+        assert set(ice_data.data.keys()) == set(ice_names)
         assert set(atmosphere_data.data.keys()) == set(atmos_names)
         # initial condition times should match:
         assert ocean_data.time.isel(time=0) == atmosphere_data.time.isel(time=0)
@@ -458,26 +546,38 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
         # check data matches expectations
         assert ocean_data.data["bar"].shape[1] == 2
         assert atmosphere_data.data["foo"].shape[1] == 3
+        assert ice_data.data["baz"].shape[1] == 3
 
     # check that the sample data matches
     ic_idx = 0
     sample_idx = 1
     ocean_ds = ics[ic_idx].ocean.ds
+    ice_ds = ics[ic_idx].ice.ds
     atmos_ds = ics[ic_idx].atmosphere.ds
     sample = data._loader._dataset[sample_idx]  # type: ignore
     assert isinstance(sample, CoupledDatasetItem)
     ocean_sample_init_time = sample.ocean[1].isel(time=0).item()
+    ice_sample_init_time = sample.ice[1].isel(time=0).item()
     atmos_sample_init_time = sample.atmosphere[1].isel(time=0).item()
 
-    # we already checked for matching ocean/atmos sample init times above, now
-    # checking that they match times at the right positions in each dataset
+    # we already checked for matching ocean/ice/atmos sample init times above,
+    # now checking that they match times at the right positions in each dataset
     assert ocean_sample_init_time == ocean_ds.isel(time=1)["time"].item()
+    assert (
+        ice_sample_init_time
+        == ice_ds.isel(time=2 + atmosphere_times_offset)["time"].item()
+    )
     assert (
         atmos_sample_init_time
         == atmos_ds.isel(time=2 + atmosphere_times_offset)["time"].item()
     )
 
     expected_ocean = ocean_ds["bar"].isel(time=slice(1, 3)).values
+    expected_ice = (
+        ice_ds["baz"]
+        .isel(time=slice(2 + atmosphere_times_offset, 5 + atmosphere_times_offset))
+        .values
+    )
     expected_atmos = (
         atmos_ds["foo"]
         .isel(time=slice(2 + atmosphere_times_offset, 5 + atmosphere_times_offset))
@@ -486,6 +586,7 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
     # check that
     assert np.allclose(sample.ocean[0]["bar"].cpu().numpy(), expected_ocean)
     assert np.allclose(sample.atmosphere[0]["foo"].cpu().numpy(), expected_atmos)
+    assert np.allclose(sample.ice[0]["baz"].cpu().numpy(), expected_ice)
 
 
 def test_zarr_engine_used_true():
@@ -494,12 +595,16 @@ def test_zarr_engine_used_true():
             concat=[
                 CoupledDatasetConfig(
                     ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+                    ice=XarrayDataConfig(
+                        data_path="ice", file_pattern="data.zarr", engine="zarr"
+                    ),
                     atmosphere=XarrayDataConfig(
                         data_path="atmos", file_pattern="data.zarr", engine="zarr"
                     ),
                 ),
                 CoupledDatasetConfig(
                     ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+                    ice=XarrayDataConfig(data_path="ice", engine="netcdf4"),
                     atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
                 ),
             ]
@@ -513,6 +618,7 @@ def test_zarr_engine_used_false():
     config = CoupledDataLoaderConfig(
         dataset=CoupledDatasetConfig(
             ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+            ice=XarrayDataConfig(data_path="ice", engine="netcdf4"),
             atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
         ),
         batch_size=1,
@@ -524,6 +630,9 @@ def test_zarr_engine_used_true_inference():
     config = InferenceDataLoaderConfig(
         dataset=CoupledDatasetWithOptionalOceanConfig(
             ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+            ice=XarrayDataConfig(
+                data_path="ice", file_pattern="data.zarr", engine="zarr"
+            ),
             atmosphere=XarrayDataConfig(
                 data_path="atmos", file_pattern="data.zarr", engine="zarr"
             ),
@@ -537,6 +646,7 @@ def test_zarr_engine_used_false_inference():
     config = InferenceDataLoaderConfig(
         dataset=CoupledDatasetWithOptionalOceanConfig(
             ocean=XarrayDataConfig(data_path="ocean", engine="netcdf4"),
+            ice=XarrayDataConfig(data_path="ice", engine="netcdf4"),
             atmosphere=XarrayDataConfig(data_path="atmos", engine="netcdf4"),
         ),
         start_indices=ExplicitIndices([0]),
@@ -546,8 +656,10 @@ def test_zarr_engine_used_false_inference():
 
 def test_coupled_data_loader_merge_no_concat(tmp_path):
     ocean_names = ["var_ocean_1", "var_ocean_2"]
+    ice_names = ["var_ice_1", "var_ice_2"]
     atmos_names = ["var_atmos_1", "var_atmos_2"]
     n_forward_times_ocean = 2
+    n_forward_times_ice = 4
     n_forward_times_atmosphere = 4
 
     data_path = tmp_path / "data"
@@ -560,10 +672,18 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
     ocean_dir_part1.mkdir()
     ocean_dir_part2.mkdir()
 
+    ice_dir = data_path / "ice"
+    ice_dir.mkdir()
+
     atmos_dir = data_path / "atmos"
     atmos_dir.mkdir()
 
     ocean_dim_sizes = {"time": n_forward_times_ocean + 1, "lat": N_LAT, "lon": N_LON}
+    ice_dim_sizes = {
+        "time": n_forward_times_ice + 1,
+        "lat": N_LAT,
+        "lon": N_LON,
+    }
     atmos_dim_sizes = {
         "time": n_forward_times_atmosphere + 1,
         "lat": N_LAT,
@@ -573,6 +693,7 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
     ocean_timestep_size = n_forward_times_atmosphere // n_forward_times_ocean
 
     ocean_config: MergeNoConcatDatasetConfig | XarrayDataConfig
+    ice_config: MergeNoConcatDatasetConfig | XarrayDataConfig
     atmos_config: MergeNoConcatDatasetConfig | XarrayDataConfig
     _save_netcdf(
         filename=ocean_dir_part1 / "data.nc",
@@ -591,6 +712,13 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
         timestep_size=ocean_timestep_size,
     )
     _save_netcdf(
+        filename=ice_dir / "data.nc",
+        dim_sizes=ice_dim_sizes,
+        variable_names=ice_names,
+        calendar="proleptic_gregorian",
+        realm="ice",
+    )
+    _save_netcdf(
         filename=atmos_dir / "data.nc",
         dim_sizes=atmos_dim_sizes,
         variable_names=atmos_names,
@@ -603,12 +731,14 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
             XarrayDataConfig(data_path=str(ocean_dir_part2)),
         ]
     )
+    ice_config = XarrayDataConfig(data_path=str(ice_dir))
     atmos_config = XarrayDataConfig(data_path=str(atmos_dir))
 
     # test CoupledDataLoaderConfig
     config = CoupledDataLoaderConfig(
         dataset=CoupledDatasetConfig(
             ocean=ocean_config,
+            ice=ice_config,
             atmosphere=atmos_config,
         ),
         batch_size=1,
@@ -617,6 +747,8 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
     coupled_requirements = CoupledDataRequirements(
         ocean_timestep=datetime.timedelta(days=ocean_timestep_size),
         ocean_requirements=DataRequirements(ocean_names, n_timesteps=2),
+        ice_timestep=datetime.timedelta(days=1),
+        ice_requirements=DataRequirements(ice_names, n_timesteps=3),
         atmosphere_timestep=datetime.timedelta(days=1),
         atmosphere_requirements=DataRequirements(atmos_names, n_timesteps=3),
     )
@@ -624,12 +756,14 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
     data = get_gridded_data(config, False, coupled_requirements)
     batch = next(iter(data.loader))
     assert set(batch.ocean_data.data.keys()) == set(ocean_names)
+    assert set(batch.ice_data.data.keys()) == set(ice_names)
     assert set(batch.atmosphere_data.data.keys()) == set(atmos_names)
 
     # test InferenceDataLoaderConfig
     inference_config = InferenceDataLoaderConfig(
         dataset=CoupledDatasetWithOptionalOceanConfig(
             ocean=ocean_config,
+            ice=ice_config,
             atmosphere=atmos_config,
         ),
         start_indices=ExplicitIndices([0]),
@@ -648,6 +782,7 @@ def test_coupled_data_loader_merge_no_concat(tmp_path):
 
     inference_batch = next(iter(loader))
     assert set(inference_batch.ocean_data.data.keys()) == set(ocean_names)
+    assert set(inference_batch.ice_data.data.keys()) == set(ice_names)
     assert set(inference_batch.atmosphere_data.data.keys()) == set(atmos_names)
 
 
@@ -656,7 +791,9 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     calendar = "proleptic_gregorian"
     ocean_names = ["bar"]
     atmos_names = ["foo"]
+    ice_names = ["baz"]
     n_forward_times_ocean = 4
+    n_forward_times_ice = 8
     n_forward_times_atmosphere = 8
     inner_steps = 2
     total_coupled_steps = 2
@@ -664,15 +801,19 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     create_coupled_data_on_disk(
         tmp_path,
         n_forward_times_ocean=n_forward_times_ocean,
+        n_forward_times_ice=n_forward_times_ice,
         n_forward_times_atmosphere=n_forward_times_atmosphere,
         ocean_names=ocean_names,
+        ice_names=ice_names,
         atmosphere_names=atmos_names,
         atmosphere_start_time_offset_from_ocean=0,
+        ice_start_time_offset_from_ocean=0,
     )
     config = CoupledForcingDataLoaderConfig(
         atmosphere=ForcingDataLoaderConfig(
             XarrayDataConfig(data_path=tmp_path / "atmos")
         ),
+        ice=ForcingDataLoaderConfig(XarrayDataConfig(data_path=tmp_path / "ice")),
         ocean=ForcingDataLoaderConfig(XarrayDataConfig(data_path=tmp_path / "ocean")),
     )
     ocean_timestep_size = n_forward_times_atmosphere / n_forward_times_ocean
@@ -681,6 +822,10 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
         ocean_requirements=DataRequirements(
             ocean_names, n_timesteps=coupled_steps_in_memory + 1
         ),
+        ice_timestep=datetime.timedelta(days=1),
+        ice_requirements=DataRequirements(
+            ice_names, n_timesteps=coupled_steps_in_memory * inner_steps + 1
+        ),
         atmosphere_timestep=datetime.timedelta(days=1),
         atmosphere_requirements=DataRequirements(
             atmos_names, n_timesteps=coupled_steps_in_memory * inner_steps + 1
@@ -688,6 +833,13 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     )
     atmos_initial_condition = BatchData.new_for_testing(
         names=atmos_names,
+        n_samples=n_initial_conditions,
+        n_timesteps=1,
+        t_initial=cftime.datetime(1970, 1, 1),
+        calendar=calendar,
+    )
+    ice_initial_condition = BatchData.new_for_testing(
+        names=ice_names,
         n_samples=n_initial_conditions,
         n_timesteps=1,
         t_initial=cftime.datetime(1970, 1, 1),
@@ -707,32 +859,48 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
         initial_condition=CoupledPrognosticState(
             ocean_data=PrognosticState(ocean_initial_condition),
             atmosphere_data=PrognosticState(atmos_initial_condition),
+            ice_data=PrognosticState(ice_initial_condition),
         ),  # type: ignore
     )
     batch_data = next(iter(data.loader))
     assert isinstance(batch_data, CoupledBatchData)
     assert isinstance(batch_data.ocean_data.data["bar"], torch.Tensor)
     assert isinstance(batch_data.atmosphere_data.data["foo"], torch.Tensor)
+    assert isinstance(batch_data.ice_data.data["baz"], torch.Tensor)
     assert batch_data.ocean_data.data["bar"].shape[0] == n_initial_conditions
     assert batch_data.ocean_data.data["bar"].shape[1] == total_coupled_steps + 1
+    assert batch_data.ice_data.data["baz"].shape[0] == n_initial_conditions
     assert batch_data.atmosphere_data.data["foo"].shape[0] == n_initial_conditions
     assert (
         batch_data.atmosphere_data.data["foo"].shape[1]
         == total_coupled_steps * inner_steps + 1
     )
+    assert (
+        batch_data.ice_data.data["baz"].shape[1]
+        == total_coupled_steps * inner_steps + 1
+    )
     assert list(batch_data.ocean_data.time.dims) == ["sample", "time"]
     assert list(batch_data.atmosphere_data.time.dims) == ["sample", "time"]
+    assert list(batch_data.ice_data.time.dims) == ["sample", "time"]
     xr.testing.assert_allclose(
         batch_data.ocean_data.time[:, 0], ocean_initial_condition.time[:, 0]
+    )
+    xr.testing.assert_allclose(
+        batch_data.ice_data.time[:, 0], ice_initial_condition.time[:, 0]
     )
     xr.testing.assert_allclose(
         batch_data.atmosphere_data.time[:, 0], atmos_initial_condition.time[:, 0]
     )
     assert batch_data.ocean_data.time.dt.calendar == calendar
+    assert batch_data.ice_data.time.dt.calendar == calendar
     assert batch_data.atmosphere_data.time.dt.calendar == calendar
     xr.testing.assert_equal(
         data.initial_condition.ocean_data.as_batch_data().time,
         ocean_initial_condition.time,
+    )
+    xr.testing.assert_equal(
+        data.initial_condition.ice_data.as_batch_data().time,
+        ice_initial_condition.time,
     )
     xr.testing.assert_equal(
         data.initial_condition.atmosphere_data.as_batch_data().time,
@@ -741,6 +909,10 @@ def test_get_forcing_data(tmp_path, n_initial_conditions):
     np.testing.assert_allclose(
         data.initial_condition.ocean_data.as_batch_data().data["bar"].cpu().numpy(),
         ocean_initial_condition.data["bar"].cpu().numpy(),
+    )
+    np.testing.assert_allclose(
+        data.initial_condition.ice_data.as_batch_data().data["baz"].cpu().numpy(),
+        ice_initial_condition.data["baz"].cpu().numpy(),
     )
     np.testing.assert_allclose(
         data.initial_condition.atmosphere_data.as_batch_data()

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -197,6 +197,10 @@ class MockCoupledData:
         elif self.ice is not None:
             # NOTE: assumes atmosphere has same img_shape
             return self.ice.ds[next(iter(self.ice.ds.data_vars))].shape[-2:]
+        else:
+            assert self.atmosphere is not None
+            data = self.atmosphere.ds[next(iter(self.atmosphere.ds.data_vars))]
+            return data.shape[-2:]
 
     @property
     def hcoord(self) -> CoupledHorizontalCoordinates:
@@ -221,15 +225,15 @@ class MockCoupledData:
         ice_vcoord = None
         atmos_vcoord = None
         if self.ocean is not None:
-            ocean_vcoord = self.ocean.vcoord
+            ocean_vcoord = cast(OptionalDepthCoordinate, self.ocean.vcoord)
         if self.ice is not None:
-            ice_vcoord = self.ice.vcoord
+            ice_vcoord = cast(OptionalDepthCoordinate, self.ice.vcoord)
         if self.atmosphere is not None:
-            atmos_vcoord = self.atmosphere.vcoord
+            atmos_vcoord = cast(
+                OptionalHybridSigmaPressureCoordinate, self.atmosphere.vcoord
+            )
         return CoupledVerticalCoordinate(
-            ocean=ocean_vcoord,
-            ice=ice_vcoord,
-            atmosphere=atmos_vcoord
+            ocean=ocean_vcoord, ice=ice_vcoord, atmosphere=atmos_vcoord
         )
 
     @property
@@ -389,6 +393,15 @@ def create_coupled_data_on_disk(
     np.random.seed(0)
 
     if n_forward_times_atmosphere is None:
+        assert (
+            n_forward_times_ocean is not None
+            and n_forward_times_ice is not None
+            and ocean_names is not None
+            and ice_names is not None
+        )
+        assert isinstance(ice_start_time_offset_from_ocean, int)
+        assert isinstance(n_levels_ocean, int)
+
         ocean_dir = data_dir / "ocean"
         ocean_dir.mkdir()
         ocean_dim_sizes = {
@@ -397,8 +410,6 @@ def create_coupled_data_on_disk(
             "lon": N_LON,
         }
         if ocean_timestep_size_in_days is None:
-            assert n_forward_times_ocean is not None
-            assert n_forward_times_ice is not None
             ocean_timestep_size = n_forward_times_ice / n_forward_times_ocean
         else:
             ocean_timestep_size = ocean_timestep_size_in_days
@@ -471,6 +482,16 @@ def create_coupled_data_on_disk(
             ),
         )
     elif n_forward_times_ice is None:
+        assert (
+            n_forward_times_ocean is not None
+            and n_forward_times_atmosphere is not None
+            and ocean_names is not None
+            and atmosphere_names is not None
+        )
+        assert isinstance(atmosphere_start_time_offset_from_ocean, int)
+        assert isinstance(n_levels_ocean, int)
+        assert isinstance(n_levels_atmosphere, int)
+
         ocean_dir = data_dir / "ocean"
         ocean_dir.mkdir()
         ocean_dim_sizes = {
@@ -479,8 +500,6 @@ def create_coupled_data_on_disk(
             "lon": N_LON,
         }
         if ocean_timestep_size_in_days is None:
-            assert n_forward_times_ocean is not None
-            assert n_forward_times_atmosphere is not None
             ocean_timestep_size = n_forward_times_atmosphere / n_forward_times_ocean
         else:
             ocean_timestep_size = ocean_timestep_size_in_days
@@ -556,6 +575,14 @@ def create_coupled_data_on_disk(
             ),
         )
     elif n_forward_times_ocean is None:
+        assert (
+            n_forward_times_ice is not None
+            and n_forward_times_atmosphere is not None
+            and ice_names is not None
+            and atmosphere_names is not None
+        )
+        assert isinstance(n_levels_atmosphere, int)
+
         ice_dir = data_dir / "ice"
         ice_dir.mkdir()
         n_times_ice = n_forward_times_ice + 1
@@ -624,6 +651,19 @@ def create_coupled_data_on_disk(
             ),
         )
     else:
+        assert (
+            n_forward_times_ocean is not None
+            and n_forward_times_ice is not None
+            and n_forward_times_atmosphere is not None
+            and ocean_names is not None
+            and ice_names is not None
+            and atmosphere_names is not None
+        )
+        assert isinstance(ice_start_time_offset_from_ocean, int)
+        assert isinstance(atmosphere_start_time_offset_from_ocean, int)
+        assert isinstance(n_levels_ocean, int)
+        assert isinstance(n_levels_atmosphere, int)
+
         ocean_dir = data_dir / "ocean"
         ocean_dir.mkdir()
         ocean_dim_sizes = {
@@ -632,8 +672,6 @@ def create_coupled_data_on_disk(
             "lon": N_LON,
         }
         if ocean_timestep_size_in_days is None:
-            assert n_forward_times_ocean is not None
-            assert n_forward_times_atmosphere is not None
             ocean_timestep_size = n_forward_times_atmosphere / n_forward_times_ocean
         else:
             ocean_timestep_size = ocean_timestep_size_in_days
@@ -658,7 +696,6 @@ def create_coupled_data_on_disk(
             timestep_start=0,  # ocean start time fixed
             masked_fill_value=masked_fill_value,
         )
-        assert n_forward_times_ice is not None
         ice_dir = data_dir / "ice"
         ice_dir.mkdir()
         n_times_ice = n_forward_times_ice + 1 + ice_start_time_offset_from_ocean
@@ -778,25 +815,31 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
         atmos_data_subset = Slice()
         ice_data_subset = Slice()
 
+    coupled_configs = []
+    for i in range(n_ics):
+        ocean_ic = ics[i].ocean
+        ice_ic = ics[i].ice
+        atmos_ic = ics[i].atmosphere
+        assert ocean_ic is not None
+        assert ice_ic is not None
+        assert atmos_ic is not None
+        coupled_configs.append(
+            CoupledDatasetConfig(
+                ocean=XarrayDataConfig(
+                    data_path=ocean_ic.data_dir,
+                ),
+                ice=XarrayDataConfig(
+                    data_path=ice_ic.data_dir,
+                    subset=ice_data_subset,
+                ),
+                atmosphere=XarrayDataConfig(
+                    data_path=atmos_ic.data_dir,
+                    subset=atmos_data_subset,
+                ),
+            )
+        )
     config = CoupledDataLoaderConfig(
-        dataset=CoupledConcatDatasetConfig(
-            concat=[
-                CoupledDatasetConfig(
-                    ocean=XarrayDataConfig(
-                        data_path=ics[i].ocean.data_dir,
-                    ),
-                    ice=XarrayDataConfig(
-                        data_path=ics[i].ice.data_dir,
-                        subset=ice_data_subset,
-                    ),
-                    atmosphere=XarrayDataConfig(
-                        data_path=ics[i].atmosphere.data_dir,
-                        subset=atmos_data_subset,
-                    ),
-                )
-                for i in range(n_ics)
-            ]
-        ),
+        dataset=CoupledConcatDatasetConfig(concat=coupled_configs),
         batch_size=1,
         num_data_workers=0,
         strict_ensemble=True,
@@ -840,9 +883,15 @@ def test_coupled_data_loader(tmp_path, atmosphere_times_offset: int):
     # check that the sample data matches
     ic_idx = 0
     sample_idx = 1
-    ocean_ds = ics[ic_idx].ocean.ds
-    ice_ds = ics[ic_idx].ice.ds
-    atmos_ds = ics[ic_idx].atmosphere.ds
+    ocean_ic = ics[ic_idx].ocean
+    ice_ic = ics[ic_idx].ice
+    atmos_ic = ics[ic_idx].atmosphere
+    assert ocean_ic is not None
+    assert ice_ic is not None
+    assert atmos_ic is not None
+    ocean_ds = ocean_ic.ds
+    ice_ds = ice_ic.ds
+    atmos_ds = atmos_ic.ds
     sample = data._loader._dataset[sample_idx]  # type: ignore
     assert isinstance(sample, CoupledDatasetItem)
     assert sample.ocean is not None

--- a/fme/coupled/data_loading/test_data_loader.py
+++ b/fme/coupled/data_loading/test_data_loader.py
@@ -170,51 +170,83 @@ class MockComponentData:
 
 @dataclasses.dataclass
 class MockCoupledData:
-    ocean: MockComponentData
-    ice: MockComponentData
-    atmosphere: MockComponentData
+    ocean: MockComponentData | None = None
+    ice: MockComponentData | None = None
+    atmosphere: MockComponentData | None = None
 
     @property
     def n_times_ocean(self):
+        assert self.ocean is not None
         return len(self.ocean.ds["time"])
 
     @property
     def n_times_ice(self):
+        assert self.ice is not None
         return len(self.ice.ds["time"])
 
     @property
     def n_times_atmosphere(self):
+        assert self.atmosphere is not None
         return len(self.atmosphere.ds["time"])
 
     @property
     def img_shape(self) -> tuple[int, int]:
-        # NOTE: assumes atmosphere and ice have same img_shape
-        return self.ocean.ds[next(iter(self.ocean.ds.data_vars))].shape[-2:]
+        if self.ocean is not None:
+            # NOTE: assumes atmosphere and ice have same img_shape
+            return self.ocean.ds[next(iter(self.ocean.ds.data_vars))].shape[-2:]
+        elif self.ice is not None:
+            # NOTE: assumes atmosphere has same img_shape
+            return self.ice.ds[next(iter(self.ice.ds.data_vars))].shape[-2:]
 
     @property
     def hcoord(self) -> CoupledHorizontalCoordinates:
+        ocean_hcoord = None
+        ice_hcoord = None
+        atmos_hcoord = None
+        if self.ocean is not None:
+            ocean_hcoord = self.ocean.hcoord
+        if self.ice is not None:
+            ice_hcoord = self.ice.hcoord
+        if self.atmosphere is not None:
+            atmos_hcoord = self.atmosphere.hcoord
         return CoupledHorizontalCoordinates(
-            ocean=self.ocean.hcoord,
-            ice=self.ice.hcoord,
-            atmosphere=self.atmosphere.hcoord,
+            ocean=ocean_hcoord,
+            ice=ice_hcoord,
+            atmosphere=atmos_hcoord,
         )
 
     @property
     def vcoord(self) -> CoupledVerticalCoordinate:
+        ocean_vcoord = None
+        ice_vcoord = None
+        atmos_vcoord = None
+        if self.ocean is not None:
+            ocean_vcoord = self.ocean.vcoord
+        if self.ice is not None:
+            ice_vcoord = self.ice.vcoord
+        if self.atmosphere is not None:
+            atmos_vcoord = self.atmosphere.vcoord
         return CoupledVerticalCoordinate(
-            ocean=cast(OptionalDepthCoordinate, self.ocean.vcoord),
-            ice=cast(OptionalDepthCoordinate, self.ice.vcoord),
-            atmosphere=cast(
-                OptionalHybridSigmaPressureCoordinate, self.atmosphere.vcoord
-            ),
+            ocean=ocean_vcoord,
+            ice=ice_vcoord,
+            atmosphere=atmos_vcoord
         )
 
     @property
     def dataset_config(self) -> CoupledDatasetConfig:
+        ocean_dir = None
+        ice_dir = None
+        atmos_dir = None
+        if self.ocean is not None:
+            ocean_dir = XarrayDataConfig(str(self.ocean.data_dir))
+        if self.ice is not None:
+            ice_dir = XarrayDataConfig(str(self.ice.data_dir))
+        if self.atmosphere is not None:
+            atmos_dir = XarrayDataConfig(str(self.atmosphere.data_dir))
         return CoupledDatasetConfig(
-            ocean=XarrayDataConfig(str(self.ocean.data_dir)),
-            ice=XarrayDataConfig(str(self.ice.data_dir)),
-            atmosphere=XarrayDataConfig(str(self.atmosphere.data_dir)),
+            ocean=ocean_dir,
+            ice=ice_dir,
+            atmosphere=atmos_dir,
         )
 
     def get_dataset_config_with_kwargs(
@@ -223,25 +255,34 @@ class MockCoupledData:
         ice_kwargs: dict[str, Any] | None = None,
         atmos_kwargs: dict[str, Any] | None = None,
     ) -> CoupledDatasetConfig:
+        ocean_dir = None
+        ice_dir = None
+        atmos_dir = None
         if ocean_kwargs is None:
             ocean_kwargs = {}
         if ice_kwargs is None:
             ice_kwargs = {}
         if atmos_kwargs is None:
             atmos_kwargs = {}
-        return CoupledDatasetConfig(
-            ocean=XarrayDataConfig(
-                data_path=str(self.ocean.data_dir),
+        if self.ocean is not None:
+            ocean_dir = XarrayDataConfig(
+                str(self.ocean.data_dir),
                 **ocean_kwargs,
-            ),
-            ice=XarrayDataConfig(
-                data_path=str(self.ice.data_dir),
+            )
+        if self.ice is not None:
+            ice_dir = XarrayDataConfig(
+                str(self.ice.data_dir),
                 **ice_kwargs,
-            ),
-            atmosphere=XarrayDataConfig(
-                data_path=str(self.atmosphere.data_dir),
+            )
+        if self.atmosphere is not None:
+            atmos_dir = XarrayDataConfig(
+                str(self.atmosphere.data_dir),
                 **atmos_kwargs,
-            ),
+            )
+        return CoupledDatasetConfig(
+            ocean=ocean_dir,
+            ice=ice_dir,
+            atmosphere=atmos_dir,
         )
 
     def build_dataset_info(self) -> CoupledDatasetInfo:
@@ -252,24 +293,30 @@ class MockCoupledData:
         """
         from fme.core.dataset_info import DatasetInfo
 
-        ocean_info = DatasetInfo(
-            horizontal_coordinates=self.ocean.hcoord,
-            vertical_coordinate=self.ocean.vcoord,
-            spatial_mask_provider=self.ocean.spatial_mask_provider,
-            timestep=self.ocean.timestep,
-        )
-        ice_info = DatasetInfo(
-            horizontal_coordinates=self.ice.hcoord,
-            vertical_coordinate=self.ice.vcoord,
-            spatial_mask_provider=self.ice.spatial_mask_provider,
-            timestep=self.ice.timestep,
-        )
-        atmos_info = DatasetInfo(
-            horizontal_coordinates=self.atmosphere.hcoord,
-            vertical_coordinate=self.atmosphere.vcoord,
-            spatial_mask_provider=self.atmosphere.spatial_mask_provider,
-            timestep=self.atmosphere.timestep,
-        )
+        ocean_info = None
+        if self.ocean is not None:
+            ocean_info = DatasetInfo(
+                horizontal_coordinates=self.ocean.hcoord,
+                vertical_coordinate=self.ocean.vcoord,
+                spatial_mask_provider=self.ocean.spatial_mask_provider,
+                timestep=self.ocean.timestep,
+            )
+        ice_info = None
+        if self.ice is not None:
+            ice_info = DatasetInfo(
+                horizontal_coordinates=self.ice.hcoord,
+                vertical_coordinate=self.ice.vcoord,
+                spatial_mask_provider=self.ice.spatial_mask_provider,
+                timestep=self.ice.timestep,
+            )
+        atmos_info = None
+        if self.atmosphere is not None:
+            atmos_info = DatasetInfo(
+                horizontal_coordinates=self.atmosphere.hcoord,
+                vertical_coordinate=self.atmosphere.vcoord,
+                spatial_mask_provider=self.atmosphere.spatial_mask_provider,
+                timestep=self.atmosphere.timestep,
+            )
         return CoupledDatasetInfo(ocean=ocean_info, atmosphere=atmos_info, ice=ice_info)
 
 

--- a/fme/coupled/data_loading/test_inference.py
+++ b/fme/coupled/data_loading/test_inference.py
@@ -413,10 +413,8 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     for batch_idx, batch in enumerate(batches):
         assert isinstance(batch, CoupledBatchData)
         assert batch.atmosphere_data is not None
-        assert batch.ocean_data is not None
         assert batch.ice_data is not None
         atmos_times = batch.atmosphere_data.time.isel(sample=0).values
-        ocean_times = batch.ocean_data.time.isel(sample=0).values
         ice_times = batch.ice_data.time.isel(sample=0).values
         atmos_values = batch.atmosphere_data.data[_ATMOS_NAME][0].cpu().numpy()
         ice_values = batch.ice_data.data[_ICE_NAME][0].cpu().numpy()
@@ -429,10 +427,6 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         assert ice_times.shape == (n_ice_per_batch,), (
             f"Batch {batch_idx}: ice shape {ice_times.shape} != "
             f"({n_ice_per_batch},)"
-        )
-        assert ocean_times.shape == (n_ocean_per_batch,), (
-            f"Batch {batch_idx}: ocean shape {ocean_times.shape} != "
-            f"({n_ocean_per_batch},)"
         )
 
         # First atmos/ice/ocean time of each batch aligns with the rollout position
@@ -447,10 +441,6 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         )
         assert ice_times[0] == batch_first_time, (
             f"Batch {batch_idx}: first ice time {ice_times[0]} != "
-            f"expected {batch_first_time}"
-        )
-        assert ocean_times[0] == batch_first_time, (
-            f"Batch {batch_idx}: first ocean time {ocean_times[0]} != "
             f"expected {batch_first_time}"
         )
 

--- a/fme/coupled/data_loading/test_inference.py
+++ b/fme/coupled/data_loading/test_inference.py
@@ -104,6 +104,9 @@ def test_inference_dataset(
         mock_data: MockCoupledData,
         atmos_ic_time_offset: int,
     ):
+        assert batch.ocean_data is not None
+        assert batch.ice_data is not None
+        assert batch.atmosphere_data is not None
         ocean_data = batch.ocean_data.data[_OCEAN_NAME].cpu().numpy()
         ice_data = batch.ice_data.data[_ICE_NAME].cpu().numpy()
         atmos_data = batch.atmosphere_data.data[_ATMOS_NAME].cpu().numpy()
@@ -409,6 +412,9 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     all_ice_times_seen = set()
     for batch_idx, batch in enumerate(batches):
         assert isinstance(batch, CoupledBatchData)
+        assert batch.atmosphere_data is not None
+        assert batch.ocean_data is not None
+        assert batch.ice_data is not None
         atmos_times = batch.atmosphere_data.time.isel(sample=0).values
         ocean_times = batch.ocean_data.time.isel(sample=0).values
         ice_times = batch.ice_data.time.isel(sample=0).values
@@ -499,12 +505,15 @@ def test_no_target_inference_with_n_repeats(tmp_path):
 
     # Last atmos time of the last batch equals IC + total rollout (catches
     # off-by-one or shift introduced by update_subset).
+    # also need assert for batches[-1].atmosphere_data
+    assert batches[-1].atmosphere_data is not None
     last_atmos_times = batches[-1].atmosphere_data.time.isel(sample=0).values
     expected_last = ic_time + _TOTAL_COUPLED_STEPS * mock_data.ocean.timestep
     assert last_atmos_times[-1] == expected_last
 
     # Last ice time of the last batch equals IC + total rollout (catches
     # off-by-one or shift introduced by update_subset).
+    assert batches[-1].ice_data is not None
     last_ice_times = batches[-1].ice_data.time.isel(sample=0).values
     expected_last = ic_time + _TOTAL_COUPLED_STEPS * mock_data.ocean.timestep
     assert last_ice_times[-1] == expected_last
@@ -536,6 +545,8 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         f"this test configuration is not exercising the seam."
     )
     for batch in batches:
+        assert batch.atmosphere_data is not None
+        assert batch.ice_data is not None
         atmos_times = batch.atmosphere_data.time.isel(sample=0).values
         atmos_values = batch.atmosphere_data.data[_ATMOS_NAME][0].cpu().numpy()
         ice_times = batch.ice_data.time.isel(sample=0).values

--- a/fme/coupled/data_loading/test_inference.py
+++ b/fme/coupled/data_loading/test_inference.py
@@ -32,21 +32,27 @@ def _setup(
     total_coupled_steps: int,
     start_indices: InferenceInitialConditionIndices | ExplicitIndices | TimestampList,
     ocean_data_config_kwargs: dict[str, Any] | None = None,
+    ice_data_config_kwargs: dict[str, Any] | None = None,
     atmos_data_config_kwargs: dict[str, Any] | None = None,
 ) -> InferenceDataset:
     dataset_config = mock_data.get_dataset_config_with_kwargs(
         ocean_kwargs=ocean_data_config_kwargs,
+        ice_kwargs=ice_data_config_kwargs,
         atmos_kwargs=atmos_data_config_kwargs,
     )
     # ocean timesteps include initial condition plus total_coupled_steps
     ocean_n_timesteps = total_coupled_steps + 1  # one forward window in memory
     n_inner_steps = int(mock_data.ocean.timestep / mock_data.atmosphere.timestep)
+    ice_n_timesteps = n_inner_steps * total_coupled_steps + 1
     atmos_n_timesteps = n_inner_steps * total_coupled_steps + 1
     ocean_names = list(mock_data.ocean.ds.data_vars)
+    ice_names = list(mock_data.ice.ds.data_vars)
     atmos_names = list(mock_data.atmosphere.ds.data_vars)
     coupled_requirements = CoupledDataRequirements(
         ocean_timestep=mock_data.ocean.timestep,
         ocean_requirements=DataRequirements(ocean_names, n_timesteps=ocean_n_timesteps),
+        ice_timestep=mock_data.ice.timestep,
+        ice_requirements=DataRequirements(ice_names, n_timesteps=ice_n_timesteps),
         atmosphere_timestep=mock_data.atmosphere.timestep,
         atmosphere_requirements=DataRequirements(
             atmos_names, n_timesteps=atmos_n_timesteps
@@ -83,10 +89,13 @@ def test_inference_dataset(
 ):
     # synthetic data settings
     _N_FORWARD_OCEAN = 5
+    _N_ICE_PER_OCEAN = 3
     _N_ATMOS_PER_OCEAN = 3
+    _N_FORWARD_ICE = _N_FORWARD_OCEAN * _N_ICE_PER_OCEAN
     _N_FORWARD_ATMOS = _N_FORWARD_OCEAN * _N_ATMOS_PER_OCEAN
     _OCEAN_NAME = "bar"
     _ATMOS_NAME = "foo"
+    _ICE_NAME = "baz"
 
     _N_STEPS = 2  # number of inference rollout steps
 
@@ -96,20 +105,31 @@ def test_inference_dataset(
         atmos_ic_time_offset: int,
     ):
         ocean_data = batch.ocean_data.data[_OCEAN_NAME].cpu().numpy()
+        ice_data = batch.ice_data.data[_ICE_NAME].cpu().numpy()
         atmos_data = batch.atmosphere_data.data[_ATMOS_NAME].cpu().numpy()
         # verify batch dimension
         assert ocean_data.shape[0] == _N_ICS
+        assert ice_data.shape[0] == _N_ICS
         assert atmos_data.shape[0] == _N_ICS
         # verify time dimension
         n_ocean_times = _N_STEPS + 1
+        n_ice_times = _N_STEPS * _N_ICE_PER_OCEAN + 1
         n_atmos_times = _N_STEPS * _N_ATMOS_PER_OCEAN + 1
         assert ocean_data.shape[1] == n_ocean_times
+        assert ice_data.shape[1] == n_ice_times
         assert atmos_data.shape[1] == n_atmos_times
         # verify tensor values
         ocean_idx_0 = _IC_INDICES[0]
         expected_ocean_0 = (
             mock_data.ocean.ds[_OCEAN_NAME]
             .isel(time=slice(ocean_idx_0, ocean_idx_0 + n_ocean_times))
+            .values
+        )
+        # keep ice aligned with atmosphere for convenience
+        ice_idx_0 = atmos_ic_time_offset
+        expected_ice_0 = (
+            mock_data.ice.ds[_ICE_NAME]
+            .isel(time=slice(ice_idx_0, ice_idx_0 + n_ice_times))
             .values
         )
         atmos_idx_0 = atmos_ic_time_offset
@@ -124,6 +144,12 @@ def test_inference_dataset(
             .isel(time=slice(ocean_idx_1, ocean_idx_1 + n_ocean_times))
             .values
         )
+        ice_idx_1 = atmos_ic_time_offset + ocean_idx_1 * n_ocean_times
+        expected_ice_1 = (
+            mock_data.ice.ds[_ICE_NAME]
+            .isel(time=slice(ice_idx_1, ice_idx_1 + n_ice_times))
+            .values
+        )
         atmos_idx_1 = atmos_ic_time_offset + ocean_idx_1 * n_ocean_times
         expected_atmos_1 = (
             mock_data.atmosphere.ds[_ATMOS_NAME]
@@ -132,6 +158,8 @@ def test_inference_dataset(
         )
         np.testing.assert_allclose(ocean_data[0], expected_ocean_0, rtol=1e-6)
         np.testing.assert_allclose(ocean_data[1], expected_ocean_1, rtol=1e-6)
+        np.testing.assert_allclose(ice_data[0], expected_ice_0, rtol=1e-6)
+        np.testing.assert_allclose(ice_data[1], expected_ice_1, rtol=1e-6)
         np.testing.assert_allclose(atmos_data[0], expected_atmos_0, rtol=1e-6)
         np.testing.assert_allclose(atmos_data[1], expected_atmos_1, rtol=1e-6)
 
@@ -140,10 +168,13 @@ def test_inference_dataset(
     mock_data = create_coupled_data_on_disk(
         tmp_path,
         n_forward_times_ocean=_N_FORWARD_OCEAN,
+        n_forward_times_ice=_N_FORWARD_ICE,
         n_forward_times_atmosphere=_N_FORWARD_ATMOS,
         ocean_names=[_OCEAN_NAME],
+        ice_names=[_ICE_NAME],
         atmosphere_names=[_ATMOS_NAME],
         atmosphere_start_time_offset_from_ocean=atmos_ic_time_offset,
+        ice_start_time_offset_from_ocean=atmos_ic_time_offset,
     )
 
     dataset = _setup(
@@ -170,16 +201,21 @@ def test_validate_inference_length_ocean(
     # ocean has too few steps
     _N_FORWARD_OCEAN = 5
     _N_ATMOS_PER_OCEAN = 3
+    _N_FORWARD_ICE = _N_FORWARD_OCEAN * _N_ATMOS_PER_OCEAN
     _N_FORWARD_ATMOS = _N_FORWARD_OCEAN * _N_ATMOS_PER_OCEAN
     _OCEAN_NAME = "bar"
     _ATMOS_NAME = "foo"
+    _ICE_NAME = "baz"
     mock_data = create_coupled_data_on_disk(
         tmp_path,
         n_forward_times_ocean=_N_FORWARD_OCEAN,
+        n_forward_times_ice=_N_FORWARD_ICE,
         n_forward_times_atmosphere=_N_FORWARD_ATMOS,
         ocean_names=[_OCEAN_NAME],
+        ice_names=[_ICE_NAME],
         atmosphere_names=[_ATMOS_NAME],
         atmosphere_start_time_offset_from_ocean=2,
+        ice_start_time_offset_from_ocean=2,
     )
 
     _N_STEPS = 4
@@ -202,22 +238,27 @@ def test_validate_inference_length_atmos(
 ):
     # atmos has too few steps
     _N_FORWARD_ATMOS = 6
+    _N_FORWARD_ICE = 6
     _N_FORWARD_OCEAN = 6
     _OCEAN_TIMESTEP_SIZE = 2  # days
     _OCEAN_NAME = "bar"
     _ATMOS_NAME = "foo"
+    _ICE_NAME = "baz"
     mock_data = create_coupled_data_on_disk(
         tmp_path,
         n_forward_times_ocean=_N_FORWARD_OCEAN,
+        n_forward_times_ice=_N_FORWARD_ICE,
         n_forward_times_atmosphere=_N_FORWARD_ATMOS,
         ocean_names=[_OCEAN_NAME],
+        ice_names=[_ICE_NAME],
         atmosphere_names=[_ATMOS_NAME],
         atmosphere_start_time_offset_from_ocean=0,
+        ice_start_time_offset_from_ocean=0,
         ocean_timestep_size_in_days=_OCEAN_TIMESTEP_SIZE,
     )
 
     _N_STEPS = 2
-    _MSG = "atmosphere dataset has an insufficient number of timepoints"
+    _MSG = "atmosphere/ice dataset has an insufficient number of timepoints"
 
     with pytest.raises(ValueError, match=rf".*{_MSG}.*"):
         _ = _setup(
@@ -231,19 +272,22 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     """Test integration of n_repeats + update_subset alignment in no-target inference.
 
     - No ocean forcing dataset (forcing_loader.ocean is None).
+    - Ice forcing uses XarrayDataConfig with n_repeats > 1.
     - Atmosphere forcing uses XarrayDataConfig with n_repeats > 1.
-    - Ocean IC time is later than the atmosphere's first time, so
+    - Ocean IC time is later than the atmosphere/ice's first time, so
       update_subset(TimeSlice(start_time=ocean.first_time)) must shift the
-      atmosphere subset.
+      atmosphere/ice subset.
     - The rollout extends past the end of the first repeat into a later
       repeat, exercising the integration of n_repeats with update_subset.
     """
     _OCEAN_NAME = "bar"
     _ATMOS_NAME = "foo"
+    _ICE_NAME = "baz"
     _N_FORWARD_OCEAN = 3  # 4 ocean times in source file
+    _N_FORWARD_ICE = 12  # 13 ice times in source file (1d step, 4d ocean step)
     _N_FORWARD_ATMOS = 12  # 13 atmos times in source file (1d step, 4d ocean step)
     _N_REPEATS = 3
-    _TOTAL_COUPLED_STEPS = 8  # rollout = 8 ocean steps = 32 atmos days
+    _TOTAL_COUPLED_STEPS = 8  # rollout = 8 ocean steps = 32 atmos/ice days
     _COUPLED_STEPS_IN_MEMORY = 2  # multi-batch (matches production config)
     _N_INNER_STEPS = 4  # = ocean_timestep / atmos_timestep
     _CALENDAR = "proleptic_gregorian"
@@ -251,19 +295,30 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     mock_data = create_coupled_data_on_disk(
         tmp_path,
         n_forward_times_ocean=_N_FORWARD_OCEAN,
+        n_forward_times_ice=_N_FORWARD_ICE,
         n_forward_times_atmosphere=_N_FORWARD_ATMOS,
         ocean_names=[_OCEAN_NAME],
+        ice_names=[_ICE_NAME],
         atmosphere_names=[_ATMOS_NAME],
         atmosphere_start_time_offset_from_ocean=0,
+        ice_start_time_offset_from_ocean=0,
     )
     # Sanity: ocean timestep is 4 days, atmos is 1 day.
     assert mock_data.ocean.timestep == datetime.timedelta(days=4)
+    assert mock_data.ice.timestep == datetime.timedelta(days=1)
     assert mock_data.atmosphere.timestep == datetime.timedelta(days=1)
 
     # IC at the second ocean time (1970-01-05): one ocean step past atmos start.
     ic_time = cftime.datetime(1970, 1, 5, calendar=_CALENDAR)
     atmos_initial_condition = BatchData.new_for_testing(
         names=[_ATMOS_NAME],
+        n_samples=1,
+        n_timesteps=1,
+        t_initial=ic_time,
+        calendar=_CALENDAR,
+    )
+    ice_initial_condition = BatchData.new_for_testing(
+        names=[_ICE_NAME],
         n_samples=1,
         n_timesteps=1,
         t_initial=ic_time,
@@ -277,11 +332,17 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         calendar=_CALENDAR,
     )
 
-    # No-target forcing config: ocean is None, atmosphere has n_repeats > 1.
+    # No-target forcing config: ocean is None, atmosphere and ice have n_repeats > 1.
     config = CoupledForcingDataLoaderConfig(
         atmosphere=ForcingDataLoaderConfig(
             XarrayDataConfig(
                 data_path=str(tmp_path / "atmos"),
+                n_repeats=_N_REPEATS,
+            ),
+        ),
+        ice=ForcingDataLoaderConfig(
+            XarrayDataConfig(
+                data_path=str(tmp_path / "ice"),
                 n_repeats=_N_REPEATS,
             ),
         ),
@@ -291,6 +352,11 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         ocean_timestep=mock_data.ocean.timestep,
         ocean_requirements=DataRequirements(
             [_OCEAN_NAME], n_timesteps=_COUPLED_STEPS_IN_MEMORY + 1
+        ),
+        ice_timestep=mock_data.ice.timestep,
+        ice_requirements=DataRequirements(
+            [_ICE_NAME],
+            n_timesteps=_COUPLED_STEPS_IN_MEMORY * _N_INNER_STEPS + 1,
         ),
         atmosphere_timestep=mock_data.atmosphere.timestep,
         atmosphere_requirements=DataRequirements(
@@ -302,6 +368,7 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     dataset_info = mock_data.build_dataset_info()
     initial_condition = CoupledPrognosticState(
         ocean_data=PrognosticState(ocean_initial_condition),
+        ice_data=PrognosticState(ice_initial_condition),
         atmosphere_data=PrognosticState(atmos_initial_condition),
     )
 
@@ -325,31 +392,44 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     ), f"Expected {expected_n_batches} batches, got {len(batches)}."
 
     n_atmos_per_batch = _COUPLED_STEPS_IN_MEMORY * _N_INNER_STEPS + 1
+    n_ice_per_batch = _COUPLED_STEPS_IN_MEMORY * _N_INNER_STEPS + 1
     n_ocean_per_batch = _COUPLED_STEPS_IN_MEMORY + 1
     source_n_atmos_times = _N_FORWARD_ATMOS + 1  # 13
-    source_span = mock_data.atmosphere.timestep * source_n_atmos_times
+    source_n_ice_times = _N_FORWARD_ICE + 1  # 13
+    atmos_source_span = mock_data.atmosphere.timestep * source_n_atmos_times
     first_atmos_time_on_disk = cftime.datetime(1970, 1, 1, calendar=_CALENDAR)
-    end_of_first_repeat = first_atmos_time_on_disk + source_span
-    source_values = mock_data.atmosphere.ds[_ATMOS_NAME].values
+    end_of_first_atmos_repeat = first_atmos_time_on_disk + atmos_source_span
+    atmos_source_values = mock_data.atmosphere.ds[_ATMOS_NAME].values
+    ice_source_span = mock_data.ice.timestep * source_n_ice_times
+    first_ice_time_on_disk = cftime.datetime(1970, 1, 1, calendar=_CALENDAR)
+    end_of_first_ice_repeat = first_ice_time_on_disk + ice_source_span
+    ice_source_values = mock_data.ice.ds[_ICE_NAME].values
 
     all_atmos_times_seen = set()
+    all_ice_times_seen = set()
     for batch_idx, batch in enumerate(batches):
         assert isinstance(batch, CoupledBatchData)
         atmos_times = batch.atmosphere_data.time.isel(sample=0).values
         ocean_times = batch.ocean_data.time.isel(sample=0).values
+        ice_times = batch.ice_data.time.isel(sample=0).values
         atmos_values = batch.atmosphere_data.data[_ATMOS_NAME][0].cpu().numpy()
+        ice_values = batch.ice_data.data[_ICE_NAME][0].cpu().numpy()
 
         # Shapes match expected per-batch window length.
         assert atmos_times.shape == (n_atmos_per_batch,), (
             f"Batch {batch_idx}: atmos shape {atmos_times.shape} != "
             f"({n_atmos_per_batch},)"
         )
+        assert ice_times.shape == (n_ice_per_batch,), (
+            f"Batch {batch_idx}: ice shape {ice_times.shape} != "
+            f"({n_ice_per_batch},)"
+        )
         assert ocean_times.shape == (n_ocean_per_batch,), (
             f"Batch {batch_idx}: ocean shape {ocean_times.shape} != "
             f"({n_ocean_per_batch},)"
         )
 
-        # First atmos/ocean time of each batch aligns with the rollout position
+        # First atmos/ice/ocean time of each batch aligns with the rollout position
         # implied by batch_idx (the alignment that update_subset is responsible
         # for).
         batch_first_time = (
@@ -357,6 +437,10 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         )
         assert atmos_times[0] == batch_first_time, (
             f"Batch {batch_idx}: first atmos time {atmos_times[0]} != "
+            f"expected {batch_first_time}"
+        )
+        assert ice_times[0] == batch_first_time, (
+            f"Batch {batch_idx}: first ice time {ice_times[0]} != "
             f"expected {batch_first_time}"
         )
         assert ocean_times[0] == batch_first_time, (
@@ -370,6 +454,12 @@ def test_no_target_inference_with_n_repeats(tmp_path):
             f"Batch {batch_idx}: atmos times not uniformly spaced; "
             f"unique diffs = {set(atmos_diffs)}"
         )
+        # Ice times are uniformly spaced (catches a bad seam between repeats).
+        ice_diffs = np.diff(ice_times)
+        assert np.all(ice_diffs == mock_data.ice.timestep), (
+            f"Batch {batch_idx}: ice times not uniformly spaced; "
+            f"unique diffs = {set(ice_diffs)}"
+        )
 
         # Per-position value check: each batch value equals the source value at
         # (offset_from_source_start % source_n_atmos_times).
@@ -380,7 +470,7 @@ def test_no_target_inference_with_n_repeats(tmp_path):
             expected_local_idx = int(offset_steps) % source_n_atmos_times
             np.testing.assert_allclose(
                 atmos_values[k],
-                source_values[expected_local_idx],
+                atmos_source_values[expected_local_idx],
                 rtol=1e-6,
                 err_msg=(
                     f"Batch {batch_idx}, position {k} (time {t}): expected "
@@ -390,16 +480,46 @@ def test_no_target_inference_with_n_repeats(tmp_path):
 
         all_atmos_times_seen.update(atmos_times.tolist())
 
+        # Per-position value check: each batch value equals the source value at
+        # (offset_from_source_start % source_n_ice_times).
+        for k, t in enumerate(ice_times):
+            offset_steps = (t - first_ice_time_on_disk) // mock_data.ice.timestep
+            expected_local_idx = int(offset_steps) % source_n_ice_times
+            np.testing.assert_allclose(
+                ice_values[k],
+                ice_source_values[expected_local_idx],
+                rtol=1e-6,
+                err_msg=(
+                    f"Batch {batch_idx}, position {k} (time {t}): expected "
+                    f"source index {expected_local_idx}."
+                ),
+            )
+
+        all_ice_times_seen.update(ice_times.tolist())
+
     # Last atmos time of the last batch equals IC + total rollout (catches
     # off-by-one or shift introduced by update_subset).
     last_atmos_times = batches[-1].atmosphere_data.time.isel(sample=0).values
     expected_last = ic_time + _TOTAL_COUPLED_STEPS * mock_data.ocean.timestep
     assert last_atmos_times[-1] == expected_last
 
+    # Last ice time of the last batch equals IC + total rollout (catches
+    # off-by-one or shift introduced by update_subset).
+    last_ice_times = batches[-1].ice_data.time.isel(sample=0).values
+    expected_last = ic_time + _TOTAL_COUPLED_STEPS * mock_data.ocean.timestep
+    assert last_ice_times[-1] == expected_last
+
     # Rollout end falls into a later repeat (sanity check that n_repeats was
     # actually exercised, not silently truncated).
-    assert last_atmos_times[-1] >= end_of_first_repeat, (
-        "Rollout did not extend past the first repeat; n_repeats may not be "
+    assert last_atmos_times[-1] >= end_of_first_atmos_repeat, (
+        "Atmosphere rollout did not extend past the first repeat; n_repeats may "
+        "not be exercised by this test configuration."
+    )
+
+    # Rollout end falls into a later repeat (sanity check that n_repeats was
+    # actually exercised, not silently truncated).
+    assert last_ice_times[-1] >= end_of_first_ice_repeat, (
+        "Ice rollout did not extend past the first repeat; n_repeats may not be "
         "exercised by this test configuration."
     )
 
@@ -408,22 +528,42 @@ def test_no_target_inference_with_n_repeats(tmp_path):
     # 1970-01-01. (Redundant with 6, but states the property explicitly.)
     first_wrap_time = cftime.datetime(1970, 1, 14, calendar=_CALENDAR)
     assert first_wrap_time in all_atmos_times_seen, (
-        f"First wraparound time {first_wrap_time} not seen in any batch; "
+        f"First wraparound time {first_wrap_time} not seen in any atmosphere "
+        f"batch; this test configuration is not exercising the seam."
+    )
+    assert first_wrap_time in all_ice_times_seen, (
+        f"First wraparound time {first_wrap_time} not seen in any ice batch; "
         f"this test configuration is not exercising the seam."
     )
     for batch in batches:
         atmos_times = batch.atmosphere_data.time.isel(sample=0).values
         atmos_values = batch.atmosphere_data.data[_ATMOS_NAME][0].cpu().numpy()
-        wrap_positions = np.where(atmos_times == first_wrap_time)[0]
-        if len(wrap_positions) == 0:
+        ice_times = batch.ice_data.time.isel(sample=0).values
+        ice_values = batch.ice_data.data[_ICE_NAME][0].cpu().numpy()
+        atmos_wrap_positions = np.where(atmos_times == first_wrap_time)[0]
+        if len(atmos_wrap_positions) == 0:
             continue
-        wrap_idx = int(wrap_positions[0])
+        ice_wrap_positions = np.where(ice_times == first_wrap_time)[0]
+        if len(ice_wrap_positions) == 0:
+            continue
+        atmos_wrap_idx = int(atmos_wrap_positions[0])
+        ice_wrap_idx = int(ice_wrap_positions[0])
         np.testing.assert_allclose(
-            atmos_values[wrap_idx],
-            source_values[0],
+            atmos_values[atmos_wrap_idx],
+            atmos_source_values[0],
             rtol=1e-6,
             err_msg=(
-                f"Value at first wraparound time ({first_wrap_time}) does not "
-                f"equal source value at {first_atmos_time_on_disk} (index 0)."
+                f"Value at first atmosphere wraparound time ({first_wrap_time}) "
+                f"does not equal source value at {first_atmos_time_on_disk} "
+                f"(index 0)."
+            ),
+        )
+        np.testing.assert_allclose(
+            ice_values[ice_wrap_idx],
+            ice_source_values[0],
+            rtol=1e-6,
+            err_msg=(
+                f"Value at first ice wraparound time ({first_wrap_time}) does not "
+                f"equal source value at {first_ice_time_on_disk} (index 0)."
             ),
         )

--- a/fme/coupled/data_loading/test_inference.py
+++ b/fme/coupled/data_loading/test_inference.py
@@ -396,7 +396,6 @@ def test_no_target_inference_with_n_repeats(tmp_path):
 
     n_atmos_per_batch = _COUPLED_STEPS_IN_MEMORY * _N_INNER_STEPS + 1
     n_ice_per_batch = _COUPLED_STEPS_IN_MEMORY * _N_INNER_STEPS + 1
-    n_ocean_per_batch = _COUPLED_STEPS_IN_MEMORY + 1
     source_n_atmos_times = _N_FORWARD_ATMOS + 1  # 13
     source_n_ice_times = _N_FORWARD_ICE + 1  # 13
     atmos_source_span = mock_data.atmosphere.timestep * source_n_atmos_times

--- a/fme/coupled/data_loading/test_inference.py
+++ b/fme/coupled/data_loading/test_inference.py
@@ -40,6 +40,11 @@ def _setup(
         ice_kwargs=ice_data_config_kwargs,
         atmos_kwargs=atmos_data_config_kwargs,
     )
+
+    assert mock_data.ocean is not None
+    assert mock_data.ice is not None
+    assert mock_data.atmosphere is not None
+
     # ocean timesteps include initial condition plus total_coupled_steps
     ocean_n_timesteps = total_coupled_steps + 1  # one forward window in memory
     n_inner_steps = int(mock_data.ocean.timestep / mock_data.atmosphere.timestep)
@@ -104,9 +109,16 @@ def test_inference_dataset(
         mock_data: MockCoupledData,
         atmos_ic_time_offset: int,
     ):
-        assert batch.ocean_data is not None
-        assert batch.ice_data is not None
-        assert batch.atmosphere_data is not None
+        assert (
+            batch.ocean_data is not None
+            and batch.ice_data is not None
+            and batch.atmosphere_data is not None
+        )
+        assert (
+            mock_data.ocean is not None
+            and mock_data.ice is not None
+            and mock_data.atmosphere is not None
+        )
         ocean_data = batch.ocean_data.data[_OCEAN_NAME].cpu().numpy()
         ice_data = batch.ice_data.data[_ICE_NAME].cpu().numpy()
         atmos_data = batch.atmosphere_data.data[_ATMOS_NAME].cpu().numpy()
@@ -306,6 +318,13 @@ def test_no_target_inference_with_n_repeats(tmp_path):
         atmosphere_start_time_offset_from_ocean=0,
         ice_start_time_offset_from_ocean=0,
     )
+
+    assert (
+        mock_data.ocean is not None
+        and mock_data.ice is not None
+        and mock_data.atmosphere is not None
+    )
+
     # Sanity: ocean timestep is 4 days, atmos is 1 day.
     assert mock_data.ocean.timestep == datetime.timedelta(days=4)
     assert mock_data.ice.timestep == datetime.timedelta(days=1)

--- a/fme/coupled/data_loading/test_inference.py
+++ b/fme/coupled/data_loading/test_inference.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, cast
+from typing import Any
 
 import cftime
 import numpy as np
@@ -15,7 +15,6 @@ from fme.ace.data_loading.inference import (
 from fme.ace.requirements import DataRequirements
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.coupled.data_loading.batch_data import CoupledBatchData, CoupledPrognosticState
-from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
 from fme.coupled.data_loading.getters import get_forcing_data
 from fme.coupled.data_loading.inference import (
     CoupledForcingDataLoaderConfig,
@@ -64,7 +63,7 @@ def _setup(
         ),
     )
     config = InferenceDataLoaderConfig(
-        dataset=cast(CoupledDatasetWithOptionalOceanConfig, dataset_config),
+        dataset=dataset_config,
         start_indices=start_indices,
     )
     dataset = InferenceDataset(
@@ -273,9 +272,9 @@ def test_validate_inference_length_atmos(
     )
 
     _N_STEPS = 2
-    _MSG = "atmosphere/ice dataset has an insufficient number of timepoints"
+    _MSG = r"(atmosphere|ice) dataset has an insufficient number of timepoints"
 
-    with pytest.raises(ValueError, match=rf".*{_MSG}.*"):
+    with pytest.raises(ValueError, match=_MSG):
         _ = _setup(
             mock_data,
             total_coupled_steps=_N_STEPS,

--- a/fme/coupled/dataset_info.py
+++ b/fme/coupled/dataset_info.py
@@ -15,53 +15,126 @@ class MissingCoupledDatasetInfo(ValueError):
 class CoupledDatasetInfo:
     def __init__(
         self,
-        ocean: DatasetInfo,
-        atmosphere: DatasetInfo,
+        ocean: DatasetInfo | None = None,
+        ice: DatasetInfo | None = None,
+        atmosphere: DatasetInfo | None = None,
     ):
         self.ocean = ocean
+        self.ice = ice
         self.atmosphere = atmosphere
 
     @property
     def ocean_spatial_mask_provider(self) -> HasGetSpatialMask:
-        try:
-            return self.ocean.spatial_mask_provider
-        except MissingDatasetInfo as err:
-            raise MissingCoupledDatasetInfo("ocean_spatial_mask_provider") from err
+        if self.ocean is not None:
+            try:
+                return self.ocean.spatial_mask_provider
+            except MissingDatasetInfo as err:
+                raise MissingCoupledDatasetInfo("ocean_spatial_mask_provider") from err
+        else:
+            return None
+
+    @property
+    def ice_spatial_mask_provider(self) -> HasGetSpatialMask:
+        if self.ice is not None:
+            try:
+                return self.ice.spatial_mask_provider
+            except MissingDatasetInfo as err:
+                raise MissingCoupledDatasetInfo("ice_spatial_mask_provider") from err
+        else:
+            return None
 
     def __eq__(self, other):
         if not isinstance(other, CoupledDatasetInfo):
             return False
-        return self.ocean == other.ocean and self.atmosphere == other.atmosphere
+        ocean_check = self.ocean == other.ocean
+        ice_check = self.ice == other.ice
+        atmos_check = self.atmosphere == other.atmosphere
+        return ocean_check and ice_check and atmos_check
 
-    def get_state(self) -> dict[Literal["ocean", "atmosphere"], dict[str, Any]]:
-        return {
-            "ocean": self.ocean.get_state(),
-            "atmosphere": self.atmosphere.get_state(),
-        }
+    def get_state(self) -> dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]]:
+        if self.atmosphere is None:
+            ds = {
+                "ocean": self.ocean.get_state(),
+                "ice": self.ice.get_state(),
+            }
+        elif self.ice is None:
+            ds = {
+                "ocean": self.ocean.get_state(),
+                "atmosphere": self.atmosphere.get_state(),
+            }
+        elif self.ocean is None:
+            ds = {
+                "ice": self.ice.get_state(),
+                "atmosphere": self.atmosphere.get_state(),
+            }
+        else:
+            ds = {
+                "ocean": self.ocean.get_state(),
+                "ice": self.ice.get_state(),
+                "atmosphere": self.atmosphere.get_state(),
+            }
+        return ds
 
     @property
     def horizontal_coordinates(self) -> CoupledHorizontalCoordinates:
-        return CoupledHorizontalCoordinates(
-            ocean=self.ocean.horizontal_coordinates,
-            atmosphere=self.atmosphere.horizontal_coordinates,
-        )
+        if self.atmosphere is None:
+            return CoupledHorizontalCoordinates(
+                ocean=self.ocean.horizontal_coordinates,
+                ice=self.ice.horizontal_coordinates,
+            )
+        elif self.ice is None:
+            return CoupledHorizontalCoordinates(
+                ocean=self.ocean.horizontal_coordinates,
+                atmosphere=self.atmosphere.horizontal_coordinates,
+            )
+        elif self.ocean is None:
+            return CoupledHorizontalCoordinates(
+                ice=self.ice.horizontal_coordinates,
+                atmosphere=self.atmosphere.horizontal_coordinates,
+            )
+        else:
+            return CoupledHorizontalCoordinates(
+                ocean=self.ocean.horizontal_coordinates,
+                ice=self.ice.horizontal_coordinates,
+                atmosphere=self.atmosphere.horizontal_coordinates,
+            )
 
     @classmethod
     def from_state(
-        cls, state: dict[Literal["ocean", "atmosphere"], dict[str, Any]]
+        cls, state: dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]]
     ) -> "CoupledDatasetInfo":
+        ocean_state = None
+        ice_state = None
+        atmosphere_state = None
+        if "ocean" in state:
+            ocean_state = DatasetInfo.from_state(state["ocean"])
+        if "ice" in state:
+            ice_state = DatasetInfo.from_state(state["ice"])
+        if "atmosphere" in state:
+            atmosphere_state = DatasetInfo.from_state(state["atmosphere"])
         return cls(
-            ocean=DatasetInfo.from_state(state["ocean"]),
-            atmosphere=DatasetInfo.from_state(state["atmosphere"]),
+            ocean=ocean_state,
+            ice=ice_state,
+            atmosphere=atmosphere_state,
         )
 
     def update_variable_metadata(
         self, variable_metadata: dict[str, Any]
     ) -> "CoupledDatasetInfo":
         """
-        Update the variable metadata for both ocean and atmosphere datasets.
+        Update the variable metadata for ocean, ice, and atmosphere datasets.
         """
+        ocean_metadata = None
+        if self.ocean is not None:
+            ocean_metadata = self.ocean.update_variable_metadata(variable_metadata)
+        ice_metadata = None
+        if self.ice is not None:
+            ice_metadata = self.ice.update_variable_metadata(variable_metadata)
+        atmos_metadata = None
+        if self.atmosphere is not None:
+            atmos_metadata = self.atmosphere.update_variable_metadata(variable_metadata)
         return CoupledDatasetInfo(
-            ocean=self.ocean.update_variable_metadata(variable_metadata),
-            atmosphere=self.atmosphere.update_variable_metadata(variable_metadata),
+            ocean=ocean_metadata,
+            ice=ice_metadata,
+            atmosphere=atmos_metadata,
         )

--- a/fme/coupled/dataset_info.py
+++ b/fme/coupled/dataset_info.py
@@ -19,134 +19,82 @@ class CoupledDatasetInfo:
         ice: DatasetInfo | None = None,
         atmosphere: DatasetInfo | None = None,
     ):
-        self.ocean = ocean
-        self.ice = ice
-        self.atmosphere = atmosphere
+        self._components: dict[str, DatasetInfo] = {
+            name: val
+            for name, val in [
+                ("ocean", ocean),
+                ("ice", ice),
+                ("atmosphere", atmosphere),
+            ]
+            if val is not None
+        }
+
+    @property
+    def ocean(self) -> DatasetInfo | None:
+        return self._components.get("ocean")
+
+    @property
+    def ice(self) -> DatasetInfo | None:
+        return self._components.get("ice")
+
+    @property
+    def atmosphere(self) -> DatasetInfo | None:
+        return self._components.get("atmosphere")
+
+    def _get_spatial_mask_provider(self, name: str) -> HasGetSpatialMask | None:
+        info = self._components.get(name)
+        if info is None:
+            return None
+        try:
+            return info.spatial_mask_provider
+        except MissingDatasetInfo as err:
+            raise MissingCoupledDatasetInfo(f"{name}_spatial_mask_provider") from err
 
     @property
     def ocean_spatial_mask_provider(self) -> HasGetSpatialMask | None:
-        if self.ocean is not None:
-            try:
-                return self.ocean.spatial_mask_provider
-            except MissingDatasetInfo as err:
-                raise MissingCoupledDatasetInfo("ocean_spatial_mask_provider") from err
-        else:
-            return None
+        return self._get_spatial_mask_provider("ocean")
 
     @property
     def ice_spatial_mask_provider(self) -> HasGetSpatialMask | None:
-        if self.ice is not None:
-            try:
-                return self.ice.spatial_mask_provider
-            except MissingDatasetInfo as err:
-                raise MissingCoupledDatasetInfo("ice_spatial_mask_provider") from err
-        else:
-            return None
+        return self._get_spatial_mask_provider("ice")
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, CoupledDatasetInfo):
             return False
-        ocean_check = self.ocean == other.ocean
-        ice_check = self.ice == other.ice
-        atmos_check = self.atmosphere == other.atmosphere
-        return ocean_check and ice_check and atmos_check
+        return self._components == other._components
 
     def get_state(self) -> dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]]:
-        if self.atmosphere is None:
-            assert self.ocean is not None
-            assert self.ice is not None
-            ds: dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]] = {
-                "ocean": self.ocean.get_state(),
-                "ice": self.ice.get_state(),
-            }
-        elif self.ice is None:
-            assert self.ocean is not None
-            ds = {
-                "ocean": self.ocean.get_state(),
-                "atmosphere": self.atmosphere.get_state(),
-            }
-        elif self.ocean is None:
-            assert self.ice is not None
-            ds = {
-                "ice": self.ice.get_state(),
-                "atmosphere": self.atmosphere.get_state(),
-            }
-        else:
-            assert self.ocean is not None
-            assert self.ice is not None
-            ds = {
-                "ocean": self.ocean.get_state(),
-                "ice": self.ice.get_state(),
-                "atmosphere": self.atmosphere.get_state(),
-            }
-        return ds
+        return {
+            name: info.get_state()  # type: ignore[misc]
+            for name, info in self._components.items()
+        }
 
     @property
     def horizontal_coordinates(self) -> CoupledHorizontalCoordinates:
-        if self.atmosphere is None:
-            assert self.ocean is not None
-            assert self.ice is not None
-            return CoupledHorizontalCoordinates(
-                ocean=self.ocean.horizontal_coordinates,
-                ice=self.ice.horizontal_coordinates,
-            )
-        elif self.ice is None:
-            assert self.ocean is not None
-            return CoupledHorizontalCoordinates(
-                ocean=self.ocean.horizontal_coordinates,
-                atmosphere=self.atmosphere.horizontal_coordinates,
-            )
-        elif self.ocean is None:
-            assert self.ice is not None
-            return CoupledHorizontalCoordinates(
-                ice=self.ice.horizontal_coordinates,
-                atmosphere=self.atmosphere.horizontal_coordinates,
-            )
-        else:
-            assert self.ocean is not None
-            assert self.ice is not None
-            return CoupledHorizontalCoordinates(
-                ocean=self.ocean.horizontal_coordinates,
-                ice=self.ice.horizontal_coordinates,
-                atmosphere=self.atmosphere.horizontal_coordinates,
-            )
+        return CoupledHorizontalCoordinates(
+            **{
+                name: info.horizontal_coordinates
+                for name, info in self._components.items()
+            }
+        )
 
     @classmethod
     def from_state(
         cls, state: dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]]
     ) -> "CoupledDatasetInfo":
-        ocean_state = None
-        ice_state = None
-        atmosphere_state = None
-        if "ocean" in state:
-            ocean_state = DatasetInfo.from_state(state["ocean"])
-        if "ice" in state:
-            ice_state = DatasetInfo.from_state(state["ice"])
-        if "atmosphere" in state:
-            atmosphere_state = DatasetInfo.from_state(state["atmosphere"])
+        parsed = {name: DatasetInfo.from_state(s) for name, s in state.items()}
         return cls(
-            ocean=ocean_state,
-            ice=ice_state,
-            atmosphere=atmosphere_state,
+            ocean=parsed.get("ocean"),
+            ice=parsed.get("ice"),
+            atmosphere=parsed.get("atmosphere"),
         )
 
     def update_variable_metadata(
         self, variable_metadata: dict[str, Any]
     ) -> "CoupledDatasetInfo":
-        """
-        Update the variable metadata for ocean, ice, and atmosphere datasets.
-        """
-        ocean_metadata = None
-        if self.ocean is not None:
-            ocean_metadata = self.ocean.update_variable_metadata(variable_metadata)
-        ice_metadata = None
-        if self.ice is not None:
-            ice_metadata = self.ice.update_variable_metadata(variable_metadata)
-        atmos_metadata = None
-        if self.atmosphere is not None:
-            atmos_metadata = self.atmosphere.update_variable_metadata(variable_metadata)
         return CoupledDatasetInfo(
-            ocean=ocean_metadata,
-            ice=ice_metadata,
-            atmosphere=atmos_metadata,
+            **{
+                name: info.update_variable_metadata(variable_metadata)
+                for name, info in self._components.items()
+            }
         )

--- a/fme/coupled/dataset_info.py
+++ b/fme/coupled/dataset_info.py
@@ -24,7 +24,7 @@ class CoupledDatasetInfo:
         self.atmosphere = atmosphere
 
     @property
-    def ocean_spatial_mask_provider(self) -> HasGetSpatialMask:
+    def ocean_spatial_mask_provider(self) -> HasGetSpatialMask | None:
         if self.ocean is not None:
             try:
                 return self.ocean.spatial_mask_provider
@@ -34,7 +34,7 @@ class CoupledDatasetInfo:
             return None
 
     @property
-    def ice_spatial_mask_provider(self) -> HasGetSpatialMask:
+    def ice_spatial_mask_provider(self) -> HasGetSpatialMask | None:
         if self.ice is not None:
             try:
                 return self.ice.spatial_mask_provider
@@ -53,21 +53,27 @@ class CoupledDatasetInfo:
 
     def get_state(self) -> dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]]:
         if self.atmosphere is None:
-            ds = {
+            assert self.ocean is not None
+            assert self.ice is not None
+            ds: dict[Literal["ocean", "ice", "atmosphere"], dict[str, Any]] = {
                 "ocean": self.ocean.get_state(),
                 "ice": self.ice.get_state(),
             }
         elif self.ice is None:
+            assert self.ocean is not None
             ds = {
                 "ocean": self.ocean.get_state(),
                 "atmosphere": self.atmosphere.get_state(),
             }
         elif self.ocean is None:
+            assert self.ice is not None
             ds = {
                 "ice": self.ice.get_state(),
                 "atmosphere": self.atmosphere.get_state(),
             }
         else:
+            assert self.ocean is not None
+            assert self.ice is not None
             ds = {
                 "ocean": self.ocean.get_state(),
                 "ice": self.ice.get_state(),
@@ -78,21 +84,27 @@ class CoupledDatasetInfo:
     @property
     def horizontal_coordinates(self) -> CoupledHorizontalCoordinates:
         if self.atmosphere is None:
+            assert self.ocean is not None
+            assert self.ice is not None
             return CoupledHorizontalCoordinates(
                 ocean=self.ocean.horizontal_coordinates,
                 ice=self.ice.horizontal_coordinates,
             )
         elif self.ice is None:
+            assert self.ocean is not None
             return CoupledHorizontalCoordinates(
                 ocean=self.ocean.horizontal_coordinates,
                 atmosphere=self.atmosphere.horizontal_coordinates,
             )
         elif self.ocean is None:
+            assert self.ice is not None
             return CoupledHorizontalCoordinates(
                 ice=self.ice.horizontal_coordinates,
                 atmosphere=self.atmosphere.horizontal_coordinates,
             )
         else:
+            assert self.ocean is not None
+            assert self.ice is not None
             return CoupledHorizontalCoordinates(
                 ocean=self.ocean.horizontal_coordinates,
                 ice=self.ice.horizontal_coordinates,

--- a/fme/coupled/inference/data_writer.py
+++ b/fme/coupled/inference/data_writer.py
@@ -86,14 +86,10 @@ class CoupledPairedDataWriter(WriterABC[CoupledPrognosticState, CoupledPairedDat
         self._atmosphere_writer = atmosphere_writer
 
     def write(self, data: CoupledPrognosticState, filename: str):
-        assert data.ocean_data is not None
-        assert data.atmosphere_data is not None
         self._ocean_writer.write(data.ocean_data, filename)
         self._atmosphere_writer.write(data.atmosphere_data, filename)
 
     def append_batch(self, batch: CoupledPairedData):
-        assert batch.ocean_data is not None
-        assert batch.atmosphere_data is not None
         self._ocean_writer.append_batch(batch.ocean_data)
         self._atmosphere_writer.append_batch(batch.atmosphere_data)
 

--- a/fme/coupled/inference/data_writer.py
+++ b/fme/coupled/inference/data_writer.py
@@ -86,10 +86,14 @@ class CoupledPairedDataWriter(WriterABC[CoupledPrognosticState, CoupledPairedDat
         self._atmosphere_writer = atmosphere_writer
 
     def write(self, data: CoupledPrognosticState, filename: str):
+        assert data.ocean_data is not None
+        assert data.atmosphere_data is not None
         self._ocean_writer.write(data.ocean_data, filename)
         self._atmosphere_writer.write(data.atmosphere_data, filename)
 
     def append_batch(self, batch: CoupledPairedData):
+        assert batch.ocean_data is not None
+        assert batch.atmosphere_data is not None
         self._ocean_writer.append_batch(batch.ocean_data)
         self._atmosphere_writer.append_batch(batch.atmosphere_data)
 

--- a/fme/coupled/inference/data_writer.py
+++ b/fme/coupled/inference/data_writer.py
@@ -18,6 +18,7 @@ from fme.coupled.data_loading.batch_data import (
 from fme.coupled.data_loading.data_typing import CoupledCoords
 
 OCEAN_OUTPUT_DIR_NAME = "ocean"
+ICE_OUTPUT_DIR_NAME = "ice"
 ATMOSPHERE_OUTPUT_DIR_NAME = "atmosphere"
 
 
@@ -28,10 +29,14 @@ class CoupledDataWriterConfig:
 
     Parameters:
         ocean: Configuration for ocean data writer.
+        ice: Configuration for ice data writer.
         atmosphere: Configuration for atmosphere data writer.
     """
 
     ocean: DataWriterConfig = dataclasses.field(
+        default_factory=lambda: DataWriterConfig()
+    )
+    ice: DataWriterConfig = dataclasses.field(
         default_factory=lambda: DataWriterConfig()
     )
     atmosphere: DataWriterConfig = dataclasses.field(
@@ -42,20 +47,24 @@ class CoupledDataWriterConfig:
         self,
         experiment_dir: str,
         initial_condition_times: npt.NDArray[cftime.datetime],
-        n_timesteps_ocean: int,
-        n_timesteps_atmosphere: int,
-        ocean_timestep: datetime.timedelta,
-        atmosphere_timestep: datetime.timedelta,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: CoupledCoords,
         dataset_metadata: dict[str, DatasetMetadata],
+        n_timesteps_ocean: int | None = None,
+        n_timesteps_ice: int | None = None,
+        n_timesteps_atmosphere: int | None = None,
+        ocean_timestep: datetime.timedelta | None = None,
+        ice_timestep: datetime.timedelta | None = None,
+        atmosphere_timestep: datetime.timedelta | None = None,
     ) -> "CoupledPairedDataWriter":
-        ocean_dir = os.path.join(experiment_dir, OCEAN_OUTPUT_DIR_NAME)
-        makedirs(ocean_dir, exist_ok=True)
-        atmos_dir = os.path.join(experiment_dir, ATMOSPHERE_OUTPUT_DIR_NAME)
-        makedirs(atmos_dir, exist_ok=True)
-        return CoupledPairedDataWriter(
-            ocean_writer=self.ocean.build_paired(
+        ocean_writer = None
+        ice_writer = None
+        atmosphere_writer = None
+        if ocean_timestep is not None:
+            assert n_timesteps_ocean is not None
+            ocean_dir = os.path.join(experiment_dir, OCEAN_OUTPUT_DIR_NAME)
+            makedirs(ocean_dir, exist_ok=True)
+            ocean_writer = self.ocean.build_paired(
                 experiment_dir=ocean_dir,
                 initial_condition_times=initial_condition_times,
                 n_timesteps=n_timesteps_ocean,
@@ -63,8 +72,25 @@ class CoupledDataWriterConfig:
                 variable_metadata=variable_metadata,
                 coords=coords.ocean,
                 dataset_metadata=dataset_metadata["ocean"],
-            ),
-            atmosphere_writer=self.atmosphere.build_paired(
+            )
+        if ice_timestep is not None:
+            assert n_timesteps_ice is not None
+            ice_dir = os.path.join(experiment_dir, ICE_OUTPUT_DIR_NAME)
+            makedirs(ice_dir, exist_ok=True)
+            ice_writer = self.ice.build_paired(
+                experiment_dir=ice_dir,
+                initial_condition_times=initial_condition_times,
+                n_timesteps=n_timesteps_ice,
+                timestep=ice_timestep,
+                variable_metadata=variable_metadata,
+                coords=coords.ice,
+                dataset_metadata=dataset_metadata["ice"],
+            )
+        if atmosphere_timestep is not None:
+            assert n_timesteps_atmosphere is not None
+            atmos_dir = os.path.join(experiment_dir, ATMOSPHERE_OUTPUT_DIR_NAME)
+            makedirs(atmos_dir, exist_ok=True)
+            atmosphere_writer = self.atmosphere.build_paired(
                 experiment_dir=atmos_dir,
                 initial_condition_times=initial_condition_times,
                 n_timesteps=n_timesteps_atmosphere,
@@ -72,31 +98,60 @@ class CoupledDataWriterConfig:
                 variable_metadata=variable_metadata,
                 coords=coords.atmosphere,
                 dataset_metadata=dataset_metadata["atmosphere"],
-            ),
+            )
+
+        return CoupledPairedDataWriter(
+            ocean_writer=ocean_writer,
+            ice_writer=ice_writer,
+            atmosphere_writer=atmosphere_writer,
         )
 
 
 class CoupledPairedDataWriter(WriterABC[CoupledPrognosticState, CoupledPairedData]):
     def __init__(
         self,
-        ocean_writer: PairedDataWriter,
-        atmosphere_writer: PairedDataWriter,
+        ocean_writer: PairedDataWriter | None = None,
+        ice_writer: PairedDataWriter | None = None,
+        atmosphere_writer: PairedDataWriter | None = None,
     ):
         self._ocean_writer = ocean_writer
+        self._ice_writer = ice_writer
         self._atmosphere_writer = atmosphere_writer
 
     def write(self, data: CoupledPrognosticState, filename: str):
-        self._ocean_writer.write(data.ocean_data, filename)
-        self._atmosphere_writer.write(data.atmosphere_data, filename)
+        if self._ocean_writer is not None:
+            assert data.ocean_data is not None
+            self._ocean_writer.write(data.ocean_data, filename)
+        if self._ice_writer is not None:
+            assert data.ice_data is not None
+            self._ice_writer.write(data.ice_data, filename)
+        if self._atmosphere_writer is not None:
+            assert data.atmosphere_data is not None
+            self._atmosphere_writer.write(data.atmosphere_data, filename)
 
     def append_batch(self, batch: CoupledPairedData):
-        self._ocean_writer.append_batch(batch.ocean_data)
-        self._atmosphere_writer.append_batch(batch.atmosphere_data)
+        if self._ocean_writer is not None:
+            assert batch.ocean_data is not None
+            self._ocean_writer.append_batch(batch.ocean_data)
+        if self._ice_writer is not None:
+            assert batch.ice_data is not None
+            self._ice_writer.append_batch(batch.ice_data)
+        if self._atmosphere_writer is not None:
+            assert batch.atmosphere_data is not None
+            self._atmosphere_writer.append_batch(batch.atmosphere_data)
 
     def flush(self):
-        self._ocean_writer.flush()
-        self._atmosphere_writer.flush()
+        if self._ocean_writer is not None:
+            self._ocean_writer.flush()
+        if self._ice_writer is not None:
+            self._ice_writer.flush()
+        if self._atmosphere_writer is not None:
+            self._atmosphere_writer.flush()
 
     def finalize(self):
-        self._ocean_writer.finalize()
-        self._atmosphere_writer.finalize()
+        if self._ocean_writer is not None:
+            self._ocean_writer.finalize()
+        if self._ice_writer is not None:
+            self._ice_writer.finalize()
+        if self._atmosphere_writer is not None:
+            self._atmosphere_writer.finalize()

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -246,6 +246,8 @@ class InferenceEvaluatorConfig:
             "ocean": dataset_metadata,
             "atmosphere": dataset_metadata,
         }
+        assert data.ocean_timestep is not None
+        assert data.atmosphere_timestep is not None
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
             initial_condition_times=data.initial_time.to_numpy(),
@@ -339,6 +341,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
 
     aggregator_config: InferenceEvaluatorAggregatorConfig = config.aggregator
     batch = next(iter(data.loader))
+    assert batch.ocean_data is not None
     initial_time = batch.ocean_data.time.isel(time=0)
     variable_metadata = get_derived_variable_metadata() | data.variable_metadata
     dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -339,6 +339,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
 
     aggregator_config: InferenceEvaluatorAggregatorConfig = config.aggregator
     batch = next(iter(data.loader))
+    assert batch.ocean_data is not None
     initial_time = batch.ocean_data.time.isel(time=0)
     variable_metadata = get_derived_variable_metadata() | data.variable_metadata
     dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -339,7 +339,6 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
 
     aggregator_config: InferenceEvaluatorAggregatorConfig = config.aggregator
     batch = next(iter(data.loader))
-    assert batch.ocean_data is not None
     initial_time = batch.ocean_data.time.isel(time=0)
     variable_metadata = get_derived_variable_metadata() | data.variable_metadata
     dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -272,10 +272,14 @@ class _Deriver(CoupledDeriver):
         ocean_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict],
         atmosphere_derive_func: Callable[[TensorMapping, TensorMapping], TensorDict],
     ):
-        self._n_ic_timesteps_ocean = n_ic_timesteps_ocean
-        self._n_ic_timesteps_atmosphere = n_ic_timesteps_atmosphere
-        self._ocean_derive_func = ocean_derive_func
-        self._atmosphere_derive_func = atmosphere_derive_func
+        self._n_ic_timesteps = {
+            "ocean": n_ic_timesteps_ocean,
+            "atmosphere": n_ic_timesteps_atmosphere,
+        }
+        self._derive_funcs = {
+            "ocean": ocean_derive_func,
+            "atmosphere": atmosphere_derive_func,
+        }
 
     def get_forward_data(
         self,
@@ -286,14 +290,10 @@ class _Deriver(CoupledDeriver):
             timer = GlobalTimer.get_instance()
             with timer.context("compute_derived_variables"):
                 data = data.compute_derived_variables(
-                    ocean_derive_func=self._ocean_derive_func,
-                    atmosphere_derive_func=self._atmosphere_derive_func,
                     forcing_data=data,
+                    derive_funcs=self._derive_funcs,
                 )
-        return data.remove_initial_condition(
-            n_ic_timesteps_ocean=self._n_ic_timesteps_ocean,
-            n_ic_timesteps_atmosphere=self._n_ic_timesteps_atmosphere,
-        )
+        return data.remove_initial_condition(n_ic_timesteps=self._n_ic_timesteps)
 
 
 def main(yaml_config: str, override_dotlist: Sequence[str] | None = None):

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -246,8 +246,6 @@ class InferenceEvaluatorConfig:
             "ocean": dataset_metadata,
             "atmosphere": dataset_metadata,
         }
-        assert data.ocean_timestep is not None
-        assert data.atmosphere_timestep is not None
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
             initial_condition_times=data.initial_time.to_numpy(),

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -187,6 +187,8 @@ class InferenceConfig:
             "ocean": dataset_metadata,
             "atmosphere": dataset_metadata,
         }
+        assert data.ocean_timestep is not None
+        assert data.atmosphere_timestep is not None
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
             initial_condition_times=data.initial_time.to_numpy(),

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -187,8 +187,6 @@ class InferenceConfig:
             "ocean": dataset_metadata,
             "atmosphere": dataset_metadata,
         }
-        assert data.ocean_timestep is not None
-        assert data.atmosphere_timestep is not None
         return self.data_writer.build_paired(
             experiment_dir=self.experiment_dir,
             initial_condition_times=data.initial_time.to_numpy(),

--- a/fme/coupled/inference/loop.py
+++ b/fme/coupled/inference/loop.py
@@ -54,6 +54,8 @@ def run_coupled_dataset_comparison(
     def _remove_overlapping_names(batch: CoupledBatchData) -> CoupledBatchData:
         if not overlapping_names:
             return batch
+        assert batch.ocean_data is not None
+        assert batch.atmosphere_data is not None
         ocean_keep = [n for n in batch.ocean_data.data if n not in overlapping_names]
         return CoupledBatchData(
             ocean_data=batch.ocean_data.subset_names(ocean_keep),
@@ -81,6 +83,7 @@ def run_coupled_dataset_comparison(
             with timer.context("wandb_logging"):
                 record_logs(logs)
 
+        assert pred.ocean_data is not None
         forward_steps_in_memory = list(pred.ocean_data.data.values())[0].size(1) - 1
         logging.info(
             f"Inference: Processing window {i + 1} of {n_windows}"

--- a/fme/coupled/inference/loop.py
+++ b/fme/coupled/inference/loop.py
@@ -54,6 +54,7 @@ def run_coupled_dataset_comparison(
     def _remove_overlapping_names(batch: CoupledBatchData) -> CoupledBatchData:
         if not overlapping_names:
             return batch
+        assert batch.ocean_data is not None
         ocean_keep = [n for n in batch.ocean_data.data if n not in overlapping_names]
         return CoupledBatchData(
             ocean_data=batch.ocean_data.subset_names(ocean_keep),
@@ -81,6 +82,7 @@ def run_coupled_dataset_comparison(
             with timer.context("wandb_logging"):
                 record_logs(logs)
 
+        assert pred.ocean_data is not None
         forward_steps_in_memory = list(pred.ocean_data.data.values())[0].size(1) - 1
         logging.info(
             f"Inference: Processing window {i + 1} of {n_windows}"

--- a/fme/coupled/inference/loop.py
+++ b/fme/coupled/inference/loop.py
@@ -54,7 +54,6 @@ def run_coupled_dataset_comparison(
     def _remove_overlapping_names(batch: CoupledBatchData) -> CoupledBatchData:
         if not overlapping_names:
             return batch
-        assert batch.ocean_data is not None
         ocean_keep = [n for n in batch.ocean_data.data if n not in overlapping_names]
         return CoupledBatchData(
             ocean_data=batch.ocean_data.subset_names(ocean_keep),
@@ -82,7 +81,6 @@ def run_coupled_dataset_comparison(
             with timer.context("wandb_logging"):
                 record_logs(logs)
 
-        assert pred.ocean_data is not None
         forward_steps_in_memory = list(pred.ocean_data.data.values())[0].size(1) - 1
         logging.info(
             f"Inference: Processing window {i + 1} of {n_windows}"

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -158,6 +158,8 @@ def inference_helper(
             n_levels_ocean=1,
             n_levels_atmosphere=1,
         )
+    assert mock_data.ocean is not None
+    assert mock_data.atmosphere is not None
     inference_data_config = InferenceDataLoaderConfig(
         dataset=CoupledDatasetWithOptionalOceanConfig(
             ocean=XarrayDataConfig(data_path=mock_data.ocean.data_dir),
@@ -285,6 +287,8 @@ def _create_dataset_info_for_stepper(
         n_levels_ocean=1,
         n_levels_atmosphere=1,
     )
+    assert mock_data.ocean is not None
+    assert mock_data.atmosphere is not None
     dataset_info = CoupledDatasetInfoBuilder(
         vcoord=mock_data.vcoord,
         hcoord=mock_data.hcoord,
@@ -408,6 +412,8 @@ def test_inference_backwards_compatibility(tmp_path: pathlib.Path):
             data_dir=stepper_data_dir,
         )
         assert mock_data is not None
+        assert mock_data.ocean is not None
+        assert mock_data.atmosphere is not None
         checkpoint_path = save_coupled_stepper(
             tmp_path,
             ocean_in_names=ocean_in_names,

--- a/fme/coupled/inference/test_inference.py
+++ b/fme/coupled/inference/test_inference.py
@@ -62,6 +62,8 @@ def _setup(
         n_levels_atmosphere=1,
         atmosphere_start_time_offset_from_ocean=atmosphere_times_offset,
     )
+    assert mock_data.ocean is not None
+    assert mock_data.atmosphere is not None
     dataset_info = CoupledDatasetInfoBuilder(
         vcoord=mock_data.vcoord,
         hcoord=mock_data.hcoord,
@@ -83,6 +85,7 @@ def _setup(
     )
     if empty_ocean_forcing:
         atmos_forcing_config = mock_data.dataset_config.atmosphere
+        assert atmos_forcing_config is not None
         forcing_loader = CoupledForcingDataLoaderConfig(
             ocean=None,
             atmosphere=ForcingDataLoaderConfig(
@@ -91,11 +94,13 @@ def _setup(
         )
     else:
         ocean_config = mock_data.dataset_config.ocean
+        atmos_forcing_config = mock_data.dataset_config.atmosphere
         assert ocean_config is not None
+        assert atmos_forcing_config is not None
         forcing_loader = CoupledForcingDataLoaderConfig(
             ocean=ForcingDataLoaderConfig(dataset=ocean_config, num_data_workers=0),
             atmosphere=ForcingDataLoaderConfig(
-                dataset=mock_data.dataset_config.atmosphere, num_data_workers=0
+                dataset=atmos_forcing_config, num_data_workers=0
             ),
         )
 

--- a/fme/coupled/requirements.py
+++ b/fme/coupled/requirements.py
@@ -57,9 +57,12 @@ def _validate_fast_n_timesteps(
         ice_timestep=ice_timestep,
     )
     if ocean_timestep is not None:
+        assert ocean_requirements is not None
         slow_n_steps = ocean_requirements.n_timesteps_schedule.get_value(0)
         slow_dt = ocean_timestep
     else:
+        assert ice_requirements is not None
+        assert ice_timestep is not None
         slow_n_steps = ice_requirements.n_timesteps_schedule.get_value(0)
         slow_dt = ice_timestep
     expected_n_steps = (slow_n_steps - 1) * n_steps_fast + 1
@@ -67,6 +70,7 @@ def _validate_fast_n_timesteps(
     if atmosphere_timestep is not None:
         fast_dt = atmosphere_timestep
     else:
+        assert ice_timestep is not None
         fast_dt = ice_timestep
 
     if fast_n_timesteps != expected_n_steps:
@@ -98,8 +102,10 @@ class CoupledDataRequirements:
         )
 
         if self.atmosphere_timestep is None:
+            assert self.ice_requirements is not None
             fast_n_timesteps = self.ice_requirements.n_timesteps_schedule.get_value(0)
         else:
+            assert self.atmosphere_requirements is not None
             fast_n_timesteps = (
                 self.atmosphere_requirements.n_timesteps_schedule.get_value(0)
             )
@@ -175,6 +181,8 @@ class CoupledTrainDataRequirements:
         )
 
         if self.atmosphere_timestep is None:
+            assert self.ice_forcing_requirements is not None
+            assert self.ice_target_requirements is not None
             # check that the ice forcing window is consistent with the ocean window
             forcing_n_timesteps = (
                 self.ice_forcing_requirements.n_timesteps_schedule.get_value(0)
@@ -187,6 +195,8 @@ class CoupledTrainDataRequirements:
             target_names = set(self.ice_target_requirements.names)
             forcing_names = set(self.ice_forcing_requirements.names)
         else:
+            assert self.atmosphere_forcing_requirements is not None
+            assert self.atmosphere_target_requirements is not None
             # check that the atmos forcing window is consistent with the ocean window
             forcing_n_timesteps = (
                 self.atmosphere_forcing_requirements.n_timesteps_schedule.get_value(0)

--- a/fme/coupled/requirements.py
+++ b/fme/coupled/requirements.py
@@ -5,71 +5,114 @@ from fme.ace.requirements import DataRequirements, PrognosticStateDataRequiremen
 
 
 def _compute_n_steps_fast(
-    atmosphere_timestep: datetime.timedelta,
-    ocean_timestep: datetime.timedelta,
+    atmosphere_timestep: datetime.timedelta | None = None,
+    ocean_timestep: datetime.timedelta | None = None,
+    ice_timestep: datetime.timedelta | None = None,
 ) -> int:
-    """Compute and validate the number of atmosphere steps per ocean step."""
-    if atmosphere_timestep > ocean_timestep:
-        raise ValueError("Atmosphere timestep must be no larger than the ocean's.")
-    n_steps_fast = ocean_timestep / atmosphere_timestep
+    """Compute and validate the number of fast steps per slow step."""
+    if atmosphere_timestep is None:
+        assert ocean_timestep is not None and ice_timestep is not None
+        if ice_timestep > ocean_timestep:
+            raise ValueError("Ice timestep must be no larger than the ocean's.")
+        n_steps_fast = ocean_timestep / ice_timestep
+    elif ice_timestep is None:
+        assert atmosphere_timestep is not None and ocean_timestep is not None
+        if atmosphere_timestep > ocean_timestep:
+            raise ValueError("Atmosphere timestep must be no larger than the ocean's.")
+        n_steps_fast = ocean_timestep / atmosphere_timestep
+    elif ocean_timestep is None:
+        assert atmosphere_timestep is not None and ice_timestep is not None
+        if atmosphere_timestep > ice_timestep:
+            raise ValueError("Atmosphere timestep must be no larger than the ice's.")
+        n_steps_fast = ice_timestep / atmosphere_timestep
+    else:
+        assert atmosphere_timestep is not None and ocean_timestep is not None
+        if atmosphere_timestep > ocean_timestep:
+            raise ValueError("Atmosphere timestep must be no larger than the ocean's.")
+        n_steps_fast = ocean_timestep / atmosphere_timestep
+
     if n_steps_fast != int(n_steps_fast):
         raise ValueError(
-            f"Expected atmosphere timestep {atmosphere_timestep} to be a "
-            f"multiple of ocean timestep {ocean_timestep}."
+            f"Expected fast timestep to be a " f"multiple of slow timestep."
         )
     return int(n_steps_fast)
 
 
-def _validate_atmosphere_n_timesteps(
-    atmosphere_timestep: datetime.timedelta,
-    ocean_timestep: datetime.timedelta,
-    ocean_requirements: DataRequirements,
-    atmosphere_n_timesteps: int,
+def _validate_fast_n_timesteps(
+    atmosphere_timestep: datetime.timedelta | None = None,
+    ocean_timestep: datetime.timedelta | None = None,
+    ice_timestep: datetime.timedelta | None = None,
+    ocean_requirements: DataRequirements | None = None,
+    ice_requirements: DataRequirements | None = None,
+    fast_n_timesteps: int | None = None,
 ) -> None:
-    """Validate that the initial value of the atmosphere data requirements
-    n_timesteps_schedule matches the value derived from the ocean requirements
+    """Validate that the initial value of the fast data requirements
+    n_timesteps_schedule matches the value derived from the slow requirements
     and the timesteps.
 
     """
     n_steps_fast = _compute_n_steps_fast(
         atmosphere_timestep=atmosphere_timestep,
         ocean_timestep=ocean_timestep,
+        ice_timestep=ice_timestep,
     )
-    slow_n_steps = ocean_requirements.n_timesteps_schedule.get_value(0)
+    if ocean_timestep is not None:
+        slow_n_steps = ocean_requirements.n_timesteps_schedule.get_value(0)
+        slow_dt = ocean_timestep
+    else:
+        slow_n_steps = ice_requirements.n_timesteps_schedule.get_value(0)
+        slow_dt = ice_timestep
     expected_n_steps = (slow_n_steps - 1) * n_steps_fast + 1
-    if atmosphere_n_timesteps != expected_n_steps:
+
+    if atmosphere_timestep is not None:
+        fast_dt = atmosphere_timestep
+    else:
+        fast_dt = ice_timestep
+
+    if fast_n_timesteps != expected_n_steps:
         raise ValueError(
-            f"Atmosphere dataset timestep is {atmosphere_timestep} and "
-            f"ocean dataset timestep is {ocean_timestep}, "
-            f"so we need {n_steps_fast} atmosphere steps for each of the "
-            f"{slow_n_steps - 1} ocean steps, giving {expected_n_steps} total "
+            f"Fast dataset timestep is {fast_dt} and "
+            f"slow dataset timestep is {slow_dt}, "
+            f"so we need {n_steps_fast} fast steps for each of the "
+            f"{slow_n_steps - 1} slow steps, giving {expected_n_steps} total "
             f"timepoints (including IC) per sample, but "
-            f"atmosphere dataset was configured to return "
-            f"{atmosphere_n_timesteps} steps."
+            f"fast dataset was configured to return "
+            f"{fast_n_timesteps} steps."
         )
 
 
 @dataclasses.dataclass
 class CoupledDataRequirements:
-    ocean_timestep: datetime.timedelta
-    ocean_requirements: DataRequirements
-    atmosphere_timestep: datetime.timedelta
-    atmosphere_requirements: DataRequirements
+    ocean_timestep: datetime.timedelta | None = None
+    ocean_requirements: DataRequirements | None = None
+    ice_timestep: datetime.timedelta | None = None
+    ice_requirements: DataRequirements | None = None
+    atmosphere_timestep: datetime.timedelta | None = None
+    atmosphere_requirements: DataRequirements | None = None
 
     def __post_init__(self):
         n_steps_fast = _compute_n_steps_fast(
             atmosphere_timestep=self.atmosphere_timestep,
             ocean_timestep=self.ocean_timestep,
+            ice_timestep=self.ice_timestep,
         )
-        atmosphere_n_timesteps = (
-            self.atmosphere_requirements.n_timesteps_schedule.get_value(0)
-        )
-        _validate_atmosphere_n_timesteps(
+
+        if self.atmosphere_timestep is None:
+            fast_n_timesteps = self.ice_requirements.n_timesteps_schedule.get_value(0)
+        else:
+            fast_n_timesteps = (
+                self.atmosphere_requirements.n_timesteps_schedule.get_value(0)
+            )
+
+        _validate_fast_n_timesteps(
             atmosphere_timestep=self.atmosphere_timestep,
             ocean_timestep=self.ocean_timestep,
+            ice_timestep=self.ice_timestep,
             ocean_requirements=self.ocean_requirements,
-            atmosphere_n_timesteps=atmosphere_n_timesteps,
+            ice_requirements=self.ice_requirements,
+            fast_n_timesteps=fast_n_timesteps,
         )
+
         self._n_steps_fast = n_steps_fast
 
     @property
@@ -84,8 +127,9 @@ class CoupledPrognosticStateDataRequirements:
 
     """
 
-    ocean: PrognosticStateDataRequirements
-    atmosphere: PrognosticStateDataRequirements
+    ocean: PrognosticStateDataRequirements | None = None
+    atmosphere: PrognosticStateDataRequirements | None = None
+    ice: PrognosticStateDataRequirements | None = None
 
 
 @dataclasses.dataclass
@@ -113,48 +157,69 @@ class CoupledTrainDataRequirements:
             length).
     """
 
-    ocean_timestep: datetime.timedelta
-    ocean_requirements: DataRequirements
-    atmosphere_timestep: datetime.timedelta
-    atmosphere_target_requirements: DataRequirements
-    atmosphere_forcing_requirements: DataRequirements
+    ocean_timestep: datetime.timedelta | None = None
+    ocean_requirements: DataRequirements | None = None
+    atmosphere_timestep: datetime.timedelta | None = None
+    atmosphere_target_requirements: DataRequirements | None = None
+    atmosphere_forcing_requirements: DataRequirements | None = None
+    ice_timestep: datetime.timedelta | None = None
+    ice_requirements: DataRequirements | None = None
+    ice_target_requirements: DataRequirements | None = None
+    ice_forcing_requirements: DataRequirements | None = None
 
     def __post_init__(self):
         n_steps_fast = _compute_n_steps_fast(
             atmosphere_timestep=self.atmosphere_timestep,
             ocean_timestep=self.ocean_timestep,
+            ice_timestep=self.ice_timestep,
         )
 
-        # check that the atmosphere forcing window is consistent with the ocean window
-        atmosphere_forcing_n_timesteps = (
-            self.atmosphere_forcing_requirements.n_timesteps_schedule.get_value(0)
-        )
-        _validate_atmosphere_n_timesteps(
+        if self.atmosphere_timestep is None:
+            # check that the ice forcing window is consistent with the ocean window
+            forcing_n_timesteps = (
+                self.ice_forcing_requirements.n_timesteps_schedule.get_value(0)
+            )
+            # check that the ice target window is no longer than the forcing window
+            target_n_timesteps = (
+                self.ice_target_requirements.n_timesteps_schedule.get_value(0)
+            )
+            # check that the ice target and forcing variable names are disjoint
+            target_names = set(self.ice_target_requirements.names)
+            forcing_names = set(self.ice_forcing_requirements.names)
+        else:
+            # check that the atmos forcing window is consistent with the ocean window
+            forcing_n_timesteps = (
+                self.atmosphere_forcing_requirements.n_timesteps_schedule.get_value(0)
+            )
+            # check that the atmos target window is no longer than the forcing window
+            target_n_timesteps = (
+                self.atmosphere_target_requirements.n_timesteps_schedule.get_value(0)
+            )
+            # check that the atmos target and forcing variable names are disjoint
+            target_names = set(self.atmosphere_target_requirements.names)
+            forcing_names = set(self.atmosphere_forcing_requirements.names)
+
+        _validate_fast_n_timesteps(
             atmosphere_timestep=self.atmosphere_timestep,
             ocean_timestep=self.ocean_timestep,
+            ice_timestep=self.ice_timestep,
             ocean_requirements=self.ocean_requirements,
-            atmosphere_n_timesteps=atmosphere_forcing_n_timesteps,
+            ice_requirements=self.ice_requirements,
+            fast_n_timesteps=forcing_n_timesteps,
         )
 
-        # check that the atmosphere target window is no longer than the forcing window
-        atmosphere_target_n_timesteps = (
-            self.atmosphere_target_requirements.n_timesteps_schedule.get_value(0)
-        )
-        if atmosphere_target_n_timesteps > atmosphere_forcing_n_timesteps:
+        if target_n_timesteps > forcing_n_timesteps:
             raise ValueError(
-                f"Atmosphere target requirements n_timesteps "
-                f"({atmosphere_target_n_timesteps}) must be no larger than the "
-                f"atmosphere forcing requirements n_timesteps "
-                f"({atmosphere_forcing_n_timesteps})."
+                f"Fast target requirements n_timesteps "
+                f"({target_n_timesteps}) must be no larger than the "
+                f"fast forcing requirements n_timesteps "
+                f"({forcing_n_timesteps})."
             )
 
-        # check that the atmosphere target and forcing variable names are disjoint
-        target_names = set(self.atmosphere_target_requirements.names)
-        forcing_names = set(self.atmosphere_forcing_requirements.names)
         overlap = target_names.intersection(forcing_names)
         if overlap:
             raise ValueError(
-                "Atmosphere target and forcing variable names must be disjoint, "
+                "Fast target and forcing variable names must be disjoint, "
                 f"but the following names appear in both: {sorted(overlap)}."
             )
 

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -624,6 +624,8 @@ class CoupledStepperConfig:
         atmosphere_parameter_initializer: ParameterInitializer | None = None,
     ):
         logging.info("Initializing coupler")
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         return CoupledStepper(
             config=self,
             ocean=self._get_ocean_stepper(
@@ -725,6 +727,8 @@ class CoupledTrainOutput(TrainOutputABC):
         Args:
             initial_condition: Initial condition data.
         """
+        assert initial_condition.ocean_data is not None
+        assert initial_condition.atmosphere_data is not None
         return CoupledTrainOutput(
             total_metrics=self.total_metrics,
             ocean=self.ocean.prepend_initial_condition(
@@ -953,6 +957,7 @@ class CoupledStepper:
             )
         for name, tensor in forcings_from_ocean.items():
             # set ocean invalid points to 0 based on the ocean masking
+            assert self._ocean_spatial_mask_provider is not None
             mask = self._ocean_spatial_mask_provider.get_mask_tensor_for(name)
             if mask is not None:
                 mask = mask.expand(tensor.shape)
@@ -1056,6 +1061,10 @@ class CoupledStepper:
         forcing_data: CoupledBatchData,
         optimizer: OptimizationABC,
     ) -> Generator[ComponentStepPrediction, None, None]:
+        assert initial_condition.atmosphere_data is not None
+        assert initial_condition.ocean_data is not None
+        assert forcing_data.ocean_data is not None
+        assert forcing_data.atmosphere_data is not None
         if (
             initial_condition.atmosphere_data.as_batch_data().n_timesteps
             != self.atmosphere.n_ic_timesteps
@@ -1191,6 +1200,8 @@ class CoupledStepper:
         output_list: list[ComponentStepPrediction],
         forcing_data: CoupledBatchData,
     ) -> CoupledBatchData:
+        assert forcing_data.atmosphere_data is not None
+        assert forcing_data.ocean_data is not None
         atmos_data = process_prediction_generator_list(
             [(x.data, None) for x in output_list if x.realm == "atmosphere"],
             time=forcing_data.atmosphere_data.time[:, self.atmosphere.n_ic_timesteps :],
@@ -1246,6 +1257,8 @@ class CoupledStepper:
         Predict multiple steps forward given initial condition and reference data.
         """
         gen_data = self._predict(initial_condition, forcing, compute_derived_variables)
+        assert forcing.atmosphere_data is not None
+        assert forcing.ocean_data is not None
         atmos_forward_data = self.atmosphere.get_forward_data(
             forcing.atmosphere_data, compute_derived_variables=compute_derived_variables
         )
@@ -1872,11 +1885,15 @@ class CoupledTrainStepper(
         evaluate_all_steps: bool = False,
     ) -> list[ComponentEnsembleStepPrediction]:
         n_ensemble = self._config.n_ensemble
+        assert data.ocean_data is not None
+        assert data.atmosphere_data is not None
         data_ensemble = CoupledBatchData(
             ocean_data=data.ocean_data.broadcast_ensemble(n_ensemble),
             atmosphere_data=data.atmosphere_data.broadcast_ensemble(n_ensemble),
         )
         # get initial condition prognostic variables
+        assert data_ensemble.atmosphere_data is not None
+        assert data_ensemble.ocean_data is not None
         input_data = CoupledPrognosticState(
             atmosphere_data=data_ensemble.atmosphere_data.get_start(
                 self.atmosphere.prognostic_names, self.n_ic_timesteps
@@ -1965,6 +1982,8 @@ class CoupledTrainStepper(
                 the stochastically-sampled range toward the accumulated loss.
 
         """
+        assert data.atmosphere_data is not None
+        assert data.ocean_data is not None
         atmos_forward_data = self.atmosphere.get_forward_data(
             data.atmosphere_data,
             compute_derived_variables=False,

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -1249,19 +1249,23 @@ class CoupledStepper:
         gen_data = self._process_prediction_generator_list(output_list, forcing)
         assert self.ocean is not None
         assert self.atmosphere is not None
+        funcs = {
+            "ocean": self.ocean.derive_func,
+            "atmosphere": self.atmosphere.derive_func,
+        }
+        n_ic_timesteps = {
+            "ocean": self.ocean.n_ic_timesteps,
+            "atmosphere": self.atmosphere.n_ic_timesteps,
+        }
         if compute_derived_variables:
             with timer.context("compute_derived_variables"):
                 gen_data = (
                     gen_data.prepend(initial_condition)
                     .compute_derived_variables(
-                        ocean_derive_func=self.ocean.derive_func,
-                        atmosphere_derive_func=self.atmosphere.derive_func,
+                        derive_funcs=funcs,
                         forcing_data=forcing,
                     )
-                    .remove_initial_condition(
-                        n_ic_timesteps_ocean=self.ocean.n_ic_timesteps,
-                        n_ic_timesteps_atmosphere=self.atmosphere.n_ic_timesteps,
-                    )
+                    .remove_initial_condition(n_ic_timesteps=n_ic_timesteps)
                 )
         return gen_data
 

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -624,8 +624,6 @@ class CoupledStepperConfig:
         atmosphere_parameter_initializer: ParameterInitializer | None = None,
     ):
         logging.info("Initializing coupler")
-        assert dataset_info.ocean is not None
-        assert dataset_info.atmosphere is not None
         return CoupledStepper(
             config=self,
             ocean=self._get_ocean_stepper(
@@ -727,8 +725,6 @@ class CoupledTrainOutput(TrainOutputABC):
         Args:
             initial_condition: Initial condition data.
         """
-        assert initial_condition.ocean_data is not None
-        assert initial_condition.atmosphere_data is not None
         return CoupledTrainOutput(
             total_metrics=self.total_metrics,
             ocean=self.ocean.prepend_initial_condition(
@@ -957,7 +953,6 @@ class CoupledStepper:
             )
         for name, tensor in forcings_from_ocean.items():
             # set ocean invalid points to 0 based on the ocean masking
-            assert self._ocean_spatial_mask_provider is not None
             mask = self._ocean_spatial_mask_provider.get_mask_tensor_for(name)
             if mask is not None:
                 mask = mask.expand(tensor.shape)
@@ -1061,10 +1056,6 @@ class CoupledStepper:
         forcing_data: CoupledBatchData,
         optimizer: OptimizationABC,
     ) -> Generator[ComponentStepPrediction, None, None]:
-        assert initial_condition.atmosphere_data is not None
-        assert initial_condition.ocean_data is not None
-        assert forcing_data.ocean_data is not None
-        assert forcing_data.atmosphere_data is not None
         if (
             initial_condition.atmosphere_data.as_batch_data().n_timesteps
             != self.atmosphere.n_ic_timesteps
@@ -1200,8 +1191,6 @@ class CoupledStepper:
         output_list: list[ComponentStepPrediction],
         forcing_data: CoupledBatchData,
     ) -> CoupledBatchData:
-        assert forcing_data.atmosphere_data is not None
-        assert forcing_data.ocean_data is not None
         atmos_data = process_prediction_generator_list(
             [(x.data, None) for x in output_list if x.realm == "atmosphere"],
             time=forcing_data.atmosphere_data.time[:, self.atmosphere.n_ic_timesteps :],
@@ -1257,8 +1246,6 @@ class CoupledStepper:
         Predict multiple steps forward given initial condition and reference data.
         """
         gen_data = self._predict(initial_condition, forcing, compute_derived_variables)
-        assert forcing.atmosphere_data is not None
-        assert forcing.ocean_data is not None
         atmos_forward_data = self.atmosphere.get_forward_data(
             forcing.atmosphere_data, compute_derived_variables=compute_derived_variables
         )
@@ -1885,15 +1872,11 @@ class CoupledTrainStepper(
         evaluate_all_steps: bool = False,
     ) -> list[ComponentEnsembleStepPrediction]:
         n_ensemble = self._config.n_ensemble
-        assert data.ocean_data is not None
-        assert data.atmosphere_data is not None
         data_ensemble = CoupledBatchData(
             ocean_data=data.ocean_data.broadcast_ensemble(n_ensemble),
             atmosphere_data=data.atmosphere_data.broadcast_ensemble(n_ensemble),
         )
         # get initial condition prognostic variables
-        assert data_ensemble.atmosphere_data is not None
-        assert data_ensemble.ocean_data is not None
         input_data = CoupledPrognosticState(
             atmosphere_data=data_ensemble.atmosphere_data.get_start(
                 self.atmosphere.prognostic_names, self.n_ic_timesteps
@@ -1982,8 +1965,6 @@ class CoupledTrainStepper(
                 the stochastically-sampled range toward the accumulated loss.
 
         """
-        assert data.atmosphere_data is not None
-        assert data.ocean_data is not None
         atmos_forward_data = self.atmosphere.get_forward_data(
             data.atmosphere_data,
             compute_derived_variables=False,

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -624,6 +624,8 @@ class CoupledStepperConfig:
         atmosphere_parameter_initializer: ParameterInitializer | None = None,
     ):
         logging.info("Initializing coupler")
+        assert dataset_info.ocean is not None
+        assert dataset_info.atmosphere is not None
         return CoupledStepper(
             config=self,
             ocean=self._get_ocean_stepper(
@@ -725,6 +727,12 @@ class CoupledTrainOutput(TrainOutputABC):
         Args:
             initial_condition: Initial condition data.
         """
+        assert (
+            self.ocean is not None
+            and self.atmosphere is not None
+            and initial_condition.ocean_data is not None
+            and initial_condition.atmosphere_data is not None
+        )
         return CoupledTrainOutput(
             total_metrics=self.total_metrics,
             ocean=self.ocean.prepend_initial_condition(
@@ -951,6 +959,7 @@ class CoupledStepper:
             forcings_from_ocean[ocean_frac_name] = torch.clip(
                 ocean_data.ocean_fraction, min=0
             )
+        assert self._ocean_spatial_mask_provider is not None
         for name, tensor in forcings_from_ocean.items():
             # set ocean invalid points to 0 based on the ocean masking
             mask = self._ocean_spatial_mask_provider.get_mask_tensor_for(name)
@@ -1056,6 +1065,12 @@ class CoupledStepper:
         forcing_data: CoupledBatchData,
         optimizer: OptimizationABC,
     ) -> Generator[ComponentStepPrediction, None, None]:
+        assert (
+            initial_condition.atmosphere_data is not None
+            and initial_condition.ocean_data is not None
+            and forcing_data.ocean_data is not None
+            and forcing_data.atmosphere_data is not None
+        )
         if (
             initial_condition.atmosphere_data.as_batch_data().n_timesteps
             != self.atmosphere.n_ic_timesteps
@@ -1191,6 +1206,8 @@ class CoupledStepper:
         output_list: list[ComponentStepPrediction],
         forcing_data: CoupledBatchData,
     ) -> CoupledBatchData:
+        assert forcing_data.atmosphere_data is not None
+        assert forcing_data.ocean_data is not None
         atmos_data = process_prediction_generator_list(
             [(x.data, None) for x in output_list if x.realm == "atmosphere"],
             time=forcing_data.atmosphere_data.time[:, self.atmosphere.n_ic_timesteps :],
@@ -1220,6 +1237,8 @@ class CoupledStepper:
             )
         )
         gen_data = self._process_prediction_generator_list(output_list, forcing)
+        assert self.ocean is not None
+        assert self.atmosphere is not None
         if compute_derived_variables:
             with timer.context("compute_derived_variables"):
                 gen_data = (
@@ -1245,6 +1264,12 @@ class CoupledStepper:
         """
         Predict multiple steps forward given initial condition and reference data.
         """
+        assert (
+            self.atmosphere is not None
+            and self.ocean is not None
+            and forcing.atmosphere_data is not None
+            and forcing.ocean_data is not None
+        )
         gen_data = self._predict(initial_condition, forcing, compute_derived_variables)
         atmos_forward_data = self.atmosphere.get_forward_data(
             forcing.atmosphere_data, compute_derived_variables=compute_derived_variables
@@ -1872,10 +1897,18 @@ class CoupledTrainStepper(
         evaluate_all_steps: bool = False,
     ) -> list[ComponentEnsembleStepPrediction]:
         n_ensemble = self._config.n_ensemble
+        assert (
+            self.ocean is not None
+            and self.atmosphere is not None
+            and data.ocean_data is not None
+            and data.atmosphere_data is not None
+        )
         data_ensemble = CoupledBatchData(
             ocean_data=data.ocean_data.broadcast_ensemble(n_ensemble),
             atmosphere_data=data.atmosphere_data.broadcast_ensemble(n_ensemble),
         )
+        assert data_ensemble.atmosphere_data is not None
+        assert data_ensemble.ocean_data is not None
         # get initial condition prognostic variables
         input_data = CoupledPrognosticState(
             atmosphere_data=data_ensemble.atmosphere_data.get_start(
@@ -1965,6 +1998,12 @@ class CoupledTrainStepper(
                 the stochastically-sampled range toward the accumulated loss.
 
         """
+        assert (
+            self.atmosphere is not None
+            and self.ocean is not None
+            and data.atmosphere_data is not None
+            and data.ocean_data is not None
+        )
         atmos_forward_data = self.atmosphere.get_forward_data(
             data.atmosphere_data,
             compute_derived_variables=False,

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -908,6 +908,8 @@ def test_get_train_window_data_requirements_name_partition(
     )
     requirements = train_config.get_train_window_data_requirements(stepper_config)
 
+    assert requirements.atmosphere_target_requirements is not None
+    assert requirements.atmosphere_forcing_requirements is not None
     target_names = set(requirements.atmosphere_target_requirements.names)
     forcing_names = set(requirements.atmosphere_forcing_requirements.names)
 
@@ -938,6 +940,9 @@ def test_get_train_window_data_requirements_bounded_atmos_n_steps():
     )
     requirements = train_config.get_train_window_data_requirements(stepper_config)
 
+    assert requirements.atmosphere_target_requirements is not None
+    assert requirements.atmosphere_forcing_requirements is not None
+    assert requirements.ocean_requirements is not None
     long_n = n_coupled_steps * stepper_config.n_inner_steps + 1
     assert (
         requirements.atmosphere_forcing_requirements.n_timesteps == long_n
@@ -965,6 +970,8 @@ def test_get_train_window_data_requirements_unbounded_falls_back_to_long():
 
     requirements = train_config.get_train_window_data_requirements(stepper_config)
 
+    assert requirements.atmosphere_target_requirements is not None
+    assert requirements.atmosphere_forcing_requirements is not None
     long_n = n_coupled_steps * stepper_config.n_inner_steps + 1
     assert requirements.atmosphere_target_requirements.n_timesteps == long_n
     assert requirements.atmosphere_forcing_requirements.n_timesteps == long_n
@@ -990,6 +997,7 @@ def test_get_train_window_data_requirements_zero_atmos_n_steps():
         ),
     )
     requirements = train_config.get_train_window_data_requirements(stepper_config)
+    assert requirements.atmosphere_target_requirements is not None
     assert requirements.atmosphere_target_requirements.n_timesteps == 1
 
 
@@ -1119,6 +1127,7 @@ def test_get_train_window_data_requirements_with_sampler():
         ),
     )
     requirements = train_config.get_train_window_data_requirements(stepper_config)
+    assert requirements.atmosphere_target_requirements is not None
     assert requirements.atmosphere_target_requirements.n_timesteps == 7 + 1
 
 
@@ -1618,6 +1627,12 @@ def test_predict_paired():
 
     # first two predicted atmos surface_temperature replaced by the ocean
     # initial condition sea surface temperature
+    assert (
+        paired_data.atmosphere_data is not None
+        and paired_data.ocean_data is not None
+        and data.atmosphere_data is not None
+        and data.ocean_data is not None
+    )
     for i in range(2):
         mask = torch.round(
             torch.minimum(

--- a/fme/coupled/train/train.py
+++ b/fme/coupled/train/train.py
@@ -167,6 +167,7 @@ def _make_coupled_aggregator_factory(
 ):
     def factory():
         batch = next(iter(data.loader))
+        assert batch.ocean_data is not None
         initial_times = batch.ocean_data.time.isel(time=0)
         n_timesteps_ocean = entry_config.n_coupled_steps + stepper.ocean.n_ic_timesteps
         n_timesteps_atmosphere = (


### PR DESCRIPTION
This is a first step towards integrating a stand-alone sea ice component into `fme.coupled`. This PR makes changes to:

- `fme.coupled.data_loading`
- `fme.coupled.dataset_info`
- `fme.coupled.requirements`

These changes both add a new `ice` component as well as make each `atmosphere`, `ocean` and `ice` component optional `None`. Therefore, if, for example, no `atmosphere` component is given, then the code assumes you are coupling an `ocean` model to an `ice` model. Similarly, if no `ice` component is given, then `atmosphere-ocean` coupling is assumed. 

Had to make some additional changes outside of `fme.coupled.data_loading` to resolve some errors that pre-commit was throwing up around assertions. These include changes to `fme.coupled.stepper`, `fme.coupled.aggregator`, `fme.coupled.inference.evaluator`, `fme.coupled.inference.test_evaluator`, `fme.coupled.inference.test_inference`, `fme.coupled.inference.loop`, `fme.coupled.inference.data_writer`, `fme.coupled.train`,  `fme.coupled.test_stepper`, 