### PR TITLE
Add 2-degree (F45) ERA5 dataset support

### DIFF
--- a/scripts/data_process/Makefile
+++ b/scripts/data_process/Makefile
@@ -251,6 +251,10 @@ era5_1deg_stats_beaker_dataset:
 era5_1deg_16layer_stats_beaker_dataset:
 	./compute_stats.sh --config configs/era5-1deg-16layer-1940-2022.yaml
 
+.PHONY: era5_2deg_stats_beaker_dataset
+era5_2deg_stats_beaker_dataset:
+	./compute_stats.sh --config configs/era5-2deg-8layer-1940-2025.yaml
+
 .PHONY: compute_cm4_trial_run_atmosphere_dataset
 compute_cm4_trial_run_atmosphere_dataset:
 	python -u compute_dataset.py \

--- a/scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml
@@ -1,0 +1,114 @@
+runs:
+  2026-06-23-era5-2deg-8layer-1940-2025: ""  # no real data source, config only for computing stats
+data_output_directory: gs://vcm-ml-intermediate
+stats:
+  output_directory: gs://vcm-ml-intermediate/2026-06-23-era5-2deg-8layer-stats-1990-2019
+  beaker_dataset: 2026-06-23-era5-2deg-8layer-stats-1990-2019
+  start_date: "1990-01-01"
+  end_date: "2019-12-31"
+  data_type: ERA5
+time_coarsen:
+  chunking:
+    time: 1
+    latitude: 90
+    longitude: 180
+  sharding:
+    time: 360
+    latitude: 90
+    longitude: 180
+  factor: 4
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-23-era5-2deg-8layer-daily-1940-2025
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-23-era5-2deg-8layer-daily-stats-1990-2019
+  snapshot_names:
+    - DPT2m
+    - PRESsfc
+    - Q10
+    - Q200
+    - Q2m
+    - Q500
+    - Q850
+    - TMP10
+    - TMP200
+    - TMP2m
+    - TMP500
+    - TMP850
+    - UGRD10
+    - UGRD10m
+    - UGRD200
+    - UGRD500
+    - UGRD850
+    - VGRD10
+    - VGRD10m
+    - VGRD200
+    - VGRD500
+    - VGRD850
+    - air_temperature_0
+    - air_temperature_1
+    - air_temperature_2
+    - air_temperature_3
+    - air_temperature_4
+    - air_temperature_5
+    - air_temperature_6
+    - air_temperature_7
+    - eastward_wind_0
+    - eastward_wind_1
+    - eastward_wind_2
+    - eastward_wind_3
+    - eastward_wind_4
+    - eastward_wind_5
+    - eastward_wind_6
+    - eastward_wind_7
+    - h10
+    - h1000
+    - h200
+    - h250
+    - h300
+    - h500
+    - h700
+    - h850
+    - northward_wind_0
+    - northward_wind_1
+    - northward_wind_2
+    - northward_wind_3
+    - northward_wind_4
+    - northward_wind_5
+    - northward_wind_6
+    - northward_wind_7
+    - ocean_fraction
+    - sea_ice_fraction
+    - soil_moisture_0
+    - soil_moisture_1
+    - soil_moisture_2
+    - soil_moisture_3
+    - specific_total_water_0
+    - specific_total_water_1
+    - specific_total_water_2
+    - specific_total_water_3
+    - specific_total_water_4
+    - specific_total_water_5
+    - specific_total_water_6
+    - specific_total_water_7
+    - surface_temperature
+  window_names:
+    - DLWRFsfc
+    - DSWRFsfc
+    - DSWRFtoa
+    - LHTFLsfc
+    - PRATEsfc
+    - SHTFLsfc
+    - ULWRFsfc
+    - ULWRFtoa
+    - USWRFsfc
+    - USWRFtoa
+    - global_mean_co2
+    - tendency_of_total_water_path_due_to_advection
+    - total_frozen_precipitation_rate
+  constant_prefixes:
+    - HGTsfc
+    - ak_
+    - bk_
+    - land_fraction
+    - latitude
+    - longitude
+  input_time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
+    start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml
@@ -13,7 +13,7 @@ time_coarsen:
     latitude: 90
     longitude: 180
   sharding:
-    time: 360
+    time: 1440
     latitude: 90
     longitude: 180
   factor: 4

