### PR TITLE
Refactor correctors to ordered sequences of Correction objects

### DIFF
--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -12,13 +12,23 @@ from fme.core.atmosphere_data import (
     compute_layer_thickness,
 )
 from fme.core.constants import GRAVITY, SPECIFIC_HEAT_OF_DRY_AIR_CONST_VOLUME
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    Correction,
+    CorrectionSequence,
+    CorrectorConfigABC,
+)
 from fme.core.corrector.state import CorrectorState
-from fme.core.corrector.utils import force_positive
+from fme.core.corrector.utils import ForcePositive
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.typing_ import TensorDict, TensorMapping
+
+
+class AreaWeightedMean(Protocol):
+    def __call__(
+        self, data: torch.Tensor, keepdim: bool, name: str | None = None
+    ) -> torch.Tensor: ...
 
 
 @dataclasses.dataclass
@@ -40,29 +50,138 @@ class EnergyBudgetConfig:
 
 
 @dataclasses.dataclass
-class AtmosphereCorrectorParams:
-    """Plain (non-dacite) scalar parameters passed to ``AtmosphereCorrector``.
+class ConserveDryAir:
+    """Correction that pins the global-mean dry-air mass to its IC value.
 
-    Built by ``AtmosphereCorrectorConfig._build`` so the corrector does not need
-    to read the (non-leaf) config. The energy budget sub-config is flattened to
-    its scalar fields; ``total_energy_budget_method`` is ``None`` exactly when the
-    correction is disabled.
+    Bundles the operators needed to apply the dry-air conservation step. The
+    reference dry-air mass is seeded from ``input_data`` the first time it runs
+    and carried across steps via ``corrector_state``.
     """
 
-    conserve_dry_air: bool
-    zero_global_mean_moisture_advection: bool
-    moisture_budget_correction: (
-        Literal[
-            "precipitation",
-            "evaporation",
-            "advection_and_precipitation",
-            "advection_and_evaporation",
-        ]
-        | None
-    )
-    force_positive_names: list[str]
-    total_energy_budget_method: Literal["constant_temperature"] | None
-    total_energy_budget_unaccounted_heating: float
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None
+    precision: torch.dtype
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "conserve_dry_air is set to True, but no vertical coordinate is "
+                "available."
+            )
+        corrector_state = _seed_global_dry_air_mass(
+            input_data=input_data,
+            corrector_state=corrector_state,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            precision=self.precision,
+        )
+        assert corrector_state.global_dry_air_mass is not None
+        gen_data = _adjust_gen_dry_air_to_target(
+            gen_data,
+            target_global_dry_air=corrector_state.global_dry_air_mass,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            precision=self.precision,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class ZeroGlobalMeanMoistureAdvection:
+    """Correction that forces zero global-mean moisture advection."""
+
+    area_weighted_mean: AreaWeightedMean
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        gen_data = _force_zero_global_mean_moisture_advection(
+            gen_data=gen_data,
+            area_weighted_mean=self.area_weighted_mean,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class MoistureBudgetCorrection:
+    """Correction that closes the moisture budget via the configured terms."""
+
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None
+    timestep_seconds: float
+    terms_to_modify: Literal[
+        "precipitation",
+        "evaporation",
+        "advection_and_precipitation",
+        "advection_and_evaporation",
+    ]
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "Moisture budget correction is turned on, but no vertical "
+                "coordinate is available."
+            )
+        gen_data = _force_conserve_moisture(
+            input_data=input_data,
+            gen_data=gen_data,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            timestep_seconds=self.timestep_seconds,
+            terms_to_modify=self.terms_to_modify,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class TotalEnergyBudgetCorrection:
+    """Correction that conserves an idealized total energy budget."""
+
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None
+    timestep_seconds: float
+    method: Literal["constant_temperature"]
+    unaccounted_heating: float
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "Energy budget correction is turned on, but no vertical coordinate"
+                " is available."
+            )
+        gen_data = _force_conserve_total_energy(
+            input_data=input_data,
+            gen_data=gen_data,
+            forcing_data=forcing_data,
+            area_weighted_mean=self.area_weighted_mean,
+            vertical_coordinate=self.vertical_coordinate,
+            timestep_seconds=self.timestep_seconds,
+            method=self.method,
+            unaccounted_heating=self.unaccounted_heating,
+        )
+        return gen_data, corrector_state
 
 
 @CorrectorSelector.register("atmosphere_corrector")
@@ -183,124 +302,47 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
         vertical_coordinate: HasAtmosphereVerticalIntegral | None,
         timestep: datetime.timedelta,
     ) -> "AtmosphereCorrector":
-        energy_budget = self.total_energy_budget_correction
-        params = AtmosphereCorrectorParams(
-            conserve_dry_air=self.conserve_dry_air,
-            zero_global_mean_moisture_advection=(
-                self.zero_global_mean_moisture_advection
-            ),
-            moisture_budget_correction=self.moisture_budget_correction,
-            force_positive_names=self.force_positive_names,
-            total_energy_budget_method=(
-                None if energy_budget is None else energy_budget.method
-            ),
-            total_energy_budget_unaccounted_heating=(
-                0.0
-                if energy_budget is None
-                else energy_budget.constant_unaccounted_heating
-            ),
-        )
-        return AtmosphereCorrector(
-            params=params,
-            gridded_operations=gridded_operations,
-            vertical_coordinate=vertical_coordinate,
-            timestep=timestep,
-        )
-
-
-class AtmosphereCorrector(CorrectorABC):
-    def __init__(
-        self,
-        params: AtmosphereCorrectorParams,
-        gridded_operations: GriddedOperations,
-        vertical_coordinate: HasAtmosphereVerticalIntegral | None,
-        timestep: datetime.timedelta,
-    ):
-        self._params = params
-        self._gridded_operations = gridded_operations
-        self._vertical_coordinate = vertical_coordinate
-
-        self._timestep_seconds = timestep.total_seconds()
-        if fme.get_device() == torch.device("mps", 0):
-            self._dry_air_precision = torch.float32
-        else:
-            self._dry_air_precision = torch.float64
-
-    def __call__(
-        self,
-        input_data: TensorMapping,
-        gen_data: TensorMapping,
-        forcing_data: TensorMapping,
-        corrector_state: CorrectorState | None,
-    ) -> tuple[TensorDict, CorrectorState | None]:
-        gen_data = dict(gen_data)
-        if len(self._params.force_positive_names) > 0:
+        area_weighted_mean = gridded_operations.area_weighted_mean
+        timestep_seconds = timestep.total_seconds()
+        corrections: list[Correction] = []
+        if len(self.force_positive_names) > 0:
             # do this step before imposing other conservation correctors, since
             # otherwise it could end up creating violations of those constraints.
-            gen_data = force_positive(gen_data, self._params.force_positive_names)
-        if self._params.conserve_dry_air:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "conserve_dry_air is set to True, but no vertical coordinate is "
-                    "available."
+            corrections.append(ForcePositive(self.force_positive_names))
+        if self.conserve_dry_air:
+            if fme.get_device() == torch.device("mps", 0):
+                precision = torch.float32
+            else:
+                precision = torch.float64
+            corrections.append(
+                ConserveDryAir(area_weighted_mean, vertical_coordinate, precision)
+            )
+        if self.zero_global_mean_moisture_advection:
+            corrections.append(ZeroGlobalMeanMoistureAdvection(area_weighted_mean))
+        if self.moisture_budget_correction is not None:
+            corrections.append(
+                MoistureBudgetCorrection(
+                    area_weighted_mean,
+                    vertical_coordinate,
+                    timestep_seconds,
+                    self.moisture_budget_correction,
                 )
-            corrector_state = _seed_global_dry_air_mass(
-                input_data=input_data,
-                corrector_state=corrector_state,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                precision=self._dry_air_precision,
             )
-            assert corrector_state.global_dry_air_mass is not None
-            gen_data = _adjust_gen_dry_air_to_target(
-                gen_data,
-                target_global_dry_air=corrector_state.global_dry_air_mass,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                precision=self._dry_air_precision,
-            )
-        if self._params.zero_global_mean_moisture_advection:
-            gen_data = _force_zero_global_mean_moisture_advection(
-                gen_data=gen_data,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-            )
-        if self._params.moisture_budget_correction is not None:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "Moisture budget correction is turned on, but no vertical "
-                    "coordinate is available."
+        if self.total_energy_budget_correction is not None:
+            corrections.append(
+                TotalEnergyBudgetCorrection(
+                    area_weighted_mean,
+                    vertical_coordinate,
+                    timestep_seconds,
+                    self.total_energy_budget_correction.method,
+                    self.total_energy_budget_correction.constant_unaccounted_heating,
                 )
-            gen_data = _force_conserve_moisture(
-                input_data=input_data,
-                gen_data=gen_data,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                timestep_seconds=self._timestep_seconds,
-                terms_to_modify=self._params.moisture_budget_correction,
             )
-        if self._params.total_energy_budget_method is not None:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "Energy budget correction is turned on, but no vertical coordinate"
-                    " is available."
-                )
-            gen_data = _force_conserve_total_energy(
-                input_data=input_data,
-                gen_data=gen_data,
-                forcing_data=forcing_data,
-                area_weighted_mean=self._gridded_operations.area_weighted_mean,
-                vertical_coordinate=self._vertical_coordinate,
-                timestep_seconds=self._timestep_seconds,
-                method=self._params.total_energy_budget_method,
-                unaccounted_heating=self._params.total_energy_budget_unaccounted_heating,
-            )
-        return gen_data, corrector_state
+        return AtmosphereCorrector(corrections)
 
 
-class AreaWeightedMean(Protocol):
-    def __call__(
-        self, data: torch.Tensor, keepdim: bool, name: str | None = None
-    ) -> torch.Tensor: ...
+class AtmosphereCorrector(CorrectionSequence):
+    pass
 
 
 def _seed_global_dry_air_mass(

--- a/fme/core/corrector/ice.py
+++ b/fme/core/corrector/ice.py
@@ -3,7 +3,11 @@ import datetime
 
 import torch
 
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    Correction,
+    CorrectionSequence,
+    CorrectorConfigABC,
+)
 from fme.core.corrector.state import CorrectorState
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
@@ -182,6 +186,28 @@ class IceBudgetCorrectionConfig:
         return {key: value.float() for key, value in out.items()}
 
 
+@dataclasses.dataclass
+class IceBudgetCorrection:
+    """Correction that reconstructs ice/snow state from budget terms.
+
+    Wraps ``IceBudgetCorrectionConfig`` so the corrector applies the operation
+    without reading config fields. ``forcing_data`` and ``corrector_state`` are
+    unused and passed through.
+    """
+
+    config: IceBudgetCorrectionConfig
+    timestep_seconds: float
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return self.config(gen_data, input_data, self.timestep_seconds), corrector_state
+
+
 @CorrectorSelector.register("ice_corrector")
 @dataclasses.dataclass
 class IceCorrectorConfig(CorrectorConfigABC):
@@ -201,37 +227,15 @@ class IceCorrectorConfig(CorrectorConfigABC):
         gridded_operations: GriddedOperations,
         timestep: datetime.timedelta,
     ) -> "IceCorrector":
-        return IceCorrector(
-            budget_correction=self.budget_correction,
-            gridded_operations=gridded_operations,
-            timestep=timestep,
-        )
+        corrections: list[Correction] = []
+        if self.budget_correction is not None:
+            corrections.append(
+                IceBudgetCorrection(self.budget_correction, timestep.total_seconds())
+            )
+        return IceCorrector(corrections)
 
 
-class IceCorrector(CorrectorABC):
+class IceCorrector(CorrectionSequence):
     """
     Implement choice of sea ice corrector.
     """
-
-    def __init__(
-        self,
-        budget_correction: IceBudgetCorrectionConfig | None,
-        gridded_operations: GriddedOperations,
-        timestep: datetime.timedelta,
-    ):
-        self._budget_correction = budget_correction
-        self._gridded_operations = gridded_operations
-        self._timestep = timestep
-
-    def __call__(
-        self,
-        input_data: TensorMapping,
-        gen_data: TensorMapping,
-        forcing_data: TensorMapping,
-        corrector_state: CorrectorState | None,
-    ) -> tuple[TensorDict, CorrectorState | None]:
-        timestep = self._timestep.total_seconds()
-        if self._budget_correction is not None:
-            gen_data = self._budget_correction(gen_data, input_data, timestep)
-
-        return dict(gen_data), corrector_state

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -1,6 +1,6 @@
 import dataclasses
 import datetime
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Any, Literal, Protocol
 
 import torch
@@ -11,14 +11,24 @@ from fme.core.constants import (
     LATENT_HEAT_OF_VAPORIZATION,
     SPECIFIC_HEAT_OF_SEA_WATER_CM4,
 )
-from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
+from fme.core.corrector.registry import (
+    Correction,
+    CorrectionSequence,
+    CorrectorConfigABC,
+)
 from fme.core.corrector.state import CorrectorState
-from fme.core.corrector.utils import force_positive
+from fme.core.corrector.utils import ForcePositive
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.ocean_data import HasOceanDepthIntegral, OceanData
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.typing_ import TensorDict, TensorMapping
+
+
+class AreaWeightedMean(Protocol):
+    def __call__(
+        self, data: torch.Tensor, keepdim: bool, name: str | None = None
+    ) -> torch.Tensor: ...
 
 
 @dataclasses.dataclass
@@ -62,12 +72,6 @@ class SeaIceFractionConfig:
         for name in self.zero_where_ice_free_names:
             out[name] = gen_data[name] * (out[self.sea_ice_fraction_name] > 0.0)
         return out
-
-
-# Operation the OceanCorrector applies to enforce sea-ice-fraction constraints;
-# provided by SeaIceFractionConfig.__call__. Passed as a callable (not the config)
-# so the corrector relies only on the operation, not on reading config fields.
-SeaIceFractionCorrection = Callable[[TensorMapping, TensorMapping], TensorDict]
 
 
 @dataclasses.dataclass
@@ -116,19 +120,81 @@ class SurfaceEnergyFluxCorrectionConfig:
 
 
 @dataclasses.dataclass
-class OceanCorrectorParams:
-    """Plain (non-dacite) scalar parameters passed to ``OceanCorrector``.
+class SeaIceFractionCorrection:
+    """Correction that enforces sea-ice-fraction constraints.
 
-    Built by ``OceanCorrectorConfig._build`` so the corrector does not need to
-    read the (non-leaf) config. The surface-energy-flux and ocean-heat-content
-    sub-configs are flattened to their scalar fields; each ``*_method`` is
-    ``None`` exactly when the corresponding correction is disabled.
+    Wraps ``SeaIceFractionConfig`` so the corrector applies the operation
+    without reading config fields. ``forcing_data`` and ``corrector_state`` are
+    unused and passed through.
     """
 
-    force_positive_names: list[str]
-    surface_energy_flux_method: Literal["residual_prediction", "prescribed"] | None
-    ocean_heat_content_method: Literal["scaled_temperature"] | None
-    ocean_heat_content_unaccounted_heating: float
+    config: SeaIceFractionConfig
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return self.config(gen_data, input_data), corrector_state
+
+
+@dataclasses.dataclass
+class SurfaceEnergyFluxCorrection:
+    """Correction that adjusts hfds using atmosphere-derived surface fluxes."""
+
+    method: Literal["residual_prediction", "prescribed"]
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        gen_data = _correct_hfds(
+            input_data,
+            gen_data,
+            forcing_data,
+            method=self.method,
+        )
+        return gen_data, corrector_state
+
+
+@dataclasses.dataclass
+class OceanHeatContentCorrection:
+    """Correction that conserves ocean heat content."""
+
+    area_weighted_mean: AreaWeightedMean
+    vertical_coordinate: HasOceanDepthIntegral | None
+    timestep_seconds: float
+    method: Literal["scaled_temperature"]
+    unaccounted_heating: float
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        if self.vertical_coordinate is None:
+            raise ValueError(
+                "Ocean heat content correction is turned on, but no vertical "
+                "coordinate is available."
+            )
+        gen_data = _force_conserve_ocean_heat_content(
+            input_data,
+            gen_data,
+            forcing_data,
+            self.area_weighted_mean,
+            self.vertical_coordinate,
+            self.timestep_seconds,
+            self.method,
+            self.unaccounted_heating,
+        )
+        return gen_data, corrector_state
 
 
 @CorrectorSelector.register("ocean_corrector")
@@ -179,85 +245,34 @@ class OceanCorrectorConfig(CorrectorConfigABC):
         vertical_coordinate: HasOceanDepthIntegral | None,
         timestep: datetime.timedelta,
     ) -> "OceanCorrector":
-        flux_correction = self.surface_energy_flux_correction
-        ohc_correction = self.ocean_heat_content_correction
-        params = OceanCorrectorParams(
-            force_positive_names=self.force_positive_names,
-            surface_energy_flux_method=(
-                None if flux_correction is None else flux_correction.method
-            ),
-            ocean_heat_content_method=(
-                None if ohc_correction is None else ohc_correction.method
-            ),
-            ocean_heat_content_unaccounted_heating=(
-                0.0
-                if ohc_correction is None
-                else ohc_correction.constant_unaccounted_heating
-            ),
-        )
-        return OceanCorrector(
-            params=params,
-            sea_ice_fraction_correction=(
-                None
-                if self.sea_ice_fraction_correction is None
-                else self.sea_ice_fraction_correction.__call__
-            ),
-            gridded_operations=gridded_operations,
-            vertical_coordinate=vertical_coordinate,
-            timestep=timestep,
-        )
-
-
-class OceanCorrector(CorrectorABC):
-    def __init__(
-        self,
-        params: OceanCorrectorParams,
-        sea_ice_fraction_correction: SeaIceFractionCorrection | None,
-        gridded_operations: GriddedOperations,
-        vertical_coordinate: HasOceanDepthIntegral | None,
-        timestep: datetime.timedelta,
-    ):
-        self._params = params
-        self._sea_ice_fraction_correction = sea_ice_fraction_correction
-        self._gridded_operations = gridded_operations
-        self._vertical_coordinate = vertical_coordinate
-        self._timestep = timestep
-
-    def __call__(
-        self,
-        input_data: TensorMapping,
-        gen_data: TensorMapping,
-        forcing_data: TensorMapping,
-        corrector_state: CorrectorState | None,
-    ) -> tuple[TensorDict, CorrectorState | None]:
-        if len(self._params.force_positive_names) > 0:
-            gen_data = force_positive(gen_data, self._params.force_positive_names)
-        if self._sea_ice_fraction_correction is not None:
-            gen_data = self._sea_ice_fraction_correction(gen_data, input_data)
-        if self._params.surface_energy_flux_method is not None:
-            gen_data = _correct_hfds(
-                input_data,
-                gen_data,
-                forcing_data,
-                method=self._params.surface_energy_flux_method,
+        area_weighted_mean = gridded_operations.area_weighted_mean
+        timestep_seconds = timestep.total_seconds()
+        corrections: list[Correction] = []
+        if len(self.force_positive_names) > 0:
+            corrections.append(ForcePositive(self.force_positive_names))
+        if self.sea_ice_fraction_correction is not None:
+            corrections.append(
+                SeaIceFractionCorrection(self.sea_ice_fraction_correction)
             )
-        if self._params.ocean_heat_content_method is not None:
-            if self._vertical_coordinate is None:
-                raise ValueError(
-                    "Ocean heat content correction is turned on, but no vertical "
-                    "coordinate is available."
+        if self.surface_energy_flux_correction is not None:
+            corrections.append(
+                SurfaceEnergyFluxCorrection(self.surface_energy_flux_correction.method)
+            )
+        if self.ocean_heat_content_correction is not None:
+            corrections.append(
+                OceanHeatContentCorrection(
+                    area_weighted_mean,
+                    vertical_coordinate,
+                    timestep_seconds,
+                    self.ocean_heat_content_correction.method,
+                    self.ocean_heat_content_correction.constant_unaccounted_heating,
                 )
-            gen_data = _force_conserve_ocean_heat_content(
-                input_data,
-                gen_data,
-                forcing_data,
-                self._gridded_operations.area_weighted_mean,
-                self._vertical_coordinate,
-                self._timestep.total_seconds(),
-                self._params.ocean_heat_content_method,
-                self._params.ocean_heat_content_unaccounted_heating,
             )
-        return dict(gen_data), corrector_state
+        return OceanCorrector(corrections)
+
+
+class OceanCorrector(CorrectionSequence):
+    pass
 
 
 def _compute_ocean_net_surface_energy_flux(
@@ -323,12 +338,6 @@ def _correct_hfds(
             f"Method {method!r} not implemented for surface energy flux correction"
         )
     return out
-
-
-class AreaWeightedMean(Protocol):
-    def __call__(
-        self, data: torch.Tensor, keepdim: bool, name: str | None = None
-    ) -> torch.Tensor: ...
 
 
 def _force_conserve_ocean_heat_content(

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 from collections.abc import Mapping
-from typing import Any, Self, final
+from typing import Any, Protocol, Self, final
 
 import dacite
 
@@ -66,6 +66,27 @@ class CorrectorConfigABC(abc.ABC):
     ) -> "CorrectorABC": ...
 
 
+class Correction(Protocol):
+    """A single correction applied to ``gen_data`` by a corrector.
+
+    Each correction is a self-contained callable object that bundles its own
+    parameters and operators (e.g. an area-weighted-mean operator or a vertical
+    coordinate) and applies one conservation/positivity step. A corrector holds
+    an ordered sequence of these and simply applies them in turn, so it does not
+    need to read any config fields itself. The signature mirrors
+    ``CorrectorABC.__call__`` so corrections compose: a correction that does not
+    maintain state passes ``corrector_state`` through unchanged.
+    """
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]: ...
+
+
 class CorrectorABC(abc.ABC):
     def train(self, mode: bool = True) -> "CorrectorABC":
         """Set the corrector to training or evaluation mode.
@@ -119,6 +140,32 @@ class CorrectorABC(abc.ABC):
             A tuple ``(corrected_gen_data, corrector_state)``.
         """
         ...
+
+
+class CorrectionSequence(CorrectorABC):
+    """A corrector that applies an ordered sequence of ``Correction`` objects.
+
+    The sequence (and thus the order in which corrections are applied) is built
+    by the corrector config's ``_build``; the corrector itself only knows to
+    apply each correction in turn.
+    """
+
+    def __init__(self, corrections: list[Correction]):
+        self._corrections = corrections
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        gen_data = dict(gen_data)
+        for correction in self._corrections:
+            gen_data, corrector_state = correction(
+                input_data, gen_data, forcing_data, corrector_state
+            )
+        return dict(gen_data), corrector_state
 
 
 class EpochScheduledCorrector(CorrectorABC):

--- a/fme/core/corrector/utils.py
+++ b/fme/core/corrector/utils.py
@@ -1,5 +1,8 @@
+import dataclasses
+
 import torch
 
+from fme.core.corrector.state import CorrectorState
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
@@ -9,3 +12,23 @@ def force_positive(data: TensorMapping, names: list[str]) -> TensorDict:
     for name in names:
         out[name] = torch.clamp(data[name], min=0.0)
     return out
+
+
+@dataclasses.dataclass
+class ForcePositive:
+    """Correction that clamps the named generated fields to be non-negative.
+
+    Implements the ``Correction`` protocol; ``input_data``, ``forcing_data`` and
+    ``corrector_state`` are unused and passed through.
+    """
+
+    names: list[str]
+
+    def __call__(
+        self,
+        input_data: TensorMapping,
+        gen_data: TensorMapping,
+        forcing_data: TensorMapping,
+        corrector_state: CorrectorState | None,
+    ) -> tuple[TensorDict, CorrectorState | None]:
+        return force_positive(gen_data, self.names), corrector_state


### PR DESCRIPTION
Follow-on to #1313 (stacked on its branch). #1313 addressed the review by passing `SeaIceFractionConfig.__call__` to `OceanCorrector` as a Callable instead of the config object. This PR generalizes that across all correctors, per the review discussion: rather than a `*CorrectorParams` scalar bag that the corrector reads, each correction step becomes a small callable object that bundles its own params plus the operators it needs and applies one step. The corrector holds an ordered sequence of these and just applies them in turn, so it no longer reads any config/params fields itself (addresses the review point that the corrector knows too much about the leaf configs).

The YAML config dataclasses are **unchanged** — `_build` packages the already-parsed config params into these function-objects. No config-schema change.

Changes:
- `fme.core.corrector.registry`: add `Correction` protocol (the `(input, gen, forcing, state) -> (gen, state)` step signature) and a `CorrectionSequence` corrector base whose `__call__` applies an ordered list of `Correction`s.
- `fme.core.corrector.utils`: add `ForcePositive` correction object (wraps the existing `force_positive`).
- `fme.core.corrector.atmosphere`: add `ConserveDryAir`, `ZeroGlobalMeanMoistureAdvection`, `MoistureBudgetCorrection`, `TotalEnergyBudgetCorrection`; `AtmosphereCorrector` is now a thin `CorrectionSequence`; `_build` assembles the ordered list (drops `AtmosphereCorrectorParams`).
- `fme.core.corrector.ocean`: add `SeaIceFractionCorrection` (wraps `SeaIceFractionConfig`), `SurfaceEnergyFluxCorrection`, `OceanHeatContentCorrection`; `OceanCorrector` is now a thin `CorrectionSequence`; `_build` assembles the ordered list (drops `OceanCorrectorParams` and the interim `SeaIceFractionCorrection` Callable alias from #1313).
- `fme.core.corrector.ice`: add `IceBudgetCorrection` (wraps `IceBudgetCorrectionConfig`); `IceCorrector` is now a thin `CorrectionSequence`.

- [x] Behavior-preserving refactor; existing 50 corrector tests pass unchanged (no new tests added)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated