### PR TITLE
Add keep_gradient_through_clamps STE for corrector clamps

### DIFF
--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -270,6 +270,10 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
         total_energy_budget_correction: If not None, force the generated data to
             conserve an idealized version of total energy using the provided
             configuration.
+        keep_gradient_through_clamps: If True, apply the ``force_positive`` clamp
+            with a straight-through estimator: the forward value is still clamped
+            to be non-negative, but gradient flows as if the clamp had not
+            happened, so clamped-negative cells still get a learning signal.
     """
 
     conserve_dry_air: bool = False
@@ -285,6 +289,7 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
     ) = None
     force_positive_names: list[str] = dataclasses.field(default_factory=list)
     total_energy_budget_correction: EnergyBudgetConfig | None = None
+    keep_gradient_through_clamps: bool = False
 
     def _get_corrector(
         self,
@@ -308,7 +313,12 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
         if len(self.force_positive_names) > 0:
             # do this step before imposing other conservation correctors, since
             # otherwise it could end up creating violations of those constraints.
-            corrections.append(ForcePositive(self.force_positive_names))
+            corrections.append(
+                ForcePositive(
+                    self.force_positive_names,
+                    keep_gradient=self.keep_gradient_through_clamps,
+                )
+            )
         if self.conserve_dry_air:
             if fme.get_device() == torch.device("mps", 0):
                 precision = torch.float32

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -270,10 +270,10 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
         total_energy_budget_correction: If not None, force the generated data to
             conserve an idealized version of total energy using the provided
             configuration.
-        keep_gradient_through_clamps: If True, apply the ``force_positive`` clamp
-            with a straight-through estimator: the forward value is still clamped
-            to be non-negative, but gradient flows as if the clamp had not
-            happened, so clamped-negative cells still get a learning signal.
+        keep_gradient_through_clamps: If True, apply the ``force_positive_names``
+            clamp with a straight-through estimator: the forward value is still
+            clamped to be non-negative, but gradient flows as if the clamp had
+            not happened, so clamped-negative cells still get a learning signal.
     """
 
     conserve_dry_air: bool = False

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -17,7 +17,7 @@ from fme.core.corrector.registry import (
     CorrectorConfigABC,
 )
 from fme.core.corrector.state import CorrectorState
-from fme.core.corrector.utils import ForcePositive
+from fme.core.corrector.utils import ForcePositive, replace_value_keep_gradient
 from fme.core.dataset_info import DatasetInfo
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.ocean_data import HasOceanDepthIntegral, OceanData
@@ -55,12 +55,17 @@ class SeaIceFractionConfig:
     remove_negative_ocean_fraction: bool = True
 
     def __call__(
-        self, gen_data: TensorMapping, input_data: TensorMapping
+        self,
+        gen_data: TensorMapping,
+        input_data: TensorMapping,
+        keep_gradient: bool = False,
     ) -> TensorDict:
         out = {**gen_data}
-        out[self.sea_ice_fraction_name] = torch.clamp(
-            out[self.sea_ice_fraction_name], min=0.0, max=1.0
-        )
+        sif = out[self.sea_ice_fraction_name]
+        clamped_sif = torch.clamp(sif, min=0.0, max=1.0)
+        if keep_gradient:
+            clamped_sif = replace_value_keep_gradient(sif, clamped_sif)
+        out[self.sea_ice_fraction_name] = clamped_sif
         if self.remove_negative_ocean_fraction:
             negative_ocean_fraction = (
                 1
@@ -68,7 +73,12 @@ class SeaIceFractionConfig:
                 - input_data[self.land_fraction_name]
             )
             negative_ocean_fraction = negative_ocean_fraction.clip(max=0)
-            out[self.sea_ice_fraction_name] += negative_ocean_fraction
+            rebalanced_sif = out[self.sea_ice_fraction_name] + negative_ocean_fraction
+            if keep_gradient:
+                rebalanced_sif = replace_value_keep_gradient(
+                    out[self.sea_ice_fraction_name], rebalanced_sif
+                )
+            out[self.sea_ice_fraction_name] = rebalanced_sif
         for name in self.zero_where_ice_free_names:
             out[name] = gen_data[name] * (out[self.sea_ice_fraction_name] > 0.0)
         return out
@@ -126,9 +136,13 @@ class SeaIceFractionCorrection:
     Wraps ``SeaIceFractionConfig`` so the corrector applies the operation
     without reading config fields. ``forcing_data`` and ``corrector_state`` are
     unused and passed through.
+
+    If ``keep_gradient`` is True, the clamp and rebalance are applied with a
+    straight-through estimator so out-of-range cells still get a learning signal.
     """
 
     config: SeaIceFractionConfig
+    keep_gradient: bool = False
 
     def __call__(
         self,
@@ -137,7 +151,10 @@ class SeaIceFractionCorrection:
         forcing_data: TensorMapping,
         corrector_state: CorrectorState | None,
     ) -> tuple[TensorDict, CorrectorState | None]:
-        return self.config(gen_data, input_data), corrector_state
+        return (
+            self.config(gen_data, input_data, keep_gradient=self.keep_gradient),
+            corrector_state,
+        )
 
 
 @dataclasses.dataclass
@@ -204,6 +221,11 @@ class OceanCorrectorConfig(CorrectorConfigABC):
     sea_ice_fraction_correction: SeaIceFractionConfig | None = None
     surface_energy_flux_correction: SurfaceEnergyFluxCorrectionConfig | None = None
     ocean_heat_content_correction: OceanHeatContentBudgetConfig | None = None
+    keep_gradient_through_clamps: bool = False
+    """If True, apply the corrector's hard clamps (``force_positive`` and the
+    ``sea_ice_fraction_correction`` bound/rebalance) with a straight-through
+    estimator: the forward value is still clamped, but gradient flows as if the
+    clamp had not happened, so out-of-range cells still get a learning signal."""
 
     @classmethod
     def remove_deprecated_keys(cls, state: Mapping[str, Any]) -> dict[str, Any]:
@@ -249,10 +271,18 @@ class OceanCorrectorConfig(CorrectorConfigABC):
         timestep_seconds = timestep.total_seconds()
         corrections: list[Correction] = []
         if len(self.force_positive_names) > 0:
-            corrections.append(ForcePositive(self.force_positive_names))
+            corrections.append(
+                ForcePositive(
+                    self.force_positive_names,
+                    keep_gradient=self.keep_gradient_through_clamps,
+                )
+            )
         if self.sea_ice_fraction_correction is not None:
             corrections.append(
-                SeaIceFractionCorrection(self.sea_ice_fraction_correction)
+                SeaIceFractionCorrection(
+                    self.sea_ice_fraction_correction,
+                    keep_gradient=self.keep_gradient_through_clamps,
+                )
             )
         if self.surface_energy_flux_correction is not None:
             corrections.append(

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -217,15 +217,31 @@ class OceanHeatContentCorrection:
 @CorrectorSelector.register("ocean_corrector")
 @dataclasses.dataclass
 class OceanCorrectorConfig(CorrectorConfigABC):
+    """Configuration for corrections applied to generated ocean data.
+
+    Parameters:
+        force_positive_names: Names of fields that should be forced to be greater
+            than or equal to zero.
+        sea_ice_fraction_correction: Optional configuration for a sea-ice-fraction
+            correction (bounds sea_ice_fraction to 0-1 and keeps the land, ocean,
+            and sea-ice fractions summing to one).
+        surface_energy_flux_correction: Optional configuration for a surface energy
+            flux correction to the generated hfds.
+        ocean_heat_content_correction: Optional configuration for an ocean heat
+            content correction.
+        keep_gradient_through_clamps: If True, apply the corrector's hard clamps
+            (the ``force_positive_names`` clamp and the
+            ``sea_ice_fraction_correction`` bound/rebalance) with a straight-through
+            estimator: the forward value is still clamped, but gradient flows as if
+            the clamp had not happened, so out-of-range cells still get a learning
+            signal.
+    """
+
     force_positive_names: list[str] = dataclasses.field(default_factory=list)
     sea_ice_fraction_correction: SeaIceFractionConfig | None = None
     surface_energy_flux_correction: SurfaceEnergyFluxCorrectionConfig | None = None
     ocean_heat_content_correction: OceanHeatContentBudgetConfig | None = None
     keep_gradient_through_clamps: bool = False
-    """If True, apply the corrector's hard clamps (``force_positive`` and the
-    ``sea_ice_fraction_correction`` bound/rebalance) with a straight-through
-    estimator: the forward value is still clamped, but gradient flows as if the
-    clamp had not happened, so out-of-range cells still get a learning signal."""
 
     @classmethod
     def remove_deprecated_keys(cls, state: Mapping[str, Any]) -> dict[str, Any]:

--- a/fme/core/corrector/test_atmosphere.py
+++ b/fme/core/corrector/test_atmosphere.py
@@ -21,7 +21,6 @@ from .atmosphere import (
     _force_conserve_total_energy,
     _force_zero_global_mean_moisture_advection,
 )
-from .utils import force_positive, replace_value_keep_gradient
 
 TIMESTEP = datetime.timedelta(hours=6)
 
@@ -272,47 +271,6 @@ def test_force_conserve_moisture(
         np.testing.assert_almost_equal(new_budget_residual, 0.0, decimal=6)
 
     np.testing.assert_almost_equal(new_dry_air, original_dry_air, decimal=6)
-
-
-def test_force_positive():
-    data = {
-        "foo": torch.tensor([[-1.0, 0.0], [0.0, 1.0], [1.0, 2.0]]),
-        "bar": torch.tensor([[-1.0, 0.0], [0.0, -3.0], [1.0, 2.0]]),
-    }
-    original_min = torch.min(data["foo"])
-    assert original_min < 0.0
-    fixed_data = force_positive(data, ["foo"])
-    new_min = torch.min(fixed_data["foo"])
-    # Ensure the minimum value of 'foo' is now 0
-    torch.testing.assert_close(new_min, torch.tensor(0.0))
-    # Ensure other variables are not modified
-    torch.testing.assert_close(fixed_data["bar"], data["bar"])
-
-
-def test_replace_value_keep_gradient():
-    x = torch.tensor([-1.0, 0.5, 2.0], requires_grad=True)
-    new_value = torch.clamp(x, min=0.0)
-    out = replace_value_keep_gradient(x, new_value)
-    # forward: exactly the projected (clamped) value
-    torch.testing.assert_close(out, torch.tensor([0.0, 0.5, 2.0]))
-    # backward: identity gradient everywhere, including the clamped tail
-    out.sum().backward()
-    torch.testing.assert_close(x.grad, torch.ones_like(x))
-
-
-def test_force_positive_keep_gradient_passes_gradient_on_clamped_cells():
-    # A clamped-negative input gets zero gradient with a plain clamp, but a
-    # nonzero (identity) gradient when keep_gradient=True.
-    x_plain = torch.tensor([-2.0, 1.0], requires_grad=True)
-    force_positive({"foo": x_plain}, ["foo"])["foo"].sum().backward()
-    torch.testing.assert_close(x_plain.grad, torch.tensor([0.0, 1.0]))
-
-    x_ste = torch.tensor([-2.0, 1.0], requires_grad=True)
-    fixed = force_positive({"foo": x_ste}, ["foo"], keep_gradient=True)
-    # forward value is still clamped
-    torch.testing.assert_close(fixed["foo"], torch.tensor([0.0, 1.0]))
-    fixed["foo"].sum().backward()
-    torch.testing.assert_close(x_ste.grad, torch.tensor([1.0, 1.0]))
 
 
 def _get_corrector_test_input(

--- a/fme/core/corrector/test_atmosphere.py
+++ b/fme/core/corrector/test_atmosphere.py
@@ -21,7 +21,7 @@ from .atmosphere import (
     _force_conserve_total_energy,
     _force_zero_global_mean_moisture_advection,
 )
-from .utils import force_positive
+from .utils import force_positive, replace_value_keep_gradient
 
 TIMESTEP = datetime.timedelta(hours=6)
 
@@ -287,6 +287,32 @@ def test_force_positive():
     torch.testing.assert_close(new_min, torch.tensor(0.0))
     # Ensure other variables are not modified
     torch.testing.assert_close(fixed_data["bar"], data["bar"])
+
+
+def test_replace_value_keep_gradient():
+    x = torch.tensor([-1.0, 0.5, 2.0], requires_grad=True)
+    new_value = torch.clamp(x, min=0.0)
+    out = replace_value_keep_gradient(x, new_value)
+    # forward: exactly the projected (clamped) value
+    torch.testing.assert_close(out, torch.tensor([0.0, 0.5, 2.0]))
+    # backward: identity gradient everywhere, including the clamped tail
+    out.sum().backward()
+    torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+
+def test_force_positive_keep_gradient_passes_gradient_on_clamped_cells():
+    # A clamped-negative input gets zero gradient with a plain clamp, but a
+    # nonzero (identity) gradient when keep_gradient=True.
+    x_plain = torch.tensor([-2.0, 1.0], requires_grad=True)
+    force_positive({"foo": x_plain}, ["foo"])["foo"].sum().backward()
+    torch.testing.assert_close(x_plain.grad, torch.tensor([0.0, 1.0]))
+
+    x_ste = torch.tensor([-2.0, 1.0], requires_grad=True)
+    fixed = force_positive({"foo": x_ste}, ["foo"], keep_gradient=True)
+    # forward value is still clamped
+    torch.testing.assert_close(fixed["foo"], torch.tensor([0.0, 1.0]))
+    fixed["foo"].sum().backward()
+    torch.testing.assert_close(x_ste.grad, torch.tensor([1.0, 1.0]))
 
 
 def _get_corrector_test_input(

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -54,6 +54,63 @@ def test_ocean_corrector_force_positive():
         assert torch.all(x >= 0.0)
 
 
+def test_sea_ice_fraction_keep_gradient_passes_gradient_through_clamp():
+    config = SeaIceFractionConfig(
+        sea_ice_fraction_name="sea_ice_fraction",
+        land_fraction_name="land_fraction",
+        remove_negative_ocean_fraction=False,
+    )
+    input_data = {"land_fraction": torch.zeros(IMG_SHAPE, device=DEVICE)}
+    # values both below 0 and above 1 so the clamp saturates at both ends
+    raw = torch.tensor([-0.5, 0.3, 1.5], device=DEVICE)
+
+    sif_plain = raw.clone().requires_grad_(True)
+    config({"sea_ice_fraction": sif_plain}, input_data)[
+        "sea_ice_fraction"
+    ].sum().backward()
+    # plain clamp: zero gradient where saturated, one in the interior
+    torch.testing.assert_close(
+        sif_plain.grad, torch.tensor([0.0, 1.0, 0.0], device=DEVICE)
+    )
+
+    sif_ste = raw.clone().requires_grad_(True)
+    out = config({"sea_ice_fraction": sif_ste}, input_data, keep_gradient=True)
+    # forward value is still clamped to [0, 1]
+    torch.testing.assert_close(
+        out["sea_ice_fraction"], torch.tensor([0.0, 0.3, 1.0], device=DEVICE)
+    )
+    out["sea_ice_fraction"].sum().backward()
+    torch.testing.assert_close(sif_ste.grad, torch.ones_like(raw))
+
+
+def test_ocean_corrector_keep_gradient_through_clamps_forward_unchanged():
+    # The straight-through flag must not change forward values; only gradients.
+    torch.manual_seed(0)
+    ops = LatLonOperations(torch.ones(size=IMG_SHAPE))
+    timestep = datetime.timedelta(seconds=3600)
+    sif = SeaIceFractionConfig(
+        sea_ice_fraction_name="sea_ice_fraction",
+        land_fraction_name="land_fraction",
+    )
+    input_data = {
+        "land_fraction": torch.ones(IMG_SHAPE, device=DEVICE) * 0.3,
+    }
+    gen_data = {
+        "so_0": torch.randn(IMG_SHAPE, device=DEVICE),
+        "sea_ice_fraction": torch.randn(IMG_SHAPE, device=DEVICE),
+    }
+    baseline = OceanCorrectorConfig(
+        force_positive_names=["so_0"], sea_ice_fraction_correction=sif
+    )._build(ops, None, timestep)(input_data, gen_data, {}, None)[0]
+    ste = OceanCorrectorConfig(
+        force_positive_names=["so_0"],
+        sea_ice_fraction_correction=sif,
+        keep_gradient_through_clamps=True,
+    )._build(ops, None, timestep)(input_data, gen_data, {}, None)[0]
+    for name in baseline:
+        torch.testing.assert_close(baseline[name], ste[name])
+
+
 def test_ocean_corrector_has_no_negative_ocean_fraction():
     config = OceanCorrectorConfig(
         sea_ice_fraction_correction=SeaIceFractionConfig(

--- a/fme/core/corrector/test_utils.py
+++ b/fme/core/corrector/test_utils.py
@@ -1,0 +1,44 @@
+import torch
+
+from .utils import _force_positive, replace_value_keep_gradient
+
+
+def test_force_positive():
+    data = {
+        "foo": torch.tensor([[-1.0, 0.0], [0.0, 1.0], [1.0, 2.0]]),
+        "bar": torch.tensor([[-1.0, 0.0], [0.0, -3.0], [1.0, 2.0]]),
+    }
+    original_min = torch.min(data["foo"])
+    assert original_min < 0.0
+    fixed_data = _force_positive(data, ["foo"])
+    new_min = torch.min(fixed_data["foo"])
+    # Ensure the minimum value of 'foo' is now 0
+    torch.testing.assert_close(new_min, torch.tensor(0.0))
+    # Ensure other variables are not modified
+    torch.testing.assert_close(fixed_data["bar"], data["bar"])
+
+
+def test_replace_value_keep_gradient():
+    x = torch.tensor([-1.0, 0.5, 2.0], requires_grad=True)
+    new_value = torch.clamp(x, min=0.0)
+    out = replace_value_keep_gradient(x, new_value)
+    # forward: exactly the projected (clamped) value
+    torch.testing.assert_close(out, torch.tensor([0.0, 0.5, 2.0]))
+    # backward: identity gradient everywhere, including the clamped tail
+    out.sum().backward()
+    torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+
+def test_force_positive_keep_gradient_passes_gradient_on_clamped_cells():
+    # A clamped-negative input gets zero gradient with a plain clamp, but a
+    # nonzero (identity) gradient when keep_gradient=True.
+    x_plain = torch.tensor([-2.0, 1.0], requires_grad=True)
+    _force_positive({"foo": x_plain}, ["foo"])["foo"].sum().backward()
+    torch.testing.assert_close(x_plain.grad, torch.tensor([0.0, 1.0]))
+
+    x_ste = torch.tensor([-2.0, 1.0], requires_grad=True)
+    fixed = _force_positive({"foo": x_ste}, ["foo"], keep_gradient=True)
+    # forward value is still clamped
+    torch.testing.assert_close(fixed["foo"], torch.tensor([0.0, 1.0]))
+    fixed["foo"].sum().backward()
+    torch.testing.assert_close(x_ste.grad, torch.tensor([1.0, 1.0]))

--- a/fme/core/corrector/utils.py
+++ b/fme/core/corrector/utils.py
@@ -6,11 +6,38 @@ from fme.core.corrector.state import CorrectorState
 from fme.core.typing_ import TensorDict, TensorMapping
 
 
-def force_positive(data: TensorMapping, names: list[str]) -> TensorDict:
-    """Clamp all tensors defined by `names` to be greater than or equal to zero."""
+def replace_value_keep_gradient(
+    x: torch.Tensor, new_value: torch.Tensor
+) -> torch.Tensor:
+    """Use `new_value` in the forward pass but keep x's gradient in the backward pass.
+
+    Lets us apply a hard correction (clamp, rebalance, etc.) to the output a
+    network sees, while the network still gets a gradient as if the correction
+    hadn't happened — so clamped/out-of-range cells still get a learning signal
+    instead of a zero gradient.
+
+    Forward: ``x + (new_value - x) = new_value`` (the exact projected value is
+    preserved). Backward: the detached term contributes zero, so the gradient is
+    the identity ``d(out)/dx = 1``.
+    """
+    return x + (new_value - x).detach()
+
+
+def force_positive(
+    data: TensorMapping, names: list[str], keep_gradient: bool = False
+) -> TensorDict:
+    """Clamp all tensors defined by `names` to be greater than or equal to zero.
+
+    If ``keep_gradient`` is True, the clamp is applied with
+    :func:`replace_value_keep_gradient` so the forward value is still clamped to
+    zero but the gradient flows as if the clamp had not happened.
+    """
     out = {**data}
     for name in names:
-        out[name] = torch.clamp(data[name], min=0.0)
+        clamped = torch.clamp(data[name], min=0.0)
+        if keep_gradient:
+            clamped = replace_value_keep_gradient(data[name], clamped)
+        out[name] = clamped
     return out
 
 
@@ -20,9 +47,15 @@ class ForcePositive:
 
     Implements the ``Correction`` protocol; ``input_data``, ``forcing_data`` and
     ``corrector_state`` are unused and passed through.
+
+    If ``keep_gradient`` is True, the clamp is applied with a straight-through
+    estimator (see :func:`replace_value_keep_gradient`): the forward value is
+    still clamped to zero, but the gradient flows as if the clamp had not
+    happened, so clamped-negative cells still get a learning signal.
     """
 
     names: list[str]
