### PR TITLE
Move data_writer sub-writer construction into the config builders

### DIFF
--- a/fme/ace/inference/data_writer/file_writer.py
+++ b/fme/ace/inference/data_writer/file_writer.py
@@ -269,6 +269,11 @@ class FileWriterConfig:
             for base_filename in base_filenames
         ]
 
+    def validate_time_coarsen(self, forward_steps_in_memory: int, n_forward_steps: int):
+        """Validate this writer's time coarsening against the inference schedule."""
+        if self.time_coarsen is not None:
+            self.time_coarsen.validate(forward_steps_in_memory, n_forward_steps)
+
     def build_paired(
         self,
         experiment_dir: str,

--- a/fme/ace/inference/data_writer/main.py
+++ b/fme/ace/inference/data_writer/main.py
@@ -75,6 +75,13 @@ class DataWriterConfig:
             filenames.extend(file.filenames)
         return filenames
 
+    def validate_time_coarsen(self, forward_steps_in_memory: int, n_forward_steps: int):
+        """Validate time coarsening (top-level and per-file) against the schedule."""
+        if self.time_coarsen is not None:
+            self.time_coarsen.validate(forward_steps_in_memory, n_forward_steps)
+        for file_config in self.files or []:
+            file_config.validate_time_coarsen(forward_steps_in_memory, n_forward_steps)
+
     def build_paired(
         self,
         experiment_dir: str,
@@ -85,19 +92,50 @@ class DataWriterConfig:
         coords: Mapping[str, np.ndarray],
         dataset_metadata: DatasetMetadata,
     ) -> "PairedDataWriter":
+        writers: list[PairedSubwriter] = []
+        if self.save_prediction_files:
+            raw_writer: PairedSubwriter = PairedRawDataWriter(
+                path=experiment_dir,
+                initial_condition_times=initial_condition_times,
+                save_names=self.names,
+                variable_metadata=variable_metadata,
+                coords=coords,
+                dataset_metadata=dataset_metadata,
+            )
+            if self.time_coarsen is not None:
+                raw_writer = self.time_coarsen.build_paired(raw_writer)
+            writers.append(raw_writer)
+        if self.save_monthly_files:
+            writers.append(
+                PairedMonthlyDataWriter(
+                    path=experiment_dir,
+                    initial_condition_times=initial_condition_times,
+                    n_timesteps=n_timesteps,
+                    timestep=timestep,
+                    save_names=self.names,
+                    variable_metadata=variable_metadata,
+                    coords=coords,
+                    dataset_metadata=dataset_metadata,
+                )
+            )
+        for writer_config in self.files or []:
+            writers.append(
+                writer_config.build_paired(
+                    experiment_dir=experiment_dir,
+                    initial_condition_times=initial_condition_times,
+                    n_timesteps=n_timesteps,
+                    timestep=timestep,
+                    variable_metadata=variable_metadata,
+                    coords=coords,
+                    dataset_metadata=dataset_metadata,
+                )
+            )
         return PairedDataWriter(
+            writers=writers,
             path=experiment_dir,
-            initial_condition_times=initial_condition_times,
-            n_timesteps=n_timesteps,
-            timestep=timestep,
             variable_metadata=variable_metadata,
             coords=coords,
-            enable_prediction_netcdfs=self.save_prediction_files,
-            enable_monthly_netcdfs=self.save_monthly_files,
-            save_names=self.names,
-            time_coarsen=self.time_coarsen,
             dataset_metadata=dataset_metadata,
-            files=self.files,
         )
 
     def build(
@@ -110,100 +148,39 @@ class DataWriterConfig:
         coords: Mapping[str, np.ndarray],
         dataset_metadata: DatasetMetadata,
     ) -> "DataWriter":
-        return DataWriter(
-            path=experiment_dir,
-            initial_condition_times=initial_condition_times,
-            n_timesteps=n_timesteps,
-            variable_metadata=variable_metadata,
-            coords=coords,
-            timestep=timestep,
-            enable_prediction_netcdfs=self.save_prediction_files,
-            enable_monthly_netcdfs=self.save_monthly_files,
-            save_names=self.names,
-            time_coarsen=self.time_coarsen,
-            dataset_metadata=dataset_metadata,
-            files=self.files,
-        )
-
-
-class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
-    def __init__(
-        self,
-        path: str,
-        initial_condition_times: npt.NDArray[cftime.datetime],
-        n_timesteps: int,
-        variable_metadata: Mapping[str, VariableMetadata],
-        coords: Mapping[str, np.ndarray],
-        timestep: datetime.timedelta,
-        enable_prediction_netcdfs: bool,
-        enable_monthly_netcdfs: bool,
-        save_names: Sequence[str] | None,
-        dataset_metadata: DatasetMetadata,
-        time_coarsen: TimeCoarsenConfig | None = None,
-        files: list[FileWriterConfig] | None = None,
-    ):
-        """
-        Args:
-            path: Path to write netCDF file(s).
-            initial_condition_times: 1D array of initial condition times
-                (start time for each inference run).
-            n_timesteps: Number of timesteps to write to the file.
-            variable_metadata: Metadata for each variable to be written to the file.
-            coords: Coordinate data to be written to the file.
-            timestep: Timestep of the model.
-            enable_prediction_netcdfs: Whether to enable writing of netCDF files
-                containing the predictions and target values.
-            enable_monthly_netcdfs: Whether to enable writing of netCDF files
-                containing the monthly predictions and target values.
-            save_names: Names of variables to save in the prediction
-                and monthly netCDF files.
-            dataset_metadata: Metadata for the dataset.
-            time_coarsen: Configuration for time coarsening of written outputs.
-            files: Configurations for individual data writers.
-
-        """
-        self._writers: list[PairedSubwriter] = []
-        self.path = path
-        self.coords = coords
-        self.variable_metadata = variable_metadata
-        self.dataset_metadata = dataset_metadata
-
-        def _time_coarsen_builder(data_writer: PairedSubwriter) -> PairedSubwriter:
-            if time_coarsen is not None:
-                return time_coarsen.build_paired(data_writer)
-            return data_writer
-
-        if enable_prediction_netcdfs:
-            self._writers.append(
-                _time_coarsen_builder(
-                    PairedRawDataWriter(
-                        path=path,
+        writers: list[Subwriter] = []
+        # TODO: handle writing HEALPix data
+        # https://github.com/ai2cm/full-model/issues/1089
+        if "face" not in coords:
+            if self.save_prediction_files:
+                raw_writer: Subwriter = RawDataWriter(
+                    path=experiment_dir,
+                    label="autoregressive_predictions",
+                    initial_condition_times=initial_condition_times,
+                    save_names=self.names,
+                    variable_metadata=variable_metadata,
+                    coords=coords,
+                    dataset_metadata=dataset_metadata,
+                )
+                if self.time_coarsen is not None:
+                    raw_writer = self.time_coarsen.build(raw_writer)
+                writers.append(raw_writer)
+            if self.save_monthly_files:
+                writers.append(
+                    MonthlyDataWriter(
+                        path=experiment_dir,
+                        label="monthly_mean_predictions",
                         initial_condition_times=initial_condition_times,
-                        save_names=save_names,
+                        save_names=self.names,
                         variable_metadata=variable_metadata,
                         coords=coords,
                         dataset_metadata=dataset_metadata,
                     )
                 )
-            )
-        if enable_monthly_netcdfs:
-            self._writers.append(
-                PairedMonthlyDataWriter(
-                    path=path,
-                    initial_condition_times=initial_condition_times,
-                    n_timesteps=n_timesteps,
-                    timestep=timestep,
-                    save_names=save_names,
-                    variable_metadata=variable_metadata,
-                    coords=coords,
-                    dataset_metadata=dataset_metadata,
-                )
-            )
-        if files is not None:
-            for writer_config in files:
-                self._writers.append(
-                    writer_config.build_paired(
-                        experiment_dir=path,
+            for writer_config in self.files or []:
+                writers.append(
+                    writer_config.build(
+                        experiment_dir=experiment_dir,
                         initial_condition_times=initial_condition_times,
                         n_timesteps=n_timesteps,
                         timestep=timestep,
@@ -212,6 +189,38 @@ class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
                         dataset_metadata=dataset_metadata,
                     )
                 )
+        return DataWriter(
+            writers=writers,
+            path=experiment_dir,
+            variable_metadata=variable_metadata,
+            coords=coords,
+            dataset_metadata=dataset_metadata,
+        )
+
+
+class PairedDataWriter(WriterABC[PrognosticState, PairedData]):
+    def __init__(
+        self,
+        writers: list[PairedSubwriter],
+        path: str,
+        variable_metadata: Mapping[str, VariableMetadata],
+        coords: Mapping[str, np.ndarray],
+        dataset_metadata: DatasetMetadata,
+    ):
+        """
+        Args:
+            writers: The sub-writers to dispatch each batch to, already built by
+                `DataWriterConfig.build_paired`.
+            path: Path to write single-snapshot netCDF file(s) via `write`.
+            variable_metadata: Metadata for each variable to be written to the file.
+            coords: Coordinate data to be written to the file.
+            dataset_metadata: Metadata for the dataset.
+        """
+        self._writers = writers
+        self.path = path
+        self.coords = coords
+        self.variable_metadata = variable_metadata
+        self.dataset_metadata = dataset_metadata
 
     def write(self, data: PrognosticState, filename: str):
         """Eagerly write data to a single netCDF file.
@@ -310,90 +319,24 @@ def _write(
 class DataWriter(WriterABC[PrognosticState, PairedData]):
     def __init__(
         self,
+        writers: list[Subwriter],
         path: str,
-        initial_condition_times: npt.NDArray[cftime.datetime],
-        n_timesteps: int,
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
-        timestep: datetime.timedelta,
-        enable_prediction_netcdfs: bool,
-        enable_monthly_netcdfs: bool,
-        save_names: Sequence[str] | None,
         dataset_metadata: DatasetMetadata,
-        time_coarsen: TimeCoarsenConfig | None = None,
-        files: list[FileWriterConfig] | None = None,
     ):
         """
         Args:
-            path: Directory within which to write netCDF file(s).
-            initial_condition_times: 1D array of initial condition times
-                (start time for each inference run).
-            n_timesteps: Number of timesteps to write to the file.
+            writers: The sub-writers to dispatch each batch to, already built by
+                `DataWriterConfig.build`. Empty for HEALPix (`face`)
+                coordinates, which are not yet supported.
+            path: Directory within which to write single-snapshot netCDF file(s)
+                via `write`.
             variable_metadata: Metadata for each variable to be written to the file.
             coords: Coordinate data to be written to the file.
-            timestep: Timestep of the model.
-            enable_prediction_netcdfs: Whether to enable writing of netCDF files
-                containing the predictions and target values.
-            enable_monthly_netcdfs: Whether to enable writing of netCDF files
-            save_names: Names of variables to save in the prediction
-                and monthly netCDF files.
             dataset_metadata: Metadata for the dataset.
-            time_coarsen: Configuration for time coarsening of raw outputs.
-            files: Configurations for individual data writers.
         """
-        self._writers: list[Subwriter] = []
-        if "face" in coords:
-            # TODO: handle writing HEALPix data
-            # https://github.com/ai2cm/full-model/issues/1089
-            return
-
-        def _time_coarsen_builder(data_writer: Subwriter) -> Subwriter:
-            if time_coarsen is not None:
-                return time_coarsen.build(data_writer)
-            return data_writer
-
-        if enable_prediction_netcdfs:
-            self._writers.append(
-                _time_coarsen_builder(
-                    RawDataWriter(
-                        path=path,
-                        label="autoregressive_predictions",
-                        initial_condition_times=initial_condition_times,
-                        save_names=save_names,
-                        variable_metadata=variable_metadata,
-                        coords=coords,
-                        dataset_metadata=dataset_metadata,
-                    )
-                )
-            )
-
-        if enable_monthly_netcdfs:
-            self._writers.append(
-                MonthlyDataWriter(
-                    path=path,
-                    label="monthly_mean_predictions",
-                    initial_condition_times=initial_condition_times,
-                    save_names=save_names,
-                    variable_metadata=variable_metadata,
-                    coords=coords,
-                    dataset_metadata=dataset_metadata,
-                )
-            )
-
-        if files is not None:
-            for writer_config in files:
-                self._writers.append(
-                    writer_config.build(
-                        experiment_dir=path,
-                        initial_condition_times=initial_condition_times,
-                        n_timesteps=n_timesteps,
-                        timestep=timestep,
-                        variable_metadata=variable_metadata,
-                        coords=coords,
-                        dataset_metadata=dataset_metadata,
-                    )
-                )
-
+        self._writers = writers
         self.path = path
         self.variable_metadata = variable_metadata
         self.dataset_metadata = dataset_metadata

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -12,11 +12,7 @@ from xarray.coding.times import CFDatetimeCoder
 from fme.ace.data_loading.batch_data import PairedData
 from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
 from fme.ace.inference.data_writer.file_writer import FileWriterConfig
-from fme.ace.inference.data_writer.main import (
-    DataWriter,
-    DataWriterConfig,
-    PairedDataWriter,
-)
+from fme.ace.inference.data_writer.main import DataWriterConfig
 from fme.ace.inference.data_writer.raw import get_batch_lead_time_microseconds
 from fme.ace.inference.data_writer.time_coarsen import TimeCoarsenConfig
 from fme.ace.inference.data_writer.zarr import ZarrWriterConfig
@@ -204,16 +200,17 @@ class TestDataWriter:
             start_time, calendar, n_initial_conditions
         )
         n_timesteps = 6
-        writer = PairedDataWriter(
-            str(tmp_path),
+        writer = DataWriterConfig(
+            save_prediction_files=True,
+            save_monthly_files=True,
+            names=None,
+        ).build_paired(
+            experiment_dir=str(tmp_path),
             initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             timestep=TIMESTEP,
             variable_metadata=sample_metadata,
             coords=coords,
-            enable_prediction_netcdfs=True,
-            enable_monthly_netcdfs=True,
-            save_names=None,
             dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
         )
         end_time = (2020, 1, 1, 12, 0, 0)
@@ -362,16 +359,17 @@ class TestDataWriter:
         initial_condition_times = get_initial_condition_times(
             start_time, calendar, n_samples
         )
-        writer = PairedDataWriter(
-            str(tmp_path),
+        writer = DataWriterConfig(
+            save_prediction_files=True,
+            save_monthly_files=True,
+            names=save_names,
+        ).build_paired(
+            experiment_dir=str(tmp_path),
             initial_condition_times=initial_condition_times,
             n_timesteps=4,  # unused
             timestep=TIMESTEP,
             variable_metadata=sample_metadata,
             coords={"lat": np.arange(4), "lon": np.arange(5)},
-            enable_prediction_netcdfs=True,
-            enable_monthly_netcdfs=True,
-            save_names=save_names,
             dataset_metadata=DatasetMetadata(),
         )
         start_time = (2020, 1, 1, 0, 0, 0)
@@ -435,16 +433,17 @@ class TestDataWriter:
         initial_condition_times = get_initial_condition_times(
             start_time, calendar, n_samples
         )
-        writer = PairedDataWriter(
-            str(tmp_path),
+        writer = DataWriterConfig(
+            save_prediction_files=True,
+            save_monthly_files=True,
+            names=None,
+        ).build_paired(
+            experiment_dir=str(tmp_path),
             initial_condition_times=initial_condition_times,
             n_timesteps=3,
             timestep=TIMESTEP,
             variable_metadata=sample_metadata,
             coords={"lat": np.arange(4), "lon": np.arange(5)},
-            enable_prediction_netcdfs=True,
-            enable_monthly_netcdfs=True,
-            save_names=None,
             dataset_metadata=DatasetMetadata(),
         )
         end_time = (2020, 1, 1, 12, 0, 0)
@@ -494,18 +493,19 @@ class TestDataWriter:
             format=ZarrWriterConfig(),
         )
 
-        writer = DataWriter(
-            str(tmp_path),
+        writer = DataWriterConfig(
+            save_prediction_files=True,
+            save_monthly_files=True,
+            names=None,
+            time_coarsen=TimeCoarsenConfig(coarsen_factor),
+            files=[region_config],
+        ).build(
+            experiment_dir=str(tmp_path),
             initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             variable_metadata=sample_metadata,
             coords={"lat": np.arange(4), "lon": np.arange(5)},
             timestep=TIMESTEP,
-            enable_prediction_netcdfs=True,
-            enable_monthly_netcdfs=True,
-            save_names=None,
-            time_coarsen=TimeCoarsenConfig(coarsen_factor),
-            files=[region_config],
             dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
         )
         end_time = (2020, 1, 1, 18, 0, 0)
@@ -624,18 +624,19 @@ class TestDataWriter:
             separate_ensemble_members=True,
             format=ZarrWriterConfig(),
         )
-        writer = DataWriter(
-            str(tmp_path),
+        writer = DataWriterConfig(
+            save_prediction_files=False,
+            save_monthly_files=False,
+            names=None,
+            time_coarsen=None,
+            files=[region_config],
+        ).build(
+            experiment_dir=str(tmp_path),
             initial_condition_times=initial_condition_times,
             n_timesteps=n_timesteps,
             variable_metadata=sample_metadata,
             coords={"lat": np.arange(n_lat), "lon": np.arange(n_lon)},
             timestep=TIMESTEP,
-            enable_prediction_netcdfs=False,
-            enable_monthly_netcdfs=False,
-            save_names=None,
-            time_coarsen=None,
-            files=[region_config],
             dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
         )
         end_time = (2020, 1, 1, 18, 0, 0)

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -241,18 +241,10 @@ class InferenceEvaluatorConfig:
     n_ensemble_per_ic: int = 1
 
     def __post_init__(self):
-        if self.data_writer.time_coarsen is not None:
-            self.data_writer.time_coarsen.validate(
-                self.forward_steps_in_memory,
-                self.n_forward_steps,
-            )
-        if self.data_writer.files is not None:
-            for file_config in self.data_writer.files:
-                if file_config.time_coarsen is not None:
-                    file_config.time_coarsen.validate(
-                        self.forward_steps_in_memory,
-                        self.n_forward_steps,
-                    )
+        self.data_writer.validate_time_coarsen(
+            self.forward_steps_in_memory,
+            self.n_forward_steps,
+        )
 
     def configure_logging(self, log_filename: str):
         config = dataclasses.asdict(self)

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -231,18 +231,10 @@ class InferenceConfig:
     n_ensemble_per_ic: int = 1
 
     def __post_init__(self):
-        if self.data_writer.time_coarsen is not None:
-            self.data_writer.time_coarsen.validate(
-                self.forward_steps_in_memory,
-                self.n_forward_steps,
-            )
-        if self.data_writer.files is not None:
-            for file_config in self.data_writer.files:
-                if file_config.time_coarsen is not None:
-                    file_config.time_coarsen.validate(
-                        self.forward_steps_in_memory,
-                        self.n_forward_steps,
-                    )
+        self.data_writer.validate_time_coarsen(
+            self.forward_steps_in_memory,
+            self.n_forward_steps,
+        )
 
     def configure_logging(self, log_filename: str):
         config = dataclasses.asdict(self)


### PR DESCRIPTION
In `fme/ace/inference/data_writer/`, the config objects and the runtime writer classes were doing parts of each other's jobs. `DataWriterConfig.build` handed `DataWriter` its raw sub-configs, and `DataWriter.__init__` then built its own child writers from them. Separately, the inference config classes reached directly into `data_writer`'s internal fields to validate time coarsening.

This PR moves writer construction into the config builders and gives the validation a real method. The writer classes now just receive a finished list of writers, and the config that defines the YAML schema stays separate from the runtime implementation. The change is behavior-preserving.

Changes:
- `fme.ace.inference.data_writer.main.DataWriterConfig`: `build` / `build_paired` now build the full list of sub-writers themselves (the prediction writer, the monthly writer, the per-file writers, and the time-coarsening wrapper) and pass that list in. `DataWriter` / `PairedDataWriter.__init__` take a ready-made `writers` list instead of raw sub-configs plus enable flags, so they no longer translate config into writers in their own `__init__`.
- `fme.ace.inference.data_writer.main.DataWriterConfig.validate_time_coarsen` (and a small `FileWriterConfig.validate_time_coarsen` helper it calls): a single method that validates the top-level and per-file time coarsening against the inference schedule.
- `fme.ace.inference.inference.InferenceConfig` / `fme.ace.inference.evaluator.InferenceEvaluatorConfig`: `__post_init__` now calls `data_writer.validate_time_coarsen(...)` instead of reaching into `data_writer.time_coarsen` and iterating `data_writer.files`.
- Tests: build writers through `DataWriterConfig.build` / `build_paired` rather than the old writer constructor signatures.

Note on HEALPix: for HEALPix (`face`) coordinates the non-paired `DataWriter` still ends up with an empty list of writers, exactly as before. The only difference is that `path` and metadata are now always stored, which only affects the HEALPix `DataWriter.write` path. That path is not used in production (both inference entrypoints use `build_paired`).

Follow-up: #1327 takes the next step of giving `FileWriter` a dedicated runtime-params object instead of its config. That part is split out so it can be discussed on its own. The similar validation on the coupled ocean/atmosphere config is also left for later; this PR keeps `time_coarsen` a public field so nothing there breaks.

- [x] Tests added (existing data_writer tests migrated to the public builder API)