### PR TITLE
Inline +4K SST perturbation-response evaluation during training

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -12,6 +12,10 @@ from fme.ace.aggregator.inference.main import (
     LegacyFlagInferenceEvaluatorAggregatorConfig,
     StepMeanEntry,
 )
+from fme.ace.aggregator.inference.perturbation_response import (
+    LatitudeBand,
+    PerturbationResponseAggregatorConfig,
+)
 from fme.ace.aggregator.inference.reduced import MeanMetricConfig
 from fme.ace.aggregator.inference.seasonal import SeasonalMetricConfig
 from fme.ace.aggregator.inference.spectrum import PowerSpectrumMetricConfig
@@ -134,8 +138,10 @@ from .train.train_config import (
     EMAConfig,
     InlineInferenceConfig,
     InlineValidationConfig,
+    LabeledPerturbation,
     LoggingConfig,
     OptimizationConfig,
+    PerturbationResponseInferenceConfig,
     TrainConfig,
 )
 

--- a/fme/ace/aggregator/inference/enso/dynamic_index.py
+++ b/fme/ace/aggregator/inference/enso/dynamic_index.py
@@ -379,11 +379,15 @@ class EnsoIndexMetricConfig:
                 f"enso_index metric requires > ~2 years of data, "
                 f"got {total_duration.days} days"
             )
+        # Localize so the region weights match the (possibly spatially
+        # scattered) data and localized area weights; identity without spatial
+        # parallelism.
+        local_coordinates = ctx.horizontal_coordinates.localize()
         nino34_region = LatLonRegion(
             lat_bounds=NINO34_LAT,
             lon_bounds=NINO34_LON,
-            lat=ctx.horizontal_coordinates.lat,
-            lon=ctx.horizontal_coordinates.lon,
+            lat=local_coordinates.lat,
+            lon=local_coordinates.lon,
         )
         return MetricBuildResult(
             aggregator=PairedRegionalIndexAggregator(

--- a/fme/ace/aggregator/inference/ipo/ipo_index.py
+++ b/fme/ace/aggregator/inference/ipo/ipo_index.py
@@ -392,9 +392,13 @@ class IpoIndexMetricConfig:
                 f"ipo_index metric requires > ~{MIN_YEARS_FOR_FILTERED_TPI} years "
                 f"of data, got {total_duration.days} days"
             )
+        # Localize so the region weights match the (possibly spatially
+        # scattered) data and localized area weights; identity without spatial
+        # parallelism.
+        local_coordinates = ctx.horizontal_coordinates.localize()
         return MetricBuildResult(
             aggregator=PairedIPOIndexAggregator(
-                lat=ctx.horizontal_coordinates.lat,
-                lon=ctx.horizontal_coordinates.lon,
+                lat=local_coordinates.lat,
+                lon=local_coordinates.lon,
             )
         )

--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -767,11 +767,15 @@ class InferenceAggregatorConfig:
             and isinstance(gridded_operations, LatLonOperations)
             and n_timesteps * dataset_info.timestep > APPROXIMATELY_TWO_YEARS
         ):
+            # Localize so the region weights match the (possibly spatially
+            # scattered) data and localized area weights; identity without
+            # spatial parallelism.
+            local_coordinates = horizontal_coordinates.localize()
             nino34_region = LatLonRegion(
                 lat_bounds=NINO34_LAT,
                 lon_bounds=NINO34_LON,
-                lat=horizontal_coordinates.lat,
-                lon=horizontal_coordinates.lon,
+                lat=local_coordinates.lat,
+                lon=local_coordinates.lon,
             )
             aggregators["enso_index"] = RegionalIndexAggregator(
                 regional_weights=nino34_region.regional_weights,

--- a/fme/ace/aggregator/inference/perturbation_response.py
+++ b/fme/ace/aggregator/inference/perturbation_response.py
@@ -338,8 +338,9 @@ class PerturbationResponseAggregator(
         logs: dict[str, float] = {}
         baseline = means[0]
         for g in range(1, self._n_groups):
-            label = self._labels[g]
-            prefix = f"perturbation_response/{label}"
+            # Keyed by the perturbation label only; the inline-inference callback
+            # adds the task-name prefix (e.g. "perturbation_response/").
+            prefix = self._labels[g]
             response = {
                 name: (means[g][name] - baseline[name]).to(torch.float64)
                 for name in cfg.recorded_names

--- a/fme/ace/aggregator/inference/perturbation_response.py
+++ b/fme/ace/aggregator/inference/perturbation_response.py
@@ -27,6 +27,7 @@ import xarray as xr
 from fme.ace.data_loading.batch_data import PairedData, PrognosticState
 from fme.core.coordinates import HorizontalCoordinates, LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
+from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.generics.aggregator import (
     InferenceAggregatorABC,
@@ -298,7 +299,9 @@ class PerturbationResponseAggregator(
 
     def _group_time_mean(self) -> list[dict[str, torch.Tensor]]:
         dist = Distributed.get_instance()
-        counts = dist.reduce_sum(self._counts.clone())
+        # Counts must be on the compute device for the distributed reduce
+        # (e.g. NCCL all_reduce rejects CPU tensors); the group sums already are.
+        counts = dist.reduce_sum(self._counts.clone().to(get_device())).cpu()
         means: list[dict[str, torch.Tensor]] = []
         for g in range(self._n_groups):
             group_sums = self._sums[g]

--- a/fme/ace/aggregator/inference/perturbation_response.py
+++ b/fme/ace/aggregator/inference/perturbation_response.py
@@ -5,9 +5,10 @@ single rollout carries several *groups* of batch members that differ only in an
 SST perturbation: group 0 is the unperturbed baseline, groups 1.. are perturbed
 (e.g. a uniform +4 K offset). The aggregator accumulates a per-group time-mean,
 differences each perturbed group against the baseline to form a warming
-*response* field, and logs the structural diagnostics the land-amplification
-goal is judged on:
+*response* field, and logs:
 
+- a 2D response map (perturbed minus baseline time-mean) for **every** predicted
+  field -- the headline diagnostic for inspecting where the model warms;
 - near-surface land/ocean warming ratio, area-weighted, by latitude band;
 - free-troposphere/surface warming ratio over tropical ocean;
 - the global-mean column warming profile, level by level.
@@ -26,6 +27,7 @@ import xarray as xr
 
 from fme.ace.data_loading.batch_data import PairedData, PrognosticState
 from fme.core.coordinates import HorizontalCoordinates, LatLonCoordinates
+from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
@@ -35,6 +37,9 @@ from fme.core.generics.aggregator import (
     InferenceSummary,
 )
 from fme.core.gridded_ops import GriddedOperations
+from fme.core.wandb import Image
+
+from ..plotting import plot_paneled_data
 
 
 @dataclasses.dataclass
@@ -93,6 +98,9 @@ class PerturbationResponseAggregatorConfig:
         ocean_fraction_name: Forcing variable giving the ocean fraction.
         ocean_fraction_cutoff: Cells with ocean fraction strictly greater than
             this are ocean; the rest are land.
+        response_map_variables: Predicted variables to log a 2D response map
+            (perturbed minus baseline time-mean) for. If ``None``, a map is
+            logged for every predicted field.
     """
 
     near_surface_temperature_name: str = "air_temperature_7"
@@ -107,6 +115,7 @@ class PerturbationResponseAggregatorConfig:
     tropical_lat_max: float = 15.0
     ocean_fraction_name: str = "ocean_fraction"
     ocean_fraction_cutoff: float = 0.5
+    response_map_variables: list[str] | None = None
 
     def __post_init__(self):
         n = len(self.column_temperature_names)
@@ -125,8 +134,13 @@ class PerturbationResponseAggregatorConfig:
             )
 
     @property
-    def recorded_names(self) -> list[str]:
-        """Variables whose per-group time-mean must be accumulated."""
+    def scalar_diagnostic_names(self) -> list[str]:
+        """Variables required by the scalar (ratio/profile) diagnostics.
+
+        These must be present among the predicted fields. The per-group
+        time-mean is accumulated for *all* predicted fields (so response maps
+        can be drawn for each); this is the subset the scalar diagnostics index.
+        """
         names = list(self.column_temperature_names)
         if self.near_surface_temperature_name not in names:
             names.append(self.near_surface_temperature_name)
@@ -146,6 +160,7 @@ class PerturbationResponseAggregatorConfig:
             config=self,
             perturbation_labels=perturbation_labels,
             group_onehot=group_onehot,
+            variable_metadata=dataset_info.variable_metadata,
             output_dir=output_dir,
             save_diagnostics=save_diagnostics,
         )
@@ -187,6 +202,7 @@ class PerturbationResponseAggregator(
         config: PerturbationResponseAggregatorConfig,
         perturbation_labels: Sequence[str],
         group_onehot: torch.Tensor,
+        variable_metadata: Mapping[str, VariableMetadata] | None = None,
         output_dir: str | None = None,
         save_diagnostics: bool = False,
     ):
@@ -200,6 +216,8 @@ class PerturbationResponseAggregator(
             group_onehot: [n_members, n_groups] one-hot mapping each local batch
                 member to its group. Group 0 is the baseline. The member order
                 must match the order of the batch dimension in recorded data.
+            variable_metadata: Optional per-variable metadata for response-map
+                captions (long name and units).
             output_dir: Directory for diagnostics netCDF; required if
                 ``save_diagnostics``.
             save_diagnostics: Whether to write the response fields to netCDF.
@@ -213,6 +231,7 @@ class PerturbationResponseAggregator(
             raise ValueError("output_dir must be set to save diagnostics.")
         self._ops = ops
         self._config = config
+        self._variable_metadata = variable_metadata or {}
         self._group_index = _validate_one_hot(group_onehot)
         self._n_groups = group_onehot.shape[1]
         if len(perturbation_labels) != self._n_groups - 1:
@@ -231,6 +250,11 @@ class PerturbationResponseAggregator(
         lats, _ = horizontal_coordinates.localize().meshgrid
         self._abs_lat = torch.abs(lats)  # [local_lat, local_lon]
 
+        # Names of all predicted fields, captured from the first recorded batch.
+        # The per-group time-mean is accumulated for every one of them so a
+        # response map can be drawn for each.
+        self._field_names: list[str] | None = None
+
         # Per-group running spatial sums (summed over members and time) and the
         # per-group count of (member, timestep) samples. Reduced across ranks at
         # summary time, so groups split unevenly across data-parallel ranks are
@@ -239,12 +263,29 @@ class PerturbationResponseAggregator(
         self._counts = torch.zeros(self._n_groups, dtype=torch.float64)
         self._ocean_fraction: torch.Tensor | None = None
 
+    def _initialize_field_names(self, prediction: Mapping[str, torch.Tensor]) -> None:
+        self._field_names = sorted(prediction.keys())
+        missing = [
+            name
+            for name in self._config.scalar_diagnostic_names
+            if name not in self._field_names
+        ]
+        if missing:
+            raise KeyError(
+                "perturbation-response scalar diagnostics require predicted "
+                f"variables {missing} which are not among the predicted fields "
+                f"{self._field_names}."
+            )
+
     @torch.no_grad()
     def record_batch(self, data: PairedData) -> InferenceLogs:
         prediction = data.prediction
         if len(prediction) == 0:
             raise ValueError("data is empty")
-        example = prediction[self._config.recorded_names[0]]
+        if self._field_names is None:
+            self._initialize_field_names(prediction)
+        assert self._field_names is not None
+        example = prediction[self._field_names[0]]
         n_members = example.shape[0]
         if n_members != self._group_index.shape[0]:
             raise ValueError(
@@ -266,7 +307,7 @@ class PerturbationResponseAggregator(
             if group_sums is None:
                 group_sums = {}
                 self._sums[g] = group_sums
-            for name in self._config.recorded_names:
+            for name in self._field_names:
                 # [n_members, n_time, lat, lon] -> [lat, lon], summed over the
                 # group's members and all timesteps in this window.
                 contribution = prediction[name][member_mask].sum(dim=1).sum(dim=0)
@@ -298,6 +339,8 @@ class PerturbationResponseAggregator(
         return []
 
     def _group_time_mean(self) -> list[dict[str, torch.Tensor]]:
+        if self._field_names is None:
+            raise ValueError("no data has been recorded yet.")
         dist = Distributed.get_instance()
         # Counts must be on the compute device for the distributed reduce
         # (e.g. NCCL all_reduce rejects CPU tensors); the group sums already are.
@@ -309,11 +352,29 @@ class PerturbationResponseAggregator(
             if group_sums is None or count == 0:
                 raise ValueError(f"no data recorded for group {self._labels[g]!r}.")
             group_mean = {}
-            for name in self._config.recorded_names:
+            for name in self._field_names:
                 total = dist.reduce_sum(group_sums[name].clone())
                 group_mean[name] = total / count
             means.append(group_mean)
         return means
+
+    def _response_map_names(self) -> list[str]:
+        assert self._field_names is not None
+        if self._config.response_map_variables is None:
+            return self._field_names
+        return [n for n in self._config.response_map_variables if n in self._field_names]
+
+    def _map_caption(self, label: str, name: str) -> str:
+        meta = self._variable_metadata.get(name)
+        if meta is not None:
+            long_name = meta.display_long_name(name)
+            units = meta.display_units("unknown units")
+        else:
+            long_name, units = name, "unknown units"
+        return (
+            f"{long_name} {label} response (perturbed - baseline time-mean) "
+            f"[{units}]"
+        )
 
     def _regional_mean(self, field: torch.Tensor, weights: torch.Tensor) -> float:
         value = self._ops.regional_area_weighted_mean(
@@ -333,6 +394,7 @@ class PerturbationResponseAggregator(
     def get_summary(self) -> InferenceSummary:
         means = self._group_time_mean()
         assert self._ocean_fraction is not None
+        assert self._field_names is not None
         ocean_fraction = self._ocean_fraction
         device = ocean_fraction.device
         abs_lat = self._abs_lat.to(device)
@@ -341,7 +403,7 @@ class PerturbationResponseAggregator(
         ocean_mask = (ocean_fraction > cfg.ocean_fraction_cutoff).to(torch.float64)
         land_mask = 1.0 - ocean_mask
 
-        logs: dict[str, float] = {}
+        logs: dict[str, float | Image] = {}
         baseline = means[0]
         for g in range(1, self._n_groups):
             # Keyed by the perturbation label only; the inline-inference callback
@@ -349,8 +411,16 @@ class PerturbationResponseAggregator(
             prefix = self._labels[g]
             response = {
                 name: (means[g][name] - baseline[name]).to(torch.float64)
-                for name in cfg.recorded_names
+                for name in self._field_names
             }
+
+            # 2D response map (perturbed - baseline time-mean) for each field.
+            for name in self._response_map_names():
+                logs[f"{prefix}/response_map/{name}"] = plot_paneled_data(
+                    [[response[name].cpu().numpy()]],
+                    diverging=True,
+                    caption=self._map_caption(prefix, name),
+                )
 
             # Near-surface land/ocean warming ratio by latitude band.
             near = response[cfg.near_surface_temperature_name]
@@ -393,6 +463,7 @@ class PerturbationResponseAggregator(
         if not self._save_diagnostics:
             return
         assert self._output_dir is not None
+        assert self._field_names is not None
         # _group_time_mean is a collective (all-reduce) and must run on every
         # rank; only the root rank then writes the (rank-identical) result, to
         # avoid a multi-writer race on the shared path.
@@ -403,7 +474,7 @@ class PerturbationResponseAggregator(
         data_vars = {}
         for g in range(1, self._n_groups):
             label = self._labels[g]
-            for name in self._config.recorded_names:
+            for name in self._field_names:
                 response = (means[g][name] - baseline[name]).cpu().numpy()
                 data_vars[f"{label}__{name}"] = (("lat", "lon"), response)
         dataset = xr.Dataset(data_vars)

--- a/fme/ace/aggregator/inference/perturbation_response.py
+++ b/fme/ace/aggregator/inference/perturbation_response.py
@@ -223,8 +223,12 @@ class PerturbationResponseAggregator(
         self._output_dir = output_dir
         self._save_diagnostics = save_diagnostics
 
-        lats, _ = horizontal_coordinates.meshgrid
-        self._abs_lat = torch.abs(lats)  # [n_lat, n_lon]
+        # Localize the latitude grid to this rank's spatial chunk so the band
+        # and land/ocean masks line up with the (possibly spatially scattered)
+        # recorded data and the localized area weights. Identity when there is
+        # no spatial (model) parallelism.
+        lats, _ = horizontal_coordinates.localize().meshgrid
+        self._abs_lat = torch.abs(lats)  # [local_lat, local_lon]
 
         # Per-group running spatial sums (summed over members and time) and the
         # per-group count of (member, timestep) samples. Reduced across ranks at

--- a/fme/ace/aggregator/inference/perturbation_response.py
+++ b/fme/ace/aggregator/inference/perturbation_response.py
@@ -136,7 +136,6 @@ class PerturbationResponseAggregatorConfig:
         dataset_info: DatasetInfo,
         perturbation_labels: Sequence[str],
         group_onehot: torch.Tensor,
-        n_timesteps: int,
         output_dir: str | None = None,
         save_diagnostics: bool = False,
     ) -> "PerturbationResponseAggregator":
@@ -387,7 +386,12 @@ class PerturbationResponseAggregator(
         if not self._save_diagnostics:
             return
         assert self._output_dir is not None
+        # _group_time_mean is a collective (all-reduce) and must run on every
+        # rank; only the root rank then writes the (rank-identical) result, to
+        # avoid a multi-writer race on the shared path.
         means = self._group_time_mean()
+        if not Distributed.get_instance().is_root():
+            return
         baseline = means[0]
         data_vars = {}
         for g in range(1, self._n_groups):

--- a/fme/ace/aggregator/inference/perturbation_response.py
+++ b/fme/ace/aggregator/inference/perturbation_response.py
@@ -1,0 +1,404 @@
+"""Inference aggregator for SST-perturbation warming-response diagnostics.
+
+This aggregator is used by the perturbation-response inline-inference type. A
+single rollout carries several *groups* of batch members that differ only in an
+SST perturbation: group 0 is the unperturbed baseline, groups 1.. are perturbed
+(e.g. a uniform +4 K offset). The aggregator accumulates a per-group time-mean,
+differences each perturbed group against the baseline to form a warming
+*response* field, and logs the structural diagnostics the land-amplification
+goal is judged on:
+
+- near-surface land/ocean warming ratio, area-weighted, by latitude band;
+- free-troposphere/surface warming ratio over tropical ocean;
+- the global-mean column warming profile, level by level.
+
+No external (e.g. c96-SHiELD) reference is involved: the diagnostics are
+computed entirely from the model's own baseline and perturbed climates.
+"""
+
+import dataclasses
+import logging
+import os
+from collections.abc import Mapping, Sequence
+
+import torch
+import xarray as xr
+
+from fme.ace.data_loading.batch_data import PairedData, PrognosticState
+from fme.core.coordinates import HorizontalCoordinates, LatLonCoordinates
+from fme.core.dataset_info import DatasetInfo
+from fme.core.distributed import Distributed
+from fme.core.generics.aggregator import (
+    InferenceAggregatorABC,
+    InferenceLogs,
+    InferenceSummary,
+)
+from fme.core.gridded_ops import GriddedOperations
+
+
+@dataclasses.dataclass
+class LatitudeBand:
+    """An absolute-latitude band (hemispherically folded).
+
+    Parameters:
+        name: Label used in log keys.
+        lat_min: Minimum absolute latitude in degrees (inclusive).
+        lat_max: Maximum absolute latitude in degrees (exclusive).
+    """
+
+    name: str
+    lat_min: float
+    lat_max: float
+
+    def __post_init__(self):
+        if not 0.0 <= self.lat_min < self.lat_max <= 90.0:
+            raise ValueError(
+                "LatitudeBand requires 0 <= lat_min < lat_max <= 90, got "
+                f"lat_min={self.lat_min}, lat_max={self.lat_max}."
+            )
+
+
+def _default_bands() -> list[LatitudeBand]:
+    # Matches the land-amplification diagnosis report's bands (folded).
+    return [
+        LatitudeBand("tropics", 0.0, 15.0),
+        LatitudeBand("subtropics", 15.0, 30.0),
+        LatitudeBand("midlatitudes", 30.0, 50.0),
+    ]
+
+
+def _default_column_temperature_names() -> list[str]:
+    # Hybrid-sigma model levels, top (0) to surface (7), for the 8-level configs.
+    return [f"air_temperature_{i}" for i in range(8)]
+
+
+@dataclasses.dataclass
+class PerturbationResponseAggregatorConfig:
+    """Configuration for the perturbation-response aggregator.
+
+    Parameters:
+        near_surface_temperature_name: Variable whose land/ocean warming ratio
+            is reported by latitude band.
+        column_temperature_names: Vertical temperature variables, ordered from
+            model top to surface, used for the vertical warming ratio and the
+            global-mean column profile.
+        vertical_surface_index: Index into ``column_temperature_names`` for the
+            surface level of the free-troposphere/surface ratio.
+        vertical_upper_index: Index into ``column_temperature_names`` for the
+            free-tropospheric level (e.g. ~200 hPa).
+        latitude_bands: Absolute-latitude bands for the land/ocean ratio.
+        tropical_lat_max: Absolute-latitude bound for the tropical-ocean region
+            used by the vertical warming ratio.
+        ocean_fraction_name: Forcing variable giving the ocean fraction.
+        ocean_fraction_cutoff: Cells with ocean fraction strictly greater than
+            this are ocean; the rest are land.
+    """
+
+    near_surface_temperature_name: str = "air_temperature_7"
+    column_temperature_names: list[str] = dataclasses.field(
+        default_factory=_default_column_temperature_names
+    )
+    vertical_surface_index: int = 7
+    vertical_upper_index: int = 2
+    latitude_bands: list[LatitudeBand] = dataclasses.field(
+        default_factory=_default_bands
+    )
+    tropical_lat_max: float = 15.0
+    ocean_fraction_name: str = "ocean_fraction"
+    ocean_fraction_cutoff: float = 0.5
+
+    def __post_init__(self):
+        n = len(self.column_temperature_names)
+        for label, index in (
+            ("vertical_surface_index", self.vertical_surface_index),
+            ("vertical_upper_index", self.vertical_upper_index),
+        ):
+            if not 0 <= index < n:
+                raise ValueError(
+                    f"{label}={index} is out of range for "
+                    f"{n} column_temperature_names."
+                )
+        if not 0.0 < self.tropical_lat_max <= 90.0:
+            raise ValueError(
+                f"tropical_lat_max must be in (0, 90], got {self.tropical_lat_max}."
+            )
+
+    @property
+    def recorded_names(self) -> list[str]:
+        """Variables whose per-group time-mean must be accumulated."""
+        names = list(self.column_temperature_names)
+        if self.near_surface_temperature_name not in names:
+            names.append(self.near_surface_temperature_name)
+        return names
+
+    def build(
+        self,
+        dataset_info: DatasetInfo,
+        perturbation_labels: Sequence[str],
+        group_onehot: torch.Tensor,
+        n_timesteps: int,
+        output_dir: str | None = None,
+        save_diagnostics: bool = False,
+    ) -> "PerturbationResponseAggregator":
+        return PerturbationResponseAggregator(
+            ops=dataset_info.gridded_operations,
+            horizontal_coordinates=dataset_info.horizontal_coordinates,
+            config=self,
+            perturbation_labels=perturbation_labels,
+            group_onehot=group_onehot,
+            output_dir=output_dir,
+            save_diagnostics=save_diagnostics,
+        )
+
+
+def _validate_one_hot(group_onehot: torch.Tensor) -> torch.Tensor:
+    """Validate a [n_members, n_groups] one-hot encoding and return group indices.
+
+    Group 0 is the baseline; groups 1.. are perturbations. More than two groups
+    (i.e. more than one perturbation) is not yet supported.
+    """
+    if group_onehot.ndim != 2:
+        raise ValueError(
+            "group_onehot must be a [n_members, n_groups] tensor, got shape "
+            f"{tuple(group_onehot.shape)}."
+        )
+    n_groups = group_onehot.shape[1]
+    if n_groups > 2:
+        raise NotImplementedError(
+            "perturbation-response evaluation currently supports a single "
+            "perturbation (two groups: baseline + perturbed); got "
+            f"{n_groups} groups."
+        )
+    row_sums = group_onehot.sum(dim=1)
+    if not torch.all((group_onehot == 0) | (group_onehot == 1)) or not torch.all(
+        row_sums == 1
+    ):
+        raise ValueError("group_onehot rows must each be one-hot (exactly one 1).")
+    return group_onehot.argmax(dim=1)
+
+
+class PerturbationResponseAggregator(
+    InferenceAggregatorABC[PrognosticState, PairedData]
+):
+    def __init__(
+        self,
+        ops: GriddedOperations,
+        horizontal_coordinates: HorizontalCoordinates,
+        config: PerturbationResponseAggregatorConfig,
+        perturbation_labels: Sequence[str],
+        group_onehot: torch.Tensor,
+        output_dir: str | None = None,
+        save_diagnostics: bool = False,
+    ):
+        """
+        Parameters:
+            ops: Gridded operations for area-weighted means.
+            horizontal_coordinates: Provides the latitude grid for band masks.
+            config: Aggregator configuration.
+            perturbation_labels: Labels for the perturbed groups (groups 1..);
+                length must be ``n_groups - 1``.
+            group_onehot: [n_members, n_groups] one-hot mapping each local batch
+                member to its group. Group 0 is the baseline. The member order
+                must match the order of the batch dimension in recorded data.
+            output_dir: Directory for diagnostics netCDF; required if
+                ``save_diagnostics``.
+            save_diagnostics: Whether to write the response fields to netCDF.
+        """
+        if not isinstance(horizontal_coordinates, LatLonCoordinates):
+            raise NotImplementedError(
+                "PerturbationResponseAggregator currently supports only "
+                "lat/lon coordinates."
+            )
+        if save_diagnostics and output_dir is None:
+            raise ValueError("output_dir must be set to save diagnostics.")
+        self._ops = ops
+        self._config = config
+        self._group_index = _validate_one_hot(group_onehot)
+        self._n_groups = group_onehot.shape[1]
+        if len(perturbation_labels) != self._n_groups - 1:
+            raise ValueError(
+                f"expected {self._n_groups - 1} perturbation label(s) for "
+                f"{self._n_groups} groups, got {len(perturbation_labels)}."
+            )
+        self._labels = ["baseline", *perturbation_labels]
+        self._output_dir = output_dir
+        self._save_diagnostics = save_diagnostics
+
+        lats, _ = horizontal_coordinates.meshgrid
+        self._abs_lat = torch.abs(lats)  # [n_lat, n_lon]
+
+        # Per-group running spatial sums (summed over members and time) and the
+        # per-group count of (member, timestep) samples. Reduced across ranks at
+        # summary time, so groups split unevenly across data-parallel ranks are
+        # handled correctly.
+        self._sums: list[dict[str, torch.Tensor] | None] = [None] * self._n_groups
+        self._counts = torch.zeros(self._n_groups, dtype=torch.float64)
+        self._ocean_fraction: torch.Tensor | None = None
+
+    @torch.no_grad()
+    def record_batch(self, data: PairedData) -> InferenceLogs:
+        prediction = data.prediction
+        if len(prediction) == 0:
+            raise ValueError("data is empty")
+        example = prediction[self._config.recorded_names[0]]
+        n_members = example.shape[0]
+        if n_members != self._group_index.shape[0]:
+            raise ValueError(
+                f"recorded batch has {n_members} members but group encoding has "
+                f"{self._group_index.shape[0]}."
+            )
+        n_time = example.shape[1]
+
+        if self._ocean_fraction is None:
+            self._ocean_fraction = self._extract_ocean_fraction(data)
+
+        group_index = self._group_index.to(example.device)
+        for g in range(self._n_groups):
+            member_mask = group_index == g
+            n_in_group = int(member_mask.sum().item())
+            if n_in_group == 0:
+                continue
+            group_sums = self._sums[g]
+            if group_sums is None:
+                group_sums = {}
+                self._sums[g] = group_sums
+            for name in self._config.recorded_names:
+                # [n_members, n_time, lat, lon] -> [lat, lon], summed over the
+                # group's members and all timesteps in this window.
+                contribution = prediction[name][member_mask].sum(dim=1).sum(dim=0)
+                if name in group_sums:
+                    group_sums[name] = group_sums[name] + contribution
+                else:
+                    group_sums[name] = contribution
+            self._counts[g] += n_in_group * n_time
+        return []
+
+    def _extract_ocean_fraction(self, data: PairedData) -> torch.Tensor:
+        name = self._config.ocean_fraction_name
+        source: Mapping[str, torch.Tensor]
+        if name in data.reference:
+            source = data.reference
+        elif name in data.prediction:
+            source = data.prediction
+        else:
+            raise KeyError(
+                f"ocean fraction variable {name!r} not found in recorded data; "
+                "set ocean_fraction_name to a variable present in the forcing."
+            )
+        # Geography is identical across members and time; take the first.
+        return source[name][0, 0]
+
+    def record_initial_condition(
+        self, initial_condition: PrognosticState
+    ) -> InferenceLogs:
+        return []
+
+    def _group_time_mean(self) -> list[dict[str, torch.Tensor]]:
+        dist = Distributed.get_instance()
+        counts = dist.reduce_sum(self._counts.clone())
+        means: list[dict[str, torch.Tensor]] = []
+        for g in range(self._n_groups):
+            group_sums = self._sums[g]
+            count = float(counts[g].item())
+            if group_sums is None or count == 0:
+                raise ValueError(f"no data recorded for group {self._labels[g]!r}.")
+            group_mean = {}
+            for name in self._config.recorded_names:
+                total = dist.reduce_sum(group_sums[name].clone())
+                group_mean[name] = total / count
+            means.append(group_mean)
+        return means
+
+    def _regional_mean(self, field: torch.Tensor, weights: torch.Tensor) -> float:
+        value = self._ops.regional_area_weighted_mean(
+            field, regional_weights=weights.to(field.device)
+        )
+        return float(value.item())
+
+    @staticmethod
+    def _ratio(numerator: float, denominator: float) -> float:
+        # The warming ratio is ill-defined when the baseline-relative ocean
+        # warming is ~zero (e.g. a checkpoint with no response yet). Return NaN
+        # rather than crash the inline eval.
+        if abs(denominator) < 1e-12:
+            return float("nan")
+        return numerator / denominator
+
+    def get_summary(self) -> InferenceSummary:
+        means = self._group_time_mean()
+        assert self._ocean_fraction is not None
+        ocean_fraction = self._ocean_fraction
+        device = ocean_fraction.device
+        abs_lat = self._abs_lat.to(device)
+        cfg = self._config
+
+        ocean_mask = (ocean_fraction > cfg.ocean_fraction_cutoff).to(torch.float64)
+        land_mask = 1.0 - ocean_mask
+
+        logs: dict[str, float] = {}
+        baseline = means[0]
+        for g in range(1, self._n_groups):
+            label = self._labels[g]
+            prefix = f"perturbation_response/{label}"
+            response = {
+                name: (means[g][name] - baseline[name]).to(torch.float64)
+                for name in cfg.recorded_names
+            }
+
+            # Near-surface land/ocean warming ratio by latitude band.
+            near = response[cfg.near_surface_temperature_name]
+            for band in cfg.latitude_bands:
+                band_mask = ((abs_lat >= band.lat_min) & (abs_lat < band.lat_max)).to(
+                    torch.float64
+                )
+                land_warming = self._regional_mean(near, land_mask * band_mask)
+                ocean_warming = self._regional_mean(near, ocean_mask * band_mask)
+                logs[f"{prefix}/land_warming/{band.name}"] = land_warming
+                logs[f"{prefix}/ocean_warming/{band.name}"] = ocean_warming
+                logs[f"{prefix}/land_ocean_warming_ratio/{band.name}"] = self._ratio(
+                    land_warming, ocean_warming
+                )
+
+            # Free-troposphere/surface warming ratio over tropical ocean.
+            tropical_ocean = ocean_mask * (abs_lat < cfg.tropical_lat_max).to(
+                torch.float64
+            )
+            surf_name = cfg.column_temperature_names[cfg.vertical_surface_index]
+            upper_name = cfg.column_temperature_names[cfg.vertical_upper_index]
+            surf_warming = self._regional_mean(response[surf_name], tropical_ocean)
+            upper_warming = self._regional_mean(response[upper_name], tropical_ocean)
+            logs[f"{prefix}/tropical_ocean_surface_warming"] = surf_warming
+            logs[f"{prefix}/tropical_ocean_upper_warming"] = upper_warming
+            logs[f"{prefix}/vertical_warming_ratio_tropical_ocean"] = self._ratio(
+                upper_warming, surf_warming
+            )
+
+            # Global-mean column warming profile, level by level.
+            for name in cfg.column_temperature_names:
+                global_warming = float(
+                    self._ops.area_weighted_mean(response[name]).item()
+                )
+                logs[f"{prefix}/column_warming/{name}"] = global_warming
+
+        return InferenceSummary(logs=logs, loss=None)
+
+    def flush_diagnostics(self, subdir: str | None) -> None:
+        if not self._save_diagnostics:
+            return
+        assert self._output_dir is not None
+        means = self._group_time_mean()
+        baseline = means[0]
+        data_vars = {}
+        for g in range(1, self._n_groups):
+            label = self._labels[g]
+            for name in self._config.recorded_names:
+                response = (means[g][name] - baseline[name]).cpu().numpy()
+                data_vars[f"{label}__{name}"] = (("lat", "lon"), response)
+        dataset = xr.Dataset(data_vars)
+        directory = self._output_dir
+        if subdir is not None:
+            directory = os.path.join(directory, subdir)
+        os.makedirs(directory, exist_ok=True)
+        path = os.path.join(directory, "perturbation_response_diagnostics.nc")
+        logging.info(f"Writing perturbation-response diagnostics to {path}")
+        dataset.to_netcdf(path)

--- a/fme/ace/aggregator/inference/test_perturbation_response.py
+++ b/fme/ace/aggregator/inference/test_perturbation_response.py
@@ -100,7 +100,7 @@ def test_response_diagnostics_recover_known_structure():
 
     assert summary.loss is None
 
-    p = "perturbation_response/p4K"
+    p = "p4K"
     # Land warms 2 K, ocean 1 K -> ratio 2 in every band.
     for band in ("tropics", "subtropics", "midlatitudes"):
         assert logs[f"{p}/land_warming/{band}"] == pytest.approx(2.0)
@@ -129,9 +129,9 @@ def test_zero_response_gives_zero_warming_and_nan_ratio():
     agg = _build_aggregator(group_onehot)
     agg.record_batch(data)
     logs = agg.get_summary().logs
-    assert logs["perturbation_response/p4K/land_warming/tropics"] == pytest.approx(0.0)
-    assert logs["perturbation_response/p4K/ocean_warming/tropics"] == pytest.approx(0.0)
-    assert np.isnan(logs["perturbation_response/p4K/land_ocean_warming_ratio/tropics"])
+    assert logs["p4K/land_warming/tropics"] == pytest.approx(0.0)
+    assert logs["p4K/ocean_warming/tropics"] == pytest.approx(0.0)
+    assert np.isnan(logs["p4K/land_ocean_warming_ratio/tropics"])
 
 
 def test_accumulates_across_windows():
@@ -142,9 +142,7 @@ def test_accumulates_across_windows():
     agg.record_batch(_paired_data(group_onehot))
     agg.record_batch(_paired_data(group_onehot))
     logs = agg.get_summary().logs
-    assert logs[
-        "perturbation_response/p4K/land_ocean_warming_ratio/tropics"
-    ] == pytest.approx(2.0)
+    assert logs["p4K/land_ocean_warming_ratio/tropics"] == pytest.approx(2.0)
 
 
 def test_more_than_one_perturbation_not_implemented():

--- a/fme/ace/aggregator/inference/test_perturbation_response.py
+++ b/fme/ace/aggregator/inference/test_perturbation_response.py
@@ -1,0 +1,201 @@
+import numpy as np
+import pytest
+import torch
+
+from fme.ace.aggregator.inference.data import make_dummy_time
+from fme.ace.aggregator.inference.perturbation_response import (
+    LatitudeBand,
+    PerturbationResponseAggregator,
+    PerturbationResponseAggregatorConfig,
+    _validate_one_hot,
+)
+from fme.ace.data_loading.batch_data import PairedData
+from fme.core.coordinates import LatLonCoordinates
+from fme.core.device import get_device
+from fme.core.gridded_ops import LatLonOperations
+
+N_LAT = 4
+N_LON = 4
+N_TIME = 3
+
+
+def _coords() -> LatLonCoordinates:
+    # One latitude per band: 5N (tropics), 20N (subtropics), 40N (midlat),
+    # 70N (outside all bands).
+    lat = torch.tensor([5.0, 20.0, 40.0, 70.0], device=get_device())
+    lon = torch.tensor([0.0, 90.0, 180.0, 270.0], device=get_device())
+    return LatLonCoordinates(lon=lon, lat=lat)
+
+
+def _ocean_fraction() -> torch.Tensor:
+    # Columns 0,1 ocean; columns 2,3 land.
+    of = torch.zeros(N_LAT, N_LON, device=get_device())
+    of[:, 0:2] = 1.0
+    return of
+
+
+def _response_fields() -> dict[str, torch.Tensor]:
+    """Near-surface warming 2 K over land, 1 K over ocean; ~200 hPa warming 2.3 K."""
+    land_ocean = torch.full((N_LAT, N_LON), 2.0, device=get_device())
+    land_ocean[:, 0:2] = 1.0  # ocean columns warm by 1 K
+    fields = {}
+    for i in range(8):
+        if i == 7:
+            fields[f"air_temperature_{i}"] = land_ocean
+        elif i == 2:
+            fields[f"air_temperature_{i}"] = torch.full(
+                (N_LAT, N_LON), 2.3, device=get_device()
+            )
+        else:
+            fields[f"air_temperature_{i}"] = torch.full(
+                (N_LAT, N_LON), 1.5, device=get_device()
+            )
+    return fields
+
+
+def _paired_data(group_onehot: torch.Tensor) -> PairedData:
+    """Baseline members are zero; perturbed members hold the response fields."""
+    group_index = group_onehot.argmax(dim=1)
+    n_members = group_onehot.shape[0]
+    responses = _response_fields()
+    prediction = {}
+    for name, response in responses.items():
+        tensor = torch.zeros(n_members, N_TIME, N_LAT, N_LON, device=get_device())
+        for m in range(n_members):
+            if group_index[m] == 1:
+                tensor[m] = response.unsqueeze(0)  # constant over time
+        prediction[name] = tensor
+    ocean_fraction = (
+        _ocean_fraction().unsqueeze(0).unsqueeze(0).expand(n_members, N_TIME, -1, -1)
+    )
+    reference = {"ocean_fraction": ocean_fraction}
+    return PairedData(
+        prediction=prediction,
+        reference=reference,
+        time=make_dummy_time(n_members, N_TIME),
+    )
+
+
+def _build_aggregator(
+    group_onehot: torch.Tensor,
+    perturbation_labels=("p4K",),
+    config: PerturbationResponseAggregatorConfig | None = None,
+) -> PerturbationResponseAggregator:
+    return PerturbationResponseAggregator(
+        ops=LatLonOperations(torch.ones(N_LAT, N_LON, device=get_device())),
+        horizontal_coordinates=_coords(),
+        config=config or PerturbationResponseAggregatorConfig(),
+        perturbation_labels=list(perturbation_labels),
+        group_onehot=group_onehot,
+    )
+
+
+def test_response_diagnostics_recover_known_structure():
+    # members: two baseline (group 0), two perturbed (group 1)
+    group_onehot = torch.tensor([[1, 0], [1, 0], [0, 1], [0, 1]], device=get_device())
+    agg = _build_aggregator(group_onehot)
+    agg.record_batch(_paired_data(group_onehot))
+    summary = agg.get_summary()
+    logs = summary.logs
+
+    assert summary.loss is None
+
+    p = "perturbation_response/p4K"
+    # Land warms 2 K, ocean 1 K -> ratio 2 in every band.
+    for band in ("tropics", "subtropics", "midlatitudes"):
+        assert logs[f"{p}/land_warming/{band}"] == pytest.approx(2.0)
+        assert logs[f"{p}/ocean_warming/{band}"] == pytest.approx(1.0)
+        assert logs[f"{p}/land_ocean_warming_ratio/{band}"] == pytest.approx(2.0)
+
+    # Tropical ocean: surface (air_temperature_7) warms 1 K, ~200 hPa
+    # (air_temperature_2) warms 2.3 K -> vertical ratio 2.3.
+    assert logs[f"{p}/tropical_ocean_surface_warming"] == pytest.approx(1.0)
+    assert logs[f"{p}/tropical_ocean_upper_warming"] == pytest.approx(2.3)
+    assert logs[f"{p}/vertical_warming_ratio_tropical_ocean"] == pytest.approx(2.3)
+
+    # Global-mean column profile: uniform fields recover their level value;
+    # air_temperature_7 is half land (2) half ocean (1) -> 1.5.
+    assert logs[f"{p}/column_warming/air_temperature_2"] == pytest.approx(2.3)
+    assert logs[f"{p}/column_warming/air_temperature_7"] == pytest.approx(1.5)
+
+
+def test_zero_response_gives_zero_warming_and_nan_ratio():
+    # A checkpoint with no response: perturbed identical to baseline. Warmings
+    # are zero and the ratio is NaN (ill-defined) rather than crashing.
+    group_onehot = torch.tensor([[1, 0], [0, 1]], device=get_device())
+    data = _paired_data(group_onehot)
+    for name in data.prediction:
+        data.prediction[name][1] = data.prediction[name][0]
+    agg = _build_aggregator(group_onehot)
+    agg.record_batch(data)
+    logs = agg.get_summary().logs
+    assert logs["perturbation_response/p4K/land_warming/tropics"] == pytest.approx(0.0)
+    assert logs["perturbation_response/p4K/ocean_warming/tropics"] == pytest.approx(0.0)
+    assert np.isnan(logs["perturbation_response/p4K/land_ocean_warming_ratio/tropics"])
+
+
+def test_accumulates_across_windows():
+    group_onehot = torch.tensor([[1, 0], [1, 0], [0, 1], [0, 1]], device=get_device())
+    agg = _build_aggregator(group_onehot)
+    # two windows with identical constant-in-time data: the time-mean response
+    # is unchanged by recording the same window twice.
+    agg.record_batch(_paired_data(group_onehot))
+    agg.record_batch(_paired_data(group_onehot))
+    logs = agg.get_summary().logs
+    assert logs[
+        "perturbation_response/p4K/land_ocean_warming_ratio/tropics"
+    ] == pytest.approx(2.0)
+
+
+def test_more_than_one_perturbation_not_implemented():
+    three_groups = torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], device=get_device())
+    with pytest.raises(NotImplementedError):
+        _validate_one_hot(three_groups)
+
+
+def test_non_one_hot_rejected():
+    bad = torch.tensor([[1, 1], [0, 1]], device=get_device())
+    with pytest.raises(ValueError):
+        _validate_one_hot(bad)
+
+
+def test_label_count_must_match_groups():
+    group_onehot = torch.tensor([[1, 0], [0, 1]], device=get_device())
+    with pytest.raises(ValueError):
+        _build_aggregator(group_onehot, perturbation_labels=("a", "b"))
+
+
+def test_latitude_band_validation():
+    with pytest.raises(ValueError):
+        LatitudeBand("bad", 30.0, 15.0)
+
+
+def test_config_rejects_out_of_range_level_index():
+    with pytest.raises(ValueError):
+        PerturbationResponseAggregatorConfig(
+            column_temperature_names=["air_temperature_0", "air_temperature_1"],
+            vertical_surface_index=5,
+        )
+
+
+def test_diagnostics_written(tmp_path):
+    group_onehot = torch.tensor([[1, 0], [0, 1]], device=get_device())
+    agg = PerturbationResponseAggregator(
+        ops=LatLonOperations(torch.ones(N_LAT, N_LON, device=get_device())),
+        horizontal_coordinates=_coords(),
+        config=PerturbationResponseAggregatorConfig(),
+        perturbation_labels=["p4K"],
+        group_onehot=group_onehot,
+        output_dir=str(tmp_path),
+        save_diagnostics=True,
+    )
+    agg.record_batch(_paired_data(group_onehot))
+    agg.flush_diagnostics(subdir="epoch_0001")
+    out = tmp_path / "epoch_0001" / "perturbation_response_diagnostics.nc"
+    assert out.exists()
+    import xarray as xr
+
+    ds = xr.open_dataset(out)
+    assert "p4K__air_temperature_7" in ds
+    # land cells (cols 2,3) warm by 2 K
+    np.testing.assert_allclose(ds["p4K__air_temperature_7"].values[:, 2:], 2.0)

--- a/fme/ace/aggregator/inference/test_perturbation_response.py
+++ b/fme/ace/aggregator/inference/test_perturbation_response.py
@@ -197,3 +197,27 @@ def test_diagnostics_written(tmp_path):
     assert "p4K__air_temperature_7" in ds
     # land cells (cols 2,3) warm by 2 K
     np.testing.assert_allclose(ds["p4K__air_temperature_7"].values[:, 2:], 2.0)
+
+
+def test_response_maps_logged_for_every_field():
+    group_onehot = torch.tensor([[1, 0], [1, 0], [0, 1], [0, 1]], device=get_device())
+    agg = _build_aggregator(group_onehot)
+    agg.record_batch(_paired_data(group_onehot))
+    logs = agg.get_summary().logs
+    # A 2D response map is logged for every predicted field (here the 8 levels).
+    for i in range(8):
+        assert f"p4K/response_map/air_temperature_{i}" in logs
+    # The scalar diagnostics still co-exist in the same logs dict.
+    assert "p4K/land_ocean_warming_ratio/tropics" in logs
+
+
+def test_response_map_variables_restricts_maps():
+    group_onehot = torch.tensor([[1, 0], [0, 1]], device=get_device())
+    config = PerturbationResponseAggregatorConfig(
+        response_map_variables=["air_temperature_7"]
+    )
+    agg = _build_aggregator(group_onehot, config=config)
+    agg.record_batch(_paired_data(group_onehot))
+    logs = agg.get_summary().logs
+    map_keys = [k for k in logs if "/response_map/" in k]
+    assert map_keys == ["p4K/response_map/air_temperature_7"]

--- a/fme/ace/data_loading/perturbation_pair.py
+++ b/fme/ace/data_loading/perturbation_pair.py
@@ -1,0 +1,150 @@
+"""Build control/perturbed paired inference data for the perturbation-response eval.
+
+A perturbation-response rollout runs an unperturbed *baseline* and one or more
+*perturbed* climates together as separate batch members of a single rollout, so
+that differencing their time-means yields a clean warming response. This module
+turns an ordinary (unperturbed) inference initial condition and forcing loader
+into a paired version: the baseline members are the originals; the perturbed
+members are copies with an SST perturbation applied to both the initial
+condition and every forcing window.
+
+Only a single perturbation (two groups: baseline + perturbed) is supported for
+now; the one-hot group encoding returned alongside the data leaves room to add
+more perturbation groups later.
+"""
+
+import dataclasses
+
+import torch
+import xarray as xr
+
+from fme.ace.data_loading.batch_data import BatchData, PrognosticState
+from fme.ace.data_loading.perturbation import SSTPerturbation
+from fme.core.generics.data import SimpleInferenceData, SizedMap
+from fme.core.labels import BatchLabels
+
+
+def _concat_along_batch(a: BatchData, b: BatchData) -> BatchData:
+    """Concatenate two BatchData along the sample (batch) dimension."""
+    if a.n_ensemble != b.n_ensemble:
+        raise ValueError("cannot concatenate BatchData with different n_ensemble.")
+    data = {name: torch.cat([a.data[name], b.data[name]], dim=0) for name in a.data}
+    time = xr.concat([a.time, b.time], dim="sample")
+    labels = None
+    if a.labels is not None and b.labels is not None:
+        labels = BatchLabels(
+            torch.cat([a.labels.tensor, b.labels.tensor], dim=0), a.labels.names
+        )
+    data_mask = None
+    if a.data_mask is not None and b.data_mask is not None:
+        data_mask = {
+            name: torch.cat([a.data_mask[name], b.data_mask[name]], dim=0)
+            for name in a.data_mask
+        }
+    return BatchData(
+        data=data,
+        time=time,
+        horizontal_dims=a.horizontal_dims,
+        labels=labels,
+        epoch=a.epoch,
+        n_ensemble=a.n_ensemble,
+        data_mask=data_mask,
+    )
+
+
+def _perturbed_copy(
+    batch: BatchData,
+    perturbation: SSTPerturbation,
+    surface_temperature_name: str,
+    lats: torch.Tensor,
+    lons: torch.Tensor,
+    ocean_fraction: torch.Tensor,
+) -> BatchData:
+    """Return a copy of ``batch`` with the SST perturbation applied to its
+    surface-temperature field. ``ocean_fraction`` selects the cells perturbed
+    (pass an all-ones tensor to perturb the whole field).
+    """
+    new_data = dict(batch.data)
+    surface_temperature = batch.data[surface_temperature_name].clone()
+    for config in perturbation.perturbations:
+        config.apply_perturbation(surface_temperature, lats, lons, ocean_fraction)
+    new_data[surface_temperature_name] = surface_temperature
+    return dataclasses.replace(batch, data=new_data)
+
+
+def build_perturbation_pair_data(
+    initial_condition: PrognosticState,
+    loader,
+    perturbation: SSTPerturbation,
+    surface_temperature_name: str,
+    ocean_fraction_name: str,
+    lats: torch.Tensor,
+    lons: torch.Tensor,
+    perturb_initial_condition_full_field: bool = True,
+) -> tuple[SimpleInferenceData, torch.Tensor]:
+    """Build paired baseline/perturbed inference data from unperturbed inputs.
+
+    Parameters:
+        initial_condition: Unperturbed (prognostic) initial condition.
+        loader: Unperturbed forcing loader yielding ``BatchData`` windows.
+        perturbation: The SST perturbation applied to the perturbed members.
+        surface_temperature_name: Name of the surface-temperature variable.
+        ocean_fraction_name: Name of the ocean-fraction forcing variable.
+        lats: Latitude meshgrid matching the (local) spatial shape of the data.
+        lons: Longitude meshgrid matching the (local) spatial shape of the data.
+        perturb_initial_condition_full_field: If True, the initial-condition
+            perturbation is applied over the whole field; if False, only over
+            the ocean (matching the forcing perturbation). The forcing
+            perturbation is always ocean-masked.
+
+    Returns:
+        A tuple of the paired inference data and a ``[2 * n_local, 2]`` one-hot
+        group encoding (group 0 = baseline, group 1 = perturbed) whose member
+        order matches the batch dimension of the paired data.
+    """
+    base_ic = initial_condition.as_batch_data()
+    n_local = next(iter(base_ic.data.values())).shape[0]
+
+    if surface_temperature_name in base_ic.data:
+        if perturb_initial_condition_full_field:
+            ocean_fraction_ic = torch.ones_like(base_ic.data[surface_temperature_name])
+        else:
+            n_ic_timesteps = base_ic.data[surface_temperature_name].shape[1]
+            first_window = next(iter(loader))
+            ocean_fraction_ic = first_window.data[ocean_fraction_name][
+                :, :n_ic_timesteps
+            ]
+        perturbed_ic = _perturbed_copy(
+            base_ic,
+            perturbation,
+            surface_temperature_name,
+            lats,
+            lons,
+            ocean_fraction_ic,
+        )
+    else:
+        # Surface temperature is a forcing variable; perturbing the first
+        # forcing window already perturbs the t0 input, so the prognostic
+        # initial condition needs no separate perturbation.
+        perturbed_ic = base_ic
+    paired_ic = PrognosticState(_concat_along_batch(base_ic, perturbed_ic))
+
+    def pair_window(window: BatchData) -> BatchData:
+        ocean_fraction = window.data[ocean_fraction_name]
+        perturbed = _perturbed_copy(
+            window,
+            perturbation,
+            surface_temperature_name,
+            lats,
+            lons,
+            ocean_fraction,
+        )
+        return _concat_along_batch(window, perturbed)
+
+    paired_loader = SizedMap(pair_window, loader)
+
+    group_onehot = torch.zeros(2 * n_local, 2)
+    group_onehot[:n_local, 0] = 1.0  # baseline block
+    group_onehot[n_local:, 1] = 1.0  # perturbed block
+
+    return SimpleInferenceData(paired_ic, paired_loader), group_onehot

--- a/fme/ace/data_loading/test_perturbation_pair.py
+++ b/fme/ace/data_loading/test_perturbation_pair.py
@@ -1,0 +1,132 @@
+import torch
+
+from fme.ace.aggregator.inference.data import make_dummy_time
+from fme.ace.data_loading.batch_data import BatchData, PrognosticState
+from fme.ace.data_loading.perturbation import PerturbationSelector, SSTPerturbation
+from fme.ace.data_loading.perturbation_pair import build_perturbation_pair_data
+from fme.core.device import get_device
+from fme.core.generics.data import SimpleInferenceData
+
+N_IC = 2
+N_LAT = 2
+N_LON = 2
+AMPLITUDE = 4.0
+
+
+def _perturbation() -> SSTPerturbation:
+    return SSTPerturbation(
+        sst=[PerturbationSelector(type="constant", config={"amplitude": AMPLITUDE})]
+    )
+
+
+def _ocean_fraction(n_time: int) -> torch.Tensor:
+    # column 0 ocean, column 1 land
+    of = torch.zeros(N_IC, n_time, N_LAT, N_LON, device=get_device())
+    of[:, :, :, 0] = 1.0
+    return of
+
+
+def _initial_condition(include_surface_temperature: bool) -> PrognosticState:
+    data = {
+        "air_temperature_7": torch.ones(N_IC, 1, N_LAT, N_LON, device=get_device()),
+    }
+    if include_surface_temperature:
+        data["surface_temperature"] = torch.full(
+            (N_IC, 1, N_LAT, N_LON), 10.0, device=get_device()
+        )
+    return PrognosticState(BatchData(data=data, time=make_dummy_time(N_IC, 1)))
+
+
+def _window(n_time: int = 2) -> BatchData:
+    data = {
+        "surface_temperature": torch.full(
+            (N_IC, n_time, N_LAT, N_LON), 20.0, device=get_device()
+        ),
+        "ocean_fraction": _ocean_fraction(n_time),
+        "air_temperature_7": torch.ones(
+            N_IC, n_time, N_LAT, N_LON, device=get_device()
+        ),
+    }
+    return BatchData(data=data, time=make_dummy_time(N_IC, n_time))
+
+
+def _meshgrid():
+    lat = torch.tensor([10.0, 20.0], device=get_device())
+    lon = torch.tensor([0.0, 180.0], device=get_device())
+    lats, lons = torch.meshgrid(lat, lon, indexing="ij")
+    return lats, lons
+
+
+def _build(full_field: bool, include_surface_temperature: bool = True):
+    lats, lons = _meshgrid()
+    base = SimpleInferenceData(
+        _initial_condition(include_surface_temperature), [_window()]
+    )
+    return build_perturbation_pair_data(
+        initial_condition=base.initial_condition,
+        loader=base.loader,
+        perturbation=_perturbation(),
+        surface_temperature_name="surface_temperature",
+        ocean_fraction_name="ocean_fraction",
+        lats=lats,
+        lons=lons,
+        perturb_initial_condition_full_field=full_field,
+    )
+
+
+def test_group_encoding_layout():
+    _, group_onehot = _build(full_field=True)
+    assert group_onehot.shape == (2 * N_IC, 2)
+    expected = torch.tensor([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
+    assert torch.equal(group_onehot.cpu(), expected)
+
+
+def test_forcing_perturbation_is_ocean_masked():
+    data, _ = _build(full_field=True)
+    window = next(iter(data.loader))
+    sst = window.data["surface_temperature"]
+    assert sst.shape[0] == 2 * N_IC
+    baseline, perturbed = sst[:N_IC], sst[N_IC:]
+    # baseline unchanged everywhere
+    assert torch.allclose(baseline, torch.full_like(baseline, 20.0))
+    # perturbed: +4 over ocean (col 0), unchanged over land (col 1)
+    assert torch.allclose(perturbed[..., 0], torch.full_like(perturbed[..., 0], 24.0))
+    assert torch.allclose(perturbed[..., 1], torch.full_like(perturbed[..., 1], 20.0))
+
+
+def test_ic_perturbation_full_field():
+    data, _ = _build(full_field=True)
+    ic = data.initial_condition.as_batch_data()
+    sst = ic.data["surface_temperature"]
+    assert sst.shape[0] == 2 * N_IC
+    baseline, perturbed = sst[:N_IC], sst[N_IC:]
+    assert torch.allclose(baseline, torch.full_like(baseline, 10.0))
+    # whole field perturbed, including land column
+    assert torch.allclose(perturbed, torch.full_like(perturbed, 14.0))
+
+
+def test_ic_perturbation_ocean_masked():
+    data, _ = _build(full_field=False)
+    ic = data.initial_condition.as_batch_data()
+    perturbed = ic.data["surface_temperature"][N_IC:]
+    # ocean column perturbed, land column not
+    assert torch.allclose(perturbed[..., 0], torch.full_like(perturbed[..., 0], 14.0))
+    assert torch.allclose(perturbed[..., 1], torch.full_like(perturbed[..., 1], 10.0))
+
+
+def test_initial_condition_unperturbed_when_surface_temperature_not_prognostic():
+    data, _ = _build(full_field=True, include_surface_temperature=False)
+    ic = data.initial_condition.as_batch_data()
+    # surface_temperature absent from IC -> IC simply duplicated, unchanged
+    air = ic.data["air_temperature_7"]
+    assert air.shape[0] == 2 * N_IC
+    assert torch.allclose(air, torch.ones_like(air))
+
+
+def test_other_forcing_variables_are_duplicated_unchanged():
+    data, _ = _build(full_field=True)
+    window = next(iter(data.loader))
+    of = window.data["ocean_fraction"]
+    assert of.shape[0] == 2 * N_IC
+    # ocean fraction identical across baseline and perturbed members
+    assert torch.allclose(of[:N_IC], of[N_IC:])

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1776,6 +1776,14 @@ class TrainStepper(
     def loss_names(self) -> list[str]:
         return self._stepper.loss_names
 
+    @property
+    def surface_temperature_name(self) -> str | None:
+        return self._stepper.surface_temperature_name
+
+    @property
+    def ocean_fraction_name(self) -> str | None:
+        return self._stepper.ocean_fraction_name
+
     def predict_paired(
         self,
         initial_condition: PrognosticState,

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -15,6 +15,10 @@ import yaml
 
 import fme
 from fme.ace.aggregator.inference.main import InferenceEvaluatorAggregatorConfig
+from fme.ace.aggregator.inference.perturbation_response import (
+    LatitudeBand,
+    PerturbationResponseAggregatorConfig,
+)
 from fme.ace.aggregator.one_step.main import OneStepAggregatorConfig
 from fme.ace.aggregator.one_step.map import OneStepMapMetricConfig
 from fme.ace.aggregator.one_step.snapshot import OneStepSnapshotMetricConfig
@@ -23,6 +27,7 @@ from fme.ace.data_loading.inference import (
     InferenceDataLoaderConfig,
     InferenceInitialConditionIndices,
 )
+from fme.ace.data_loading.perturbation import PerturbationSelector, SSTPerturbation
 from fme.ace.inference.data_writer.file_writer import FileWriterConfig
 from fme.ace.inference.data_writer.main import DataWriterConfig
 from fme.ace.inference.evaluator import InferenceEvaluatorConfig
@@ -62,6 +67,8 @@ from fme.ace.train.train import main as train_main
 from fme.ace.train.train_config import (
     InlineInferenceConfig,
     InlineValidationConfig,
+    LabeledPerturbation,
+    PerturbationResponseInferenceConfig,
     TrainBuilders,
     TrainConfig,
 )
@@ -168,6 +175,7 @@ def _get_test_yaml_files(
     batch_size: int = 2,
     sample_with_replacement: int | None = 10,
     lr_tuning: LRTuningConfig | None = None,
+    with_perturbation_inference: bool = False,
 ):
     if derived_forcings is None:
         derived_forcings = DerivedForcingsConfig()
@@ -321,6 +329,54 @@ def _get_test_yaml_files(
     else:
         n_forward_steps_arg = n_forward_steps
 
+    perturbation_inference_configs: list[PerturbationResponseInferenceConfig] = []
+    if with_perturbation_inference:
+        perturbation_inference_configs = [
+            PerturbationResponseInferenceConfig(
+                loader=InferenceDataLoaderConfig(
+                    dataset=XarrayDataConfig(
+                        data_path=str(valid_data_path),
+                        spatial_dimensions=spatial_dimensions_str,
+                        labels=[] if conditional else None,
+                    ),
+                    start_indices=InferenceInitialConditionIndices(
+                        first=0,
+                        n_initial_conditions=2,
+                        interval=1,
+                    ),
+                ),
+                n_forward_steps=inference_forward_steps,
+                forward_steps_in_memory=2,
+                perturbations=[
+                    LabeledPerturbation(
+                        label="p4K",
+                        perturbation=SSTPerturbation(
+                            sst=[
+                                PerturbationSelector(
+                                    type="constant",
+                                    config={"amplitude": 4.0},
+                                )
+                            ]
+                        ),
+                    )
+                ],
+                aggregator=PerturbationResponseAggregatorConfig(
+                    near_surface_temperature_name="surface_temperature",
+                    column_temperature_names=[
+                        "specific_total_water_0",
+                        "specific_total_water_1",
+                    ],
+                    vertical_surface_index=1,
+                    vertical_upper_index=0,
+                    latitude_bands=[
+                        LatitudeBand(name="all", lat_min=0.0, lat_max=90.0)
+                    ],
+                    tropical_lat_max=90.0,
+                    ocean_fraction_name=mask_name,
+                ),
+            )
+        ]
+
     if crps_training:
         loss = StepLossConfig(
             type="EnsembleLoss",
@@ -422,6 +478,7 @@ def _get_test_yaml_files(
             n_forward_steps=n_forward_steps_arg,
         ),
         inference=inference_configs,
+        perturbation_inference=perturbation_inference_configs,
         validate_using_ema=validate_using_ema,
         max_epochs=max_epochs,
         segment_epochs=segment_epochs,
@@ -506,6 +563,7 @@ def _setup(
     multi_validation: bool = False,
     use_variable_masking: bool = False,
     lr_tuning: LRTuningConfig | None = None,
+    with_perturbation_inference: bool = False,
 ):
     if not path.exists():
         path.mkdir()
@@ -617,6 +675,7 @@ def _setup(
         multi_validation=multi_validation,
         partial_train_data_path=partial_data_dir,
         lr_tuning=lr_tuning,
+        with_perturbation_inference=with_perturbation_inference,
     )
     return train_config_filename, inference_config_filename
 
@@ -1093,6 +1152,48 @@ def test_train_without_inline_inference(tmp_path):
     assert "val_extra/mean/loss" in epoch_logs
     val_extra_output = tmp_path / "results" / "output" / "val_extra" / "epoch_0001"
     assert val_extra_output.exists()
+
+
+def test_train_with_perturbation_inference(tmp_path):
+    train_config, _ = _setup(
+        tmp_path,
+        "SphericalFourierNeuralOperatorNet",
+        log_to_wandb=True,
+        n_time=10,
+        inference_forward_steps=2,
+        save_per_epoch_diagnostics=True,
+        skip_inline_inference=True,
+        with_perturbation_inference=True,
+    )
+    with mock_wandb() as wandb:
+        train_main(yaml_config=train_config)
+        epoch_logs = wandb.get_logs()[-1]
+
+    response_keys = [
+        k for k in epoch_logs if k.startswith("perturbation_response/p4K/")
+    ]
+    assert response_keys, "expected perturbation_response metrics in the epoch log"
+    assert "perturbation_response/p4K/land_ocean_warming_ratio/all" in epoch_logs
+    assert (
+        "perturbation_response/p4K/vertical_warming_ratio_tropical_ocean" in epoch_logs
+    )
+    assert (
+        "perturbation_response/p4K/column_warming/specific_total_water_0" in epoch_logs
+    )
+    # diagnostic-only: must not contribute to checkpoint selection
+    assert np.isinf(epoch_logs["best_inference_error"])
+
+    diagnostics = (
+        tmp_path
+        / "results"
+        / "output"
+        / "perturbation_response"
+        / "epoch_0001"
+        / "perturbation_response_diagnostics.nc"
+    )
+    assert diagnostics.exists()
+    ds = xr.open_dataset(diagnostics, decode_timedelta=False)
+    assert "p4K__surface_temperature" in ds
 
 
 def test_lr_tuning_with_loss_schedule(tmp_path):

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -292,7 +292,6 @@ def _make_perturbation_response_task(
             dataset_info=entry_dataset_info,
             perturbation_labels=entry_config.perturbation_labels,
             group_onehot=group_onehot,
-            n_timesteps=entry_config.n_forward_steps,
             output_dir=os.path.join(output_dir, name),
             save_diagnostics=save_per_epoch_diagnostics,
         )

--- a/fme/ace/train/train.py
+++ b/fme/ace/train/train.py
@@ -60,10 +60,12 @@ import fme
 from fme.ace.aggregator import TrainAggregator
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.gridded_data import InferenceGriddedData
+from fme.ace.data_loading.perturbation_pair import build_perturbation_pair_data
 from fme.ace.stepper import TrainOutput, TrainStepper
 from fme.ace.train.train_config import (
     InlineInferenceConfig,
     InlineValidationConfig,
+    PerturbationResponseInferenceConfig,
     TrainBuilders,
     TrainConfig,
 )
@@ -187,6 +189,12 @@ def get_inference_callback(
     stepper: TrainStepper,
     output_dir: str,
     save_per_epoch_diagnostics: bool,
+    perturbation_inference_entries: Sequence[
+        tuple[
+            PerturbationResponseInferenceConfig, InferenceGriddedData, DatasetInfo, str
+        ]
+    ] = (),
+    perturbation_inference_epoch_sets: Sequence[set[int]] = (),
 ) -> InferenceCallback:
     tasks: list[InferenceTask] = []
     for i, (entry_config, data, entry_dataset_info, name) in enumerate(
@@ -210,11 +218,86 @@ def get_inference_callback(
             )
         )
 
+    for i, (
+        perturbation_config,
+        perturbation_data,
+        perturbation_dataset_info,
+        perturbation_name,
+    ) in enumerate(perturbation_inference_entries):
+        paired_data, aggregator_factory = _make_perturbation_response_task(
+            entry_config=perturbation_config,
+            data=perturbation_data,
+            entry_dataset_info=perturbation_dataset_info,
+            name=perturbation_name,
+            stepper=stepper,
+            output_dir=output_dir,
+            save_per_epoch_diagnostics=save_per_epoch_diagnostics,
+        )
+        tasks.append(
+            InferenceTask(
+                name=perturbation_name,
+                data=paired_data,
+                aggregator_factory=aggregator_factory,
+                epoch_set=frozenset(perturbation_inference_epoch_sets[i]),
+                weight=0.0,  # diagnostic only; never affects checkpoint selection
+            )
+        )
+
+    all_epochs = sorted(
+        set(inference_epochs).union(*perturbation_inference_epoch_sets)
+        if perturbation_inference_epoch_sets
+        else set(inference_epochs)
+    )
     return build_inference_callback(
         tasks=tasks,
-        inference_epochs=inference_epochs,
+        inference_epochs=all_epochs,
         stepper=stepper,
     )
+
+
+def _make_perturbation_response_task(
+    entry_config: PerturbationResponseInferenceConfig,
+    data: InferenceGriddedData,
+    entry_dataset_info: DatasetInfo,
+    name: str,
+    stepper: TrainStepper,
+    output_dir: str,
+    save_per_epoch_diagnostics: bool,
+):
+    """Build paired control/perturbed data and the response-aggregator factory."""
+    surface_temperature_name = stepper.surface_temperature_name
+    ocean_fraction_name = stepper.ocean_fraction_name
+    if surface_temperature_name is None or ocean_fraction_name is None:
+        raise ValueError(
+            "perturbation-response inference requires the stepper to define "
+            "surface_temperature_name and ocean_fraction_name."
+        )
+    lats, lons = data.horizontal_coordinates.meshgrid
+    labeled = entry_config.perturbations[0]
+    paired_data, group_onehot = build_perturbation_pair_data(
+        initial_condition=data.initial_condition,
+        loader=data.loader,
+        perturbation=labeled.perturbation,
+        surface_temperature_name=surface_temperature_name,
+        ocean_fraction_name=ocean_fraction_name,
+        lats=lats,
+        lons=lons,
+        perturb_initial_condition_full_field=(
+            entry_config.perturb_initial_condition_full_field
+        ),
+    )
+
+    def factory():
+        return entry_config.aggregator.build(
+            dataset_info=entry_dataset_info,
+            perturbation_labels=entry_config.perturbation_labels,
+            group_onehot=group_onehot,
+            n_timesteps=entry_config.n_forward_steps,
+            output_dir=os.path.join(output_dir, name),
+            save_diagnostics=save_per_epoch_diagnostics,
+        )
+
+    return paired_data, factory
 
 
 def _make_ace_aggregator_factory(
@@ -267,6 +350,10 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
     inference_entries = builder.get_inference_data(variable_metadata)
     inference_epochs = config.get_inference_epochs()
     inference_epoch_sets = config.get_inference_epoch_sets()
+    perturbation_inference_entries = builder.get_perturbation_inference_data(
+        variable_metadata
+    )
+    perturbation_inference_epoch_sets = config.get_perturbation_inference_epoch_sets()
 
     dataset_info = train_data.dataset_info
     logging.info("Starting model initialization")
@@ -315,6 +402,8 @@ def build_trainer(builder: TrainBuilders, config: TrainConfig) -> "Trainer":
         stepper=stepper,
         output_dir=config.output_dir,
         save_per_epoch_diagnostics=config.save_per_epoch_diagnostics,
+        perturbation_inference_entries=perturbation_inference_entries,
+        perturbation_inference_epoch_sets=perturbation_inference_epoch_sets,
     )
 
     do_gc_collect = fme.get_device() != torch.device("cpu")

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -12,12 +12,16 @@ from fme.ace.aggregator import (
     LegacyFlagOneStepAggregatorConfig,
     OneStepAggregatorConfig,
 )
+from fme.ace.aggregator.inference.perturbation_response import (
+    PerturbationResponseAggregatorConfig,
+)
 from fme.ace.aggregator.train import TrainAggregatorConfig
 from fme.ace.data_loading.batch_data import PrognosticState
 from fme.ace.data_loading.config import DataLoaderConfig
 from fme.ace.data_loading.getters import get_gridded_data, get_inference_data
 from fme.ace.data_loading.gridded_data import GriddedData, InferenceGriddedData
 from fme.ace.data_loading.inference import InferenceDataLoaderConfig
+from fme.ace.data_loading.perturbation import SSTPerturbation
 from fme.ace.requirements import DataRequirements, PrognosticStateDataRequirements
 from fme.ace.stepper import TrainStepper
 from fme.ace.stepper.single_module import (
@@ -154,6 +158,104 @@ class InlineInferenceConfig:
 
 
 @dataclasses.dataclass
+class LabeledPerturbation:
+    """A named SST perturbation for the perturbation-response eval.
+
+    Parameters:
+        label: Label used in wandb log keys for this perturbation's response.
+        perturbation: The SST perturbation applied to the perturbed members.
+    """
+
+    label: str
+    perturbation: SSTPerturbation
+
+
+@dataclasses.dataclass
+class PerturbationResponseInferenceConfig:
+    """Configuration for an inline perturbation-response evaluation.
+
+    At each evaluated checkpoint this runs a single rollout carrying an
+    unperturbed baseline and a perturbed climate as separate batch members,
+    differences their time-means, and logs structural warming-response
+    diagnostics (see ``PerturbationResponseAggregatorConfig``). It does not
+    contribute to checkpoint selection.
+
+    Parameters:
+        loader: Data loader for the (unperturbed) initial condition and forcing.
+            Must not itself specify perturbations; the perturbation is given by
+            ``perturbations``.
+        n_forward_steps: Number of forward steps to take.
+        forward_steps_in_memory: Number of forward steps to take before
+            re-reading data from disk.
+        perturbations: Labeled SST perturbations. Exactly one is supported for
+            now (baseline + one perturbed group).
+        aggregator: Configuration of the perturbation-response aggregator.
+        epochs: Epochs on which to run. By default runs every epoch.
+        name: Name used as wandb log prefix and output subdirectory. If None,
+            defaults to "perturbation_response" for a single config and
+            "perturbation_response_{i}" when there are multiple.
+        perturb_initial_condition_full_field: If True, the initial-condition
+            perturbation is applied over the whole field; if False, only over
+            the ocean (the forcing perturbation is always ocean-masked).
+    """
+
+    loader: InferenceDataLoaderConfig
+    n_forward_steps: int
+    forward_steps_in_memory: int
+    perturbations: list[LabeledPerturbation]
+    aggregator: PerturbationResponseAggregatorConfig = dataclasses.field(
+        default_factory=lambda: PerturbationResponseAggregatorConfig()
+    )
+    epochs: Slice = dataclasses.field(default_factory=lambda: Slice())
+    name: str | None = None
+    perturb_initial_condition_full_field: bool = True
+
+    def __post_init__(self):
+        if self.loader.perturbations is not None:
+            raise ValueError(
+                "PerturbationResponseInferenceConfig.loader must be unperturbed; "
+                "specify the perturbation via the perturbations field instead."
+            )
+        if len(self.perturbations) != 1:
+            raise NotImplementedError(
+                "perturbation-response evaluation currently supports exactly one "
+                f"perturbation, got {len(self.perturbations)}."
+            )
+        labels = [p.label for p in self.perturbations]
+        if len(labels) != len(set(labels)):
+            raise ValueError(f"Duplicate perturbation labels: {labels}")
+        dist = Distributed.get_instance()
+        if self.loader.start_indices.n_initial_conditions % dist.world_size != 0:
+            raise ValueError(
+                "Number of inference initial conditions must be divisible by the "
+                "number of parallel workers, got "
+                f"{self.loader.start_indices.n_initial_conditions} and "
+                f"{dist.world_size}."
+            )
+
+    @property
+    def using_labels(self) -> bool:
+        return self.loader.using_labels
+
+    @property
+    def perturbation_labels(self) -> list[str]:
+        return [p.label for p in self.perturbations]
+
+    def get_base_inference_data(
+        self,
+        window_requirements: DataRequirements,
+        initial_condition: PrognosticStateDataRequirements,
+    ) -> InferenceGriddedData:
+        """Build the unperturbed base inference data; pairing happens later."""
+        return get_inference_data(
+            config=self.loader,
+            total_forward_steps=self.n_forward_steps,
+            window_requirements=window_requirements,
+            initial_condition=initial_condition,
+        )
+
+
+@dataclasses.dataclass
 class TrainConfig:
     """
     Configuration for training a model.
@@ -232,6 +334,9 @@ class TrainConfig:
     inference: InlineInferenceConfig | list[InlineInferenceConfig] = dataclasses.field(
         default_factory=list
     )
+    perturbation_inference: (
+        PerturbationResponseInferenceConfig | list[PerturbationResponseInferenceConfig]
+    ) = dataclasses.field(default_factory=list)
     stepper_training: TrainStepperConfig = dataclasses.field(
         default_factory=lambda: TrainStepperConfig()
     )
@@ -292,6 +397,28 @@ class TrainConfig:
                 raise ValueError(
                     f"train_loader and inference {inference_name!r} loader "
                     "must both use labels or both not use labels"
+                )
+        resolved_perturbation_names = self.perturbation_inference_names
+        all_inference_names = resolved_inference_names + resolved_perturbation_names
+        if len(all_inference_names) != len(set(all_inference_names)):
+            raise ValueError(
+                f"Duplicate inference names across inference and "
+                f"perturbation_inference: {all_inference_names}"
+            )
+        perturbation_reserved_overlap = (
+            set(resolved_perturbation_names) & self._RESERVED_NAMES
+        )
+        if perturbation_reserved_overlap:
+            raise ValueError(
+                f"Perturbation inference names {sorted(perturbation_reserved_overlap)} "
+                f"collide with reserved names {sorted(self._RESERVED_NAMES)}"
+            )
+        for i, perturbation_entry in enumerate(self.perturbation_inference_list):
+            if self.train_loader.using_labels != perturbation_entry.using_labels:
+                raise ValueError(
+                    f"train_loader and perturbation_inference "
+                    f"{resolved_perturbation_names[i]!r} loader must both use labels "
+                    "or both not use labels"
                 )
         if self.lr_tuning is not None and self.optimization.has_lr_schedule:
             raise ValueError(
@@ -390,6 +517,25 @@ class TrainConfig:
         """
         return os.path.join(self.experiment_dir, "output")
 
+    @property
+    def perturbation_inference_list(self) -> list[PerturbationResponseInferenceConfig]:
+        if isinstance(self.perturbation_inference, PerturbationResponseInferenceConfig):
+            return [self.perturbation_inference]
+        return self.perturbation_inference
+
+    @property
+    def perturbation_inference_names(self) -> list[str]:
+        entries = self.perturbation_inference_list
+        names = []
+        for i, entry in enumerate(entries):
+            if entry.name is not None:
+                names.append(entry.name)
+            elif len(entries) == 1:
+                names.append("perturbation_response")
+            else:
+                names.append(f"perturbation_response_{i}")
+        return names
+
     def get_inference_epoch_sets(self) -> list[set[int]]:
         inference = self.inference_list
         if not inference:
@@ -403,6 +549,14 @@ class TrainConfig:
         if not epoch_sets:
             return []
         return sorted(set().union(*epoch_sets))
+
+    def get_perturbation_inference_epoch_sets(self) -> list[set[int]]:
+        entries = self.perturbation_inference_list
+        if not entries:
+            return []
+        start_epoch = 0 if self.evaluate_before_training else 1
+        all_epochs = list(range(start_epoch, self.max_epochs + 1))
+        return [set(all_epochs[entry.epochs.slice]) for entry in entries]
 
 
 class TrainBuilders:
@@ -463,6 +617,46 @@ class TrainBuilders:
                 )
             )
             data = entry.get_inference_data(
+                window_requirements=window_requirements,
+                initial_condition=self.config.stepper_config.get_prognostic_state_data_requirements(),
+            )
+            dataset_info = data.dataset_info.update_variable_metadata(variable_metadata)
+            entries.append((entry, data, dataset_info, name))
+        return entries
+
+    def get_perturbation_inference_data(
+        self,
+        variable_metadata: Mapping[str, VariableMetadata],
+    ) -> list[
+        tuple[
+            PerturbationResponseInferenceConfig,
+            InferenceGriddedData,
+            DatasetInfo,
+            str,
+        ]
+    ]:
+        """Build the unperturbed base inference data for each perturbation entry.
+
+        The control/perturbed pairing is applied in ``build_trainer``, where the
+        stepper's surface-temperature and ocean-fraction variable names are
+        available.
+        """
+        names = self.config.perturbation_inference_names
+        entries: list[
+            tuple[
+                PerturbationResponseInferenceConfig,
+                InferenceGriddedData,
+                DatasetInfo,
+                str,
+            ]
+        ] = []
+        for entry, name in zip(self.config.perturbation_inference_list, names):
+            window_requirements = (
+                self.config.stepper_config.get_evaluation_window_data_requirements(
+                    entry.forward_steps_in_memory
+                )
+            )
+            data = entry.get_base_inference_data(
                 window_requirements=window_requirements,
                 initial_condition=self.config.stepper_config.get_prognostic_state_data_requirements(),
             )

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -180,6 +180,12 @@ class PerturbationResponseInferenceConfig:
     diagnostics (see ``PerturbationResponseAggregatorConfig``). It does not
     contribute to checkpoint selection.
 
+    Initial-condition ensembles (``n_ensemble_per_ic > 1``) are not supported:
+    the baseline/perturbed members occupy the batch dimension directly.
+
+    Spatial (model) parallelism is supported via per-rank-localized masks;
+    the diagnostics are reduced across data-parallel ranks.
+
     Parameters:
         loader: Data loader for the (unperturbed) initial condition and forcing.
             Must not itself specify perturbations; the perturbation is given by


### PR DESCRIPTION
Make the +4 K uniform-SST warming response visible **during training** by
running an unperturbed baseline and a perturbed climate together as separate
batch members of a single inline rollout at evaluated checkpoints, differencing
their time-means, and logging the structural diagnostics the land-amplification
goal is judged on. This is a diagnostic eval only — it never contributes to
checkpoint selection — and involves no external (c96-SHiELD) reference; it
reports the model's own response structure.

This is a new inline-inference type (peer to inline inference), not a change to
the inference evaluator: the response needs a 0 K baseline climatology, so its
top-level operation differs (run + difference two climates). It reuses the
existing `InferenceTask`/`InferenceCallback` plumbing with `weight=0`.

Changes:
- `fme.ace.aggregator.inference.perturbation_response` — new `PerturbationResponseAggregator` + `PerturbationResponseAggregatorConfig`: accumulates a per-group time-mean over baseline/perturbed batch members (one-hot group encoding, group 0 = baseline; >1 perturbation raises `NotImplementedError`), differences each perturbation against the baseline, and logs near-surface land/ocean warming ratio by latitude band, free-troposphere/surface warming ratio over tropical ocean, and the global-mean column warming profile. NaN-guarded ratios; cross-rank reduction via `reduce_sum`.
- `fme.ace.data_loading.perturbation_pair.build_perturbation_pair_data` — turns an unperturbed inference IC + forcing loader into a paired baseline/perturbed rollout. Perturbs every forcing window (ocean-masked) and the prognostic IC when surface temperature is prognostic, with a configurable IC-perturbation scope (whole-field vs ocean-masked). Returns the `[2*n_local, 2]` one-hot group encoding.
- `fme.ace.train.train_config` — `LabeledPerturbation`, `PerturbationResponseInferenceConfig`, the `TrainConfig.perturbation_inference` field, name/label validation, epoch sets, and `TrainBuilders.get_perturbation_inference_data`.
- `fme.ace.train.train` — `get_inference_callback` also builds weight-0 perturbation-response tasks; `_make_perturbation_response_task` does the pairing; `build_trainer` wiring.
- `fme.ace.stepper.single_module.TrainStepper` — expose `surface_temperature_name`/`ocean_fraction_name` (delegating to the inner stepper).

- [x] Tests added (aggregator unit tests, paired-data unit tests, end-to-end training smoke test asserting the response log keys + diagnostics appear and that the eval does not affect checkpoint selection)
- [ ] If dependencies changed, "deps only" image rebuilt — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
