### PR TITLE
Refactor corrector configs to the Builder pattern

### DIFF
--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -12,13 +12,23 @@ from fme.core.atmosphere_data import (
     compute_layer_thickness,
 )
 from fme.core.constants import GRAVITY, SPECIFIC_HEAT_OF_DRY_AIR_CONST_VOLUME
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    Correction,
+    CorrectionSequence,
+    CorrectorConfigABC,
+)
 from fme.core.corrector.state import CorrectorState
-from fme.core.corrector.utils import force_positive
+from fme.core.corrector.utils import ForcePositive
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.typing_ import TensorDict, TensorMapping
+
+
+class AreaWeightedMean(Protocol):
+    def __call__(
+        self, data: torch.Tensor, keepdim: bool, name: str | None = None
+    ) -> torch.Tensor: ...
 
 
 @dataclasses.dataclass
@@ -40,29 +50,138 @@ class EnergyBudgetConfig:
 
 
 @dataclasses.dataclass
-class AtmosphereCorrectorParams:
-    """Plain (non-dacite) scalar parameters passed to ``AtmosphereCorrector``.
+class ConserveDryAir:
+    """Correction that pins the global-mean dry-air mass to its IC value.
 
-    Built by ``AtmosphereCorrectorConfig._build`` so the corrector does not need
-    to read the (non-leaf) config. The energy budget sub-config is flattened to
-    its scalar fields; ``total_energy_budget_method`` is ``None`` exactly when the
-    correction is disabled.
+    Bundles the operators needed to apply the dry-air conservation step. The
+    reference dry-air mass is seeded from ``input_data`` the first time it runs
+    and carried across steps via ``corrector_state``.
     """
 
-    conserve_dry_air: bool
-    zero_global_mean_moisture_advection: bool
-    moisture_budget_correction: (
-        Literal[
-            "precipitation",
-            "evaporation",
-            "advection_and_precipitation",
-            "advection_and_evaporation",
-        ]
-        | None
-    )
-    force_positive_names: list[str]
-    total_energy_budget_method: Literal["constant_temperature"] | None
-    total_energy_budget_unaccounted_heating: float
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None
+    precision: torch.dtype
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "conserve_dry_air is set to True, but no vertical coordinate is "
+                "available."
+            )
+        corrector_state = _seed_global_dry_air_mass(
+            input_data=input_data,
+            corrector_state=corrector_state,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            precision=self.precision,
+        )
+        assert corrector_state.global_dry_air_mass is not None
+        gen_data = _adjust_gen_dry_air_to_target(
+            gen_data,
+            target_global_dry_air=corrector_state.global_dry_air_mass,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            precision=self.precision,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class ZeroGlobalMeanMoistureAdvection:
+    """Correction that forces zero global-mean moisture advection."""
+
+    area_weighted_mean: AreaWeightedMean
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        gen_data = _force_zero_global_mean_moisture_advection(
+            gen_data=gen_data,
+            area_weighted_mean=self.area_weighted_mean,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class MoistureBudgetCorrection:
+    """Correction that closes the moisture budget via the configured terms."""
+
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None
+    timestep_seconds: float
+    terms_to_modify: Literal[
+        "precipitation",
+        "evaporation",
+        "advection_and_precipitation",
+        "advection_and_evaporation",
+    ]
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "Moisture budget correction is turned on, but no vertical "
+                "coordinate is available."
+            )
+        gen_data = _force_conserve_moisture(
+            input_data=input_data,
+            gen_data=gen_data,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            timestep_seconds=self.timestep_seconds,
+            terms_to_modify=self.terms_to_modify,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class TotalEnergyBudgetCorrection:
+    """Correction that conserves an idealized total energy budget."""
+
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None
+    timestep_seconds: float
+    method: Literal["constant_temperature"]
+    unaccounted_heating: float
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "Energy budget correction is turned on, but no vertical coordinate"
+                " is available."
+            )
+        gen_data = _force_conserve_total_energy(
+            input_data=input_data,
+            gen_data=gen_data,
+            forcing_data=forcing_data,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            timestep_seconds=self.timestep_seconds,
+            method=self.method,
+            unaccounted_heating=self.unaccounted_heating,
+        )
+        return gen_data, corrector_state
 
 
 @CorrectorSelector.register("atmosphere_corrector")
@@ -183,124 +302,47 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
         vertical_coordinate: HasAtmosphereVerticalIntegral | None,
         timestep: datetime.timedelta,
     ) -> "AtmosphereCorrector":
-        energy_budget = self.total_energy_budget_correction
-        params = AtmosphereCorrectorParams(
-            conserve_dry_air=self.conserve_dry_air,
-            zero_global_mean_moisture_advection=(
-                self.zero_global_mean_moisture_advection
-            ),
-            moisture_budget_correction=self.moisture_budget_correction,
-            force_positive_names=self.force_positive_names,
-            total_energy_budget_method=(
-                None if energy_budget is None else energy_budget.method
-            ),
-            total_energy_budget_unaccounted_heating=(
-                0.0
-                if energy_budget is None
-                else energy_budget.constant_unaccounted_heating
-            ),
-        )
-        return AtmosphereCorrector(
-            params=params,
-            gridded_operations=gridded_operations,
-            vertical_coordinate=vertical_coordinate,
-            timestep=timestep,
-        )
-
-
-class AtmosphereCorrector(CorrectorABC):
-    def __init__(
-        self,
-        params: AtmosphereCorrectorParams,
-        gridded_operations: GriddedOperations,
-        vertical_coordinate: HasAtmosphereVerticalIntegral | None,
-        timestep: datetime.timedelta,
-    ):
-        self._params = params
-        self._gridded_operations = gridded_operations
-        self._vertical_coordinate = vertical_coordinate
-
-        self._timestep_seconds = timestep.total_seconds()
-        if fme.get_device() == torch.device("mps", 0):
-            self._dry_air_precision = torch.float32
-        else:
-            self._dry_air_precision = torch.float64
-
-    def __call__(
-        self,
-        input_data: TensorMapping,
-        gen_data: TensorMapping,
-        forcing_data: TensorMapping,
-        corrector_state: CorrectorState | None,
-    ) -> tuple[TensorDict, CorrectorState | None]:
-        gen_data = dict(gen_data)
-        if len(self._params.force_positive_names) > 0:
+        area_weighted_mean = gridded_operations.area_weighted_mean
+        timestep_seconds = timestep.total_seconds()
+        corrections: list[Correction] = []
+        if len(self.force_positive_names) > 0:
             # do this step before imposing other conservation correctors, since
             # otherwise it could end up creating violations of those constraints.
-            gen_data = force_positive(gen_data, self._params.force_positive_names)
-        if self._params.conserve_dry_air:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "conserve_dry_air is set to True, but no vertical coordinate is "
-                    "available."
+            corrections.append(ForcePositive(self.force_positive_names))
+        if self.conserve_dry_air:
+            if fme.get_device() == torch.device("mps", 0):
+                precision = torch.float32
+            else:
+                precision = torch.float64
+            corrections.append(
+                ConserveDryAir(area_weighted_mean, vertical_coordinate, precision)
+            )
+        if self.zero_global_mean_moisture_advection:
+            corrections.append(ZeroGlobalMeanMoistureAdvection(area_weighted_mean))
+        if self.moisture_budget_correction is not None:
+            corrections.append(
+                MoistureBudgetCorrection(
+                    area_weighted_mean,
+                    vertical_coordinate,
+                    timestep_seconds,
+                    self.moisture_budget_correction,
                 )
-            corrector_state = _seed_global_dry_air_mass(
-                input_data=input_data,
-                corrector_state=corrector_state,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                precision=self._dry_air_precision,
             )
-            assert corrector_state.global_dry_air_mass is not None
-            gen_data = _adjust_gen_dry_air_to_target(
-                gen_data,
-                target_global_dry_air=corrector_state.global_dry_air_mass,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                precision=self._dry_air_precision,
-            )
-        if self._params.zero_global_mean_moisture_advection:
-            gen_data = _force_zero_global_mean_moisture_advection(
-                gen_data=gen_data,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-            )
-        if self._params.moisture_budget_correction is not None:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "Moisture budget correction is turned on, but no vertical "
-                    "coordinate is available."
+        if self.total_energy_budget_correction is not None:
+            corrections.append(
+                TotalEnergyBudgetCorrection(
+                    area_weighted_mean,
+                    vertical_coordinate,
+                    timestep_seconds,
+                    self.total_energy_budget_correction.method,
+                    self.total_energy_budget_correction.constant_unaccounted_heating,
                 )
-            gen_data = _force_conserve_moisture(
-                input_data=input_data,
-                gen_data=gen_data,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                timestep_seconds=self._timestep_seconds,
-                terms_to_modify=self._params.moisture_budget_correction,
             )
-        if self._params.total_energy_budget_method is not None:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "Energy budget correction is turned on, but no vertical coordinate"
-                    " is available."
-                )
-            gen_data = _force_conserve_total_energy(
-                input_data=input_data,
-                gen_data=gen_data,
-                forcing_data=forcing_data,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                timestep_seconds=self._timestep_seconds,
-                method=self._params.total_energy_budget_method,
-                unaccounted_heating=self._params.total_energy_budget_unaccounted_heating,
-            )
-        return gen_data, corrector_state
+        return AtmosphereCorrector(corrections)
 
 
-class AreaWeightedMean(Protocol):
-    def __call__(
-        self, data: torch.Tensor, keepdim: bool, name: str | None = None
-    ) -> torch.Tensor: ...
+class AtmosphereCorrector(CorrectionSequence):
+    pass
 
 
 def _seed_global_dry_air_mass(

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -39,6 +39,32 @@ class EnergyBudgetConfig:
     constant_unaccounted_heating: float = 0.0
 
 
+@dataclasses.dataclass
+class AtmosphereCorrectorParams:
+    """Plain (non-dacite) scalar parameters passed to ``AtmosphereCorrector``.
+
+    Built by ``AtmosphereCorrectorConfig._build`` so the corrector does not need
+    to read the (non-leaf) config. The energy budget sub-config is flattened to
+    its scalar fields; ``total_energy_budget_method`` is ``None`` exactly when the
+    correction is disabled.
+    """
+
+    conserve_dry_air: bool
+    zero_global_mean_moisture_advection: bool
+    moisture_budget_correction: (
+        Literal[
+            "precipitation",
+            "evaporation",
+            "advection_and_precipitation",
+            "advection_and_evaporation",
+        ]
+        | None
+    )
+    force_positive_names: list[str]
+    total_energy_budget_method: Literal["constant_temperature"] | None
+    total_energy_budget_unaccounted_heating: float
+
+
 @CorrectorSelector.register("atmosphere_corrector")
 @dataclasses.dataclass
 class AtmosphereCorrectorConfig(CorrectorConfigABC):
@@ -145,23 +171,52 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
         self,
         dataset_info: DatasetInfo,
     ) -> "AtmosphereCorrector":
-        return AtmosphereCorrector(
-            self,
+        return self._build(
             dataset_info.gridded_operations,
             dataset_info.atmosphere_vertical_coordinate,
             dataset_info.timestep,
+        )
+
+    def _build(
+        self,
+        gridded_operations: GriddedOperations,
+        vertical_coordinate: HasAtmosphereVerticalIntegral | None,
+        timestep: datetime.timedelta,
+    ) -> "AtmosphereCorrector":
+        energy_budget = self.total_energy_budget_correction
+        params = AtmosphereCorrectorParams(
+            conserve_dry_air=self.conserve_dry_air,
+            zero_global_mean_moisture_advection=(
+                self.zero_global_mean_moisture_advection
+            ),
+            moisture_budget_correction=self.moisture_budget_correction,
+            force_positive_names=self.force_positive_names,
+            total_energy_budget_method=(
+                None if energy_budget is None else energy_budget.method
+            ),
+            total_energy_budget_unaccounted_heating=(
+                0.0
+                if energy_budget is None
+                else energy_budget.constant_unaccounted_heating
+            ),
+        )
+        return AtmosphereCorrector(
+            params=params,
+            gridded_operations=gridded_operations,
+            vertical_coordinate=vertical_coordinate,
+            timestep=timestep,
         )
 
 
 class AtmosphereCorrector(CorrectorABC):
     def __init__(
         self,
-        config: AtmosphereCorrectorConfig,
+        params: AtmosphereCorrectorParams,
         gridded_operations: GriddedOperations,
         vertical_coordinate: HasAtmosphereVerticalIntegral | None,
         timestep: datetime.timedelta,
     ):
-        self._config = config
+        self._params = params
         self._gridded_operations = gridded_operations
         self._vertical_coordinate = vertical_coordinate
 
@@ -179,11 +234,11 @@ class AtmosphereCorrector(CorrectorABC):
         corrector_state: CorrectorState | None,
     ) -> tuple[TensorDict, CorrectorState | None]:
         gen_data = dict(gen_data)
-        if len(self._config.force_positive_names) > 0:
+        if len(self._params.force_positive_names) > 0:
             # do this step before imposing other conservation correctors, since
             # otherwise it could end up creating violations of those constraints.
-            gen_data = force_positive(gen_data, self._config.force_positive_names)
-        if self._config.conserve_dry_air:
+            gen_data = force_positive(gen_data, self._params.force_positive_names)
+        if self._params.conserve_dry_air:
             if self._vertical_coordinate is None:
                 raise ValueError(
                     "conserve_dry_air is set to True, but no vertical coordinate is "
@@ -204,12 +259,12 @@ class AtmosphereCorrector(CorrectorABC):
                 vertical_coordinate=self._vertical_coordinate,
                 precision=self._dry_air_precision,
             )
-        if self._config.zero_global_mean_moisture_advection:
+        if self._params.zero_global_mean_moisture_advection:
             gen_data = _force_zero_global_mean_moisture_advection(
                 gen_data=gen_data,
                 area_weighted_mean=self._gridded_operations.area_weighted_mean,
             )
-        if self._config.moisture_budget_correction is not None:
+        if self._params.moisture_budget_correction is not None:
             if self._vertical_coordinate is None:
                 raise ValueError(
                     "Moisture budget correction is turned on, but no vertical "
@@ -221,9 +276,9 @@ class AtmosphereCorrector(CorrectorABC):
                 area_weighted_mean=self._gridded_operations.area_weighted_mean,
                 vertical_coordinate=self._vertical_coordinate,
                 timestep_seconds=self._timestep_seconds,
-                terms_to_modify=self._config.moisture_budget_correction,
+                terms_to_modify=self._params.moisture_budget_correction,
             )
-        if self._config.total_energy_budget_correction is not None:
+        if self._params.total_energy_budget_method is not None:
             if self._vertical_coordinate is None:
                 raise ValueError(
                     "Energy budget correction is turned on, but no vertical coordinate"
@@ -236,8 +291,8 @@ class AtmosphereCorrector(CorrectorABC):
                 area_weighted_mean=self._gridded_operations.area_weighted_mean,
                 vertical_coordinate=self._vertical_coordinate,
                 timestep_seconds=self._timestep_seconds,
-                method=self._config.total_energy_budget_correction.method,
-                unaccounted_heating=self._config.total_energy_budget_correction.constant_unaccounted_heating,
+                method=self._params.total_energy_budget_method,
+                unaccounted_heating=self._params.total_energy_budget_unaccounted_heating,
             )
         return gen_data, corrector_state
 

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -27,7 +27,7 @@ from fme.core.typing_ import TensorDict, TensorMapping
 
 class AreaWeightedMean(Protocol):
     def __call__(
-        self, data: torch.Tensor, keepdim: bool, name: str | None = None
+        self, data: torch.Tensor, keepdim: bool = False, name: str | None = None
     ) -> torch.Tensor: ...
 
 

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -191,10 +191,20 @@ class IceCorrectorConfig(CorrectorConfigABC):
         self,
         dataset_info: DatasetInfo,
     ) -> "IceCorrector":
-        return IceCorrector(
-            self,
+        return self._build(
             dataset_info.gridded_operations,
             dataset_info.timestep,
+        )
+
+    def _build(
+        self,
+        gridded_operations: GriddedOperations,
+        timestep: datetime.timedelta,
+    ) -> "IceCorrector":
+        return IceCorrector(
+            budget_correction=self.budget_correction,
+            gridded_operations=gridded_operations,
+            timestep=timestep,
         )
 
 
@@ -205,11 +215,11 @@ class IceCorrector(CorrectorABC):
 
     def __init__(
         self,
-        config: IceCorrectorConfig,
+        budget_correction: IceBudgetCorrectionConfig | None,
         gridded_operations: GriddedOperations,
         timestep: datetime.timedelta,
     ):
-        self._config = config
+        self._budget_correction = budget_correction
         self._gridded_operations = gridded_operations
         self._timestep = timestep
 
@@ -221,7 +231,7 @@ class IceCorrector(CorrectorABC):
         corrector_state: CorrectorState | None,
     ) -> tuple[TensorDict, CorrectorState | None]:
         timestep = self._timestep.total_seconds()
-        if self._config.budget_correction is not None:
-            gen_data = self._config.budget_correction(gen_data, input_data, timestep)
+        if self._budget_correction is not None:
+            gen_data = self._budget_correction(gen_data, input_data, timestep)
 
         return dict(gen_data), corrector_state

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -3,7 +3,11 @@ import datetime
 
 import torch
 
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    Correction,
+    CorrectionSequence,
+    CorrectorConfigABC,
+)
 from fme.core.corrector.state import CorrectorState
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
@@ -182,6 +186,28 @@ class IceBudgetCorrectionConfig:
         return {key: value.float() for key, value in out.items()}
 
 
+@dataclasses.dataclass
+class IceBudgetCorrection:
+    """Correction that reconstructs ice/snow state from budget terms.
+
+    Wraps ``IceBudgetCorrectionConfig`` so the corrector applies the operation
+    without reading config fields. ``forcing_data`` and ``corrector_state`` are
+    unused and passed through.
+    """
+
+    config: IceBudgetCorrectionConfig
+    timestep_seconds: float
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return self.config(gen_data, input_data, self.timestep_seconds), corrector_state
+
+
 @CorrectorSelector.register("ice_corrector")
 @dataclasses.dataclass
 class IceCorrectorConfig(CorrectorConfigABC):
@@ -201,37 +227,15 @@ class IceCorrectorConfig(CorrectorConfigABC):
         gridded_operations: GriddedOperations,
         timestep: datetime.timedelta,
     ) -> "IceCorrector":
-        return IceCorrector(
-            budget_correction=self.budget_correction,
-            gridded_operations=gridded_operations,
-            timestep=timestep,
-        )
+        corrections: list[Correction] = []
+        if self.budget_correction is not None:
+            corrections.append(
+                IceBudgetCorrection(self.budget_correction, timestep.total_seconds())
+            )
+        return IceCorrector(corrections)
 
 
-class IceCorrector(CorrectorABC):
+class IceCorrector(CorrectionSequence):
     """
     Implement choice of sea ice corrector.
     """
-
-    def __init__(
-        self,
-        budget_correction: IceBudgetCorrectionConfig | None,
-        gridded_operations: GriddedOperations,
-        timestep: datetime.timedelta,
-    ):
-        self._budget_correction = budget_correction
-        self._gridded_operations = gridded_operations
-        self._timestep = timestep
-
-    def __call__(
-        self,
-        input_data: TensorMapping,
-        gen_data: TensorMapping,
-        forcing_data: TensorMapping,
-        corrector_state: CorrectorState | None,
-    ) -> tuple[TensorDict, CorrectorState | None]:
-        timestep = self._timestep.total_seconds()
-        if self._budget_correction is not None:
-            gen_data = self._budget_correction(gen_data, input_data, timestep)
-
-        return dict(gen_data), corrector_state

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -1,6 +1,6 @@
 import dataclasses
 import datetime
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any, Literal, Protocol
 
 import torch
@@ -62,6 +62,12 @@ class SeaIceFractionConfig:
         for name in self.zero_where_ice_free_names:
             out[name] = gen_data[name] * (out[self.sea_ice_fraction_name] > 0.0)
         return out
+
+
+# Operation the OceanCorrector applies to enforce sea-ice-fraction constraints;
+# provided by SeaIceFractionConfig.__call__. Passed as a callable (not the config)
+# so the corrector relies only on the operation, not on reading config fields.
+SeaIceFractionCorrection = Callable[[TensorMapping, TensorMapping], TensorDict]
 
 
 @dataclasses.dataclass
@@ -191,7 +197,11 @@ class OceanCorrectorConfig(CorrectorConfigABC):
         )
         return OceanCorrector(
             params=params,
-            sea_ice_fraction_correction=self.sea_ice_fraction_correction,
+            sea_ice_fraction_correction=(
+                None
+                if self.sea_ice_fraction_correction is None
+                else self.sea_ice_fraction_correction.__call__
+            ),
             gridded_operations=gridded_operations,
             vertical_coordinate=vertical_coordinate,
             timestep=timestep,
@@ -202,7 +212,7 @@ class OceanCorrector(CorrectorABC):
     def __init__(
         self,
         params: OceanCorrectorParams,
-        sea_ice_fraction_correction: SeaIceFractionConfig | None,
+        sea_ice_fraction_correction: SeaIceFractionCorrection | None,
         gridded_operations: GriddedOperations,
         vertical_coordinate: HasOceanDepthIntegral | None,
         timestep: datetime.timedelta,

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -1,6 +1,6 @@
 import dataclasses
 import datetime
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Any, Literal, Protocol
 
 import torch
@@ -11,14 +11,24 @@ from fme.core.constants import (
     LATENT_HEAT_OF_VAPORIZATION,
     SPECIFIC_HEAT_OF_SEA_WATER_CM4,
 )
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    Correction,
+    CorrectionSequence,
+    CorrectorConfigABC,
+)
 from fme.core.corrector.state import CorrectorState
-from fme.core.corrector.utils import force_positive
+from fme.core.corrector.utils import ForcePositive
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.ocean_data import HasOceanDepthIntegral, OceanData
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.typing_ import TensorDict, TensorMapping
+
+
+class AreaWeightedMean(Protocol):
+    def __call__(
+        self, data: torch.Tensor, keepdim: bool, name: str | None = None
+    ) -> torch.Tensor: ...
 
 
 @dataclasses.dataclass
@@ -62,12 +72,6 @@ class SeaIceFractionConfig:
         for name in self.zero_where_ice_free_names:
             out[name] = gen_data[name] * (out[self.sea_ice_fraction_name] > 0.0)
         return out
-
-
-# Operation the OceanCorrector applies to enforce sea-ice-fraction constraints;
-# provided by SeaIceFractionConfig.__call__. Passed as a callable (not the config)
-# so the corrector relies only on the operation, not on reading config fields.
-SeaIceFractionCorrection = Callable[[TensorMapping, TensorMapping], TensorDict]
 
 
 @dataclasses.dataclass
@@ -116,19 +120,81 @@ class SurfaceEnergyFluxCorrectionConfig:
 
 
 @dataclasses.dataclass
-class OceanCorrectorParams:
-    """Plain (non-dacite) scalar parameters passed to ``OceanCorrector``.
+class SeaIceFractionCorrection:
+    """Correction that enforces sea-ice-fraction constraints.
 
-    Built by ``OceanCorrectorConfig._build`` so the corrector does not need to
-    read the (non-leaf) config. The surface-energy-flux and ocean-heat-content
-    sub-configs are flattened to their scalar fields; each ``*_method`` is
-    ``None`` exactly when the corresponding correction is disabled.
+    Wraps ``SeaIceFractionConfig`` so the corrector applies the operation
+    without reading config fields. ``forcing_data`` and ``corrector_state`` are
+    unused and passed through.
     """
 
-    force_positive_names: list[str]
-    surface_energy_flux_method: Literal["residual_prediction", "prescribed"] | None
-    ocean_heat_content_method: Literal["scaled_temperature"] | None
-    ocean_heat_content_unaccounted_heating: float
+    config: SeaIceFractionConfig
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return self.config(gen_data, input_data), corrector_state
+
+
+@dataclasses.dataclass
+class SurfaceEnergyFluxCorrection:
+    """Correction that adjusts hfds using atmosphere-derived surface fluxes."""
+
+    method: Literal["residual_prediction", "prescribed"]
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        gen_data = _correct_hfds(
+            input_data,
+            gen_data,
+            forcing_data,
+            method=self.method,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class OceanHeatContentCorrection:
+    """Correction that conserves ocean heat content."""
+
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasOceanDepthIntegral | None
+    timestep_seconds: float
+    method: Literal["scaled_temperature"]
+    unaccounted_heating: float
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "Ocean heat content correction is turned on, but no vertical "
+                "coordinate is available."
+            )
+        gen_data = _force_conserve_ocean_heat_content(
+            input_data,
+            gen_data,
+            forcing_data,
+            self.area_weighted_mean,
+            self.vertical_coordinate,
+            self.timestep_seconds,
+            self.method,
+            self.unaccounted_heating,
+        )
+        return gen_data, corrector_state
 
 
 @CorrectorSelector.register("ocean_corrector")
@@ -179,85 +245,34 @@ class OceanCorrectorConfig(CorrectorConfigABC):
         vertical_coordinate: HasOceanDepthIntegral | None,
         timestep: datetime.timedelta,
     ) -> "OceanCorrector":
-        flux_correction = self.surface_energy_flux_correction
-        ohc_correction = self.ocean_heat_content_correction
-        params = OceanCorrectorParams(
-            force_positive_names=self.force_positive_names,
-            surface_energy_flux_method=(
-                None if flux_correction is None else flux_correction.method
-            ),
-            ocean_heat_content_method=(
-                None if ohc_correction is None else ohc_correction.method
-            ),
-            ocean_heat_content_unaccounted_heating=(
-                0.0
-                if ohc_correction is None
-                else ohc_correction.constant_unaccounted_heating
-            ),
-        )
-        return OceanCorrector(
-            params=params,
-            sea_ice_fraction_correction=(
-                None
-                if self.sea_ice_fraction_correction is None
-                else self.sea_ice_fraction_correction.__call__
-            ),
-            gridded_operations=gridded_operations,
-            vertical_coordinate=vertical_coordinate,
-            timestep=timestep,
-        )
-
-
-class OceanCorrector(CorrectorABC):
-    def __init__(
-        self,
-        params: OceanCorrectorParams,
-        sea_ice_fraction_correction: SeaIceFractionCorrection | None,
-        gridded_operations: GriddedOperations,
-        vertical_coordinate: HasOceanDepthIntegral | None,
-        timestep: datetime.timedelta,
-    ):
-        self._params = params
-        self._sea_ice_fraction_correction = sea_ice_fraction_correction
-        self._gridded_operations = gridded_operations
-        self._vertical_coordinate = vertical_coordinate
-        self._timestep = timestep
-
-    def __call__(
-        self,
-        input_data: TensorMapping,
-        gen_data: TensorMapping,
-        forcing_data: TensorMapping,
-        corrector_state: CorrectorState | None,
-    ) -> tuple[TensorDict, CorrectorState | None]:
-        if len(self._params.force_positive_names) > 0:
-            gen_data = force_positive(gen_data, self._params.force_positive_names)
-        if self._sea_ice_fraction_correction is not None:
-            gen_data = self._sea_ice_fraction_correction(gen_data, input_data)
-        if self._params.surface_energy_flux_method is not None:
-            gen_data = _correct_hfds(
-                input_data,
-                gen_data,
-                forcing_data,
-                method=self._params.surface_energy_flux_method,
+        area_weighted_mean = gridded_operations.area_weighted_mean
+        timestep_seconds = timestep.total_seconds()
+        corrections: list[Correction] = []
+        if len(self.force_positive_names) > 0:
+            corrections.append(ForcePositive(self.force_positive_names))
+        if self.sea_ice_fraction_correction is not None:
+            corrections.append(
+                SeaIceFractionCorrection(self.sea_ice_fraction_correction)
             )
-        if self._params.ocean_heat_content_method is not None:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "Ocean heat content correction is turned on, but no vertical "
-                    "coordinate is available."
+        if self.surface_energy_flux_correction is not None:
+            corrections.append(
+                SurfaceEnergyFluxCorrection(self.surface_energy_flux_correction.method)
+            )
+        if self.ocean_heat_content_correction is not None:
+            corrections.append(
+                OceanHeatContentCorrection(
+                    area_weighted_mean,
+                    vertical_coordinate,
+                    timestep_seconds,
+                    self.ocean_heat_content_correction.method,
+                    self.ocean_heat_content_correction.constant_unaccounted_heating,
                 )
-            gen_data = _force_conserve_ocean_heat_content(
-                input_data,
-                gen_data,
-                forcing_data,
-                self._gridded_operations.area_weighted_mean,
-                self._vertical_coordinate,
-                self._timestep.total_seconds(),
-                self._params.ocean_heat_content_method,
-                self._params.ocean_heat_content_unaccounted_heating,
             )
-        return dict(gen_data), corrector_state
+        return OceanCorrector(corrections)
+
+
+class OceanCorrector(CorrectionSequence):
+    pass
 
 
 def _compute_ocean_net_surface_energy_flux(
@@ -323,12 +338,6 @@ def _correct_hfds(
             f"Method {method!r} not implemented for surface energy flux correction"
         )
     return out
-
-
-class AreaWeightedMean(Protocol):
-    def __call__(
-        self, data: torch.Tensor, keepdim: bool, name: str | None = None
-    ) -> torch.Tensor: ...
 
 
 def _force_conserve_ocean_heat_content(

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -109,6 +109,22 @@ class SurfaceEnergyFluxCorrectionConfig:
     method: Literal["residual_prediction", "prescribed"]
 
 
+@dataclasses.dataclass
+class OceanCorrectorParams:
+    """Plain (non-dacite) scalar parameters passed to ``OceanCorrector``.
+
+    Built by ``OceanCorrectorConfig._build`` so the corrector does not need to
+    read the (non-leaf) config. The surface-energy-flux and ocean-heat-content
+    sub-configs are flattened to their scalar fields; each ``*_method`` is
+    ``None`` exactly when the corresponding correction is disabled.
+    """
+
+    force_positive_names: list[str]
+    surface_energy_flux_method: Literal["residual_prediction", "prescribed"] | None
+    ocean_heat_content_method: Literal["scaled_temperature"] | None
+    ocean_heat_content_unaccounted_heating: float
+
+
 @CorrectorSelector.register("ocean_corrector")
 @dataclasses.dataclass
 class OceanCorrectorConfig(CorrectorConfigABC):
@@ -145,23 +161,54 @@ class OceanCorrectorConfig(CorrectorConfigABC):
         self,
         dataset_info: DatasetInfo,
     ) -> "OceanCorrector":
-        return OceanCorrector(
-            self,
+        return self._build(
             dataset_info.gridded_operations,
             dataset_info.ocean_vertical_coordinate,
             dataset_info.timestep,
+        )
+
+    def _build(
+        self,
+        gridded_operations: GriddedOperations,
+        vertical_coordinate: HasOceanDepthIntegral | None,
+        timestep: datetime.timedelta,
+    ) -> "OceanCorrector":
+        flux_correction = self.surface_energy_flux_correction
+        ohc_correction = self.ocean_heat_content_correction
+        params = OceanCorrectorParams(
+            force_positive_names=self.force_positive_names,
+            surface_energy_flux_method=(
+                None if flux_correction is None else flux_correction.method
+            ),
+            ocean_heat_content_method=(
+                None if ohc_correction is None else ohc_correction.method
+            ),
+            ocean_heat_content_unaccounted_heating=(
+                0.0
+                if ohc_correction is None
+                else ohc_correction.constant_unaccounted_heating
+            ),
+        )
+        return OceanCorrector(
+            params=params,
+            sea_ice_fraction_correction=self.sea_ice_fraction_correction,
+            gridded_operations=gridded_operations,
+            vertical_coordinate=vertical_coordinate,
+            timestep=timestep,
         )
 
 
 class OceanCorrector(CorrectorABC):
     def __init__(
         self,
-        config: OceanCorrectorConfig,
+        params: OceanCorrectorParams,
+        sea_ice_fraction_correction: SeaIceFractionConfig | None,
         gridded_operations: GriddedOperations,
         vertical_coordinate: HasOceanDepthIntegral | None,
         timestep: datetime.timedelta,
     ):
-        self._config = config
+        self._params = params
+        self._sea_ice_fraction_correction = sea_ice_fraction_correction
         self._gridded_operations = gridded_operations
         self._vertical_coordinate = vertical_coordinate
         self._timestep = timestep
@@ -173,18 +220,18 @@ class OceanCorrector(CorrectorABC):
         forcing_data: TensorMapping,
         corrector_state: CorrectorState | None,
     ) -> tuple[TensorDict, CorrectorState | None]:
-        if len(self._config.force_positive_names) > 0:
-            gen_data = force_positive(gen_data, self._config.force_positive_names)
-        if self._config.sea_ice_fraction_correction is not None:
-            gen_data = self._config.sea_ice_fraction_correction(gen_data, input_data)
-        if self._config.surface_energy_flux_correction is not None:
+        if len(self._params.force_positive_names) > 0:
+            gen_data = force_positive(gen_data, self._params.force_positive_names)
+        if self._sea_ice_fraction_correction is not None:
+            gen_data = self._sea_ice_fraction_correction(gen_data, input_data)
+        if self._params.surface_energy_flux_method is not None:
             gen_data = _correct_hfds(
                 input_data,
                 gen_data,
                 forcing_data,
-                method=self._config.surface_energy_flux_correction.method,
+                method=self._params.surface_energy_flux_method,
             )
-        if self._config.ocean_heat_content_correction is not None:
+        if self._params.ocean_heat_content_method is not None:
             if self._vertical_coordinate is None:
                 raise ValueError(
                     "Ocean heat content correction is turned on, but no vertical "
@@ -197,8 +244,8 @@ class OceanCorrector(CorrectorABC):
                 self._gridded_operations.area_weighted_mean,
                 self._vertical_coordinate,
                 self._timestep.total_seconds(),
-                self._config.ocean_heat_content_correction.method,
-                self._config.ocean_heat_content_correction.constant_unaccounted_heating,
+                self._params.ocean_heat_content_method,
+                self._params.ocean_heat_content_unaccounted_heating,
             )
         return dict(gen_data), corrector_state
 

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -27,7 +27,7 @@ from fme.core.typing_ import TensorDict, TensorMapping
 
 class AreaWeightedMean(Protocol):
     def __call__(
-        self, data: torch.Tensor, keepdim: bool, name: str | None = None
+        self, data: torch.Tensor, keepdim: bool = False, name: str | None = None
     ) -> torch.Tensor: ...
 
 

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 from collections.abc import Mapping
-from typing import Any, Self, final
+from typing import Any, Protocol, Self, final
 
 import dacite
 
@@ -66,6 +66,27 @@ class CorrectorConfigABC(abc.ABC):
     ) -> "CorrectorABC": ...
 
 
+class Correction(Protocol):
+    """A single correction applied to ``gen_data`` by a corrector.
+
+    Each correction is a self-contained callable object that bundles its own
+    parameters and operators (e.g. an area-weighted-mean operator or a vertical
+    coordinate) and applies one conservation/positivity step. A corrector holds
+    an ordered sequence of these and simply applies them in turn, so it does not
+    need to read any config fields itself. The signature mirrors
+    ``CorrectorABC.__call__`` so corrections compose: a correction that does not
+    maintain state passes ``corrector_state`` through unchanged.
+    """
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]: ...
+
+
 class CorrectorABC(abc.ABC):
     def train(self, mode: bool = True) -> "CorrectorABC":
         """Set the corrector to training or evaluation mode.
@@ -119,6 +140,32 @@ class CorrectorABC(abc.ABC):
             A tuple ``(corrected_gen_data, corrector_state)``.
         """
         ...
+
+
+class CorrectionSequence(CorrectorABC):
+    """A corrector that applies an ordered sequence of ``Correction`` objects.
+
+    The sequence (and thus the order in which corrections are applied) is built
+    by the corrector config's ``_build``; the corrector itself only knows to
+    apply each correction in turn.
+    """
+
+    def __init__(self, corrections: list[Correction]):
+        self._corrections = corrections
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        gen_data = dict(gen_data)
+        for correction in self._corrections:
+            gen_data, corrector_state = correction(
+                input_data, gen_data, forcing_data, corrector_state
+            )
+        return dict(gen_data), corrector_state
 
 
 class EpochScheduledCorrector(CorrectorABC):

--- a/fme/core/corrector/test_atmosphere.py
+++ b/fme/core/corrector/test_atmosphere.py
@@ -14,7 +14,6 @@ from fme.core.gridded_ops import GriddedOperations, HEALPixOperations, LatLonOpe
 from fme.core.typing_ import TensorMapping
 
 from .atmosphere import (
-    AtmosphereCorrector,
     AtmosphereCorrectorConfig,
     EnergyBudgetConfig,
     _adjust_gen_dry_air_to_target,
@@ -460,7 +459,7 @@ def test_corrector_integration(air_temperature_prefix):
         0.5 + torch.rand(size=(tensor_shape[-2], 1)).broadcast_to(size=tensor_shape)
     )
     timestep = datetime.timedelta(seconds=3600)
-    corrector = AtmosphereCorrector(config, ops, vertical_coord, timestep)
+    corrector = config._build(ops, vertical_coord, timestep)
     corrector(input_data, gen_data, forcing_data, None)
 
 
@@ -472,7 +471,7 @@ def _build_conserve_dry_air_corrector(tensor_shape):
         torch.ones(size=(tensor_shape[-2], 1)).broadcast_to(size=tensor_shape)
     )
     timestep = datetime.timedelta(seconds=3600)
-    return AtmosphereCorrector(config, ops, vertical_coord, timestep), vertical_coord
+    return config._build(ops, vertical_coord, timestep), vertical_coord
 
 
 def _global_dry_air_mass(
@@ -551,6 +550,6 @@ def test_conserve_dry_air_requires_vertical_coordinate():
     config = AtmosphereCorrectorConfig(conserve_dry_air=True)
     ops = LatLonOperations(torch.ones(size=(5, 1)).broadcast_to(size=(5, 5)))
     timestep = datetime.timedelta(seconds=3600)
-    corrector = AtmosphereCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
     with pytest.raises(ValueError, match="vertical coordinate"):
         corrector({}, {}, {}, None)

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -6,7 +6,6 @@ import torch
 from fme import get_device
 from fme.core.coordinates import DepthCoordinate
 from fme.core.corrector.ocean import (
-    OceanCorrector,
     OceanCorrectorConfig,
     OceanHeatContentBudgetConfig,
     SeaIceFractionConfig,
@@ -43,7 +42,7 @@ def test_ocean_corrector_force_positive():
     config = OceanCorrectorConfig(force_positive_names=["so_0", "so_1"])
     ops = LatLonOperations(torch.ones(size=IMG_SHAPE))
     timestep = datetime.timedelta(seconds=3600)
-    corrector = OceanCorrector(config, ops, _VERTICAL_COORD, timestep)
+    corrector = config._build(ops, _VERTICAL_COORD, timestep)
     input_data = {f"so_{i}": torch.randn(IMG_SHAPE, device=DEVICE) for i in range(NZ)}
     input_data["sst"] = torch.randn(IMG_SHAPE, device=DEVICE)
     gen_data = {f"so_{i}": torch.randn(IMG_SHAPE, device=DEVICE) for i in range(NZ)}
@@ -71,7 +70,7 @@ def test_ocean_corrector_has_no_negative_ocean_fraction():
     gen_data["sst"] = torch.randn(IMG_SHAPE, device=DEVICE)
     gen_data["sea_ice_fraction"] = torch.randn(IMG_SHAPE, device=DEVICE) * 0.5
     gen_data["sea_ice_fraction"][_LAT, _LON] = -0.5
-    corrector = OceanCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
     violation = (input_data["land_fraction"] + gen_data["sea_ice_fraction"]) > 1.0
     assert violation.any()
     negative_sea_ice_fraction = gen_data["sea_ice_fraction"] < 0.0
@@ -103,7 +102,7 @@ def test_ocean_corrector_has_negative_ocean_fraction():
     gen_data["sst"] = torch.randn(IMG_SHAPE, device=DEVICE)
     gen_data["sea_ice_fraction"] = torch.randn(IMG_SHAPE, device=DEVICE) * 0.5
     gen_data["sea_ice_fraction"][_LAT, _LON] = -0.5
-    corrector = OceanCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
     violation = (input_data["land_fraction"] + gen_data["sea_ice_fraction"]) > 1.0
     assert violation.any()
     negative_sea_ice_fraction = gen_data["sea_ice_fraction"] < 0.0
@@ -135,7 +134,7 @@ def test_zero_where_ice_free_names():
         "sea_ice_fraction": torch.rand(IMG_SHAPE, device=DEVICE),
         "HI": torch.rand(IMG_SHAPE, device=DEVICE) * 10,
     }
-    corrector = OceanCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
     gen_data_corrected, _ = corrector(input_data, gen_data, {}, None)
     sea_ice_zero = gen_data_corrected["sea_ice_fraction"] == 0.0
     thickness = gen_data_corrected["HI"]
@@ -161,7 +160,7 @@ def test_zero_where_ice_free_names_multiple_variables():
         "HI": torch.rand(IMG_SHAPE, device=DEVICE) * 10,
         "HS": torch.rand(IMG_SHAPE, device=DEVICE) * 5,
     }
-    corrector = OceanCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
     gen_data_corrected, _ = corrector(input_data, gen_data, {}, None)
     sea_ice_zero = gen_data_corrected["sea_ice_fraction"] == 0.0
     for name in ["HI", "HS"]:
@@ -222,7 +221,7 @@ def test_surface_energy_flux_correction_resid():
     )
     ops = LatLonOperations(torch.ones(size=IMG_SHAPE))
     timestep = datetime.timedelta(seconds=3600)
-    corrector = OceanCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
 
     sst = torch.full(IMG_SHAPE, 300.0, device=DEVICE)
     gen_hfds = torch.full(IMG_SHAPE, 5.0, device=DEVICE)
@@ -264,7 +263,7 @@ def test_surface_energy_flux_correction_prescribed():
     )
     ops = LatLonOperations(torch.ones(size=IMG_SHAPE))
     timestep = datetime.timedelta(seconds=3600)
-    corrector = OceanCorrector(config, ops, None, timestep)
+    corrector = config._build(ops, None, timestep)
 
     sst = torch.full(IMG_SHAPE, 300.0, device=DEVICE)
     gen_hfds = torch.full(IMG_SHAPE, 5.0, device=DEVICE)
@@ -363,7 +362,7 @@ def test_ocean_heat_content_correction(hfds_type):
     }
     input_data = OceanData(input_data_dict, depth_coordinate)
     gen_data = OceanData(gen_data_dict, depth_coordinate)
-    corrector = OceanCorrector(config, ops, depth_coordinate, timestep)
+    corrector = config._build(ops, depth_coordinate, timestep)
     gen_data_corrected_dict, _ = corrector(
         input_data_dict, gen_data_dict, forcing_data_dict, None
     )

--- a/fme/core/corrector/utils.py
+++ b/fme/core/corrector/utils.py
@@ -1,5 +1,8 @@
+import dataclasses
+
 import torch
 
+from fme.core.corrector.state import CorrectorState
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -9,3 +12,23 @@ def force_positive(data: TensorMapping, names: list[str]) -> TensorDict:
     for name in names:
         out[name] = torch.clamp(data[name], min=0.0)
     return out
+
+
+@dataclasses.dataclass
+class ForcePositive:
+    """Correction that clamps the named generated fields to be non-negative.
+
+    Implements the ``Correction`` protocol; ``input_data``, ``forcing_data`` and
+    ``corrector_state`` are unused and passed through.
+    """
+
+    names: list[str]
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return force_positive(gen_data, self.names), corrector_state


### PR DESCRIPTION
This PR refactors the three correctors so the corrector no longer reads config fields at all. Each correction step (force-positive, dry-air conservation, moisture/energy budget closure, sea-ice-fraction, surface-energy-flux, ocean-heat-content, ice budget) becomes a small callable `Correction` object that bundles its own scalar params plus the operators it needs (e.g. an area-weighted-mean operator, a vertical coordinate) and applies one step. Each `*CorrectorConfig._build()` packages the configured params into an ordered list of these objects; the corrector is a thin `CorrectionSequence` that simply applies them in order. So `yaml` answers "how is this configurable" (the config dataclasses) while the `Correction` objects answer "what operation does the corrector apply".

The YAML config dataclasses are **unchanged** — `_build` only repackages already-parsed config params into the function-objects. Behavior-preserving (all corrector unit tests pass unchanged in intent). Intended as the template-setting sibling for the rest of the burn-down.

Changes:
- `fme.core.corrector.registry`: add the `Correction` protocol (the `(input, gen, forcing, state) -> (gen, state)` step signature) and a `CorrectionSequence` corrector base whose `__call__` applies an ordered list of `Correction`s.
- `fme.core.corrector.utils`: add the `ForcePositive` correction object (wraps the existing `force_positive`).
- `fme.core.corrector.atmosphere`: add `ConserveDryAir`, `ZeroGlobalMeanMoistureAdvection`, `MoistureBudgetCorrection`, `TotalEnergyBudgetCorrection`; `AtmosphereCorrector` is now a thin `CorrectionSequence`; `_build` assembles the ordered list.
- `fme.core.corrector.ocean`: add `SeaIceFractionCorrection` (wraps `SeaIceFractionConfig`), `SurfaceEnergyFluxCorrection`, `OceanHeatContentCorrection`; `OceanCorrector` is now a thin `CorrectionSequence`; `_build` assembles the ordered list.
- `fme.core.corrector.ice`: add `IceBudgetCorrection` (wraps `IceBudgetCorrectionConfig`); `IceCorrector` is now a thin `CorrectionSequence`.
- `test_atmosphere`, `test_ocean`: route direct impl construction through `config._build(...)` so the tests exercise the real build path.

- [x] Behavior-preserving refactor; existing 50 corrector tests pass unchanged (no new tests added)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated