### PR TITLE
Block n_ensemble_per_ic>1 in segmented runs

### DIFF
--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -412,6 +412,14 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
         multiple folders, each corresponding to one of the segments and labeled by
         the segment number.
     """
+    if config.n_ensemble_per_ic > 1:
+        raise ValueError(
+            "Ensemble inference (n_ensemble_per_ic > 1) is not supported with "
+            "segmented inference. A segment's restart already carries the "
+            "broadcasted ensemble as its sample dimension, so later segments "
+            "cannot re-broadcast it consistently. Run with n_ensemble_per_ic=1, "
+            "or run a single non-segmented inference for ensemble runs."
+        )
     logging.info(
         f"Starting segmented inference with {segments} segments. "
         f"Saving to {config.experiment_dir}."
@@ -434,6 +442,3 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
         config_copy.initial_condition = InitialConditionConfig(
             path=restart_path, engine="netcdf4"
         )
-        # The restart already holds the broadcasted ensemble as its sample dim, so
-        # later segments must not broadcast again (would give n_ensemble**2 samples).
-        config_copy.n_ensemble_per_ic = 1

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -434,3 +434,6 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
         config_copy.initial_condition = InitialConditionConfig(
             path=restart_path, engine="netcdf4"
         )
+        # The restart already holds the broadcasted ensemble as its sample dim, so
+        # later segments must not broadcast again (would give n_ensemble**2 samples).
+        config_copy.n_ensemble_per_ic = 1

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -279,24 +279,12 @@ def test_run_segmented_inference(tmp_path, monkeypatch):
         assert mock.call_count == 3
 
 
-def test_segmented_inference_does_not_rebroadcast_ensemble(tmp_path, monkeypatch):
-    # The first segment broadcasts the singleton IC to n_ensemble members; the
-    # restart it writes already carries that ensemble as its sample dimension.
-    # Later segments must therefore run with n_ensemble_per_ic=1 -- otherwise the
-    # ensemble is broadcast again, giving n_ensemble**2 samples and OOMing the GPU.
-    n_ensemble_seen: list[int] = []
-
-    def mock(config: fme.ace.InferenceConfig):
-        n_ensemble_seen.append(config.n_ensemble_per_ic)
-        _run_inference_from_config_mock(config)
-
+def test_segmented_inference_rejects_ensemble(tmp_path):
+    # Ensemble inference is unsupported with segmented inference: a segment's
+    # restart already carries the broadcasted ensemble as its sample dimension,
+    # so later segments cannot re-broadcast it consistently. The config should be
+    # rejected up front rather than silently re-interpreted.
     config = _get_mock_config(str(tmp_path))
     config.n_ensemble_per_ic = 3
-    monkeypatch.setenv("WANDB_NAME", "run_name")
-    with unittest.mock.patch(
-        "fme.ace.inference.inference.run_inference_from_config", new=mock
-    ):
+    with pytest.raises(ValueError, match="n_ensemble_per_ic"):
         run_segmented_inference(config, 3)
-
-    # segment 0 broadcasts (3); segments 1 and 2 reuse the restart's ensemble (1)
-    assert n_ensemble_seen == [3, 1, 1]

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -277,3 +277,26 @@ def test_run_segmented_inference(tmp_path, monkeypatch):
             with open(os.path.join(segment_dir, WRITTEN_WANDB_NAME_FILENAME)) as f:
                 assert f.read() == f"run_name-segment_{i:04d}"
         assert mock.call_count == 3
+
+
+def test_segmented_inference_does_not_rebroadcast_ensemble(tmp_path, monkeypatch):
+    # The first segment broadcasts the singleton IC to n_ensemble members; the
+    # restart it writes already carries that ensemble as its sample dimension.
+    # Later segments must therefore run with n_ensemble_per_ic=1 -- otherwise the
+    # ensemble is broadcast again, giving n_ensemble**2 samples and OOMing the GPU.
+    n_ensemble_seen: list[int] = []
+
+    def mock(config: fme.ace.InferenceConfig):
+        n_ensemble_seen.append(config.n_ensemble_per_ic)
+        _run_inference_from_config_mock(config)
+
+    config = _get_mock_config(str(tmp_path))
+    config.n_ensemble_per_ic = 3
+    monkeypatch.setenv("WANDB_NAME", "run_name")
+    with unittest.mock.patch(
+        "fme.ace.inference.inference.run_inference_from_config", new=mock
+    ):
+        run_segmented_inference(config, 3)
+
+    # segment 0 broadcasts (3); segments 1 and 2 reuse the restart's ensemble (1)
+    assert n_ensemble_seen == [3, 1, 1]


### PR DESCRIPTION
Segmented inference reused the same `n_ensemble_per_ic` for every segment, but a segment's `restart.nc` already holds the broadcasted ensemble as its `sample` dimension. `broadcast_ensemble` guards only on the `n_ensemble` attribute (1 for a freshly loaded restart), not the actual sample count, so if `n_ensemble_per_ic>1` then segments after the first re-broadcast the ensemble (`n_ensemble` → `n_ensemble**2` samples) and OOM the GPU. Rather than silently de-broadcasting on restart segments — which quietly reinterprets the user's config — this PR rejects the combination up front: `n_ensemble_per_ic>` is unsupported with segmented inference, and should use a single non-segmented inference.

Changes:
- `fme.ace.inference.run_segmented_inference` — raise `ValueError` when `n_ensemble_per_ic > 1`, before any segment runs
- `fme.ace.inference.test_segmented` — test asserting `run_segmented_inference` raises `ValueError` for `n_ensemble_per_ic > 1`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated