### PR TITLE
Add inference trend-map aggregator

### DIFF
--- a/docs/default-aggregator-config.yaml
+++ b/docs/default-aggregator-config.yaml
@@ -100,5 +100,10 @@ aggregator:
     name: ipo_index
     enabled: true
     strict: false
+  trend:
+    variables: null
+    name: trend
+    enabled: false
+    strict: false
   monthly_reference_data: null
   time_mean_reference_data: null

--- a/docs/evaluator_config.rst
+++ b/docs/evaluator_config.rst
@@ -151,6 +151,9 @@ in the default aggregator configuration above.
 .. autoclass:: fme.ace.IpoIndexMetricConfig
    :noindex:
 
+.. autoclass:: fme.ace.TrendMetricConfig
+   :noindex:
+
 .. autoclass:: fme.ace.EnsembleMetricConfig
    :noindex:
 

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -16,6 +16,7 @@ from fme.ace.aggregator.inference.reduced import MeanMetricConfig
 from fme.ace.aggregator.inference.seasonal import SeasonalMetricConfig
 from fme.ace.aggregator.inference.spectrum import PowerSpectrumMetricConfig
 from fme.ace.aggregator.inference.time_mean import TimeMeanMetricConfig
+from fme.ace.aggregator.inference.trend import TrendMetricConfig
 from fme.ace.aggregator.inference.video import VideoMetricConfig
 from fme.ace.aggregator.inference.zonal_mean import ZonalMeanMetricConfig
 from fme.ace.aggregator.one_step import (

--- a/fme/ace/aggregator/inference/__init__.py
+++ b/fme/ace/aggregator/inference/__init__.py
@@ -19,5 +19,6 @@ from .reduced import MeanMetricConfig
 from .seasonal import SeasonalMetricConfig
 from .spectrum import PowerSpectrumMetricConfig
 from .time_mean import TimeMeanMetricConfig
+from .trend import TrendMetricConfig
 from .video import VideoMetricConfig
 from .zonal_mean import ZonalMeanMetricConfig

--- a/fme/ace/aggregator/inference/main.py
+++ b/fme/ace/aggregator/inference/main.py
@@ -38,6 +38,7 @@ from .reduced import MeanMetricConfig, SingleTargetMeanAggregator
 from .seasonal import SeasonalMetricConfig
 from .spectrum import PowerSpectrumMetricConfig, SphericalPowerSpectrumAggregator
 from .time_mean import TimeMeanAggregator, TimeMeanMetricConfig
+from .trend import TrendMetricConfig
 from .utils import LatLonRegion
 from .video import VideoMetricConfig
 from .zonal_mean import ZonalMeanMetricConfig
@@ -63,6 +64,7 @@ MetricConfig = (
     | EnsoCoefficientMetricConfig
     | EnsembleMetricConfig
     | IpoIndexMetricConfig
+    | TrendMetricConfig
 )
 
 
@@ -199,6 +201,8 @@ class InferenceEvaluatorAggregatorConfig:
         enso_index: ENSO index metrics.
         enso_coefficient: ENSO regression coefficient metrics.
         ipo_index: Interdecadal Pacific Oscillation index metrics.
+        trend: Per-grid-cell linear trend (slope vs. time) map metrics.
+            Disabled by default.
         monthly_reference_data: Path to monthly reference data to compare against.
         time_mean_reference_data: Path to reference time means to compare against.
     """
@@ -247,6 +251,7 @@ class InferenceEvaluatorAggregatorConfig:
     ipo_index: IpoIndexMetricConfig = dataclasses.field(
         default_factory=IpoIndexMetricConfig
     )
+    trend: TrendMetricConfig = dataclasses.field(default_factory=TrendMetricConfig)
     monthly_reference_data: str | None = None
     time_mean_reference_data: str | None = None
 
@@ -287,6 +292,7 @@ class InferenceEvaluatorAggregatorConfig:
             self.enso_index,
             self.enso_coefficient,
             self.ipo_index,
+            self.trend,
         ]
         return [m for m in all_metrics if m.enabled]
 

--- a/fme/ace/aggregator/inference/test_trend.py
+++ b/fme/ace/aggregator/inference/test_trend.py
@@ -1,0 +1,139 @@
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from fme.core.device import get_device
+from fme.core.gridded_ops import LatLonOperations
+from fme.core.testing import mock_distributed
+
+from .build_context import maybe_filter
+from .data import InferenceBatchData, make_dummy_time
+from .main import InferenceEvaluatorAggregatorConfig
+from .trend import TrendEvaluatorAggregator, TrendMetricConfig, _years_since_reference
+
+N_LAT, N_LON = 3, 4
+
+
+def _ops() -> LatLonOperations:
+    return LatLonOperations(torch.ones(N_LAT, N_LON).to(get_device()))
+
+
+def _linear_batch(
+    slope_target: float,
+    slope_gen: float,
+    *,
+    intercept: float = 5.0,
+    i_time_start: int = 1,
+    time: xr.DataArray | None = None,
+    names: Sequence[str] = ("a",),
+    n_sample: int = 2,
+    n_time: int = 8,
+) -> InferenceBatchData:
+    """Build a batch whose value at each grid cell is exactly linear in time,
+    ``intercept + slope * t`` (t in years), so the recovered trend equals
+    ``slope`` exactly."""
+    if time is None:
+        time = make_dummy_time(n_sample, n_time)
+    n_sample, n_time = time.shape
+    tau = torch.tensor(_years_since_reference(time), dtype=torch.float32)
+
+    def field(slope: float) -> torch.Tensor:
+        y = intercept + slope * tau  # (sample, time)
+        return (
+            y[:, :, None, None]
+            .expand(n_sample, n_time, N_LAT, N_LON)
+            .contiguous()
+            .to(get_device())
+        )
+
+    target = {name: field(slope_target) for name in names}
+    gen = {name: field(slope_gen) for name in names}
+    return InferenceBatchData(
+        prediction=gen,
+        prediction_norm=gen,
+        target=target,
+        target_norm=target,
+        time=time,
+        i_time_start=i_time_start,
+    )
+
+
+def test_trend_recovers_known_slope():
+    agg = TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"])
+    agg.record_batch(_linear_batch(slope_target=2.0, slope_gen=-1.5))
+    ds = agg.get_dataset()
+    target = ds["a"].sel(source="target").values
+    gen = ds["a"].sel(source="prediction").values
+    np.testing.assert_allclose(target, 2.0, rtol=1e-4)
+    np.testing.assert_allclose(gen, -1.5, rtol=1e-4)
+
+
+def test_trend_logs_contain_maps_and_rmse():
+    agg = TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"])
+    agg.record_batch(_linear_batch(slope_target=2.0, slope_gen=-1.5))
+    logs = agg.get_logs(label="trend")
+    assert "trend/trend_maps/a" in logs
+    assert "trend/trend_difference_map/a" in logs
+    # constant trends differing by 3.5 everywhere -> area-weighted RMSE is 3.5
+    assert logs["trend/rmse/a"] == pytest.approx(3.5, rel=1e-3)
+
+
+def test_trend_streaming_matches_single_batch():
+    """Splitting the time series across batches gives the same trend as
+    recording it all at once -- the streaming property we rely on."""
+    time = make_dummy_time(n_sample=2, n_time=10)
+    single = TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"])
+    single.record_batch(
+        _linear_batch(slope_target=2.0, slope_gen=-1.0, time=time, i_time_start=0)
+    )
+
+    streamed = TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"])
+    first = time.isel(time=slice(0, 4))
+    second = time.isel(time=slice(4, None))
+    streamed.record_batch(
+        _linear_batch(slope_target=2.0, slope_gen=-1.0, time=first, i_time_start=0)
+    )
+    streamed.record_batch(
+        _linear_batch(slope_target=2.0, slope_gen=-1.0, time=second, i_time_start=4)
+    )
+
+    xr.testing.assert_allclose(single.get_dataset(), streamed.get_dataset())
+
+
+def test_trend_metrics_call_distributed():
+    """All trend statistics must be reduced across processes."""
+    with mock_distributed(0.0) as mock:
+        agg = TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"])
+        agg.record_batch(_linear_batch(slope_target=2.0, slope_gen=-1.0))
+        agg.get_dataset()
+        assert mock.reduce_called
+
+
+def test_trend_variable_filtering():
+    agg = maybe_filter(
+        TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"]),
+        ["a"],
+    )
+    agg.record_batch(_linear_batch(slope_target=2.0, slope_gen=-1.0, names=("a", "b")))
+    ds = agg.get_dataset()
+    assert list(ds.data_vars) == ["a"]
+
+
+def test_trend_metric_config_disabled_by_default():
+    assert TrendMetricConfig().enabled is False
+
+
+def test_trend_excluded_from_default_metrics():
+    names = [m.get_name() for m in InferenceEvaluatorAggregatorConfig()._get_metrics()]
+    assert "trend" not in names
+
+
+def test_trend_included_when_enabled():
+    config = InferenceEvaluatorAggregatorConfig(
+        trend=TrendMetricConfig(enabled=True, variables=["a"])
+    )
+    names = [m.get_name() for m in config._get_metrics()]
+    assert "trend" in names

--- a/fme/ace/aggregator/inference/test_trend.py
+++ b/fme/ace/aggregator/inference/test_trend.py
@@ -75,10 +75,10 @@ def test_trend_logs_contain_maps_and_rmse():
     agg = TrendEvaluatorAggregator(_ops(), horizontal_dims=["lat", "lon"])
     agg.record_batch(_linear_batch(slope_target=2.0, slope_gen=-1.5))
     logs = agg.get_logs(label="trend")
-    assert "trend/trend_maps/a" in logs
-    assert "trend/trend_difference_map/a" in logs
+    assert "trend/maps/a" in logs
+    assert "trend/difference_map/a" in logs
     # constant trends differing by 3.5 everywhere -> area-weighted RMSE is 3.5
-    assert logs["trend/rmse/a"] == pytest.approx(3.5, rel=1e-3)
+    assert logs["trend/weighted_rmse/a"] == pytest.approx(3.5, rel=1e-3)
 
 
 def test_trend_streaming_matches_single_batch():

--- a/fme/ace/aggregator/inference/trend.py
+++ b/fme/ace/aggregator/inference/trend.py
@@ -18,6 +18,10 @@ from ..plotting import plot_paneled_data
 from .build_context import MetricBuildContext, MetricNotSupportedError, maybe_filter
 from .data import InferenceBatchData, MetricBuildResult, SubAggregator
 
+# A fixed Julian year (365.25 days) is used for the slope's per-year units
+# regardless of the data calendar; this introduces a small (~1.5%) scaling
+# error for non-365.25-day calendars (e.g. CMIP6 360-day), which is fine for
+# a diagnostic trend.
 SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60
 # A fixed reference epoch is used (rather than each sample's start time) so the
 # running sums stay consistent across batches and distributed ranks without
@@ -60,11 +64,11 @@ class TrendEvaluatorAggregator:
     """
 
     _image_captions = {
-        "trend_maps": (
+        "maps": (
             "{name} linear trend; (left) target and (right) generated "
             "[{units} / year]"
         ),
-        "trend_difference_map": (
+        "difference_map": (
             "{name} linear trend difference (generated - target) [{units} / year]"
         ),
     }
@@ -207,18 +211,18 @@ class TrendEvaluatorAggregator:
         for name in gen_trends:
             target_map = target_trends[name]
             gen_map = gen_trends[name]
-            images[f"trend_maps/{name}"] = plot_paneled_data(
+            images[f"maps/{name}"] = plot_paneled_data(
                 [[target_map.cpu().numpy(), gen_map.cpu().numpy()]],
                 diverging=True,
-                caption=self._caption("trend_maps", name),
+                caption=self._caption("maps", name),
             )
             difference = gen_map - target_map
-            images[f"trend_difference_map/{name}"] = plot_paneled_data(
+            images[f"difference_map/{name}"] = plot_paneled_data(
                 [[difference.cpu().numpy()]],
                 diverging=True,
-                caption=self._caption("trend_difference_map", name),
+                caption=self._caption("difference_map", name),
             )
-            metrics[f"rmse/{name}"] = float(
+            metrics[f"weighted_rmse/{name}"] = float(
                 self._ops.area_weighted_rmse(
                     predicted=gen_map.to(torch.float32),
                     truth=target_map.to(torch.float32),

--- a/fme/ace/aggregator/inference/trend.py
+++ b/fme/ace/aggregator/inference/trend.py
@@ -1,0 +1,293 @@
+import dataclasses
+from collections.abc import Mapping
+from typing import Any
+
+import cftime
+import numpy as np
+import torch
+import xarray as xr
+
+from fme.core.dataset.data_typing import VariableMetadata
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.gridded_ops import GriddedOperations
+from fme.core.typing_ import TensorDict, TensorMapping
+from fme.core.wandb import Image
+
+from ..plotting import plot_paneled_data
+from .build_context import MetricBuildContext, MetricNotSupportedError, maybe_filter
+from .data import InferenceBatchData, MetricBuildResult, SubAggregator
+
+SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60
+# A fixed reference epoch is used (rather than each sample's start time) so the
+# running sums stay consistent across batches and distributed ranks without
+# communication. The regression slope is shift-invariant, so the epoch does not
+# affect the result; it is chosen near the climate-data era only to keep the
+# magnitude of the time regressor small, which improves the floating-point
+# conditioning of the (float64) running sums.
+_REFERENCE_UNITS = "seconds since 2000-01-01 00:00:00"
+
+
+def _years_since_reference(time: xr.DataArray) -> np.ndarray:
+    """Convert a ``(sample, time)`` datetime array to floating-point years
+    since a fixed reference epoch.
+    """
+    calendar = time.dt.calendar
+    seconds = cftime.date2num(
+        time.values.ravel(), units=_REFERENCE_UNITS, calendar=calendar
+    ).reshape(time.shape)
+    return seconds / SECONDS_PER_YEAR
+
+
+class TrendEvaluatorAggregator:
+    """Per-grid-cell linear trend (least-squares slope vs. time) maps.
+
+    The trend of each variable at each grid cell is the ordinary least-squares
+    slope of its value against time. It is computed by accumulating the
+    regression sufficient statistics -- the running sums of ``t``, ``t**2``,
+    ``y``, ``t*y`` and the observation count ``n`` -- in a single streaming
+    pass over the inference batches. Because only these sums are retained, the
+    memory cost is independent of the number of timesteps, so trends can be
+    computed for runs whose full time series does not fit in memory.
+
+    For grid cell with values ``y`` at times ``t`` (in years), the slope is
+
+        slope = (n * sum(t*y) - sum(t) * sum(y)) / (n * sum(t**2) - sum(t)**2)
+
+    Both the predicted and target trend maps are produced, along with a bias
+    map (generated - target) and the area-weighted RMSE between them. Slope
+    units are ``<variable units> / year``.
+    """
+
+    _image_captions = {
+        "trend_maps": (
+            "{name} linear trend; (left) target and (right) generated "
+            "[{units} / year]"
+        ),
+        "trend_difference_map": (
+            "{name} linear trend difference (generated - target) [{units} / year]"
+        ),
+    }
+
+    def __init__(
+        self,
+        gridded_operations: GriddedOperations,
+        horizontal_dims: list[str],
+        variable_metadata: Mapping[str, VariableMetadata] | None = None,
+    ):
+        """
+        Args:
+            gridded_operations: Computes gridded (area-weighted) operations.
+            horizontal_dims: Names of the horizontal dimensions, used for the
+                output dataset.
+            variable_metadata: Mapping of variable names to metadata used in
+                image captions and dataset attributes.
+        """
+        self._ops = gridded_operations
+        self._horizontal_dims = horizontal_dims
+        self._variable_metadata = variable_metadata or {}
+        device = get_device()
+        # time regressor statistics, shared across variables and grid cells
+        self._n = torch.zeros((), dtype=torch.float64, device=device)
+        self._sum_t = torch.zeros((), dtype=torch.float64, device=device)
+        self._sum_tt = torch.zeros((), dtype=torch.float64, device=device)
+        # per-variable [n_lat, n_lon] running sums of y and t*y
+        self._target_sum_y: TensorDict = {}
+        self._target_sum_ty: TensorDict = {}
+        self._gen_sum_y: TensorDict = {}
+        self._gen_sum_ty: TensorDict = {}
+
+    @staticmethod
+    def _add_running_sums(
+        sum_y: TensorDict,
+        sum_ty: TensorDict,
+        tensor_data: TensorMapping,
+        t: torch.Tensor,
+    ) -> None:
+        """Accumulate sum(y) and sum(t*y) over the (sample, time) dimensions.
+
+        Args:
+            sum_y: Running sum of y, mutated in place.
+            sum_ty: Running sum of t*y, mutated in place.
+            tensor_data: Mapping of variable name to a (sample, time, lat, lon)
+                tensor, already sliced to the timesteps being recorded.
+            t: Time in years with shape (sample, time), matching ``tensor_data``.
+        """
+        t_broadcast = t[:, :, None, None]
+        for name, tensor in tensor_data.items():
+            y = tensor.to(torch.float64)
+            contrib_y = y.sum(dim=(0, 1))
+            contrib_ty = (t_broadcast * y).sum(dim=(0, 1))
+            if name in sum_y:
+                sum_y[name] = sum_y[name] + contrib_y
+                sum_ty[name] = sum_ty[name] + contrib_ty
+            else:
+                sum_y[name] = contrib_y
+                sum_ty[name] = contrib_ty
+
+    @torch.no_grad()
+    def record_batch(self, data: InferenceBatchData) -> None:
+        # Mirror TimeMeanAggregator: when the initial condition is the first
+        # timestep of the first batch, skip it so it is not double-counted.
+        time_slice = slice(1, None) if data.i_time_start == 0 else slice(None)
+        years = _years_since_reference(data.time)[:, time_slice]
+        t = torch.tensor(years, dtype=torch.float64, device=get_device())
+        if t.shape[1] == 0:
+            return
+        self._n = self._n + t.numel()
+        self._sum_t = self._sum_t + t.sum()
+        self._sum_tt = self._sum_tt + (t * t).sum()
+        gen = {name: tensor[:, time_slice] for name, tensor in data.prediction.items()}
+        self._add_running_sums(self._gen_sum_y, self._gen_sum_ty, gen, t)
+        target = {name: tensor[:, time_slice] for name, tensor in data.target.items()}
+        self._add_running_sums(self._target_sum_y, self._target_sum_ty, target, t)
+
+    def _compute_trends(
+        self, sum_y: TensorDict, sum_ty: TensorDict
+    ) -> TensorDict | None:
+        """Reduce sufficient statistics across ranks and finalize the slopes.
+
+        Returns ``None`` on non-root ranks.
+        """
+        dist = Distributed.get_instance()
+        # reduce additive sufficient statistics across data-parallel ranks;
+        # clone first so repeated get_logs/get_dataset calls stay correct.
+        n = dist.reduce_sum(self._n.clone())
+        sum_t = dist.reduce_sum(self._sum_t.clone())
+        sum_tt = dist.reduce_sum(self._sum_tt.clone())
+        names = sorted(sum_y.keys())
+        stacked_y = dist.reduce_sum(torch.stack([sum_y[name] for name in names], dim=0))
+        stacked_ty = dist.reduce_sum(
+            torch.stack([sum_ty[name] for name in names], dim=0)
+        )
+        if not dist.is_root():
+            return None
+        denom = n * sum_tt - sum_t * sum_t
+        trends: TensorDict = {}
+        for i, name in enumerate(names):
+            numerator = n * stacked_ty[i] - sum_t * stacked_y[i]
+            trends[name] = numerator / denom
+        return trends
+
+    def _get_trends(self) -> tuple[TensorDict | None, TensorDict | None]:
+        if not self._gen_sum_y:
+            raise ValueError("No data has been recorded yet.")
+        target_trends = self._compute_trends(self._target_sum_y, self._target_sum_ty)
+        gen_trends = self._compute_trends(self._gen_sum_y, self._gen_sum_ty)
+        return target_trends, gen_trends
+
+    def _caption(self, key: str, name: str) -> str:
+        if name in self._variable_metadata:
+            caption_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units("unknown units")
+        else:
+            caption_name, units = name, "unknown units"
+        return self._image_captions[key].format(name=caption_name, units=units)
+
+    @torch.no_grad()
+    def get_logs(self, label: str) -> dict[str, float | Image]:
+        target_trends, gen_trends = self._get_trends()
+        if target_trends is None or gen_trends is None:
+            return {}  # only the root process returns logs
+        images: dict[str, Image] = {}
+        metrics: dict[str, float] = {}
+        for name in gen_trends:
+            target_map = target_trends[name]
+            gen_map = gen_trends[name]
+            images[f"trend_maps/{name}"] = plot_paneled_data(
+                [[target_map.cpu().numpy(), gen_map.cpu().numpy()]],
+                diverging=True,
+                caption=self._caption("trend_maps", name),
+            )
+            difference = gen_map - target_map
+            images[f"trend_difference_map/{name}"] = plot_paneled_data(
+                [[difference.cpu().numpy()]],
+                diverging=True,
+                caption=self._caption("trend_difference_map", name),
+            )
+            metrics[f"rmse/{name}"] = float(
+                self._ops.area_weighted_rmse(
+                    predicted=gen_map.to(torch.float32),
+                    truth=target_map.to(torch.float32),
+                    name=name,
+                )
+                .cpu()
+                .numpy()
+            )
+        logs: dict[str, Any] = {}
+        if len(label) > 0:
+            label = label + "/"
+        logs.update({f"{label}{key}": image for key, image in images.items()})
+        logs.update({f"{label}{key}": metric for key, metric in metrics.items()})
+        return logs
+
+    def _var_attrs(self, name: str) -> dict[str, str]:
+        if name in self._variable_metadata:
+            long_name = self._variable_metadata[name].display_long_name(name)
+            units = self._variable_metadata[name].display_units("unknown units")
+        else:
+            long_name, units = name, "unknown units"
+        return {
+            "long_name": f"{long_name} linear trend",
+            "units": f"{units} / year",
+        }
+
+    def get_dataset(self) -> xr.Dataset:
+        target_trends, gen_trends = self._get_trends()
+        if target_trends is None or gen_trends is None:
+            return xr.Dataset()
+        target_ds = xr.Dataset(
+            {
+                name: (
+                    self._horizontal_dims,
+                    value.cpu().numpy(),
+                    self._var_attrs(name),
+                )
+                for name, value in target_trends.items()
+            }
+        ).expand_dims({"source": ["target"]})
+        gen_ds = xr.Dataset(
+            {
+                name: (
+                    self._horizontal_dims,
+                    value.cpu().numpy(),
+                    self._var_attrs(name),
+                )
+                for name, value in gen_trends.items()
+            }
+        ).expand_dims({"source": ["prediction"]})
+        return xr.concat([target_ds, gen_ds], dim="source")
+
+
+@dataclasses.dataclass
+class TrendMetricConfig:
+    """Configuration for the linear-trend-map inference metric.
+
+    Attributes:
+        variables: Variables to compute trends for. If ``None``, all available
+            variables are included.
+        name: Name used to label the metric's logs and diagnostics.
+        enabled: Whether the metric is computed. Disabled by default.
+        strict: If True, raise rather than skip when the metric is not
+            supported for the current configuration.
+    """
+
+    variables: list[str] | None = None
+    name: str = "trend"
+    enabled: bool = False
+    strict: bool = False
+
+    def get_name(self) -> str:
+        return self.name
+
+    def build(self, ctx: MetricBuildContext) -> MetricBuildResult:
+        if ctx.n_timesteps < 2:
+            raise MetricNotSupportedError(
+                f"trend metric requires at least 2 timesteps, got {ctx.n_timesteps}"
+            )
+        agg: SubAggregator = TrendEvaluatorAggregator(
+            ctx.ops,
+            horizontal_dims=list(ctx.horizontal_coordinates.dims),
+            variable_metadata=ctx.variable_metadata,
+        )
+        return MetricBuildResult(aggregator=maybe_filter(agg, self.variables))

--- a/fme/ace/aggregator/inference/trend.py
+++ b/fme/ace/aggregator/inference/trend.py
@@ -142,39 +142,52 @@ class TrendEvaluatorAggregator:
         target = {name: tensor[:, time_slice] for name, tensor in data.target.items()}
         self._add_running_sums(self._target_sum_y, self._target_sum_ty, target, t)
 
-    def _compute_trends(
-        self, sum_y: TensorDict, sum_ty: TensorDict
-    ) -> TensorDict | None:
-        """Reduce sufficient statistics across ranks and finalize the slopes.
-
-        Returns ``None`` on non-root ranks.
+    @staticmethod
+    def _reduce_running_sums(
+        dist: Distributed, sum_y: TensorDict, sum_ty: TensorDict
+    ) -> tuple[list[str], torch.Tensor, torch.Tensor]:
+        """Reduce the per-variable running sums across ranks, stacked in a
+        rank-deterministic (sorted) order.
         """
+        names = sorted(sum_y.keys())
+        reduced_y = dist.reduce_sum(torch.stack([sum_y[name] for name in names], dim=0))
+        reduced_ty = dist.reduce_sum(
+            torch.stack([sum_ty[name] for name in names], dim=0)
+        )
+        return names, reduced_y, reduced_ty
+
+    def _get_trends(self) -> tuple[TensorDict | None, TensorDict | None]:
+        """Reduce sufficient statistics across ranks and finalize the target
+        and generated slopes. Returns ``(None, None)`` on non-root ranks.
+
+        All collectives are issued unconditionally and in the same order on
+        every rank, before the ``is_root`` early-return, to avoid deadlock.
+        """
+        if not self._gen_sum_y:
+            raise ValueError("No data has been recorded yet.")
         dist = Distributed.get_instance()
-        # reduce additive sufficient statistics across data-parallel ranks;
-        # clone first so repeated get_logs/get_dataset calls stay correct.
+        # The time-regressor statistics are shared between target and generated,
+        # so reduce them once. Clone first so repeated get_logs/get_dataset
+        # calls stay correct (reduce_sum mutates its argument in place).
         n = dist.reduce_sum(self._n.clone())
         sum_t = dist.reduce_sum(self._sum_t.clone())
         sum_tt = dist.reduce_sum(self._sum_tt.clone())
-        names = sorted(sum_y.keys())
-        stacked_y = dist.reduce_sum(torch.stack([sum_y[name] for name in names], dim=0))
-        stacked_ty = dist.reduce_sum(
-            torch.stack([sum_ty[name] for name in names], dim=0)
+        gen = self._reduce_running_sums(dist, self._gen_sum_y, self._gen_sum_ty)
+        target = self._reduce_running_sums(
+            dist, self._target_sum_y, self._target_sum_ty
         )
         if not dist.is_root():
-            return None
+            return None, None
         denom = n * sum_tt - sum_t * sum_t
-        trends: TensorDict = {}
-        for i, name in enumerate(names):
-            numerator = n * stacked_ty[i] - sum_t * stacked_y[i]
-            trends[name] = numerator / denom
-        return trends
 
-    def _get_trends(self) -> tuple[TensorDict | None, TensorDict | None]:
-        if not self._gen_sum_y:
-            raise ValueError("No data has been recorded yet.")
-        target_trends = self._compute_trends(self._target_sum_y, self._target_sum_ty)
-        gen_trends = self._compute_trends(self._gen_sum_y, self._gen_sum_ty)
-        return target_trends, gen_trends
+        def slopes(reduced: tuple[list[str], torch.Tensor, torch.Tensor]) -> TensorDict:
+            names, sum_y, sum_ty = reduced
+            return {
+                name: (n * sum_ty[i] - sum_t * sum_y[i]) / denom
+                for i, name in enumerate(names)
+            }
+
+        return slopes(target), slopes(gen)
 
     def _caption(self, key: str, name: str) -> str:
         if name in self._variable_metadata:
@@ -281,9 +294,13 @@ class TrendMetricConfig:
         return self.name
 
     def build(self, ctx: MetricBuildContext) -> MetricBuildResult:
-        if ctx.n_timesteps < 2:
+        # The initial condition is dropped when it is the first recorded
+        # timestep, so require at least two forward steps to leave >= 2 points
+        # for the regression (otherwise the slope is an undefined 0/0).
+        if ctx.n_forward_steps < 2:
             raise MetricNotSupportedError(
-                f"trend metric requires at least 2 timesteps, got {ctx.n_timesteps}"
+                "trend metric requires at least 2 forward steps, got "
+                f"{ctx.n_forward_steps}"
             )
         agg: SubAggregator = TrendEvaluatorAggregator(
             ctx.ops,


### PR DESCRIPTION
Long climate inference runs can be too large to hold in memory, but a linear
trend is a sufficient-statistic computation: the least-squares slope of a
field against time depends on the data only through a handful of additive
running sums. This adds an inference-time aggregator that exploits that to
produce per-grid-cell **trend maps** in a single streaming pass, with memory
independent of the number of timesteps.

The aggregator accumulates, per grid cell, the regression sufficient
statistics (sums of `t`, `t**2`, `y`, `t*y`, and the count `n`) and finalizes
the slope `(n·Σt·y − Σt·Σy) / (n·Σt² − (Σt)²)` only when logs/diagnostics are
requested. It produces predicted and target trend maps, a difference map, and
area-weighted RMSE; slope units are `<variable units> / year`. The additive
sufficient statistics are reduced across data-parallel ranks (`reduce_sum`,
emit on root only), matching the existing `enso_coefficient` / `annual`
distributed patterns. Time is referenced to a fixed epoch and accumulated in
float64; the slope is shift-invariant so the epoch only affects conditioning.

It is configured via `TrendMetricConfig` with a configurable `variables` list
(`None` = all), wired into `InferenceEvaluatorAggregatorConfig` as the `trend`
metric, and is **disabled by default**.

Changes:
- `fme.ace.aggregator.inference.trend` (new): `TrendEvaluatorAggregator` and
  `TrendMetricConfig`, plus the `_years_since_reference` time helper.
- `fme.ace.aggregator.inference.main`: add `trend` to the `MetricConfig`
  union, to `InferenceEvaluatorAggregatorConfig` (default-disabled field), and
  to the enabled-metric list.
- `fme.ace.aggregator.inference.__init__`: export `TrendMetricConfig`.
- Tests: known-slope recovery, streaming-equals-single-batch, distributed
  reduction (`mock_distributed`), variable filtering, and default-disabled /
  enable-on-config wiring.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
