### PR TITLE
Add canonical v2 ERA5-only residual baseline config (stitched train window)

### DIFF
--- a/configs/baselines/aimip-like/run-train.sh
+++ b/configs/baselines/aimip-like/run-train.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_PATH=$(git rev-parse --show-prefix)  # relative to the root of the repository
+BEAKER_USERNAME=$(beaker account whoami --format=json | jq -r '.[0].name')
+WANDB_USERNAME=${WANDB_USERNAME:-${BEAKER_USERNAME}}
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+cd "$REPO_ROOT"
+
+run_training() {
+  local config_filename="$1"
+  local job_name="$2"
+  local N_GPUS="$3"
+  local WORKSPACE="${4:-ai2/climate-titan}"
+  local PRIORITY="${5:-urgent}"
+  local CLUSTER="${6:-ai2/titan}"  # space-separated list allowed, e.g. "ai2/jupiter ai2/titan"
+  local CONFIG_PATH="$SCRIPT_PATH/$config_filename"
+
+  # Expand the (possibly multi-value) cluster list into repeated --cluster flags
+  local cluster_args=()
+  for c in $CLUSTER; do
+    cluster_args+=(--cluster "$c")
+  done
+
+  python -m fme.ace.validate_config --config_type train "$CONFIG_PATH"
+
+  # Extract additional args from config header
+  local extra_args=()
+  while IFS= read -r line; do
+    [[ "$line" =~ ^#\ arg:\ (.*) ]] && extra_args+=(${BASH_REMATCH[1]})
+  done < "$CONFIG_PATH"
+
+  gantry run \
+    --name "$job_name" \
+    --description 'Run ACE training (AIMIP-like baseline)' \
+    --beaker-image "$(cat $REPO_ROOT/latest_deps_only_image.txt)" \
+    --workspace "$WORKSPACE" \
+    --priority "$PRIORITY" \
+    "${cluster_args[@]}" \
+    --env WANDB_USERNAME="$WANDB_USERNAME" \
+    --env WANDB_NAME="$job_name" \
+    --env WANDB_JOB_TYPE=training \
+    --env WANDB_RUN_GROUP= \
+    --env GOOGLE_APPLICATION_CREDENTIALS=/tmp/google_application_credentials.json \
+    --env-secret WANDB_API_KEY=wandb-api-key-ai2cm-sa \
+    --dataset-secret google-credentials:/tmp/google_application_credentials.json \
+    --gpus "$N_GPUS" \
+    --shared-memory 400GiB \
+    --weka climate-default:/climate-default \
+    --budget ai2/atec-climate \
+    --allow-dirty \
+    --system-python \
+    --install "pip install --no-deps ." \
+    "${extra_args[@]}" \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.ace.train "$CONFIG_PATH"
+}
+
+# =============================================================================
+# v2 ERA5-only residual baseline (canonical).
+#
+# The selected 4°/daily residual recipe (filter_num_groups 16 × spectral_ratio
+# 0.125 "ws64", embed_dim 512; residual-recipe-selection, run j8r0z322), with
+# one change from v1: the train_loader splits each ERA5 production stream at the
+# canonical in-window stitch boundaries (1986-04-01, 1993-08-01, 2000-01-01,
+# 2010-01-01) so no training sample's 1-step residual target straddles a
+# stream-to-stream discontinuity. See
+# research/knowledge/era5-stitching-discontinuities.md. All weights-affecting
+# settings other than the training data window are identical to v1.
+# =============================================================================
+
+# --- v2 baseline, seed 0 (1 GPU; Jupiter+Titan, high) ---
+run_training "train-4deg-daily-v2-era5-only.yaml" "train-4deg-daily-v2-era5-only-rs0" 1 ai2/ace high "ai2/jupiter ai2/titan"

--- a/configs/baselines/aimip-like/run-train.sh
+++ b/configs/baselines/aimip-like/run-train.sh
@@ -3,9 +3,10 @@
 set -e
 
 SCRIPT_PATH=$(git rev-parse --show-prefix)  # relative to the root of the repository
-BEAKER_USERNAME=$(beaker account whoami --format=json | jq -r '.[0].name')
-WANDB_USERNAME=${WANDB_USERNAME:-${BEAKER_USERNAME}}
 REPO_ROOT=$(git rev-parse --show-toplevel)
+# NB: do NOT set WANDB_USERNAME here. The beaker run env already carries the
+# correct value; overriding it with the beaker account name misattributes the
+# wandb run to the service account.
 
 cd "$REPO_ROOT"
 
@@ -39,7 +40,6 @@ run_training() {
     --workspace "$WORKSPACE" \
     --priority "$PRIORITY" \
     "${cluster_args[@]}" \
-    --env WANDB_USERNAME="$WANDB_USERNAME" \
     --env WANDB_NAME="$job_name" \
     --env WANDB_JOB_TYPE=training \
     --env WANDB_RUN_GROUP= \

--- a/configs/baselines/aimip-like/train-4deg-daily-v2-era5-only.yaml
+++ b/configs/baselines/aimip-like/train-4deg-daily-v2-era5-only.yaml
@@ -1,0 +1,598 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 1
+  step: 5
+max_epochs: 120
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 0
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T00:00:00'
+          - '2015-01-02T00:00:00'
+          - '2015-01-03T00:00:00'
+          - '2015-01-04T00:00:00'
+          - '2015-01-05T00:00:00'
+          - '2015-01-06T00:00:00'
+          - '2015-01-07T00:00:00'
+          - '2015-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 0
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T00:00:00'
+          - '1995-01-02T00:00:00'
+          - '1995-01-03T00:00:00'
+          - '1995-01-04T00:00:00'
+          - '1995-01-05T00:00:00'
+          - '1995-01-06T00:00:00'
+          - '1995-01-07T00:00:00'
+          - '1995-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T00:00:00'
+          - '2024-06-02T00:00:00'
+          - '2024-06-03T00:00:00'
+          - '2024-06-04T00:00:00'
+          - '2024-06-05T00:00:00'
+          - '2024-06-06T00:00:00'
+          - '2024-06-07T00:00:00'
+          - '2024-06-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T00:00:00'
+          - '1994-06-02T00:00:00'
+          - '1994-06-03T00:00:00'
+          - '1994-06-04T00:00:00'
+          - '1994-06-05T00:00:00'
+          - '1994-06-06T00:00:00'
+          - '1994-06-07T00:00:00'
+          - '1994-06-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: long_46year
+    weight: 0.0
+    epochs:
+      start: 0
+      step: 5
+    n_forward_steps: 16794
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1979-01-01T00:00:00'
+          - '1979-01-02T00:00:00'
+          - '1979-01-03T00:00:00'
+          - '1979-01-04T00:00:00'
+          - '1979-01-05T00:00:00'
+          - '1979-01-06T00:00:00'
+          - '1979-01-07T00:00:00'
+          - '1979-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        target: denorm
+        variables: *inference_variables
+      time_mean_norm:
+        target: norm
+        variables: *inference_variables
+      annual:
+        variables: *inference_variables
+      power_spectrum:
+        variables: *inference_variables
+      histogram:
+        enabled: true
+  - name: long_46year_constant_co2
+    weight: 0.0
+    epochs:
+      start: 0
+      step: 5
+    n_forward_steps: 16794
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1979-01-01T00:00:00'
+          - '1979-01-02T00:00:00'
+          - '1979-01-03T00:00:00'
+          - '1979-01-04T00:00:00'
+          - '1979-01-05T00:00:00'
+          - '1979-01-06T00:00:00'
+          - '1979-01-07T00:00:00'
+          - '1979-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+      persistence_names:
+        - global_mean_co2
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        target: denorm
+        variables: *inference_variables
+      time_mean_norm:
+        target: norm
+        variables: *inference_variables
+      annual:
+        variables: *inference_variables
+      power_spectrum:
+        variables: *inference_variables
+      histogram:
+        enabled: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 4
+  prefetch_factor: 4
+  time_buffer: 8
+  time_buffer_pool_size: 32
+  dataset:
+    strict: false
+    # ERA5 production-stream stitch boundaries that fall inside the training
+    # window are placed on subset boundaries, so no sample pairs across a
+    # stream-to-stream jump (the global-mean 1-step finite difference at a
+    # stitch is a coherent, resolution-independent bias step, out of
+    # distribution as a residual target). See knowledge/era5-stitching-discontinuities.
+    concat:
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1993-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1995-01-01'
+          stop_time: '1999-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2000-01-01'
+          stop_time: '2009-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2010-01-01'
+          stop_time: '2013-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 16
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default
+          file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1994-01-01'
+            stop_time: '1994-12-31'
+        - data_path: /climate-default
+          file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '2014-01-01'
+            stop_time: '2014-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      global_mean_removal:
+        kind: shared
+        append_as_input: true


### PR DESCRIPTION
Anchors the selected 4°/daily ERA5-only residual baseline as a canonical config on `main` (`configs/baselines/aimip-like/`), instead of living only on the `experiment/2026-06-15-residual-config-sweep` branch. This is the **v2** baseline: the same selected recipe as v1 (run `j8r0z322`), with one weights-affecting change — the training data window is stitched to exclude ERA5 stream-to-stream discontinuities.

Why the stitch: ERA5 is assembled from overlapping production streams; at a stream boundary the global-mean state jumps discontinuously from one day to the next. For a residual-prediction model that jump is an out-of-distribution target. The jump is a *coherent global-mean bias step*, which daily averaging + 4° coarsening preserve (it is resolution-independent), so it must be excluded at 4°/daily too. The `train_loader` places each in-window canonical boundary (`1986-04-01`, `1993-08-01`, `2000-01-01`, `2010-01-01`) on a `concat` subset edge, so no sample pairs across a stitch while every valid daily state is kept.

Changes:
- `configs/baselines/aimip-like/train-4deg-daily-v2-era5-only.yaml` — fg16 × spectral_ratio 0.125 ("ws64"), embed_dim 512 residual recipe (identical to v1 `train-4deg-daily-v1-era5-only-fg16-sr0p125-residual.yaml` @ `f6632e8d5`) except the stitched `train_loader` concat. Validates against `main` with `fme.ace.validate_config --config_type train`.
- `configs/baselines/aimip-like/run-train.sh` — launcher with the v2 seed-0 line.

- [ ] Tests added (n/a — config + launch script only)
- [ ] If dependencies changed, "deps only" image rebuilt (n/a)