+    keep_gradient: bool = False
 
     def __call__(
         self,
@@ -31,4 +64,7 @@ class ForcePositive:
         forcing_data: TensorMapping,
         corrector_state: CorrectorState | None,
     ) -> tuple[TensorDict, CorrectorState | None]:
-        return force_positive(gen_data, self.names), corrector_state
+        return (
+            force_positive(gen_data, self.names, keep_gradient=self.keep_gradient),
+            corrector_state,
+        )

--- a/fme/core/corrector/utils.py
+++ b/fme/core/corrector/utils.py
@@ -23,7 +23,7 @@ def replace_value_keep_gradient(
     return x + (new_value - x).detach()
 
 
-def force_positive(
+def _force_positive(
     data: TensorMapping, names: list[str], keep_gradient: bool = False
 ) -> TensorDict:
     """Clamp all tensors defined by `names` to be greater than or equal to zero.
@@ -65,6 +65,6 @@ class ForcePositive:
         corrector_state: CorrectorState | None,
     ) -> tuple[TensorDict, CorrectorState | None]:
         return (
-            force_positive(gen_data, self.names, keep_gradient=self.keep_gradient),
+            _force_positive(gen_data, self.names, keep_gradient=self.keep_gradient),
             corrector_state,
         )


### PR DESCRIPTION
The hard `torch.clamp` operations in the correctors run inside the training autograd path, and `clamp` has zero gradient in its saturated tail — so a cell the network pushes out of range gets no learning signal to come back; the projection silently absorbs the error. This adds a straight-through estimator (STE) that keeps the exact projected (clamped) value in the forward pass while letting gradient flow as identity in the backward pass, gated behind a new default-off `keep_gradient_through_clamps` flag on each corrector. Because forward values are unchanged when the flag is on, it is cleanly A/B-able against a baseline; only the gradient path differs, and default-off preserves existing behavior.

Validated by a same-seed A/B on the selected 4° residual baseline: with the flag on, training is stable to convergence (best_val_loss neutral) and the predicted near-zero precipitation distribution moves toward target (the dry-cell over-prediction is roughly halved across all four climate evals).

Changes:
- `fme.core.corrector.utils.replace_value_keep_gradient`: new STE helper (`x + (new_value - x).detach()` — forward is `new_value`, backward is identity).
- `fme.core.corrector.utils.force_positive` / `ForcePositive`: optional `keep_gradient` that applies the precip clamp via the STE.
- `fme.core.corrector.ocean.SeaIceFractionConfig` / `SeaIceFractionCorrection`: optional `keep_gradient` applying the STE to the 0-1 sea-ice-fraction clamp and the negative-ocean-fraction rebalance.
- `fme.core.corrector.atmosphere.AtmosphereCorrectorConfig` / `ocean.OceanCorrectorConfig`: new default-off `keep_gradient_through_clamps` field wiring the above.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated