### PR TITLE
Fix SeparateICZarrWriterAdapter mislabeling time calendar as julian

### DIFF
--- a/fme/ace/inference/data_writer/test_zarr.py
+++ b/fme/ace/inference/data_writer/test_zarr.py
@@ -127,6 +127,66 @@ def test_zarr_adapter_can_overwrite(tmpdir, writer_cls):
     adapter.append_batch(data, time)
 
 
+@pytest.mark.parametrize("calendar", ["julian", "proleptic_gregorian", "noleap"])
+def test_separate_ic_writer_preserves_time_calendar(tmpdir, calendar):
+    """A downstream reader must decode the written ``time`` to the source dates.
+
+    Regression test: previously ``SeparateICZarrWriterAdapter`` encoded the time
+    values with the source calendar but did not pass ``time_calendar`` to the
+    ``ZarrWriter``, so the coordinate was tagged with the default ``"julian"``
+    calendar. For non-julian data the values then no longer matched the label, so
+    decoding shifted every timestamp. The shift comes from leap days accumulated
+    between the 1970 encoding epoch and the data dates, so it appears even when the
+    coordinate itself does not span a leap day (here ~12 days for 2020).
+    """
+    n_timesteps = 2
+    data = {"foo": torch.zeros((1, n_timesteps, 2, 2))}
+    timestep = datetime.timedelta(days=1)
+    initial_condition_times = get_initial_condition_times(
+        (2019, 12, 31, 0, 0, 0), calendar, n_initial_conditions=1
+    )
+    # Daily batch times so the timestep-derived lead times reproduce them exactly.
+    batch_time = xr.DataArray(
+        xr.date_range(
+            "2020-01-01",
+            freq="1D",
+            periods=n_timesteps,
+            calendar=calendar,
+            use_cftime=True,
+        ).values[None, :],
+        dims=("sample", "time"),
+    )
+    adapter = SeparateICZarrWriterAdapter(
+        path=str(tmpdir / "test.zarr"),
+        dims=("time", "lat", "lon"),
+        data_coords=ensure_numpy_coords(
+            {
+                "lat": xr.DataArray([0, 1], dims=["lat"]),
+                "lon": xr.DataArray([0, 1], dims=["lon"]),
+            }
+        ),
+        timestep=timestep,
+        n_timesteps=n_timesteps,
+        initial_condition_times=initial_condition_times,
+    )
+    adapter.append_batch(data, batch_time)
+    adapter.finalize()
+
+    output = str(tmpdir / "test_ic0000.zarr")
+    # A downstream reader uses xarray's default decoding, which honors the stored
+    # ``calendar`` attribute. The decoded calendar dates must match the source;
+    # before the fix they were offset (compare day strings to ignore the cftime
+    # subclass and isolate the actual dates).
+    decoded = xr.open_zarr(output)
+    np.testing.assert_array_equal(
+        decoded.time.dt.strftime("%Y-%m-%d").values,
+        batch_time.isel(sample=0).dt.strftime("%Y-%m-%d").values,
+    )
+    # The stored attribute itself must also name the true calendar.
+    raw = xr.open_zarr(output, decode_times=False)
+    assert raw.time.attrs["calendar"] == calendar
+
+
 def test_zarr_adapter_single_timestep_data(
     tmpdir,
 ):

--- a/fme/ace/inference/data_writer/test_zarr.py
+++ b/fme/ace/inference/data_writer/test_zarr.py
@@ -131,13 +131,12 @@ def test_zarr_adapter_can_overwrite(tmpdir, writer_cls):
 def test_separate_ic_writer_preserves_time_calendar(tmpdir, calendar):
     """A downstream reader must decode the written ``time`` to the source dates.
 
-    Regression test: previously ``SeparateICZarrWriterAdapter`` encoded the time
-    values with the source calendar but did not pass ``time_calendar`` to the
-    ``ZarrWriter``, so the coordinate was tagged with the default ``"julian"``
-    calendar. For non-julian data the values then no longer matched the label, so
-    decoding shifted every timestamp. The shift comes from leap days accumulated
-    between the 1970 encoding epoch and the data dates, so it appears even when the
-    coordinate itself does not span a leap day (here ~12 days for 2020).
+    ``SeparateICZarrWriterAdapter`` encodes the time values with the source
+    calendar, so the stored ``calendar`` attribute must name that same calendar.
+    A mismatched label (e.g. ``"julian"`` for non-julian data) leaves the values
+    inconsistent with the label, so decoding shifts every timestamp by the leap
+    days accumulated between the 1970 encoding epoch and the data dates -- a shift
+    present even when the coordinate does not span a leap day (~12 days for 2020).
     """
     n_timesteps = 2
     data = {"foo": torch.zeros((1, n_timesteps, 2, 2))}
@@ -174,9 +173,8 @@ def test_separate_ic_writer_preserves_time_calendar(tmpdir, calendar):
 
     output = str(tmpdir / "test_ic0000.zarr")
     # A downstream reader uses xarray's default decoding, which honors the stored
-    # ``calendar`` attribute. The decoded calendar dates must match the source;
-    # before the fix they were offset (compare day strings to ignore the cftime
-    # subclass and isolate the actual dates).
+    # ``calendar`` attribute. The decoded calendar dates must match the source
+    # (compare day strings to ignore the cftime subclass and isolate the dates).
     decoded = xr.open_zarr(output)
     np.testing.assert_array_equal(
         decoded.time.dt.strftime("%Y-%m-%d").values,

--- a/fme/ace/inference/data_writer/zarr.py
+++ b/fme/ace/inference/data_writer/zarr.py
@@ -327,6 +327,7 @@ class SeparateICZarrWriterAdapter:
                     array_attributes=self.variable_metadata,
                     group_attributes=self.dataset_metadata,
                     nondim_coords=self._nondim_coords,
+                    time_calendar=first_batch_time.dt.calendar,
                     mode="w",
                     overwrite_check=self.overwrite_check,
                 )


### PR DESCRIPTION
The zarr data writer used with `separate_ensemble_members: true` (`SeparateICZarrWriterAdapter`) encoded the `time` coordinate values using the source calendar but constructed the `ZarrWriter` without a `time_calendar` argument, so the coordinate was always tagged with the default `"julian"` calendar. For non-julian data (e.g. the noleap CM4 piControl dataset) this silently mislabeled every timestamp, so any reader that honors the CF `calendar` attribute misinterprets the dates (a >1-year offset for piControl data starting near year 1). This PR passes the source calendar through to the writer so the label matches the already-correct encoded values.

Changes:
- `fme.ace.inference.data_writer.zarr.SeparateICZarrWriterAdapter._initialize_writers`: pass `time_calendar=first_batch_time.dt.calendar` when constructing each `ZarrWriter`.
- `fme.ace.inference.data_writer.test_zarr.test_separate_ic_writer_preserves_time_calendar`: new regression test, parametrized over julian/proleptic_gregorian/noleap, asserting the stored `time` calendar attribute matches the source and decoded times round-trip. Fails on noleap/proleptic_gregorian before the fix.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #1324
