### PR TITLE
Add exclude_top_levels option to energy budget corrector

### DIFF
--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -33,10 +33,23 @@ class EnergyBudgetConfig:
             to the energy flux into the atmosphere when conserving total energy.
             This can be useful for correcting errors in energy budget in target data.
             The same additional heating is imposed at all time steps and grid cells.
+        exclude_top_levels: Number of topmost vertical levels (level 0, then 0-1,
+            etc.) to exclude from receiving the temperature correction. The global
+            magnitude of the correction is still computed across all levels; the
+            excluded top levels simply do not receive the per-level temperature
+            addition. Defaults to 0 (apply the correction to all levels).
     """
 
     method: Literal["constant_temperature"]
     constant_unaccounted_heating: float = 0.0
+    exclude_top_levels: int = 0
+
+    def __post_init__(self):
+        if self.exclude_top_levels < 0:
+            raise ValueError(
+                "exclude_top_levels must be non-negative, got "
+                f"{self.exclude_top_levels}"
+            )
 
 
 @CorrectorSelector.register("atmosphere_corrector")
@@ -238,6 +251,7 @@ class AtmosphereCorrector(CorrectorABC):
                 timestep_seconds=self._timestep_seconds,
                 method=self._config.total_energy_budget_correction.method,
                 unaccounted_heating=self._config.total_energy_budget_correction.constant_unaccounted_heating,
+                exclude_top_levels=self._config.total_energy_budget_correction.exclude_top_levels,
             )
         return gen_data, corrector_state
 
@@ -439,10 +453,16 @@ def _force_conserve_total_energy(
     timestep_seconds: float,
     method: Literal["constant_temperature"] = "constant_temperature",
     unaccounted_heating: float = 0.0,
+    exclude_top_levels: int = 0,
 ) -> TensorDict:
     """Apply a correction to the generated data to conserve total energy.
 
     This function also inserts the unaccounted heating into the generated data.
+
+    The global magnitude of the temperature correction is computed across all
+    vertical levels; ``exclude_top_levels`` only restricts which levels receive
+    the per-level temperature addition, skipping the topmost ``exclude_top_levels``
+    levels (level 0, then 0-1, etc.).
     """
     if method != "constant_temperature":
         raise NotImplementedError(
@@ -480,9 +500,17 @@ def _force_conserve_total_energy(
     energy_to_temp_factor_gm = area_weighted_mean(energy_to_temperature_factor, True)
     temperature_correction = energy_correction / energy_to_temp_factor_gm
 
-    # apply same temperature correction to all vertical layers
+    # apply same temperature correction to all vertical layers, optionally
+    # skipping the topmost `exclude_top_levels` levels (level 0 is the top).
+    # The global magnitude of the correction above was computed across all
+    # levels regardless; this only restricts which levels receive the addition.
     air_temperature_names = gen.get_all_vertical_level_names("air_temperature")
-    for name in air_temperature_names:
+    if exclude_top_levels > len(air_temperature_names):
+        raise ValueError(
+            f"exclude_top_levels ({exclude_top_levels}) exceeds the number of "
+            f"air_temperature levels ({len(air_temperature_names)})."
+        )
+    for name in air_temperature_names[exclude_top_levels:]:
         gen.data[name] = gen.data[name] + temperature_correction
     # filter required here because we merged forcing data into gen above
     return {k: v for k, v in gen.data.items() if k in gen_data}

--- a/fme/core/corrector/test_atmosphere.py
+++ b/fme/core/corrector/test_atmosphere.py
@@ -410,6 +410,71 @@ def test__force_conserve_total_energy(negative_pressure: bool):
         sum(tensor.sum() for tensor in corrected_gen_data.values()).backward()
 
 
+def test__force_conserve_total_energy_exclude_top_levels():
+    """When top levels are excluded, they receive no temperature addition while
+    the remaining levels receive the same per-level correction magnitude that
+    is computed across all levels regardless of exclusion."""
+    tensor_shape = (5, 5)
+    ops = LatLonOperations(
+        0.5 + torch.rand(size=(tensor_shape[-2], 1)).broadcast_to(size=tensor_shape)
+    )
+    timestep = datetime.timedelta(seconds=3600)
+    input_data, gen_data, forcing_data, vertical_coord = _get_corrector_test_input(
+        tensor_shape
+    )
+
+    common = dict(
+        input_data=input_data,
+        gen_data=gen_data,
+        forcing_data=forcing_data,
+        area_weighted_mean=ops.area_weighted_mean,
+        vertical_coordinate=vertical_coord,
+        timestep_seconds=timestep.total_seconds(),
+        unaccounted_heating=10.0,
+    )
+
+    all_levels = _force_conserve_total_energy(**common, exclude_top_levels=0)
+    excluded = _force_conserve_total_energy(**common, exclude_top_levels=1)
+
+    # level 0 (top) receives no correction when excluded
+    torch.testing.assert_close(
+        excluded["air_temperature_0"], gen_data["air_temperature_0"]
+    )
+
+    # the per-level correction magnitude is unchanged by exclusion: level 1
+    # gets the same addition it would have gotten with no exclusion, since the
+    # global magnitude is computed across all levels regardless.
+    torch.testing.assert_close(
+        excluded["air_temperature_1"], all_levels["air_temperature_1"]
+    )
+
+
+def test_energy_budget_config_rejects_negative_exclude_top_levels():
+    with pytest.raises(ValueError):
+        EnergyBudgetConfig("constant_temperature", exclude_top_levels=-1)
+
+
+def test__force_conserve_total_energy_exclude_too_many_levels_raises():
+    tensor_shape = (5, 5)
+    ops = LatLonOperations(
+        0.5 + torch.rand(size=(tensor_shape[-2], 1)).broadcast_to(size=tensor_shape)
+    )
+    timestep = datetime.timedelta(seconds=3600)
+    input_data, gen_data, forcing_data, vertical_coord = _get_corrector_test_input(
+        tensor_shape
+    )
+    with pytest.raises(ValueError):
+        _force_conserve_total_energy(
+            input_data=input_data,
+            gen_data=gen_data,
+            forcing_data=forcing_data,
+            area_weighted_mean=ops.area_weighted_mean,
+            vertical_coordinate=vertical_coord,
+            timestep_seconds=timestep.total_seconds(),
+            exclude_top_levels=3,  # only 2 air_temperature levels exist
+        )
+
+
 def test__force_conserve_energy_doesnt_clobber():
     tensor_shape = (5, 5)
 


### PR DESCRIPTION
The `constant_temperature` total-energy-budget correction applies a vertically- and horizontally-uniform air-temperature increment to enforce total-energy conservation. It currently adds that increment to *every* vertical level, including the thin model top level. In the 4°/daily ERA5-only baseline this introduces a positive bias in the topmost air temperature level. This PR adds an option to exclude the top N levels from receiving the increment, so the bias can be tested/removed without changing the conserved global magnitude.

Changes:
- `fme.core.corrector.atmosphere.EnergyBudgetConfig`: add `exclude_top_levels: int = 0` field (with a non-negative `__post_init__` check); it only restricts which levels receive the per-level temperature addition, the global magnitude of the correction is still computed across all levels.
- `fme.core.corrector.atmosphere._force_conserve_total_energy`: accept `exclude_top_levels` and skip the topmost N `air_temperature` levels (level 0 is the model top) when applying the increment; raise if it exceeds the number of levels. Threaded through `AtmosphereCorrector.__call__`.
- `fme.core.corrector.test_atmosphere`: excluded top level receives no increment while remaining levels get the same per-level magnitude as the no-exclusion case; negative-value and too-many-levels error cases.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated