### PR TITLE
Exclude missing variables from channel_mean

### DIFF
--- a/fme/ace/aggregator/inference/test_time_mean.py
+++ b/fme/ace/aggregator/inference/test_time_mean.py
@@ -42,6 +42,45 @@ def test_rmse_of_time_mean_all_channels():
     assert logs["time_mean_norm/rmse/channel_mean"] == 1.5
 
 
+def test_channel_mean_excludes_all_nan_target_channels():
+    """A variable whose target is entirely NaN (e.g. filled by
+    allow_missing_variables) has a NaN RMSE and is excluded from the channel
+    mean rather than poisoning it."""
+    torch.manual_seed(0)
+    area_weights = torch.ones(1, 1).to(get_device())
+    agg = TimeMeanEvaluatorAggregator(
+        LatLonOperations(area_weights),
+        horizontal_dims=["lat", "lon"],
+        target="norm",
+    )
+    target_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()),
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 3,
+        # "c" is missing from the data: entirely-NaN target.
+        "c": torch.full([2, 3, 4, 4], torch.nan, device=get_device()),
+    }
+    gen_data_norm = {
+        "a": torch.ones([2, 3, 4, 4], device=get_device()) * 2.0,
+        "b": torch.ones([2, 3, 4, 4], device=get_device()) * 5,
+        "c": torch.ones([2, 3, 4, 4], device=get_device()),
+    }
+    agg.record_batch(
+        InferenceBatchData(
+            prediction=gen_data_norm,
+            prediction_norm=gen_data_norm,
+            target=target_data_norm,
+            target_norm=target_data_norm,
+            time=make_dummy_time(2, 3),
+            i_time_start=0,
+        )
+    )
+    logs = agg.get_logs(label="time_mean_norm")
+    # "c" is still recorded per-variable as NaN...
+    assert np.isnan(logs["time_mean_norm/rmse/c"])
+    # ...but excluded from channel_mean: mean of "a" (1) and "b" (2).
+    assert logs["time_mean_norm/rmse/channel_mean"] == 1.5
+
+
 def test_custom_channel_mean_names():
     torch.manual_seed(0)
     area_weights = torch.ones(1, 1).to(get_device())

--- a/fme/ace/aggregator/inference/time_mean.py
+++ b/fme/ace/aggregator/inference/time_mean.py
@@ -384,8 +384,17 @@ class TimeMeanEvaluatorAggregator:
             channel_mean_names = [
                 name for name in channel_mean_names if name not in all_nan_target_names
             ]
-            values_to_average = [rmse_all_channels[name] for name in channel_mean_names]
-            logs.update({metric_name: sum(values_to_average) / len(values_to_average)})
+            if channel_mean_names:
+                values_to_average = [
+                    rmse_all_channels[name] for name in channel_mean_names
+                ]
+                logs.update(
+                    {metric_name: sum(values_to_average) / len(values_to_average)}
+                )
+            else:
+                raise ValueError(
+                    "All target variables are NaN; cannot compute channel mean."
+                )
 
         if len(label) != 0:
             return {f"{label}/{key}": logs[key] for key in logs}

--- a/fme/ace/aggregator/inference/time_mean.py
+++ b/fme/ace/aggregator/inference/time_mean.py
@@ -342,8 +342,14 @@ class TimeMeanEvaluatorAggregator:
         preds = self._get_target_gen_pairs()
         bias_map_key = "bias_map"
         rmse_all_channels = {}
+        # Variables whose target is entirely NaN have no valid data (e.g. filled
+        # by allow_missing_variables); their RMSE is NaN and they are excluded
+        # from the channel mean below.
+        all_nan_target_names: set[str] = set()
         for pred in preds:
             rmse_all_channels[pred.name] = pred.rmse()
+            if torch.isnan(pred.target).all():
+                all_nan_target_names.add(pred.name)
             should_log = self._log_variables is None or pred.name in self._log_variables
             if should_log:
                 bias_image = plot_paneled_data(
@@ -363,7 +369,7 @@ class TimeMeanEvaluatorAggregator:
         if self._target == "norm":
             metric_name = "rmse/channel_mean"
             if self._channel_mean_names is None:
-                values_to_average = list(rmse_all_channels.values())
+                channel_mean_names = list(rmse_all_channels)
             else:
                 missing = [
                     n for n in self._channel_mean_names if n not in rmse_all_channels
@@ -374,9 +380,11 @@ class TimeMeanEvaluatorAggregator:
                         f"recorded data: {missing}. Available: "
                         f"{sorted(rmse_all_channels)}."
                     )
-                values_to_average = [
-                    rmse_all_channels[name] for name in self._channel_mean_names
-                ]
+                channel_mean_names = list(self._channel_mean_names)
+            channel_mean_names = [
+                name for name in channel_mean_names if name not in all_nan_target_names
+            ]
+            values_to_average = [rmse_all_channels[name] for name in channel_mean_names]
             logs.update({metric_name: sum(values_to_average) / len(values_to_average)})
 
         if len(label) != 0:

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -325,17 +325,17 @@ class _EnsembleAggregator:
                     names = list(self._channel_mean_names)
                 # Exclude variables whose target was entirely NaN (e.g. filled
                 # by allow_missing_variables) from the channel mean.
-                excluded = self._all_nan_target_names or set()
-                names = [name for name in names if name not in excluded]
+                nan_targets = self._all_nan_target_names or set()
+                names = [name for name in names if name not in nan_targets]
                 if names:
                     scalars = [data[f"{metric}/{key}"] for key in names]
                     data[f"{metric}/channel_mean"] = sum(scalars) / len(scalars)
         if self._report_variables is not None:
-            excluded = all_variable_names - self._report_variables
+            nan_targets = all_variable_names - self._report_variables
             data = {
                 k: v
                 for k, v in data.items()
-                if not any(seg in excluded for seg in k.split("/"))
+                if not any(seg in nan_targets for seg in k.split("/"))
             }
         return data
 

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -219,6 +219,10 @@ class _EnsembleAggregator:
         self._report_variables = (
             frozenset(report_variables) if report_variables is not None else None
         )
+        # Variables whose target is entirely NaN (e.g. filled by
+        # allow_missing_variables); detected once on the first batch since
+        # missingness is constant, then excluded from the channel mean.
+        self._all_nan_target_names: set[str] | None = None
 
     def _get_variable_metrics(self, gen_data: TensorMapping):
         if self._variable_metrics is None:
@@ -269,6 +273,10 @@ class _EnsembleAggregator:
                     target=target_data[name],
                     gen=gen_data[name],
                 )
+        if self._all_nan_target_names is None:
+            self._all_nan_target_names = {
+                name for name in gen_data if torch.isnan(target_data[name]).all()
+            }
         self._n_batches += 1
 
     def _get_caption(self, name: str) -> str:
@@ -315,6 +323,10 @@ class _EnsembleAggregator:
                             f"{sorted(all_keys)}."
                         )
                     names = list(self._channel_mean_names)
+                # Exclude variables whose target was entirely NaN (e.g. filled
+                # by allow_missing_variables) from the channel mean.
+                excluded = self._all_nan_target_names or set()
+                names = [name for name in names if name not in excluded]
                 if names:
                     scalars = [data[f"{metric}/{key}"] for key in names]
                     data[f"{metric}/channel_mean"] = sum(scalars) / len(scalars)

--- a/fme/ace/aggregator/one_step/reduced_metrics.py
+++ b/fme/ace/aggregator/one_step/reduced_metrics.py
@@ -102,15 +102,19 @@ class AreaWeightedReducedMetric:
             self._all_nan_target_names = {
                 name for name in channel_mean_names if torch.isnan(target[name]).all()
             }
-        # Exclude variables whose target is entirely NaN (e.g. filled by
-        # allow_missing_variables) from the channel mean.
-        included = [
+        # Targets may be entirely NaN if filled by allow_missing_variables
+        non_nan_targets = [
             name
             for name in channel_mean_names
             if name not in self._all_nan_target_names
         ]
-        for name in included:
-            self._channel_mean += batch_avgs[name] / len(included)
+        if not non_nan_targets:
+            raise ValueError(
+                "All target variables are NaN; cannot compute channel mean."
+            )
+        for name in non_nan_targets:
+            self._channel_mean += batch_avgs[name] / len(non_nan_targets)
+
         self._accumulator.add(batch_avgs)
 
     def get(self) -> TensorDict:

--- a/fme/ace/aggregator/one_step/reduced_metrics.py
+++ b/fme/ace/aggregator/one_step/reduced_metrics.py
@@ -68,6 +68,10 @@ class AreaWeightedReducedMetric:
         self._channel_mean: torch.Tensor | None = None
         self._device = device
         self._channel_mean_names = channel_mean_names
+        # Variables whose target is entirely NaN (e.g. filled by
+        # allow_missing_variables); detected once on the first batch since
+        # missingness is constant, then excluded from the channel mean.
+        self._all_nan_target_names: set[str] | None = None
 
     def _get_channel_mean_names(self, tensors: TensorDict) -> Sequence[str]:
         if self._channel_mean_names is None:
@@ -94,8 +98,19 @@ class AreaWeightedReducedMetric:
                 f"channel_mean_names contains entries not present in the "
                 f"recorded data: {missing}. Available: {sorted(batch_avgs)}."
             )
-        for name in channel_mean_names:
-            self._channel_mean += batch_avgs[name] / len(channel_mean_names)
+        if self._all_nan_target_names is None:
+            self._all_nan_target_names = {
+                name for name in channel_mean_names if torch.isnan(target[name]).all()
+            }
+        # Exclude variables whose target is entirely NaN (e.g. filled by
+        # allow_missing_variables) from the channel mean.
+        included = [
+            name
+            for name in channel_mean_names
+            if name not in self._all_nan_target_names
+        ]
+        for name in included:
+            self._channel_mean += batch_avgs[name] / len(included)
         self._accumulator.add(batch_avgs)
 
     def get(self) -> TensorDict:

--- a/fme/ace/aggregator/one_step/test_ensemble.py
+++ b/fme/ace/aggregator/one_step/test_ensemble.py
@@ -285,6 +285,43 @@ def test_aggregator_norm_logs_channel_mean_all_variables():
         )
 
 
+def test_aggregator_norm_channel_mean_excludes_all_nan_target():
+    """A variable whose target is entirely NaN (e.g. filled by
+    allow_missing_variables) is excluded from the channel mean."""
+    torch.manual_seed(0)
+    area_weights = torch.ones([4, 4], device=get_device())
+    agg = _EnsembleAggregator(
+        gridded_operations=LatLonOperations(area_weights),
+        log_mean_maps=False,
+        target="norm",
+    )
+    names = ["a", "b", "c"]
+    target = _make_ensemble_batch(names)
+    gen = _make_ensemble_batch(names)
+    # "c" is missing from the data: entirely-NaN target.
+    target = EnsembleTensorDict(
+        {**target, "c": torch.full_like(target["c"], torch.nan)}
+    )
+    agg.record_batch(
+        target_data=target,
+        gen_data=gen,
+        target_data_norm=target,
+        gen_data_norm=gen,
+    )
+    logs = agg.get_logs(label="metrics")
+    for metric in ("crps", "ensemble_mean_rmse"):
+        channel_mean = float(logs[f"metrics/{metric}/channel_mean"])
+        assert not math.isnan(channel_mean)
+        # equals the mean of the two valid-target channels (a, b); "c" excluded.
+        expected = (logs[f"metrics/{metric}/a"] + logs[f"metrics/{metric}/b"]) / 2
+        torch.testing.assert_close(
+            torch.tensor(channel_mean),
+            torch.tensor(float(expected)),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+
 def test_aggregator_norm_logs_channel_mean_subset():
     """channel_mean_names restricts the channel mean to the listed variables."""
     torch.manual_seed(0)

--- a/fme/ace/aggregator/one_step/test_reduced_metrics.py
+++ b/fme/ace/aggregator/one_step/test_reduced_metrics.py
@@ -103,3 +103,28 @@ def test_area_weighted_reduced_metric_empty():
     )
     metrics = metric.get()
     assert torch.isnan(metrics["anything"])
+
+
+def test_get_channel_mean_excludes_all_nan_target_channels():
+    """A variable whose target is entirely NaN (e.g. filled by
+    allow_missing_variables) is excluded from the channel mean."""
+    metric = AreaWeightedReducedMetric(
+        device=DEVICE, compute_metric=mock_area_weighted_metric
+    )
+    target = {
+        "a": torch.zeros(1, 1, device=DEVICE),
+        "b": torch.zeros(1, 1, device=DEVICE),
+        # "c" is missing from the data: entirely-NaN target.
+        "c": torch.full((1, 1), torch.nan, device=DEVICE),
+    }
+    gen = {
+        "a": torch.full((1, 1), 2.0, device=DEVICE),  # metric = 2
+        "b": torch.full((1, 1), 4.0, device=DEVICE),  # metric = 4
+        "c": torch.ones(1, 1, device=DEVICE),  # metric = NaN (target is NaN)
+    }
+    metric.record(target, gen)
+
+    # channel mean over the two valid-target channels; "c" excluded.
+    torch.testing.assert_close(
+        metric.get_channel_mean(), torch.tensor(3.0, device=DEVICE)
+    )


### PR DESCRIPTION
If `allow_missing_variables=True` during training, the channel mean metrics are all NaN because that flag sets the missing variables target values to NaN. This PR updates the channel mean to exclude fields with all-nan targets so that it is finite for training with missing variables.

I opted to check the targets for all-nans since it was a lot cleaner than threading missing variable names through the dataset info through to the aggregator. If we want to be strict about only excluding the fields if allow_missing_variables is True then `XarrayDataset._missing_names` would have to be threaded through to the aggregator.

- [x] Tests added