--- a/scripts/era5/Makefile
+++ b/scripts/era5/Makefile
@@ -9,6 +9,8 @@ OUTPUT_PATH_ONE_DEGREE=gs://vcm-ml-intermediate/2026-03-19-era5-1deg-8layer-1940
 OUTPUT_GRID_ONE_DEGREE=F90
 OUTPUT_PATH_FOUR_DEGREE=gs://vcm-ml-intermediate/2026-03-19-era5-4deg-8layer-1940-2025.zarr
 OUTPUT_GRID_FOUR_DEGREE=F22.5
+OUTPUT_PATH_TWO_DEGREE=gs://vcm-ml-intermediate/2026-06-23-era5-2deg-8layer-1940-2025.zarr
+OUTPUT_GRID_TWO_DEGREE=F45
 
 # Test run parameters
 START_TIME_TEST_RUN ?= 2025-12-30T00:00:00
@@ -56,6 +58,18 @@ era5_dataflow_four_degree:
 		DataflowRunner \
 		$(OUTPUT_PATH_FOUR_DEGREE) \
 		$(OUTPUT_GRID_FOUR_DEGREE) \
+		$(START_TIME) \
+		$(END_TIME) \
+		--check_data_validity
+
+.PHONY: era5_dataflow_two_degree
+era5_dataflow_two_degree:
+	cd pipeline && \
+		conda run --no-capture-output -n $(LOCAL_ENVIRONMENT) \
+		./run-dataflow.sh \
+		DataflowRunner \
+		$(OUTPUT_PATH_TWO_DEGREE) \
+		$(OUTPUT_GRID_TWO_DEGREE) \
 		$(START_TIME) \
 		$(END_TIME) \
 		--check_data_validity

--- a/scripts/era5/pipeline/xr-beam-pipeline.py
+++ b/scripts/era5/pipeline/xr-beam-pipeline.py
@@ -31,6 +31,7 @@ OUTPUT_PRESSURE_LEVELS_GEOPOTENTIAL = [1000, 850, 700, 500, 300, 250, 200, 100, 
 # Gaussian grid specs: name -> N (grid number; nlat=2N, nlon=4N)
 GAUSSIAN_GRID_N = {
     "F22.5": 22.5,
+    "F45": 45,
     "F90": 90,
     "F360": 360,
 }
@@ -1087,7 +1088,10 @@ def _get_parser():
         "--output_grid",
         type=str,
         default="F90",
-        help="Output grid specification: 'F90' for 1 degree, 'F360' for 0.25 degree.",
+        help=(
+            "Output grid specification: 'F22.5' for 4 degree, 'F45' for 2 degree, "
+            "'F90' for 1 degree, 'F360' for 0.25 degree."
+        ),
     )
     parser.add_argument(
         "--output_time_chunksize",


### PR DESCRIPTION
Adds support for generating a 2-degree (F45) ERA5 dataset, needed for the multi-resolution SHT latent-stepping emulator (1°↔2° prototype): both the native-2° baseline and the 2° training data. The 2° product mirrors the existing 1-degree 8-layer / daily / 1940–2025 ERA5 dataset so configs port across resolutions, and is produced the same way (conservative xESMF regrid from native 0.25°) as the 1° and 4° datasets so the native-2° baseline is comparable.

The F45 grid is 90×180 Gauss–Legendre (`leggauss(90)`), which is exactly the grid the model's SHT lands on when truncating 1°→2° (the ACE registries set `data_grid="legendre-gauss"`), so the data grid is consistent with the model's internal resolution change.

Changes:
- `scripts/era5/pipeline/xr-beam-pipeline.py`: register `F45` (N=45) in `GAUSSIAN_GRID_N`; update `--output_grid` help. Regridding (conservative xESMF) and 8-layer vertical default are unchanged.
- `scripts/era5/Makefile`: add `era5_dataflow_two_degree` (`output_grid=F45`, 1940–2025). Kept out of the `era5_dataflow` aggregate so it doesn't relaunch the already-produced 1°/4° runs.
- `scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml`: new config — chunking/sharding 90×180, factor-4 daily coarsen, stats 1990–2019, same ~70-variable set as the 1° config.
- `scripts/data_process/Makefile`: add `era5_2deg_stats_beaker_dataset`.

No Dataflow or training jobs have been launched; running the pipeline is gated on review/go-ahead.

- [ ] Tests added (none — no test infrastructure exists for the ERA5 ingest pipeline; F45 grid math verified to produce 90×180 Gauss–Legendre at 2° spacing)
- [ ] If dependencies changed, "deps only" image rebuilt (n/a — no dependency changes)