### PR TITLE
Refactor to replace `BatchedLatlonCoordinates` with `LatLonCoordinates` in downscaling

### DIFF
--- a/fme/downscaling/aggregators/main.py
+++ b/fme/downscaling/aggregators/main.py
@@ -985,7 +985,7 @@ class Aggregator:
         """
         _check_batch_dims_for_recording(outputs, coarse, 3)
         if self.include_positional_comparisons:
-            self._fine_latlon_coordinates = batch.fine.latlon_coordinates[0]
+            self._fine_latlon_coordinates = batch.fine.latlon_coordinates
         target, prediction = outputs.target, outputs.prediction
         target = filter_tensor_mapping(target, prediction.keys())
 

--- a/fme/downscaling/aggregators/test_aggregators.py
+++ b/fme/downscaling/aggregators/test_aggregators.py
@@ -5,10 +5,11 @@ import wandb
 import xarray as xr
 
 from fme.core import get_device, metrics
+from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.testing.wandb import mock_wandb
 from fme.core.typing_ import TensorMapping
-from fme.downscaling.data import BatchData, BatchedLatLonCoordinates, PairedBatchData
+from fme.downscaling.data import BatchData, PairedBatchData
 
 from .. import metrics_and_maths
 from ..models import ModelOutputs
@@ -264,16 +265,14 @@ def test_aggregator_integration(n_latent_steps, percentiles=[99.999]):
     prediction = {"x": torch.ones(*fine_shape, device=get_device())}
     target = {"x": torch.ones(*fine_shape, device=get_device())}
     coarse = {"x": torch.ones(*coarse_shape, device=get_device())}
-    fine_coordinates = BatchedLatLonCoordinates(
-        lat=torch.randn(n_batch, n_lat),
-        lon=torch.randn(n_batch, n_lon),
-        dims=["batch", "lat", "lon"],
-    ).to_device()
-    coarse_coordinates = BatchedLatLonCoordinates(
-        lat=torch.randn(n_batch, coarse_n_lat),
-        lon=torch.randn(n_batch, coarse_n_lon),
-        dims=["batch", "lat", "lon"],
-    ).to_device()
+    fine_coordinates = LatLonCoordinates(
+        lat=torch.linspace(-80.0, 80.0, n_lat),
+        lon=torch.linspace(0.0, 360.0, n_lon),
+    ).to(get_device())
+    coarse_coordinates = LatLonCoordinates(
+        lat=torch.linspace(-80.0, 80.0, coarse_n_lat),
+        lon=torch.linspace(0.0, 360.0, coarse_n_lon),
+    ).to(get_device())
     time = xr.DataArray(torch.zeros(n_batch), dims=["batch"])
     batch = PairedBatchData(
         fine=BatchData(target, time, fine_coordinates),
@@ -314,15 +313,15 @@ def test_aggregator_integration(n_latent_steps, percentiles=[99.999]):
         aggregator.get_wandb(prefix="test")
         ds_paired = aggregator.get_dataset()
         np.testing.assert_array_equal(
-            ds_paired.lat.values, batch.fine.latlon_coordinates[0].lat.cpu().numpy()
+            ds_paired.lat.values, batch.fine.latlon_coordinates.lat.cpu().numpy()
         )
         np.testing.assert_array_equal(
-            ds_paired.lon.values, batch.fine.latlon_coordinates[0].lon.cpu().numpy()
+            ds_paired.lon.values, batch.fine.latlon_coordinates.lon.cpu().numpy()
         )
 
         no_target_aggregator = NoTargetAggregator(
             downscale_factor=downscale_factor,
-            latlon_coordinates=batch.fine.latlon_coordinates[0],
+            latlon_coordinates=batch.fine.latlon_coordinates,
         )
         no_target_aggregator.record_batch(
             prediction=prediction, coarse=coarse, time=batch.fine.time
@@ -330,10 +329,10 @@ def test_aggregator_integration(n_latent_steps, percentiles=[99.999]):
         no_target_aggregator.get_wandb(prefix="test_no_target")
         ds = no_target_aggregator.get_dataset()
         np.testing.assert_array_equal(
-            ds.lat.values, batch.fine.latlon_coordinates[0].lat.cpu().numpy()
+            ds.lat.values, batch.fine.latlon_coordinates.lat.cpu().numpy()
         )
         np.testing.assert_array_equal(
-            ds.lon.values, batch.fine.latlon_coordinates[0].lon.cpu().numpy()
+            ds.lon.values, batch.fine.latlon_coordinates.lon.cpu().numpy()
         )
 
 

--- a/fme/downscaling/data/__init__.py
+++ b/fme/downscaling/data/__init__.py
@@ -15,7 +15,6 @@ from .datasets import (
 )
 from .static import StaticInput, StaticInputs, load_coords_from_path, load_static_inputs
 from .utils import (
-    BatchedLatLonCoordinates,
     ClosedInterval,
     LatLonCoordinates,
     adjust_fine_coord_range,

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -22,7 +22,6 @@ from fme.core.generics.data import SizedMap
 from fme.core.typing_ import TensorMapping
 from fme.downscaling.data.patching import Patch, get_patches
 from fme.downscaling.data.utils import (
-    BatchedLatLonCoordinates,
     ClosedInterval,
     check_leading_dim,
     expand_and_fold_tensor,
@@ -387,7 +386,7 @@ class BatchData:
 
     data: TensorMapping
     time: xr.DataArray
-    latlon_coordinates: BatchedLatLonCoordinates
+    latlon_coordinates: LatLonCoordinates
 
     def _validate(self):
         leading_dim = None
@@ -400,9 +399,16 @@ class BatchData:
             raise ValueError("Data must have at least one variable")
 
         check_leading_dim("time", self.time.shape, leading_dim)
-        check_leading_dim("lat", self.latlon_coordinates.lat.shape[:-1], leading_dim)
-        check_leading_dim("lon", self.latlon_coordinates.lon.shape[:-1], leading_dim)
-
+        if self.latlon_coordinates.lat.dim() != 1:
+            raise ValueError(
+                "Expected 1D lat coordinates, got shape "
+                f"{self.latlon_coordinates.lat.shape}"
+            )
+        if self.latlon_coordinates.lon.dim() != 1:
+            raise ValueError(
+                "Expected 1D lon coordinates, got shape "
+                f"{self.latlon_coordinates.lon.shape}"
+            )
         # TODO: temporary constraint for only 1 leading batch dimension
         if len(leading_dim) != 1:
             raise NotImplementedError("Only 1 leading batch dimension is supported")
@@ -421,12 +427,12 @@ class BatchData:
 
     @property
     def lat_interval(self) -> ClosedInterval:
-        lat = self.latlon_coordinates.lat[0]  # all batch members identical; use first
+        lat = self.latlon_coordinates.lat
         return ClosedInterval(lat.min().item(), lat.max().item())
 
     @property
     def lon_interval(self) -> ClosedInterval:
-        lon = self.latlon_coordinates.lon[0]  # all batch members identical; use first
+        lon = self.latlon_coordinates.lon
         return ClosedInterval(lon.min().item(), lon.max().item())
 
     @classmethod
@@ -435,26 +441,26 @@ class BatchData:
         items: Sequence[BatchItem],
         dim_name: str = "batch",
     ) -> Self:
-        data, times, latlon_coordinates = zip(*items)
+        data, times, coordinates = zip(*items)
 
         return cls(
             torch.utils.data.default_collate(data),
             xr.concat(times, dim_name),
-            BatchedLatLonCoordinates.from_sequence(latlon_coordinates),
+            coordinates[0],
         )
 
     def to_device(self) -> "BatchData":
         return BatchData(
             move_tensordict_to_device(self.data),
             self.time,
-            self.latlon_coordinates.to_device(),
+            self.latlon_coordinates.to(get_device()),
         )
 
     def __getitem__(self, k):
         return BatchItem(
             {key: value[k] for key, value in self.data.items()},
             self.time[k],
-            self.latlon_coordinates[k],
+            self.latlon_coordinates,
         )
 
     def __len__(self):
@@ -477,15 +483,7 @@ class BatchData:
             )
         time = self.time.expand_dims(dim={dim_name: num_samples}, axis=sample_dim)
         time = time.stack({"repeated_batch": time.dims})
-        latlon_coordinates = BatchedLatLonCoordinates(
-            lat=expand_and_fold_tensor(
-                self.latlon_coordinates.lat, num_samples, sample_dim
-            ),
-            lon=expand_and_fold_tensor(
-                self.latlon_coordinates.lon, num_samples, sample_dim
-            ),
-        )
-        return BatchData(data, time, latlon_coordinates)
+        return BatchData(data, time, self.latlon_coordinates)
 
     def latlon_slice(
         self,
@@ -496,10 +494,9 @@ class BatchData:
         # are specified as index slices rather than coordinate ranges. This is useful
         # for dividing a region into patches.
         sliced_data = {k: v[..., lat_slice, lon_slice] for k, v in self.data.items()}
-        sliced_latlon = BatchedLatLonCoordinates(
-            lat=self.latlon_coordinates.lat[..., lat_slice],
-            lon=self.latlon_coordinates.lon[..., lon_slice],
-            dims=self.latlon_coordinates.dims,
+        sliced_latlon = LatLonCoordinates(
+            lat=self.latlon_coordinates.lat[lat_slice],
+            lon=self.latlon_coordinates.lon[lon_slice],
         )
         return BatchData(
             data=sliced_data,
@@ -798,10 +795,8 @@ def patched_batch_gen_from_paired_loader(
         )
         if region_sampling is not None:
             assert fine_patches is not None  # for type checking
-            coarse_lats = batch.coarse.latlon_coordinates.lat[
-                0
-            ]  # dims are [batch, lat/lon]
-            coarse_lons = batch.coarse.latlon_coordinates.lon[0]
+            coarse_lats = batch.coarse.latlon_coordinates.lat
+            coarse_lons = batch.coarse.latlon_coordinates.lon
             indices = _sample_indices_with_region_sampling(
                 coarse_patches, coarse_lats, coarse_lons, region_sampling
             )

--- a/fme/downscaling/data/test_config.py
+++ b/fme/downscaling/data/test_config.py
@@ -417,7 +417,7 @@ def test_PairedDataLoaderConfig_prime_meridian_crossing(tmp_path):
     # test_build_aligned_subset_pair_preserves_scale_factor_across_seam.
     coarse_spacing = 360.0 / coarse_n_lon
     for grid, margin in ((batch.coarse, 0.0), (batch.fine, coarse_spacing / 2)):
-        lon = grid.latlon_coordinates.lon[0].cpu()  # batch members are identical
+        lon = grid.latlon_coordinates.lon.cpu()
         _assert_lon_in_extent_convention(lon, lon_extent, margin=margin)
         values = grid.data["var0"][0].cpu()  # (n_lat, n_lon)
         # lon broadcasts against the trailing lon dim of values

--- a/fme/downscaling/data/test_datasets.py
+++ b/fme/downscaling/data/test_datasets.py
@@ -25,7 +25,7 @@ from fme.downscaling.data.datasets import (
     patched_batch_gen_from_paired_loader,
 )
 from fme.downscaling.data.patching import Patch, _HorizontalSlice
-from fme.downscaling.data.utils import BatchedLatLonCoordinates, ClosedInterval
+from fme.downscaling.data.utils import ClosedInterval
 
 
 @pytest.mark.parametrize("drop_last", [True, False])
@@ -99,75 +99,6 @@ def get_batch_items(num_items=3, lat_dim=8, lon_dim=16):
         BatchItem(*item)
         for item in get_example_data_tuples(num_items, lat_dim, lon_dim)
     ]
-
-
-def test_batched_latlon_coordinates_from_sequence():
-    coords = get_example_latlon_coordinates()
-    items = [coords] * 3
-
-    # Test from_sequence method
-    batched = BatchedLatLonCoordinates.from_sequence(items)
-
-    # Verify shape matches shapes
-    assert batched.lat.shape == (3, 4)  # batch_size=3, n_lat=4
-    assert batched.lon.shape == (3, 5)  # batch_size=3, n_lon=5
-    assert torch.allclose(batched.lat[0], coords.lat)
-    assert torch.allclose(batched.lon[1], coords.lon)
-
-    # Test dunder methods
-    assert len(batched) == 3
-    batched2 = BatchedLatLonCoordinates.from_sequence(items)
-    assert batched == batched2
-
-    item = batched[0]
-    assert isinstance(item, LatLonCoordinates)
-    assert torch.allclose(item.lat, coords.lat)
-    assert torch.allclose(item.lon, coords.lon)
-
-
-def test_batched_latlon_shape_inconsistent():
-    coords = get_example_latlon_coordinates()
-    # inconsistent shapes in join
-    mishaped_coord = LatLonCoordinates(
-        lat=torch.tensor(
-            [
-                0.0,
-                30.0,
-            ]
-        ),
-        lon=torch.tensor([0.0, 90.0, 180.0, 270.0, 360.0]),
-    )
-    with pytest.raises(RuntimeError):
-        BatchedLatLonCoordinates.from_sequence([coords, mishaped_coord])
-
-    # inconsistent leading dimensions
-    lat = torch.randn(3, 5, 6)
-    lon = torch.randn(5, 3, 12)
-    with pytest.raises(ValueError):
-        BatchedLatLonCoordinates(lat=lat, lon=lon)
-
-    # inconsistent leading dimensions
-    lat = torch.randn(5, 6)
-    lon = torch.randn(3, 5, 12)
-    with pytest.raises(ValueError):
-        BatchedLatLonCoordinates(lat=lat, lon=lon)
-
-    # fail on single dimensional input
-    lat = torch.randn(5)
-    lon = torch.randn(3, 12)
-    with pytest.raises(ValueError):
-        BatchedLatLonCoordinates(lat=lat, lon=lon)
-
-
-def test_batched_latlon_coordinates_area_weights():
-    # Create example coordinates
-    coords = get_example_latlon_coordinates()
-    items = [coords] * 3
-
-    # Test from_sequence method
-    batched = BatchedLatLonCoordinates.from_sequence(items)
-    area_weights = batched.area_weights
-    assert area_weights.shape == (3, 4, 5)
 
 
 def test_batch_item():
@@ -320,8 +251,8 @@ def test_batch_data_from_sequence():
     assert len(batched.time) == num_items
     xr.testing.assert_equal(batched.time[0], items[0].time)
 
-    assert batched.latlon_coordinates.lat.shape == (num_items, 8)
-    assert batched.latlon_coordinates.lon.shape == (num_items, 16)
+    assert batched.latlon_coordinates.lat.shape == (8,)
+    assert batched.latlon_coordinates.lon.shape == (16,)
 
 
 def test_batch_data_get_item():
@@ -341,8 +272,8 @@ def test_batch_data_expand_and_fold():
     assert torch.equal(expanded.data["x"][9], batched.data["x"][0])
     assert expanded.time.shape == (30,)
     assert expanded.time[9].values == batched.time[0].values
-    assert expanded.latlon_coordinates.lat.shape == (30, 8)
-    assert expanded.latlon_coordinates.lon.shape == (30, 16)
+    assert expanded.latlon_coordinates.lat.shape == (8,)
+    assert expanded.latlon_coordinates.lon.shape == (16,)
 
 
 def get_mock_dataset(field_leading_dim=1):
@@ -458,11 +389,11 @@ def test_BatchData_slice_latlon():
 
     assert torch.equal(
         batch_slice.latlon_coordinates.lat,
-        batch.latlon_coordinates.lat[:, lat_slice],
+        batch.latlon_coordinates.lat[lat_slice],
     )
     assert torch.equal(
         batch_slice.latlon_coordinates.lon,
-        batch.latlon_coordinates.lon[:, lon_slice],
+        batch.latlon_coordinates.lon[lon_slice],
     )
     assert torch.equal(
         batch_slice.data["x"],
@@ -481,10 +412,7 @@ def _make_batch_data_for_patching(batch_size=2):
         )
     }
     time = xr.DataArray(list(range(batch_size)), dims=["batch"])
-    latlon_coordinates = BatchedLatLonCoordinates(
-        lat=lat.unsqueeze(0).expand(batch_size, -1).clone(),
-        lon=lon.unsqueeze(0).expand(batch_size, -1).clone(),
-    )
+    latlon_coordinates = LatLonCoordinates(lat=lat, lon=lon)
     return BatchData(data=data, time=time, latlon_coordinates=latlon_coordinates)
 
 
@@ -505,15 +433,15 @@ def test_batch_data_generate_from_patches():
     assert len(generated) == 2
 
     # Patch 0: rows 1-2, all columns
-    expected_lat = torch.tensor([[1.0, 2.0], [1.0, 2.0]])
-    expected_lon = torch.tensor([[0.0, 1.0, 2.0, 3.0], [0.0, 1.0, 2.0, 3.0]])
+    expected_lat = torch.tensor([1.0, 2.0])
+    expected_lon = torch.tensor([0.0, 1.0, 2.0, 3.0])
     assert torch.equal(generated[0].latlon_coordinates.lat, expected_lat)
     assert torch.equal(generated[0].latlon_coordinates.lon, expected_lon)
     assert torch.equal(generated[0].data["x"], batch.data["x"][:, 1:3, :])
 
     # Patch 1: rows 0-1, column 2
-    expected_lat = torch.tensor([[0.0, 1.0], [0.0, 1.0]])
-    expected_lon = torch.tensor([[2.0], [2.0]])
+    expected_lat = torch.tensor([0.0, 1.0])
+    expected_lon = torch.tensor([2.0])
     assert torch.equal(generated[1].latlon_coordinates.lat, expected_lat)
     assert torch.equal(generated[1].latlon_coordinates.lon, expected_lon)
     assert torch.equal(generated[1].data["x"], batch.data["x"][:, 0:2, 2:3])
@@ -623,10 +551,7 @@ def _make_paired_batch(
     coarse = BatchData(
         data={"x": torch.zeros(batch_size, n_lat, n_lon)},
         time=xr.DataArray(list(range(batch_size)), dims=["batch"]),
-        latlon_coordinates=BatchedLatLonCoordinates(
-            lat=lat_coarse.unsqueeze(0).expand(batch_size, -1).clone(),
-            lon=lon_coarse.unsqueeze(0).expand(batch_size, -1).clone(),
-        ),
+        latlon_coordinates=LatLonCoordinates(lat=lat_coarse, lon=lon_coarse),
     )
     n_lat_fine = n_lat * downscale_factor
     n_lon_fine = n_lon * downscale_factor
@@ -635,10 +560,7 @@ def _make_paired_batch(
     fine = BatchData(
         data={"x": torch.zeros(batch_size, n_lat_fine, n_lon_fine)},
         time=xr.DataArray(list(range(batch_size)), dims=["batch"]),
-        latlon_coordinates=BatchedLatLonCoordinates(
-            lat=lat_fine.unsqueeze(0).expand(batch_size, -1).clone(),
-            lon=lon_fine.unsqueeze(0).expand(batch_size, -1).clone(),
-        ),
+        latlon_coordinates=LatLonCoordinates(lat=lat_fine, lon=lon_fine),
     )
     return PairedBatchData(fine=fine, coarse=coarse)
 

--- a/fme/downscaling/data/test_patching.py
+++ b/fme/downscaling/data/test_patching.py
@@ -137,17 +137,17 @@ def test_paired_patches_with_random_offset_consistent(overlap):
         # that corresponds to the first patch coordinate in order to
         # determine the offset applied
         coarse_y_offset = torch.where(
-            full_coarse_coords.lat[0] == coarse_patch_coords.lat[0, 0]
+            full_coarse_coords.lat == coarse_patch_coords.lat[0]
         )[0].item()
         coarse_x_offset = torch.where(
-            full_coarse_coords.lon[0] == coarse_patch_coords.lon[0, 0]
+            full_coarse_coords.lon == coarse_patch_coords.lon[0]
         )[0].item()
-        fine_y_offset = torch.where(
-            full_fine_coords.lat[0] == fine_patch_coords.lat[0, 0]
-        )[0].item()
-        fine_x_offset = torch.where(
-            full_fine_coords.lon[0] == fine_patch_coords.lon[0, 0]
-        )[0].item()
+        fine_y_offset = torch.where(full_fine_coords.lat == fine_patch_coords.lat[0])[
+            0
+        ].item()
+        fine_x_offset = torch.where(full_fine_coords.lon == fine_patch_coords.lon[0])[
+            0
+        ].item()
 
         assert fine_y_offset == coarse_y_offset * downscale_factor
         assert fine_x_offset == coarse_x_offset * downscale_factor

--- a/fme/downscaling/data/utils.py
+++ b/fme/downscaling/data/utils.py
@@ -6,8 +6,6 @@ import torch
 
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset.properties import DatasetProperties
-from fme.core.device import get_device
-from fme.core.metrics import spherical_area_weights
 
 
 def null_generator(num: int):
@@ -375,61 +373,3 @@ def get_offset(random_offset: bool, full_size: int, patch_size: int) -> int:
 
 def scale_tuple(extent: tuple[int, int], scale_factor: int) -> tuple[int, int]:
     return (extent[0] * scale_factor, extent[1] * scale_factor)
-
-
-@dataclasses.dataclass
-class BatchedLatLonCoordinates:
-    """
-    Container for batched latitude and longitude coordinates.
-    Expects leading batch dimensions (that are the same) for
-    lat and lon coordinates.
-    """
-
-    lat: torch.Tensor
-    lon: torch.Tensor
-    dims: list[str] = dataclasses.field(default_factory=lambda: ["batch", "lat", "lon"])
-
-    def __post_init__(self):
-        self._validate()
-
-    def _validate(self):
-        if self.lat.dim() != 2 or self.lon.dim() != 2:
-            raise ValueError(
-                f"Expected 2D lat and lon coordinates, got shapes {self.lat.shape} "
-                f"and {self.lon.shape}."
-            )
-
-        if self.lat.shape[0] != self.lon.shape[0]:
-            raise ValueError(
-                f"Latitude batch dimension {self.lat.shape[0]} does not match "
-                f"longitude batch dimension {self.lon.shape[0]}"
-            )
-
-    @classmethod
-    def from_sequence(
-        cls,
-        items: Sequence[LatLonCoordinates],
-    ) -> "BatchedLatLonCoordinates":
-        lats = torch.utils.data.default_collate([i.lat for i in items])
-        lons = torch.utils.data.default_collate([i.lon for i in items])
-        return BatchedLatLonCoordinates(lats, lons)
-
-    @property
-    def area_weights(self) -> torch.Tensor:
-        return spherical_area_weights(self.lat, self.lon.shape[-1])
-
-    def to_device(self) -> "BatchedLatLonCoordinates":
-        device = get_device()
-        return BatchedLatLonCoordinates(self.lat.to(device), self.lon.to(device))
-
-    def __getitem__(self, k):
-        lats = self.lat[k]
-        lons = self.lon[k]
-
-        return LatLonCoordinates(lat=lats, lon=lons)
-
-    def __eq__(self, other):
-        return torch.equal(self.lat, other.lat) and torch.equal(self.lon, other.lon)
-
-    def __len__(self):
-        return self.lat.shape[0]

--- a/fme/downscaling/inference/test_inference.py
+++ b/fme/downscaling/inference/test_inference.py
@@ -193,12 +193,8 @@ def test_run_target_generation_skips_padding_items(
     mock_work_item.is_padding = True
     mock_work_item.batch.horizontal_shape = (16, 16)
     # Coarse coords are interior so fine can have buffer on each side.
-    mock_work_item.batch.latlon_coordinates.lat = (
-        torch.arange(1, 9).float().unsqueeze(0)
-    )
-    mock_work_item.batch.latlon_coordinates.lon = (
-        torch.arange(1, 9).float().unsqueeze(0)
-    )
+    mock_work_item.batch.latlon_coordinates.lat = torch.arange(1, 9).float()
+    mock_work_item.batch.latlon_coordinates.lon = torch.arange(1, 9).float()
     mock_work_item.batch.lat_interval = ClosedInterval(1.0, 8.0)
     mock_work_item.batch.lon_interval = ClosedInterval(1.0, 8.0)
     mock_output_target.data.get_generator.return_value = iter([mock_work_item])

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -415,8 +415,8 @@ class DiffusionModel:
     def _get_fine_interval_from_batch(
         self, batch: BatchData
     ) -> tuple[ClosedInterval, ClosedInterval]:
-        coarse_lat = batch.latlon_coordinates.lat[0]
-        coarse_lon = batch.latlon_coordinates.lon[0]
+        coarse_lat = batch.latlon_coordinates.lat
+        coarse_lon = batch.latlon_coordinates.lon
         fine_lat_interval = adjust_fine_coord_range(
             batch.lat_interval,
             full_coarse_coord=coarse_lat,

--- a/fme/downscaling/predictors/test_composite.py
+++ b/fme/downscaling/predictors/test_composite.py
@@ -3,12 +3,12 @@ import pytest
 import torch
 import xarray as xr
 
+from fme.core.coordinates import LatLonCoordinates
 from fme.core.device import get_device
 from fme.core.packer import Packer
 from fme.downscaling.aggregators.shape_helpers import upsample_tensor
 from fme.downscaling.data import BatchData, PairedBatchData
 from fme.downscaling.data.patching import get_patches
-from fme.downscaling.data.utils import BatchedLatLonCoordinates
 from fme.downscaling.models import ModelOutputs
 from fme.downscaling.predictors.composite import (
     PatchPredictor,
@@ -82,34 +82,24 @@ def get_paired_test_data(
             batch_size, coarse_lat_size, coarse_lon_size, device=get_device()
         )
     }
-    coarse_lat_coords = (
-        torch.linspace(0, 10, coarse_lat_size).unsqueeze(0).expand(batch_size, -1)
-    )
-    coarse_lon_coords = (
-        torch.linspace(0, 10, coarse_lon_size).unsqueeze(0).expand(batch_size, -1)
-    )
+    coarse_lat_coords = torch.linspace(0, 10, coarse_lat_size, device=get_device())
+    coarse_lon_coords = torch.linspace(0, 10, coarse_lon_size, device=get_device())
 
     fine_data = {
         "x": torch.rand(batch_size, fine_lat_size, fine_lon_size, device=get_device())
     }
-    fine_lat_coords = (
-        torch.linspace(0.0, 10.0, fine_lat_size).unsqueeze(0).expand(batch_size, -1)
-    )
-    fine_lon_coords = (
-        torch.linspace(0.0, 10.0, fine_lon_size).unsqueeze(0).expand(batch_size, -1)
-    )
+    fine_lat_coords = torch.linspace(0.0, 10.0, fine_lat_size, device=get_device())
+    fine_lon_coords = torch.linspace(0.0, 10.0, fine_lon_size, device=get_device())
     coarse_batch_data = BatchData(
         data=coarse_data,
-        latlon_coordinates=BatchedLatLonCoordinates(
+        latlon_coordinates=LatLonCoordinates(
             lat=coarse_lat_coords, lon=coarse_lon_coords
         ),
         time=xr.DataArray(np.arange(batch_size), dims=["time"]),
     )
     fine_batch_data = BatchData(
         data=fine_data,
-        latlon_coordinates=BatchedLatLonCoordinates(
-            lat=fine_lat_coords, lon=fine_lon_coords
-        ),
+        latlon_coordinates=LatLonCoordinates(lat=fine_lat_coords, lon=fine_lon_coords),
         time=xr.DataArray(np.arange(batch_size), dims=["time"]),
     )
     return PairedBatchData(coarse=coarse_batch_data, fine=fine_batch_data)

--- a/fme/downscaling/test_models.py
+++ b/fme/downscaling/test_models.py
@@ -10,13 +10,7 @@ from fme.core.device import get_device
 from fme.core.loss import LossConfig
 from fme.core.normalizer import NormalizationConfig
 from fme.core.optimization import OptimizationConfig
-from fme.downscaling.data import (
-    BatchData,
-    BatchedLatLonCoordinates,
-    PairedBatchData,
-    StaticInput,
-    StaticInputs,
-)
+from fme.downscaling.data import BatchData, PairedBatchData, StaticInput, StaticInputs
 from fme.downscaling.models import (
     CheckpointModelConfig,
     DiffusionModel,
@@ -91,12 +85,9 @@ def make_batch_data(
     assert lon_size == len(lon_values)
     data = {"x": torch.ones(batch_size, lat_size, lon_size, device=get_device())}
     time = xr.DataArray(range(batch_size), dims=["batch"])
-    lat = torch.tensor(lat_values, dtype=torch.float32)
-    lon = torch.tensor(lon_values, dtype=torch.float32)
-    latlon = BatchedLatLonCoordinates(
-        lat=lat.unsqueeze(0).expand(batch_size, -1),
-        lon=lon.unsqueeze(0).expand(batch_size, -1),
-    )
+    lat = torch.as_tensor(lat_values, dtype=torch.float32, device=get_device())
+    lon = torch.as_tensor(lon_values, dtype=torch.float32, device=get_device())
+    latlon = LatLonCoordinates(lat=lat, lon=lon)
     return BatchData(data=data, time=time, latlon_coordinates=latlon)
 
 


### PR DESCRIPTION
The downscaling batches currently have a `BatchedLatLonCoordinates` object as metadata although the code assumes elsewhere that all batch elements have the same lat/lon coordinates (e.g. `BatchData.lat_interval` uses the first batch element's coords only). 

This refactor removes the `BatchedLatLonCoordinates` class and replaces it with a regular `LatLonCoordinates`. This simplifies places in the code that reference `self.latlon_coordinates.lat[0],  self.latlon_coordinates.lon[0]` etc.
 