### PR TITLE
Skip flaky test_contract_dhconv_groups_are_faster

### DIFF
--- a/fme/core/models/conditional_sfno/test_s2convolutions.py
+++ b/fme/core/models/conditional_sfno/test_s2convolutions.py
@@ -46,6 +46,16 @@ def benchmark(fn, iters=10, warmup=1) -> BenchmarkResult:
     )
 
 
+@pytest.mark.skip(
+    reason=(
+        "Flaky: this test relies on wall-clock timing of grouped vs. ungrouped "
+        "DHConv contractions, which is sensitive to GPU contention and varies "
+        "run-to-run (e.g. failed in "
+        "https://github.com/ai2cm/ace/actions/runs/27963422691/job/82750794061). "
+        "We have no plans to refactor this code, so it does not need to run in "
+        "regular CI, but it is kept here (skipped) for reference."
+    )
+)
 @pytest.mark.skipif(
     get_device().type != "cuda",
     reason=(


### PR DESCRIPTION
`test_contract_dhconv_groups_are_faster` asserts that grouped DHConv contractions are faster than ungrouped ones based on wall-clock GPU timing. That timing is sensitive to GPU contention and varies run-to-run, making the test flaky (e.g. it failed in https://github.com/ai2cm/ace/actions/runs/27963422691/job/82750794061). Since we have no plans to refactor this code, the test does not need to run in regular CI, but it is worth keeping (skipped) for reference.

Changes:
- `fme.core.models.conditional_sfno.test_s2convolutions.test_contract_dhconv_groups_are_faster`: add an unconditional `@pytest.mark.skip` with a reason citing the flaky timing assertion and the example CI failure.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated