### PR TITLE
HEALPix UNet code cleanup

### DIFF
--- a/fme/ace/models/healpix/healpix_activations.py
+++ b/fme/ace/models/healpix/healpix_activations.py
@@ -19,7 +19,7 @@
 
 import dataclasses
 
-import torch as th
+import torch
 import torch.nn as nn
 
 
@@ -30,11 +30,9 @@ class CappedGELUConfig:
 
     Parameters:
         cap_value: Cap value for the GELU function, default is 10.
-        enable_nhwc: Flag to enable NHWC data format, default is False.
     """
 
     cap_value: int = 10
-    enable_nhwc: bool = False
 
     def build(self) -> nn.Module:
         """
@@ -53,7 +51,7 @@ class CappedGELU(nn.Module):
     Example
     -------
     >>> capped_gelu_func = modulus.models.layers.CappedGELU()
-    >>> input = th.Tensor([[-2,-1],[0,1],[2,3]])
+    >>> input = torch.Tensor([[-2,-1],[0,1],[2,3]])
     >>> capped_gelu_func(input)
     tensor([[-0.0455, -0.1587],
             [ 0.0000,  0.8413],
@@ -65,12 +63,12 @@ class CappedGELU(nn.Module):
         """
         Args:
             cap_value: Maximum that values will be capped at
-            **kwargs: Keyword arguments to be passed to the `th.nn.GELU` function
+            **kwargs: Keyword arguments to be passed to the `torch.nn.GELU` function
         """
 
         super().__init__()
-        self.add_module("gelu", th.nn.GELU(**kwargs))
-        self.register_buffer("cap", th.tensor(cap_value, dtype=th.float32))
+        self.add_module("gelu", torch.nn.GELU(**kwargs))
+        self.register_buffer("cap", torch.tensor(cap_value, dtype=torch.float32))
 
     def forward(self, inputs):
         """
@@ -83,5 +81,5 @@ class CappedGELU(nn.Module):
         x = self.gelu(inputs)
         # Convert cap to a scalar value for clamping (ignores grad)
         cap_value = self.cap.item()
-        x = th.clamp(x, max=cap_value)
+        x = torch.clamp(x, max=cap_value)
         return x

--- a/fme/ace/models/healpix/healpix_blocks.py
+++ b/fme/ace/models/healpix/healpix_blocks.py
@@ -17,31 +17,58 @@
 
 import dataclasses
 import math
-from typing import Literal, Optional, Sequence, Tuple, Union, cast
+from typing import Literal, Optional, Sequence, Tuple, Union
 
-import torch as th
+import torch
 import torch.nn as nn
 
 from .healpix_activations import CappedGELUConfig
 from .healpix_layers import HEALPixLayer
 
+HpxPaddingMode = Literal["earth2grid", "karlbauer", "isolatitude"]
 
-def _healpix_layer_kwargs(
-    enable_nhwc: bool,
-    hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid",
-    nside: Optional[int] = None,
-) -> dict:
+
+@dataclasses.dataclass(frozen=True)
+class HEALPixLayerBuildContext:
+    """Per-layer HEALPix runtime settings passed to block ``build`` methods."""
+
+    hpx_padding_mode: HpxPaddingMode = "earth2grid"
+    nside: int | None = None
+    nside_after: int | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class HEALPixBuildContext:
+    """Shared HEALPix runtime settings for a UNet (or encoder/decoder) build.
+
+    Configure ``hpx_padding_mode`` once at the model level; child blocks receive a
+    per-level view via ``layer()``.
+    """
+
+    hpx_padding_mode: HpxPaddingMode = "earth2grid"
+    nside_levels: tuple[int, ...] | None = None
+
+    def layer(
+        self, level: int, *, nside_after: int | None = None
+    ) -> HEALPixLayerBuildContext:
+        nside = None if self.nside_levels is None else self.nside_levels[level]
+        return HEALPixLayerBuildContext(
+            hpx_padding_mode=self.hpx_padding_mode,
+            nside=nside,
+            nside_after=nside_after,
+        )
+
+
+def _healpix_layer_kwargs(ctx: HEALPixLayerBuildContext) -> dict:
     """
     Build keyword arguments passed to ``HEALPixLayer``.
 
     Args:
-        enable_nhwc: Use channels-last memory format.
-        hpx_padding_mode: HEALPix padding backend.
-        nside: Native face height/width; included in the dict only when not ``None``.
+        ctx: Per-layer HEALPix build context.
     """
-    out: dict = {"enable_nhwc": enable_nhwc, "hpx_padding_mode": hpx_padding_mode}
-    if nside is not None:
-        out["nside"] = nside
+    out: dict = {"hpx_padding_mode": ctx.hpx_padding_mode}
+    if ctx.nside is not None:
+        out["nside"] = ctx.nside
     return out
 
 
@@ -49,262 +76,340 @@ def _healpix_layer_kwargs(
 
 
 @dataclasses.dataclass
-class DownsamplingBlockConfig:
-    """
-    Configuration for the downsampling block (pooling or dealiased strided blur).
+class MaxPoolDownsamplingBlockConfig:
+    """Configuration for a HEALPix max-pooling downsample block."""
 
-    Parameters:
-        block_type: One of ``"MaxPool"``, ``"AvgPool"``, or ``"DealiasedDownsample"``.
-        pooling: Pooling size for pool blocks.
-        stride: Spatial stride for ``DealiasedDownsample`` (power of two).
-        enable_nhwc: Use channels-last memory format.
-        hpx_padding_mode: HEALPix padding backend passed to child modules.
-        nside: Native face height/width for HEALPix padding.
-        in_channels: Input channels for ``DealiasedDownsample`` (set by encoder before build).
-        resample_filter: 1D filter weights for dealiased blur stages.
-    """
-
-    block_type: Literal["MaxPool", "AvgPool", "DealiasedDownsample"]
+    block_type: Literal["MaxPool"] = "MaxPool"
     pooling: int = 2
-    enable_nhwc: bool = False
-    hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid"
-    nside: Optional[int] = None
-    in_channels: Optional[int] = None
-    resample_filter: Sequence[float] = dataclasses.field(
-        default_factory=lambda: [1.0, 2.0, 1.0]
-    )
-    stride: int = 2
 
     def downsample_spatial_factor(self) -> int:
-        if self.block_type in ("MaxPool", "AvgPool"):
-            return self.pooling
-        if self.block_type == "DealiasedDownsample":
-            return self.stride
-        raise ValueError(f"Unsupported block type: {self.block_type}")
+        return self.pooling
 
-    def build(self) -> nn.Module:
-        if self.block_type == "MaxPool":
-            return MaxPool(
-                pooling=self.pooling,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        if self.block_type == "AvgPool":
-            return AvgPool(
-                pooling=self.pooling,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        if self.block_type == "DealiasedDownsample":
-            if self.in_channels is None:
-                raise ValueError(
-                    "DealiasedDownsample requires in_channels "
-                    "(set by UNetEncoder before build)"
-                )
-            return DealiasedDownsample(
-                in_channels=self.in_channels,
-                resample_filter=self.resample_filter,
-                stride=self.stride,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        raise ValueError(f"Unsupported block type: {self.block_type}")
+    def build(
+        self,
+        *,
+        in_channels: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        del in_channels
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        return MaxPool(
+            pooling=self.pooling,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
 
 
 @dataclasses.dataclass
-class UpsamplingBlockConfig:
-    """
-    Configuration for HEALPix upsampling (transpose conv, interpolate+conv, pure
-    ``nn.Upsample``, etc.).
+class AvgPoolDownsamplingBlockConfig:
+    """Configuration for a HEALPix average-pooling downsample block."""
 
-    ``block_type`` ``"Interpolate"`` uses ``stride`` as ``nn.Upsample`` ``scale_factor``
-    and ``upsample_mode`` as the interpolation mode.
+    block_type: Literal["AvgPool"] = "AvgPool"
+    pooling: int = 2
 
-    Parameters:
-        block_type: Upsampling implementation to build.
-        in_channels: Input channel count for conv-based upsamplers.
-        out_channels: Output channel count for conv-based upsamplers.
-        stride: Upsampling scale factor (also used as ``nn.Upsample`` scale when applicable).
-        kernel_size: Convolution kernel size for ``SmoothedInterpolateConv``.
-        dilation: Convolution dilation for ``SmoothedInterpolateConv``.
-        upsample_mode: Interpolation mode for smoothed / pure interpolate paths.
-        activation: Optional ``CappedGELUConfig`` for transpose-conv upsampling.
-        enable_nhwc: Use channels-last memory format.
-        hpx_padding_mode: HEALPix padding backend passed to child modules.
-        nside: Native face height/width for HEALPix padding at upsample input.
-        nside_after: Face height/width after upsampling (``SmoothedInterpolateConv`` only).
-        align_corners: Passed to ``nn.Upsample`` when ``block_type`` is ``"Interpolate"``.
-        scale_factor: Alias for ``stride`` when set in config.
-        mode: Alias for ``upsample_mode`` when set in config.
-    """
+    def downsample_spatial_factor(self) -> int:
+        return self.pooling
 
-    block_type: Literal[
-        "TransposedConvUpsample",
-        "SmoothedInterpolateConv",
-        "Interpolate",
-    ]
-    in_channels: int = 3
-    out_channels: int = 1
+    def build(
+        self,
+        *,
+        in_channels: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        del in_channels
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        return AvgPool(
+            pooling=self.pooling,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+@dataclasses.dataclass
+class DealiasedDownsampleBlockConfig:
+    """Configuration for a dealiased strided-blur downsample block."""
+
+    block_type: Literal["DealiasedDownsample"] = "DealiasedDownsample"
+    pooling: int = 2
+    resample_filter: Sequence[float] = dataclasses.field(
+        default_factory=lambda: [1.0, 2.0, 1.0]
+    )
+
+    def downsample_spatial_factor(self) -> int:
+        return self.pooling
+
+    def build(
+        self,
+        *,
+        in_channels: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        if in_channels is None:
+            raise ValueError(
+                "DealiasedDownsample requires in_channels to be passed to build()"
+            )
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        return DealiasedDownsample(
+            in_channels=in_channels,
+            resample_filter=self.resample_filter,
+            stride=self.pooling,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+DownsamplingBlockConfig = (
+    MaxPoolDownsamplingBlockConfig
+    | AvgPoolDownsamplingBlockConfig
+    | DealiasedDownsampleBlockConfig
+)
+
+
+@dataclasses.dataclass
+class TransposedConvUpsampleBlockConfig:
+    """Configuration for transpose-convolution upsampling."""
+
+    block_type: Literal["TransposedConvUpsample"] = "TransposedConvUpsample"
+    stride: int = 2
+    activation: Optional[CappedGELUConfig] = None
+
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        return TransposedConvUpsample(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            upsampling=self.stride,
+            activation=self.activation,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+@dataclasses.dataclass
+class SmoothedInterpolateConvBlockConfig:
+    """Configuration for smoothed interpolate + conv upsampling."""
+
+    block_type: Literal["SmoothedInterpolateConv"] = "SmoothedInterpolateConv"
     stride: int = 2
     kernel_size: int = 3
     dilation: int = 1
     upsample_mode: str = "nearest"
     activation: Optional[CappedGELUConfig] = None
-    enable_nhwc: bool = False
-    hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid"
-    nside: Optional[int] = None
-    nside_after: Optional[int] = None
-    align_corners: bool = False
-    scale_factor: Optional[int] = None
-    mode: Optional[str] = None
 
-    def __post_init__(self) -> None:
-        if self.scale_factor is not None:
-            self.stride = self.scale_factor
-        if self.mode is not None:
-            self.upsample_mode = self.mode
-
-    def build(self) -> nn.Module:
-        if self.block_type == "TransposedConvUpsample":
-            return TransposedConvUpsample(
-                in_channels=self.in_channels,
-                out_channels=self.out_channels,
-                upsampling=self.stride,
-                activation=self.activation,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        if self.block_type == "SmoothedInterpolateConv":
-            return SmoothedInterpolateConv(
-                in_channels=self.in_channels,
-                out_channels=self.out_channels,
-                kernel_size=self.kernel_size,
-                dilation=self.dilation,
-                scale_factor=self.stride,
-                mode=self.upsample_mode,
-                activation=self.activation.build() if self.activation else None,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-                nside_after=self.nside_after,
-            )
-        if self.block_type == "Interpolate":
-            if self.align_corners is False:
-                return nn.Upsample(
-                    scale_factor=self.stride,
-                    mode=self.upsample_mode,
-                )
-            return nn.Upsample(
-                scale_factor=self.stride,
-                mode=self.upsample_mode,
-                align_corners=self.align_corners,
-            )
-        raise ValueError(f"Unsupported block type: {self.block_type}")
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        return SmoothedInterpolateConv(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=self.kernel_size,
+            dilation=self.dilation,
+            scale_factor=self.stride,
+            mode=self.upsample_mode,
+            activation=self.activation.build() if self.activation else None,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+            nside_after=layer_ctx.nside_after,
+        )
 
 
 @dataclasses.dataclass
-class ConvBlockConfig:
-    """
-    Configuration for convolutional residual / ConvNeXt style blocks (no spatial resample).
+class InterpolateUpsampleBlockConfig:
+    """Configuration for pure ``nn.Upsample`` upsampling (no conv)."""
 
-    Parameters:
-        in_channels: Number of input channels.
-        out_channels: Number of output channels.
-        kernel_size: Convolution kernel size.
-        dilation: Convolution dilation.
-        n_layers: Number of repeated layers (for multi-block types).
-        upscale_factor: Channel upscale factor inside ConvNeXt blocks.
-        latent_channels: Latent channel width; defaults to ``max(in_channels, out_channels)``.
-        activation: Optional ``CappedGELUConfig`` between layers.
-        enable_nhwc: Use channels-last memory format.
-        hpx_padding_mode: HEALPix padding backend passed to child modules.
-        nside: Native face height/width for HEALPix padding.
-        block_type: Which block implementation to build.
-    """
+    block_type: Literal["Interpolate"] = "Interpolate"
+    stride: int = 2
+    upsample_mode: str = "nearest"
+    align_corners: bool = False
 
-    in_channels: int = 3
-    out_channels: int = 1
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        del in_channels, out_channels, ctx
+        if self.align_corners is False:
+            return nn.Upsample(
+                scale_factor=self.stride,
+                mode=self.upsample_mode,
+            )
+        return nn.Upsample(
+            scale_factor=self.stride,
+            mode=self.upsample_mode,
+            align_corners=self.align_corners,
+        )
+
+
+UpsamplingBlockConfig = (
+    TransposedConvUpsampleBlockConfig
+    | SmoothedInterpolateConvBlockConfig
+    | InterpolateUpsampleBlockConfig
+)
+
+
+@dataclasses.dataclass
+class BasicConvBlockConfig:
+    """Configuration for stacked basic conv blocks."""
+
+    block_type: Literal["BasicConvBlock"] = "BasicConvBlock"
     kernel_size: int = 3
-    dilation: int = 1
+    n_layers: int = 1
+    activation: Optional[CappedGELUConfig] = None
+
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        latent_channels: int | None = None,
+        dilation: int = 1,
+        n_layers: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        n_layers_resolved = self.n_layers if n_layers is None else n_layers
+        return BasicConvBlock(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=self.kernel_size,
+            dilation=dilation,
+            n_layers=n_layers_resolved,
+            latent_channels=latent_channels,
+            activation=self.activation,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+@dataclasses.dataclass
+class ConvNeXtBlockConfig:
+    """Configuration for a single ConvNeXt block."""
+
+    block_type: Literal["ConvNeXtBlock"] = "ConvNeXtBlock"
+    kernel_size: int = 3
+    upscale_factor: int = 4
+    activation: Optional[CappedGELUConfig] = None
+
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        latent_channels: int | None = None,
+        dilation: int = 1,
+        n_layers: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        del n_layers
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        if latent_channels is None:
+            latent_channels = 1
+        return ConvNeXtBlock(
+            in_channels=in_channels,
+            latent_channels=latent_channels,
+            out_channels=out_channels,
+            kernel_size=self.kernel_size,
+            dilation=dilation,
+            upscale_factor=self.upscale_factor,
+            activation=self.activation,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+@dataclasses.dataclass
+class SymmetricConvNeXtBlockConfig:
+    """Configuration for a single symmetric ConvNeXt block."""
+
+    block_type: Literal["SymmetricConvNeXtBlock"] = "SymmetricConvNeXtBlock"
+    kernel_size: int = 3
+    upscale_factor: int = 4
+    activation: Optional[CappedGELUConfig] = None
+
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        latent_channels: int | None = None,
+        dilation: int = 1,
+        n_layers: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        del n_layers
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        if latent_channels is None:
+            latent_channels = 1
+        return SymmetricConvNeXtBlock(
+            in_channels=in_channels,
+            latent_channels=latent_channels,
+            out_channels=out_channels,
+            kernel_size=self.kernel_size,
+            dilation=dilation,
+            upscale_factor=self.upscale_factor,
+            activation=self.activation,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+@dataclasses.dataclass
+class MultiSymmetricConvNeXtBlockConfig:
+    """Configuration for a stack of symmetric ConvNeXt blocks."""
+
+    block_type: Literal["Multi_SymmetricConvNeXtBlock"] = "Multi_SymmetricConvNeXtBlock"
+    kernel_size: int = 3
     n_layers: int = 1
     upscale_factor: int = 4
-    latent_channels: Optional[int] = None
     activation: Optional[CappedGELUConfig] = None
-    enable_nhwc: bool = False
-    hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid"
-    nside: Optional[int] = None
-    block_type: Literal[
-        "BasicConvBlock",
-        "ConvNeXtBlock",
-        "SymmetricConvNeXtBlock",
-        "Multi_SymmetricConvNeXtBlock",
-    ] = "BasicConvBlock"
 
-    def build(self) -> nn.Module:
-        if self.block_type == "BasicConvBlock":
-            return BasicConvBlock(
-                in_channels=self.in_channels,
-                out_channels=self.out_channels,
-                kernel_size=self.kernel_size,
-                dilation=self.dilation,
-                n_layers=self.n_layers,
-                latent_channels=self.latent_channels,
-                activation=self.activation,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        if self.block_type == "ConvNeXtBlock":
-            if self.latent_channels is None:
-                self.latent_channels = 1
-            return ConvNeXtBlock(
-                in_channels=self.in_channels,
-                latent_channels=cast(int, self.latent_channels),
-                out_channels=self.out_channels,
-                kernel_size=self.kernel_size,
-                dilation=self.dilation,
-                upscale_factor=self.upscale_factor,
-                activation=self.activation,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        if self.block_type == "SymmetricConvNeXtBlock":
-            if self.latent_channels is None:
-                self.latent_channels = 1
-            return SymmetricConvNeXtBlock(
-                in_channels=self.in_channels,
-                latent_channels=cast(int, self.latent_channels),
-                out_channels=self.out_channels,
-                kernel_size=self.kernel_size,
-                dilation=self.dilation,
-                upscale_factor=self.upscale_factor,
-                activation=self.activation,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        if self.block_type == "Multi_SymmetricConvNeXtBlock":
-            if self.latent_channels is None:
-                self.latent_channels = 1
-            return Multi_SymmetricConvNeXtBlock(
-                in_channels=self.in_channels,
-                latent_channels=cast(int, self.latent_channels),
-                out_channels=self.out_channels,
-                kernel_size=self.kernel_size,
-                dilation=self.dilation,
-                upscale_factor=self.upscale_factor,
-                n_layers=self.n_layers,
-                activation=self.activation,
-                enable_nhwc=self.enable_nhwc,
-                hpx_padding_mode=self.hpx_padding_mode,
-                nside=self.nside,
-            )
-        raise ValueError(f"Unsupported block type: {self.block_type}")
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        *,
+        latent_channels: int | None = None,
+        dilation: int = 1,
+        n_layers: int | None = None,
+        ctx: HEALPixLayerBuildContext | None = None,
+    ) -> nn.Module:
+        layer_ctx = ctx or HEALPixLayerBuildContext()
+        n_layers_resolved = self.n_layers if n_layers is None else n_layers
+        if latent_channels is None:
+            latent_channels = 1
+        return Multi_SymmetricConvNeXtBlock(
+            in_channels=in_channels,
+            latent_channels=latent_channels,
+            out_channels=out_channels,
+            kernel_size=self.kernel_size,
+            dilation=dilation,
+            upscale_factor=self.upscale_factor,
+            n_layers=n_layers_resolved,
+            activation=self.activation,
+            hpx_padding_mode=layer_ctx.hpx_padding_mode,
+            nside=layer_ctx.nside,
+        )
+
+
+ConvBlockConfig = (
+    BasicConvBlockConfig
+    | ConvNeXtBlockConfig
+    | SymmetricConvNeXtBlockConfig
+    | MultiSymmetricConvNeXtBlockConfig
+)
 
 
 # --- Downsampling modules ---
@@ -333,10 +438,15 @@ class MaxPool(nn.Module):
         self.maxpool = HEALPixLayer(
             layer=nn.MaxPool2d,
             kernel_size=pooling,
-            **_healpix_layer_kwargs(enable_nhwc, hpx_padding_mode, nside),
+            **_healpix_layer_kwargs(
+                HEALPixLayerBuildContext(
+                    hpx_padding_mode=hpx_padding_mode,
+                    nside=nside,
+                )
+            ),
         )
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Input tensor ``[N * 12, C, H, W]``.
@@ -370,10 +480,15 @@ class AvgPool(nn.Module):
         self.avgpool = HEALPixLayer(
             layer=nn.AvgPool2d,
             kernel_size=pooling,
-            **_healpix_layer_kwargs(enable_nhwc, hpx_padding_mode, nside),
+            **_healpix_layer_kwargs(
+                HEALPixLayerBuildContext(
+                    hpx_padding_mode=hpx_padding_mode,
+                    nside=nside,
+                )
+            ),
         )
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Input tensor ``[N * 12, C, H, W]``.
@@ -390,8 +505,8 @@ class DealiasBlurConv2d(nn.Module):
     @staticmethod
     def _normalized_depthwise_blur_weights(
         resample_filter: Sequence[float], in_channels: int
-    ) -> th.Tensor:
-        f = th.as_tensor(list(resample_filter), dtype=th.float32)
+    ) -> torch.Tensor:
+        f = torch.as_tensor(list(resample_filter), dtype=torch.float32)
         if f.ndim != 1:
             raise ValueError("resample_filter must be 1D")
         m = int(f.numel())
@@ -429,7 +544,7 @@ class DealiasBlurConv2d(nn.Module):
             self._normalized_depthwise_blur_weights(filt, in_channels),
         )
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Input tensor ``[N, C, H, W]``.
@@ -437,7 +552,7 @@ class DealiasBlurConv2d(nn.Module):
         Returns:
             Depthwise-blurred tensor with optional strided downsampling.
         """
-        return th.nn.functional.conv2d(
+        return torch.nn.functional.conv2d(
             x,
             self.weight.to(device=x.device, dtype=x.dtype),
             bias=None,
@@ -485,9 +600,10 @@ class DealiasedDownsample(nn.Module):
         n_layers = int(math.log2(stride))
         pool_layers = []
         healpix_kwargs = _healpix_layer_kwargs(
-            enable_nhwc,
-            hpx_padding_mode,
-            nside,
+            HEALPixLayerBuildContext(
+                hpx_padding_mode=hpx_padding_mode,
+                nside=nside,
+            )
         )
         for _ in range(n_layers):
             pool_layers.append(
@@ -508,7 +624,7 @@ class DealiasedDownsample(nn.Module):
 
         self.pool = nn.Sequential(*pool_layers)
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Input tensor ``[N * 12, C, H, W]``.
@@ -563,9 +679,10 @@ class TransposedConvUpsample(nn.Module):
                 stride=upsampling,
                 padding=0,
                 **_healpix_layer_kwargs(
-                    enable_nhwc,
-                    hpx_padding_mode,
-                    nside,
+                    HEALPixLayerBuildContext(
+                        hpx_padding_mode=hpx_padding_mode,
+                        nside=nside,
+                    )
                 ),
             )
         )
@@ -580,7 +697,7 @@ class TransposedConvUpsample(nn.Module):
             x: The values to upsample.
 
         Returns:
-            th.Tensor: The upsampled values.
+            torch.Tensor: The upsampled values.
         """
         return self.upsampler(x)
 
@@ -608,14 +725,15 @@ class SmoothedInterpolate(nn.Module):
         self.scale_factor = scale_factor
         self.mode = mode
         self.trim_size = trim_size
-        self.interp = th.nn.functional.interpolate
 
-        smoother_kernel = th.tensor([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
+        smoother_kernel = torch.tensor(
+            [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]]
+        )
         smoother_kernel = smoother_kernel.unsqueeze(0).unsqueeze(0)
         smoother_kernel = smoother_kernel.repeat((in_channels, 1, 1, 1))
         self.register_buffer("smoother_kernel", smoother_kernel)
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Input tensor ``[N, C, H, W]``.
@@ -623,10 +741,12 @@ class SmoothedInterpolate(nn.Module):
         Returns:
             Upsampled and smoothed tensor, optionally trimmed.
         """
-        x = self.interp(x, scale_factor=self.scale_factor, mode=self.mode)
+        x = torch.nn.functional.interpolate(
+            x, scale_factor=self.scale_factor, mode=self.mode
+        )
 
         x = (
-            th.nn.functional.conv2d(
+            torch.nn.functional.conv2d(
                 x,
                 self.smoother_kernel,
                 padding=0,
@@ -703,14 +823,16 @@ class SmoothedInterpolateConv(nn.Module):
 
         trim_size = 1
         healpix_kwargs = _healpix_layer_kwargs(
-            enable_nhwc,
-            hpx_padding_mode,
-            nside,
+            HEALPixLayerBuildContext(
+                hpx_padding_mode=hpx_padding_mode,
+                nside=nside,
+            )
         )
         healpix_kwargs_after = _healpix_layer_kwargs(
-            enable_nhwc,
-            hpx_padding_mode,
-            nside_after,
+            HEALPixLayerBuildContext(
+                hpx_padding_mode=hpx_padding_mode,
+                nside=nside_after,
+            )
         )
 
         block = [
@@ -736,7 +858,7 @@ class SmoothedInterpolateConv(nn.Module):
             block.append(activation)
         self.block = nn.Sequential(*block)
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Input tensor ``[N * 12, C, H, W]``.
@@ -786,15 +908,16 @@ class BasicConvBlock(nn.Module):
         for n in range(n_layers):
             convblock.append(
                 HEALPixLayer(
-                    layer=th.nn.Conv2d,
+                    layer=torch.nn.Conv2d,
                     in_channels=in_channels if n == 0 else latent_channels,
                     out_channels=out_channels if n == n_layers - 1 else latent_channels,
                     kernel_size=kernel_size,
                     dilation=dilation,
                     **_healpix_layer_kwargs(
-                        enable_nhwc,
-                        hpx_padding_mode,
-                        nside,
+                        HEALPixLayerBuildContext(
+                            hpx_padding_mode=hpx_padding_mode,
+                            nside=nside,
+                        )
                     ),
                 )
             )
@@ -809,7 +932,7 @@ class BasicConvBlock(nn.Module):
             x: Inputs to the forward pass.
 
         Returns:
-            th.Tensor: Result of the forward pass.
+            torch.Tensor: Result of the forward pass.
         """
         return self.convblock(x)
 
@@ -858,9 +981,10 @@ class ConvNeXtBlock(nn.Module):
         """
         super().__init__()
         healpix_kwargs = _healpix_layer_kwargs(
-            enable_nhwc,
-            hpx_padding_mode,
-            nside,
+            HEALPixLayerBuildContext(
+                hpx_padding_mode=hpx_padding_mode,
+                nside=nside,
+            )
         )
 
         # Instantiate 1x1 conv to increase/decrease channel depth if necessary
@@ -868,7 +992,7 @@ class ConvNeXtBlock(nn.Module):
             self.skip_module = lambda x: x  # Identity-function required in forward pass
         else:
             self.skip_module = HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=out_channels,
                 kernel_size=1,
@@ -879,7 +1003,7 @@ class ConvNeXtBlock(nn.Module):
         # 3x3 convolution increasing channels
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=int(latent_channels * upscale_factor),
                 kernel_size=kernel_size,
@@ -892,7 +1016,7 @@ class ConvNeXtBlock(nn.Module):
         # 3x3 convolution maintaining increased channels
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels * upscale_factor),
                 out_channels=int(latent_channels * upscale_factor),
                 kernel_size=kernel_size,
@@ -905,7 +1029,7 @@ class ConvNeXtBlock(nn.Module):
         # Linear postprocessing
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels * upscale_factor),
                 out_channels=out_channels,
                 kernel_size=1,
@@ -968,9 +1092,10 @@ class DoubleConvNeXtBlock(nn.Module):
         """
         super().__init__()
         healpix_kwargs = _healpix_layer_kwargs(
-            enable_nhwc,
-            hpx_padding_mode,
-            nside,
+            HEALPixLayerBuildContext(
+                hpx_padding_mode=hpx_padding_mode,
+                nside=nside,
+            )
         )
 
         if in_channels == int(latent_channels):
@@ -979,7 +1104,7 @@ class DoubleConvNeXtBlock(nn.Module):
             )  # Identity-function required in forward pass
         else:
             self.skip_module1 = HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=int(latent_channels),
                 kernel_size=1,
@@ -991,7 +1116,7 @@ class DoubleConvNeXtBlock(nn.Module):
             )  # Identity-function required in forward pass
         else:
             self.skip_module2 = HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=out_channels,
                 kernel_size=1,
@@ -1003,7 +1128,7 @@ class DoubleConvNeXtBlock(nn.Module):
         # 3x3 convolution establishing latent channels channels
         convblock1.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=int(latent_channels),
                 kernel_size=kernel_size,
@@ -1016,7 +1141,7 @@ class DoubleConvNeXtBlock(nn.Module):
         # 1x1 convolution establishing increased channels
         convblock1.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=int(latent_channels * upscale_factor),
                 kernel_size=1,
@@ -1029,7 +1154,7 @@ class DoubleConvNeXtBlock(nn.Module):
         # 1x1 convolution returning to latent channels
         convblock1.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels * upscale_factor),
                 out_channels=int(latent_channels),
                 kernel_size=1,
@@ -1046,7 +1171,7 @@ class DoubleConvNeXtBlock(nn.Module):
         # 3x3 convolution establishing latent channels channels
         convblock2.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=int(latent_channels),
                 kernel_size=kernel_size,
@@ -1059,7 +1184,7 @@ class DoubleConvNeXtBlock(nn.Module):
         # 1x1 convolution establishing increased channels
         convblock2.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=int(latent_channels * upscale_factor),
                 kernel_size=1,
@@ -1072,7 +1197,7 @@ class DoubleConvNeXtBlock(nn.Module):
         # 1x1 convolution reducing to output channels
         convblock2.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels * upscale_factor),
                 out_channels=out_channels,
                 kernel_size=1,
@@ -1139,15 +1264,16 @@ class SymmetricConvNeXtBlock(nn.Module):
         """
         super().__init__()
         healpix_kwargs = _healpix_layer_kwargs(
-            enable_nhwc,
-            hpx_padding_mode,
-            nside,
+            HEALPixLayerBuildContext(
+                hpx_padding_mode=hpx_padding_mode,
+                nside=nside,
+            )
         )
         if in_channels == int(latent_channels):
             self.skip_module = lambda x: x  # Identity-function required in forward pass
         else:
             self.skip_module = HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=out_channels,
                 kernel_size=1,
@@ -1159,7 +1285,7 @@ class SymmetricConvNeXtBlock(nn.Module):
         # 3x3 convolution establishing latent channels channels
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=int(latent_channels),
                 kernel_size=kernel_size,
@@ -1172,7 +1298,7 @@ class SymmetricConvNeXtBlock(nn.Module):
         # 1x1 convolution establishing increased channels
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=int(latent_channels * upscale_factor),
                 kernel_size=1,
@@ -1185,7 +1311,7 @@ class SymmetricConvNeXtBlock(nn.Module):
         # 1x1 convolution returning to latent channels
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels * upscale_factor),
                 out_channels=int(latent_channels),
                 kernel_size=1,
@@ -1198,7 +1324,7 @@ class SymmetricConvNeXtBlock(nn.Module):
         # 3x3 convolution from latent channels to latent channels
         convblock.append(
             HEALPixLayer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=out_channels,  # int(latent_channels),
                 kernel_size=kernel_size,
@@ -1304,7 +1430,6 @@ class Interpolate(nn.Module):
             mode: Interpolation mode used for upsampling, passed to `nn.functional.interpolate`.
         """
         super().__init__()
-        self.interp = nn.functional.interpolate
         self.scale_factor = scale_factor
         self.mode = mode
 
@@ -1315,6 +1440,8 @@ class Interpolate(nn.Module):
             inputs: Inputs to interpolate.
 
         Returns:
-            th.Tensor: The interpolated values.
+            torch.Tensor: The interpolated values.
         """
-        return self.interp(inputs, scale_factor=self.scale_factor, mode=self.mode)
+        return nn.functional.interpolate(
+            inputs, scale_factor=self.scale_factor, mode=self.mode
+        )

--- a/fme/ace/models/healpix/healpix_blocks.py
+++ b/fme/ace/models/healpix/healpix_blocks.py
@@ -421,7 +421,6 @@ class MaxPool(nn.Module):
     def __init__(
         self,
         pooling: int = 2,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -430,7 +429,6 @@ class MaxPool(nn.Module):
         """
         Args:
             pooling: ``MaxPool2d`` kernel size (and stride).
-            enable_nhwc: Use channels-last memory format.
             hpx_padding_mode: HEALPix padding backend passed to ``HEALPixLayer``.
             nside: Native face height/width for HEALPix padding.
         """
@@ -463,7 +461,6 @@ class AvgPool(nn.Module):
     def __init__(
         self,
         pooling: int = 2,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -472,7 +469,6 @@ class AvgPool(nn.Module):
         """
         Args:
             pooling: ``AvgPool2d`` kernel size (and stride).
-            enable_nhwc: Use channels-last memory format.
             hpx_padding_mode: HEALPix padding backend passed to ``HEALPixLayer``.
             nside: Native face height/width for HEALPix padding.
         """
@@ -570,7 +566,6 @@ class DealiasedDownsample(nn.Module):
         in_channels: int = 3,
         resample_filter: Sequence[float] | None = None,
         stride: int = 2,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -581,7 +576,6 @@ class DealiasedDownsample(nn.Module):
             in_channels: Number of input channels.
             resample_filter: 1D filter weights for each blur stage.
             stride: Total downsampling factor (must be a power of two).
-            enable_nhwc: Use channels-last memory format.
             hpx_padding_mode: HEALPix padding backend passed to ``HEALPixLayer``.
             nside: Native face height/width for HEALPix padding.
         """
@@ -651,7 +645,6 @@ class TransposedConvUpsample(nn.Module):
         out_channels: int = 1,
         upsampling: int = 2,
         activation: Optional[CappedGELUConfig] = None,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -663,7 +656,6 @@ class TransposedConvUpsample(nn.Module):
             out_channels: The number of output channels.
             upsampling: Stride size that will be used for upsampling.
             activation: ModuleConfig for the activation function used in upsampling.
-            enable_nhwc: Enable nhwc format, passed to wrapper.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -777,7 +769,6 @@ class SmoothedInterpolateConv(nn.Module):
         scale_factor: int = 2,
         mode: str = "nearest",
         activation: Optional[nn.Module] = None,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -793,7 +784,6 @@ class SmoothedInterpolateConv(nn.Module):
             scale_factor: Interpolation scale factor.
             mode: Interpolation mode for the smoothed upsample step.
             activation: Optional activation module appended after the conv.
-            enable_nhwc: Use channels-last memory format.
             hpx_padding_mode: HEALPix padding backend passed to ``HEALPixLayer``.
             nside: Face height/width before upsampling (isolatitude gather indices).
             nside_after: Face height/width after upsampling for the conv step; required
@@ -884,7 +874,6 @@ class BasicConvBlock(nn.Module):
         n_layers=1,
         latent_channels=None,
         activation=None,
-        enable_nhwc=False,
         hpx_padding_mode="earth2grid",
         nside=None,
     ):
@@ -897,7 +886,6 @@ class BasicConvBlock(nn.Module):
             n_layers: Number of convolutional layers.
             latent_channels: Number of latent channels.
             activation: ModuleConfig for activation function to use.
-            enable_nhwc: Enable nhwc format, passed to wrapper.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -958,7 +946,6 @@ class ConvNeXtBlock(nn.Module):
         dilation: int = 1,
         upscale_factor: int = 4,
         activation: Optional[CappedGELUConfig] = None,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -975,7 +962,6 @@ class ConvNeXtBlock(nn.Module):
             dilation: Dilation rate for convolutions.
             upscale_factor: Factor by which to upscale the number of latent channels.
             activation: Configuration for the activation function used between layers.
-            enable_nhwc: Whether to enable NHWC format.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1069,7 +1055,6 @@ class DoubleConvNeXtBlock(nn.Module):
         upscale_factor: int = 4,
         latent_channels: int = 1,
         activation: Optional[CappedGELUConfig] = None,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -1086,7 +1071,6 @@ class DoubleConvNeXtBlock(nn.Module):
             upscale_factor: Factor by which to upscale the number of latent channels (default is 4).
             latent_channels: Number of latent channels used in the block (default is 1).
             activation: Configuration for the activation function used between layers (default is None).
-            enable_nhwc: Whether to enable NHWC format (default is False).
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1241,7 +1225,6 @@ class SymmetricConvNeXtBlock(nn.Module):
         dilation: int = 1,
         upscale_factor: int = 4,
         activation: Optional[CappedGELUConfig] = None,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -1258,7 +1241,6 @@ class SymmetricConvNeXtBlock(nn.Module):
             upscale_factor: Upscale factor.
             latent_channels: Number of latent channels used in the block (default is 1).
             activation: Configuration for the activation function used between layers (default is None).
-            enable_nhwc: Whether to enable NHWC format (default is False).
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1360,7 +1342,6 @@ class Multi_SymmetricConvNeXtBlock(nn.Module):
         upscale_factor: int = 4,
         n_layers: int = 1,
         activation: Optional[CappedGELUConfig] = None,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -1376,7 +1357,6 @@ class Multi_SymmetricConvNeXtBlock(nn.Module):
             upscale_factor: Channel upscale factor inside each block.
             n_layers: Number of stacked ``SymmetricConvNeXtBlock`` modules.
             activation: Optional ``CappedGELUConfig`` between layers.
-            enable_nhwc: Use channels-last memory format.
             hpx_padding_mode: HEALPix padding backend passed to child blocks.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1393,7 +1373,6 @@ class Multi_SymmetricConvNeXtBlock(nn.Module):
                     dilation=dilation,
                     upscale_factor=upscale_factor,
                     activation=activation,
-                    enable_nhwc=enable_nhwc,
                     hpx_padding_mode=hpx_padding_mode,
                     nside=nside,
                 )

--- a/fme/ace/models/healpix/healpix_decoder.py
+++ b/fme/ace/models/healpix/healpix_decoder.py
@@ -16,12 +16,12 @@
 # limitations under the License.
 
 import dataclasses
-from typing import List, Literal, Optional, Sequence
+from typing import List, Optional, Sequence
 
-import torch as th
+import torch
 import torch.nn as nn
 
-from .healpix_blocks import ConvBlockConfig, UpsamplingBlockConfig
+from .healpix_blocks import ConvBlockConfig, HEALPixBuildContext, UpsamplingBlockConfig
 
 
 @dataclasses.dataclass
@@ -36,13 +36,7 @@ class UNetDecoderConfig:
         output_layer: Configuration for the output layer block.
         n_channels: Number of channels for each layer, by default (34, 68, 136).
         n_layers: Number of layers in each block, by default (1, 2, 2).
-        output_channels: Number of output channels, by default 1.
         dilations: List of dilation rates for the layers, by default None.
-        enable_nhwc: Flag to enable NHWC data format, by default False.
-        hpx_padding_mode: HEALPix padding backend (``"earth2grid"``, ``"karlbauer"``,
-            or ``"isolatitude"``), by default ``"earth2grid"``.
-        nside: Face height/width per decoder level (shallowest to deepest), or
-            ``None`` to omit per-level padding resolution.
     """
 
     conv_block: ConvBlockConfig
@@ -50,15 +44,20 @@ class UNetDecoderConfig:
     output_layer: ConvBlockConfig
     n_channels: List[int] = dataclasses.field(default_factory=lambda: [34, 68, 136])
     n_layers: List[int] = dataclasses.field(default_factory=lambda: [1, 2, 2])
-    output_channels: int = 1
     dilations: Optional[list] = None
-    enable_nhwc: bool = False
-    hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid"
-    nside: Optional[Sequence[int]] = None
 
-    def build(self) -> nn.Module:
+    def build(
+        self,
+        output_channels: int,
+        *,
+        ctx: HEALPixBuildContext,
+    ) -> nn.Module:
         """
         Builds the UNet Decoder model.
+
+        Args:
+            output_channels: Number of output channels (determined at build time).
+            ctx: Shared HEALPix runtime settings for all child modules.
 
         Returns:
             UNet Decoder model.
@@ -69,11 +68,9 @@ class UNetDecoderConfig:
             output_layer=self.output_layer,
             n_channels=self.n_channels,
             n_layers=self.n_layers,
-            output_channels=self.output_channels,
+            output_channels=output_channels,
             dilations=self.dilations,
-            enable_nhwc=self.enable_nhwc,
-            hpx_padding_mode=self.hpx_padding_mode,
-            nside=self.nside,
+            ctx=ctx,
         )
 
 
@@ -89,11 +86,7 @@ class UNetDecoder(nn.Module):
         n_layers: Sequence = (1, 2, 2),
         output_channels: int = 1,
         dilations: Optional[list] = None,
-        enable_nhwc: bool = False,
-        hpx_padding_mode: Literal[
-            "earth2grid", "karlbauer", "isolatitude"
-        ] = "earth2grid",
-        nside: Optional[Sequence[int]] = None,
+        ctx: HEALPixBuildContext | None = None,
     ):
         """
         Initialize the UNetDecoder.
@@ -106,30 +99,24 @@ class UNetDecoder(nn.Module):
             n_layers: Sequence specifying the number of layers in each block.
             output_channels: Number of output channels.
             dilations: List of dilations to use for the convolutional blocks.
-            enable_nhwc: If True, use channel last format.
-            hpx_padding_mode: HEALPix padding backend. Default ``"earth2grid"``;
-                also supports ``"karlbauer"`` and ``"isolatitude"``.
-            nside: Face height/width per level (shallowest to deepest). Length must
-                match ``len(n_channels)`` when set. Decoder stage ``n`` (deepest first)
-                uses ``nside[-(n + 1)]``.
+            ctx: Shared HEALPix runtime settings for all child modules.
         """
         super().__init__()
+        build_ctx = ctx or HEALPixBuildContext()
         self.channel_dim = 1
 
         if dilations is None:
             dilations = [1 for _ in range(len(n_channels))]
 
-        nside_levels: Optional[tuple[int, ...]] = None
-        if nside is not None:
-            nside_levels = tuple(int(v) for v in nside)
-            if len(nside_levels) != len(n_channels):
-                raise ValueError(
-                    f"nside length must match decoder levels; got {len(nside_levels)} "
-                    f"vs {len(n_channels)}"
-                )
+        nside_levels = build_ctx.nside_levels
+        if nside_levels is not None and len(nside_levels) != len(n_channels):
+            raise ValueError(
+                f"nside length must match decoder levels; got {len(nside_levels)} "
+                f"vs {len(n_channels)}"
+            )
 
-        conv_tpl = dataclasses.replace(conv_block)
-        up_tpl = dataclasses.replace(up_sampling_block)
+        conv_tpl = conv_block
+        up_tpl = up_sampling_block
         up_factor = up_tpl.stride
         n_levels = len(n_channels)
 
@@ -149,33 +136,27 @@ class UNetDecoder(nn.Module):
                             f"must equal nside[{n_levels - n}] * upsample factor "
                             f"({up_factor}), but nside[{n_levels - n}]={before}"
                         )
-                up_cfg = dataclasses.replace(
-                    up_tpl,
+                up_sample_module = up_tpl.build(
                     in_channels=curr_channel,
                     out_channels=curr_channel,
-                    enable_nhwc=enable_nhwc,
-                    hpx_padding_mode=hpx_padding_mode,
-                    nside=None if nside_levels is None else nside_levels[n_levels - n],
-                    nside_after=level_nside,
+                    ctx=build_ctx.layer(
+                        n_levels - n,
+                        nside_after=level_nside,
+                    ),
                 )
-                up_sample_module = up_cfg.build()
 
             next_channel = (
                 n_channels[n + 1] if n < len(n_channels) - 1 else n_channels[-1]
             )
 
-            conv_cfg = dataclasses.replace(
-                conv_tpl,
+            conv_module = conv_tpl.build(
                 in_channels=curr_channel * 2 if n > 0 else curr_channel,
-                latent_channels=curr_channel,
                 out_channels=next_channel,
+                latent_channels=curr_channel,
                 dilation=dilations[n],
                 n_layers=n_layers[n],
-                enable_nhwc=enable_nhwc,
-                hpx_padding_mode=hpx_padding_mode,
-                nside=level_nside,
+                ctx=build_ctx.layer(n_levels - 1 - n),
             )
-            conv_module = conv_cfg.build()
 
             self.decoder.append(
                 nn.ModuleDict(
@@ -188,19 +169,14 @@ class UNetDecoder(nn.Module):
 
         self.decoder = nn.ModuleList(self.decoder)
 
-        out_nside = None if nside_levels is None else nside_levels[0]
-        out_cfg = dataclasses.replace(
-            output_layer,
+        self.output_layer = output_layer.build(
             in_channels=curr_channel,
             out_channels=output_channels,
             dilation=dilations[-1],
-            enable_nhwc=enable_nhwc,
-            hpx_padding_mode=hpx_padding_mode,
-            nside=out_nside,
+            ctx=build_ctx.layer(0),
         )
-        self.output_layer = out_cfg.build()
 
-    def forward(self, inputs: Sequence[th.Tensor]) -> th.Tensor:
+    def forward(self, inputs: Sequence[torch.Tensor]) -> torch.Tensor:
         """
         Forward pass of the UNetDecoder.
 
@@ -214,6 +190,6 @@ class UNetDecoder(nn.Module):
         for n, layer in enumerate(self.decoder):
             if layer["upsamp"] is not None:
                 up = layer["upsamp"](x)
-                x = th.cat([up, inputs[-1 - n]], dim=self.channel_dim)
+                x = torch.cat([up, inputs[-1 - n]], dim=self.channel_dim)
             x = layer["conv"](x)
         return self.output_layer(x)

--- a/fme/ace/models/healpix/healpix_encoder.py
+++ b/fme/ace/models/healpix/healpix_encoder.py
@@ -16,12 +16,16 @@
 # limitations under the License.
 
 import dataclasses
-from typing import List, Literal, Optional, Sequence
+from typing import List, Optional, Sequence
 
-import torch as th
+import torch
 import torch.nn as nn
 
-from .healpix_blocks import ConvBlockConfig, DownsamplingBlockConfig
+from .healpix_blocks import (
+    ConvBlockConfig,
+    DownsamplingBlockConfig,
+    HEALPixBuildContext,
+)
 
 
 @dataclasses.dataclass
@@ -32,30 +36,29 @@ class UNetEncoderConfig:
     Parameters:
         conv_block: Configuration for the convolutional block.
         down_sampling_block: Configuration for the down-sampling block.
-        input_channels: Number of input channels, by default 3.
         n_channels: Number of channels for each layer, by default (136, 68, 34).
         n_layers: Number of layers in each block, by default (2, 2, 1).
         dilations: List of dilation rates for the layers, by default None.
-        enable_nhwc: Flag to enable NHWC data format, by default False.
-        hpx_padding_mode: HEALPix padding backend (``"earth2grid"``, ``"karlbauer"``,
-            or ``"isolatitude"``), by default ``"earth2grid"``.
-        nside: Face height/width per encoder level (shallowest to deepest), or
-            ``None`` to omit per-level padding resolution.
     """
 
     conv_block: ConvBlockConfig
     down_sampling_block: DownsamplingBlockConfig
-    input_channels: int = 3
     n_channels: List[int] = dataclasses.field(default_factory=lambda: [136, 68, 34])
     n_layers: List[int] = dataclasses.field(default_factory=lambda: [2, 2, 1])
     dilations: Optional[list] = None
-    enable_nhwc: bool = False
-    hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid"
-    nside: Optional[Sequence[int]] = None
 
-    def build(self) -> nn.Module:
+    def build(
+        self,
+        input_channels: int,
+        *,
+        ctx: HEALPixBuildContext,
+    ) -> nn.Module:
         """
         Builds the UNet Encoder model.
+
+        Args:
+            input_channels: Number of input channels (determined at build time).
+            ctx: Shared HEALPix runtime settings for all child modules.
 
         Returns:
             UNet Encoder model.
@@ -63,13 +66,11 @@ class UNetEncoderConfig:
         return UNetEncoder(
             conv_block=self.conv_block,
             down_sampling_block=self.down_sampling_block,
-            input_channels=self.input_channels,
+            input_channels=input_channels,
             n_channels=self.n_channels,
             n_layers=self.n_layers,
             dilations=self.dilations,
-            enable_nhwc=self.enable_nhwc,
-            hpx_padding_mode=self.hpx_padding_mode,
-            nside=self.nside,
+            ctx=ctx,
         )
 
 
@@ -84,11 +85,7 @@ class UNetEncoder(nn.Module):
         n_channels: Sequence = (16, 32, 64),
         n_layers: Sequence = (2, 2, 1),
         dilations: Optional[list] = None,
-        enable_nhwc: bool = False,
-        hpx_padding_mode: Literal[
-            "earth2grid", "karlbauer", "isolatitude"
-        ] = "earth2grid",
-        nside: Optional[Sequence[int]] = None,
+        ctx: HEALPixBuildContext | None = None,
     ):
         """
         Args:
@@ -98,30 +95,25 @@ class UNetEncoder(nn.Module):
             n_channels: # of channels in each encoder layer
             n_layers:, # of layers to use for the convolutional blocks
             dilations: list of dilations to use for the the convolutional blocks
-            enable_nhwc: if channel last format should be used
-            hpx_padding_mode: HEALPix padding backend. Default ``"earth2grid"``;
-                also supports ``"karlbauer"`` and ``"isolatitude"``.
-            nside: Face height/width per encoder level (shallowest to deepest). Length
-                must match ``len(n_channels)`` when set.
+            ctx: Shared HEALPix runtime settings for all child modules.
         """
         super().__init__()
+        build_ctx = ctx or HEALPixBuildContext()
         self.n_channels = n_channels
-        self.hpx_padding_mode = hpx_padding_mode
+        self.hpx_padding_mode = build_ctx.hpx_padding_mode
 
         if dilations is None:
             dilations = [1 for _ in range(len(n_channels))]
 
-        nside_levels: Optional[tuple[int, ...]] = None
-        if nside is not None:
-            nside_levels = tuple(int(v) for v in nside)
-            if len(nside_levels) != len(n_channels):
-                raise ValueError(
-                    f"nside length must match encoder levels; got {len(nside_levels)} "
-                    f"vs {len(n_channels)}"
-                )
+        nside_levels = build_ctx.nside_levels
+        if nside_levels is not None and len(nside_levels) != len(n_channels):
+            raise ValueError(
+                f"nside length must match encoder levels; got {len(nside_levels)} "
+                f"vs {len(n_channels)}"
+            )
 
-        conv_tpl = dataclasses.replace(conv_block)
-        down_tpl = dataclasses.replace(down_sampling_block)
+        conv_tpl = conv_block
+        down_tpl = down_sampling_block
         down_factor = down_tpl.downsample_spatial_factor()
 
         old_channels = input_channels
@@ -137,34 +129,30 @@ class UNetEncoder(nn.Module):
                             f"nside[{n}] * downsample factor ({down_factor}), "
                             f"but nside[{n}]={fine}"
                         )
-                down_cfg = dataclasses.replace(
-                    down_tpl,
-                    enable_nhwc=enable_nhwc,
-                    hpx_padding_mode=hpx_padding_mode,
-                    nside=None if nside_levels is None else nside_levels[n - 1],
-                    in_channels=old_channels,
+                modules.append(
+                    down_tpl.build(
+                        in_channels=old_channels,
+                        ctx=build_ctx.layer(n - 1),
+                    )
                 )
-                modules.append(down_cfg.build())
 
-            conv_cfg = dataclasses.replace(
-                conv_tpl,
-                in_channels=old_channels,
-                latent_channels=curr_channel,
-                out_channels=curr_channel,
-                dilation=dilations[n],
-                n_layers=n_layers[n],
-                enable_nhwc=enable_nhwc,
-                hpx_padding_mode=hpx_padding_mode,
-                nside=None if nside_levels is None else nside_levels[n],
+            modules.append(
+                conv_tpl.build(
+                    in_channels=old_channels,
+                    out_channels=curr_channel,
+                    latent_channels=curr_channel,
+                    dilation=dilations[n],
+                    n_layers=n_layers[n],
+                    ctx=build_ctx.layer(n),
+                )
             )
-            modules.append(conv_cfg.build())
             old_channels = curr_channel
 
             self.encoder.append(nn.Sequential(*modules))
 
         self.encoder = nn.ModuleList(self.encoder)
 
-    def forward(self, inputs: th.Tensor) -> Sequence[th.Tensor]:
+    def forward(self, inputs: torch.Tensor) -> Sequence[torch.Tensor]:
         """
         Forward pass of the HEALPix Unet encoder
 

--- a/fme/ace/models/healpix/healpix_layers.py
+++ b/fme/ace/models/healpix/healpix_layers.py
@@ -77,8 +77,8 @@ class HEALPixLayer(torch.nn.Module):
             Native resolution of each HEALPix face (height = width). Required when
             ``hpx_padding_mode=="isolatitude"``.
         **kwargs
-            Forwarded to ``layer`` after removing ``enable_nhwc`` (e.g. ``in_channels``,
-            ``out_channels``, ``kernel_size``, ``dilation``, ``enable_nhwc``). If ``nside``
+            Forwarded to ``layer`` (e.g. ``in_channels``, ``out_channels``,
+            ``kernel_size``, ``dilation``). If ``nside``
             appears here (e.g. Hydra), it is consumed and overrides the corresponding
             argument.
         """
@@ -88,12 +88,6 @@ class HEALPixLayer(torch.nn.Module):
         if "nside" in kwargs:
             _ns = kwargs.pop("nside")
             nside = int(_ns) if _ns is not None else None
-
-        if "enable_nhwc" in kwargs:
-            enable_nhwc = kwargs["enable_nhwc"]
-            del kwargs["enable_nhwc"]
-        else:
-            enable_nhwc = False
 
         kernel_size = 3 if "kernel_size" not in kwargs else kwargs["kernel_size"]
         dilation = 1 if "dilation" not in kwargs else kwargs["dilation"]
@@ -107,16 +101,12 @@ class HEALPixLayer(torch.nn.Module):
             padding_layer = make_hpx_padding_layer(
                 padding=padding,
                 hpx_padding_mode=hpx_padding_mode,
-                enable_nhwc=enable_nhwc,
                 nside=nside,
             )
             layers.append(padding_layer)
 
         layers.append(layer(**kwargs))
         self.layers = torch.nn.Sequential(*layers)
-
-        if enable_nhwc:
-            self.layers = self.layers.to(memory_format=torch.channels_last)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """

--- a/fme/ace/models/healpix/healpix_layers.py
+++ b/fme/ace/models/healpix/healpix_layers.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-import torch as th
+import torch
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ from .healpix_paddings import (
 )
 
 
-class HEALPixLayer(th.nn.Module):
+class HEALPixLayer(torch.nn.Module):
     """
     Apply a base ``torch.nn.Module`` on data laid out as HEALPix faces.
 
@@ -102,7 +102,7 @@ class HEALPixLayer(th.nn.Module):
         # Define a HEALPixPadding layer if padding is necessary
         if padding > 0:
             # Disable native padding for conv layers
-            if issubclass(layer, th.nn.modules.conv._ConvNd):
+            if issubclass(layer, torch.nn.modules.conv._ConvNd):
                 kwargs["padding"] = 0
             padding_layer = make_hpx_padding_layer(
                 padding=padding,
@@ -113,12 +113,12 @@ class HEALPixLayer(th.nn.Module):
             layers.append(padding_layer)
 
         layers.append(layer(**kwargs))
-        self.layers = th.nn.Sequential(*layers)
+        self.layers = torch.nn.Sequential(*layers)
 
         if enable_nhwc:
-            self.layers = self.layers.to(memory_format=th.channels_last)
+            self.layers = self.layers.to(memory_format=torch.channels_last)
 
-    def forward(self, x: th.Tensor) -> th.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Run padding (if configured) and the wrapped layer.
 

--- a/fme/ace/models/healpix/healpix_paddings.py
+++ b/fme/ace/models/healpix/healpix_paddings.py
@@ -79,7 +79,6 @@ except ImportError:
 def make_hpx_padding_layer(
     padding: int,
     hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"],
-    enable_nhwc: bool,
     nside: int | None = None,
 ) -> torch.nn.Module:
     """
@@ -91,8 +90,6 @@ def make_hpx_padding_layer(
         Symmetric pad width on each face edge (``p >= 1``).
     hpx_padding_mode : Literal["earth2grid", "karlbauer", "isolatitude"]
         Padding strategy to use for the HEALPix padding layer.
-    enable_nhwc : bool
-        Passed to padding modules that support channels-last output.
     nside : int or None, optional
         Native face height/width. Required when ``hpx_padding_mode=="isolatitude"``;
         ignored otherwise.
@@ -114,9 +111,9 @@ def make_hpx_padding_layer(
                 "hpx_padding_mode=earth2grid requires the earth2grid package "
                 f"(have_earth2grid={have_earth2grid})."
             )
-        return HEALPixPaddingv2(padding=padding, enable_nhwc=enable_nhwc)
+        return HEALPixPaddingv2(padding=padding)
     if hpx_padding_mode == "karlbauer":
-        return HEALPixPadding(padding=padding, enable_nhwc=enable_nhwc)
+        return HEALPixPadding(padding=padding)
     if hpx_padding_mode == "isolatitude":
         if nside is None:
             raise ValueError(
@@ -126,7 +123,6 @@ def make_hpx_padding_layer(
         return HEALPixPaddingIsolatitude(
             padding=padding,
             nside=nside,
-            enable_nhwc=enable_nhwc,
         )
     raise ValueError(
         f"Unsupported hpx_padding_mode={hpx_padding_mode!r}; "
@@ -136,16 +132,6 @@ def make_hpx_padding_layer(
 
 class HEALPixFoldFaces(torch.nn.Module):
     """Merge the HEALPix face dimension into the batch dimension (NCHW layout)."""
-
-    def __init__(self, enable_nhwc: bool = False):
-        """
-        Parameters
-        ----------
-        enable_nhwc: bool, optional
-            Use nhwc format instead of nchw format
-        """
-        super().__init__()
-        self.enable_nhwc = enable_nhwc
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         """
@@ -159,33 +145,24 @@ class HEALPixFoldFaces(torch.nn.Module):
         Returns:
         -------
         torch.Tensor
-            Four-dimensional tensor with faces stacked on the batch axis. If
-            ``enable_nhwc`` is True, result uses channels-last memory format.
+            Four-dimensional tensor with faces stacked on the batch axis.
         """
         N, F, C, H, W = tensor.shape
-        tensor = torch.reshape(tensor, shape=(N * F, C, H, W))
-
-        if self.enable_nhwc:
-            tensor = tensor.to(memory_format=torch.channels_last)
-
-        return tensor
+        return torch.reshape(tensor, shape=(N * F, C, H, W))
 
 
 class HEALPixUnfoldFaces(torch.nn.Module):
     """Split the batch axis so the HEALPix face index is its own dimension."""
 
-    def __init__(self, num_faces: int = 12, enable_nhwc: bool = False):
+    def __init__(self, num_faces: int = 12):
         """
         Parameters
         ----------
         num_faces: int, optional
             The number of faces on the grid, default 12
-        enable_nhwc: bool, optional
-            If nhwc format is being used, default False
         """
         super().__init__()
         self.num_faces = num_faces
-        self.enable_nhwc = enable_nhwc
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         """
@@ -226,19 +203,16 @@ class HEALPixPaddingv2(torch.nn.Module):
     Orientation and arrangement of the HEALPix faces are outlined above.
     """
 
-    def __init__(self, padding: int, enable_nhwc: bool = False):  # pragma: no cover
+    def __init__(self, padding: int):  # pragma: no cover
         """
         Parameters
         ----------
         padding : int
             The padding size
-        enable_nhwc : bool, optional
-            Whether to use channels-last memory format.
         """
         super().__init__()
-        self.enable_nhwc = enable_nhwc
-        self.unfold = HEALPixUnfoldFaces(num_faces=12, enable_nhwc=self.enable_nhwc)
-        self.fold = HEALPixFoldFaces(enable_nhwc=self.enable_nhwc)
+        self.unfold = HEALPixUnfoldFaces(num_faces=12)
+        self.fold = HEALPixFoldFaces()
         self.padding = lambda x: healpix_pad(x, padding=padding)
 
     def forward(self, x):  # pragma: no cover
@@ -259,12 +233,7 @@ class HEALPixPaddingv2(torch.nn.Module):
         """
         x = self.unfold(x)
         xp = self.padding(x)
-        xp = self.fold(xp)
-
-        if self.enable_nhwc:
-            xp = xp.to(memory_format=torch.channels_last)
-
-        return xp
+        return self.fold(xp)
 
 
 class HEALPixPadding(torch.nn.Module):
@@ -284,26 +253,23 @@ class HEALPixPadding(torch.nn.Module):
     docstring.
     """
 
-    def __init__(self, padding: int, enable_nhwc: bool = False):
+    def __init__(self, padding: int):
         """
         Parameters
         ----------
         padding : int
             Symmetric pad width ``p >= 1`` on each face edge.
-        enable_nhwc : bool, optional
-            Match channels-last usage in the surrounding encoder/decoder.
         """
         super().__init__()
         self.p = padding
         self.d = [-2, -1]
-        self.enable_nhwc = enable_nhwc
         if not isinstance(padding, int) or padding < 1:
             raise ValueError(
                 f"invalid value for 'padding', expected int > 0 but got {padding}"
             )
 
-        self.fold = HEALPixFoldFaces(enable_nhwc=self.enable_nhwc)
-        self.unfold = HEALPixUnfoldFaces(num_faces=12, enable_nhwc=self.enable_nhwc)
+        self.fold = HEALPixFoldFaces()
+        self.unfold = HEALPixUnfoldFaces(num_faces=12)
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         """
@@ -408,12 +374,7 @@ class HEALPixPadding(torch.nn.Module):
         )
 
         # [N, 12, C, H', W'] -> [N*12, C, H', W']
-        res = self.fold(res)
-
-        if self.enable_nhwc:
-            res = res.to(memory_format=torch.channels_last)
-
-        return res
+        return self.fold(res)
 
     def pn(
         self,
@@ -661,7 +622,6 @@ class HEALPixPaddingIsolatitude(torch.nn.Module):
         self,
         padding: int,
         nside: int,
-        enable_nhwc: bool = False,
     ):
         """
         Parameters
@@ -671,12 +631,9 @@ class HEALPixPaddingIsolatitude(torch.nn.Module):
         nside : int
             Native face height/width ``H`` (square faces). Gather indices are built for
             this size at init; ``forward`` rejects other ``H``.
-        enable_nhwc : bool, optional
-            Channels-last output when True.
         """
         super().__init__()
         self.p = padding
-        self.enable_nhwc = enable_nhwc
         if not isinstance(nside, int) or nside < 1:
             raise ValueError(f"nside must be a positive int, got {nside!r}")
         self._nside = nside
@@ -772,8 +729,6 @@ class HEALPixPaddingIsolatitude(torch.nn.Module):
             .permute(0, 2, 1, 3, 4)
             .reshape(BF, C, Hp, Wp)
         )
-        if self.enable_nhwc:
-            out = out.to(memory_format=torch.channels_last)
 
         return out
 
@@ -998,9 +953,7 @@ def _br_isolat(
     return torch.rot90(ret, k=1, dims=d)
 
 
-def isolatitude_pad_folded(
-    data: torch.Tensor, p: int, enable_nhwc: bool
-) -> torch.Tensor:
+def isolatitude_pad_folded(data: torch.Tensor, p: int) -> torch.Tensor:
     """
     Apply isolatitude HEALPix padding on **folded** face data.
 
@@ -1013,8 +966,6 @@ def isolatitude_pad_folded(
         Shape ``[N * 12, C, H, W]`` with square faces ``H == W``.
     p : int
         Pad width per edge; output spatial size is ``H + 2 * p``.
-    enable_nhwc : bool
-        If True, return channels-last memory format.
 
     Returns:
     -------
@@ -1093,10 +1044,7 @@ def isolatitude_pad_folded(
         (p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p10, p11), dim=1
     )
     n, _, _, hpad, wpad = res.shape
-    res = res.reshape(n * 12, c, hpad, wpad)
-    if enable_nhwc:
-        res = res.to(memory_format=torch.channels_last)
-    return res
+    return res.reshape(n * 12, c, hpad, wpad)
 
 
 def decode_two_channel_identity_to_linear_indices(
@@ -1162,7 +1110,7 @@ def build_isolatitude_gather_index(p: int, H: int) -> tuple[torch.Tensor, torch.
     ch1 = ids * ids
     x_folded = torch.stack((ch0, ch1), dim=1).unsqueeze(0).reshape(12, 2, H, H)
 
-    y_folded = isolatitude_pad_folded(x_folded, p, False)
+    y_folded = isolatitude_pad_folded(x_folded, p)
     y = y_folded.reshape(1, 12, 2, Hpad, Hpad)
     y0 = y[:, :, 0].reshape(-1)
     y1 = y[:, :, 1].reshape(-1)

--- a/fme/ace/models/healpix/healpix_paddings.py
+++ b/fme/ace/models/healpix/healpix_paddings.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-import torch as th
+import torch
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ def make_hpx_padding_layer(
     hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"],
     enable_nhwc: bool,
     nside: int | None = None,
-) -> th.nn.Module:
+) -> torch.nn.Module:
     """
     Construct the HEALPix padding submodule for a given mode.
 
@@ -134,7 +134,7 @@ def make_hpx_padding_layer(
     )
 
 
-class HEALPixFoldFaces(th.nn.Module):
+class HEALPixFoldFaces(torch.nn.Module):
     """Merge the HEALPix face dimension into the batch dimension (NCHW layout)."""
 
     def __init__(self, enable_nhwc: bool = False):
@@ -147,7 +147,7 @@ class HEALPixFoldFaces(th.nn.Module):
         super().__init__()
         self.enable_nhwc = enable_nhwc
 
-    def forward(self, tensor: th.Tensor) -> th.Tensor:
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Reshape ``[B, F, C, H, W]`` to ``[B * F, C, H, W]``.
 
@@ -163,15 +163,15 @@ class HEALPixFoldFaces(th.nn.Module):
             ``enable_nhwc`` is True, result uses channels-last memory format.
         """
         N, F, C, H, W = tensor.shape
-        tensor = th.reshape(tensor, shape=(N * F, C, H, W))
+        tensor = torch.reshape(tensor, shape=(N * F, C, H, W))
 
         if self.enable_nhwc:
-            tensor = tensor.to(memory_format=th.channels_last)
+            tensor = tensor.to(memory_format=torch.channels_last)
 
         return tensor
 
 
-class HEALPixUnfoldFaces(th.nn.Module):
+class HEALPixUnfoldFaces(torch.nn.Module):
     """Split the batch axis so the HEALPix face index is its own dimension."""
 
     def __init__(self, num_faces: int = 12, enable_nhwc: bool = False):
@@ -187,7 +187,7 @@ class HEALPixUnfoldFaces(th.nn.Module):
         self.num_faces = num_faces
         self.enable_nhwc = enable_nhwc
 
-    def forward(self, tensor: th.Tensor) -> th.Tensor:
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Reshape ``[B * F, C, H, W]`` to ``[B, F, C, H, W]``.
 
@@ -204,12 +204,12 @@ class HEALPixUnfoldFaces(th.nn.Module):
         """
         NF, C, H, W = tensor.shape
         n_batch = NF // self.num_faces
-        tensor = th.reshape(tensor, shape=(n_batch, self.num_faces, C, H, W))
+        tensor = torch.reshape(tensor, shape=(n_batch, self.num_faces, C, H, W))
 
         return tensor
 
 
-class HEALPixPaddingv2(th.nn.Module):
+class HEALPixPaddingv2(torch.nn.Module):
     """
     Padding layer for data on a HEALPix sphere. This version uses a faster method
     to calculate the padding.
@@ -262,12 +262,12 @@ class HEALPixPaddingv2(th.nn.Module):
         xp = self.fold(xp)
 
         if self.enable_nhwc:
-            xp = xp.to(memory_format=th.channels_last)
+            xp = xp.to(memory_format=torch.channels_last)
 
         return xp
 
 
-class HEALPixPadding(th.nn.Module):
+class HEALPixPadding(torch.nn.Module):
     """
     Karlbauer et al. (2024) HEALPix padding.
 
@@ -305,7 +305,7 @@ class HEALPixPadding(th.nn.Module):
         self.fold = HEALPixFoldFaces(enable_nhwc=self.enable_nhwc)
         self.unfold = HEALPixUnfoldFaces(num_faces=12, enable_nhwc=self.enable_nhwc)
 
-    def forward(self, data: th.Tensor) -> th.Tensor:
+    def forward(self, data: torch.Tensor) -> torch.Tensor:
         """
         Pad each face using values from neighboring faces (Karlbauer et al. scheme).
 
@@ -325,8 +325,8 @@ class HEALPixPadding(th.nn.Module):
 
         # Extract the twelve faces (as views of the original tensors)
         f00, f01, f02, f03, f04, f05, f06, f07, f08, f09, f10, f11 = [
-            th.squeeze(x, dim=1)
-            for x in th.split(tensor=data, split_size_or_sections=1, dim=1)
+            torch.squeeze(x, dim=1)
+            for x in torch.split(tensor=data, split_size_or_sections=1, dim=1)
         ]
 
         # Assemble the four padded faces on the northern hemisphere
@@ -403,7 +403,7 @@ class HEALPixPadding(th.nn.Module):
             c=f11, t=f04, tl=f03, lft=f07, bl=f10, b=f10, br=f09, rgt=f08, tr=f08
         )
 
-        res = th.stack(
+        res = torch.stack(
             (p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p10, p11), dim=1
         )
 
@@ -411,22 +411,22 @@ class HEALPixPadding(th.nn.Module):
         res = self.fold(res)
 
         if self.enable_nhwc:
-            res = res.to(memory_format=th.channels_last)
+            res = res.to(memory_format=torch.channels_last)
 
         return res
 
     def pn(
         self,
-        c: th.Tensor,
-        t: th.Tensor,
-        tl: th.Tensor,
-        lft: th.Tensor,
-        bl: th.Tensor,
-        b: th.Tensor,
-        br: th.Tensor,
-        rgt: th.Tensor,
-        tr: th.Tensor,
-    ) -> th.Tensor:
+        c: torch.Tensor,
+        t: torch.Tensor,
+        tl: torch.Tensor,
+        lft: torch.Tensor,
+        bl: torch.Tensor,
+        b: torch.Tensor,
+        br: torch.Tensor,
+        rgt: torch.Tensor,
+        tr: torch.Tensor,
+    ) -> torch.Tensor:
         """
         Applies padding to a northern hemisphere face c under consideration of
         its given neighbors according to the strategy of Karlbauer et al. (2024).
@@ -461,11 +461,11 @@ class HEALPixPadding(th.nn.Module):
         d = self.d  # rotation plane: last two spatial dims of each face
 
         # Vertical extent: top row from ``t`` (rotated), bottom from ``b``
-        c = th.cat((t.rot90(1, d)[..., -p:, :], c, b[..., :p, :]), dim=-2)
+        c = torch.cat((t.rot90(1, d)[..., -p:, :], c, b[..., :p, :]), dim=-2)
 
         # Horizontal strips: corners from ``tl`` / ``bl`` / ``tr`` / ``br``,
         # edges from ``lft`` / ``rgt``
-        left = th.cat(
+        left = torch.cat(
             (
                 tl.rot90(2, d)[..., -p:, -p:],
                 lft.rot90(-1, d)[..., -p:],
@@ -473,22 +473,22 @@ class HEALPixPadding(th.nn.Module):
             ),
             dim=-2,
         )
-        right = th.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
+        right = torch.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
 
-        return th.cat((left, c, right), dim=-1)
+        return torch.cat((left, c, right), dim=-1)
 
     def pe(
         self,
-        c: th.Tensor,
-        t: th.Tensor,
-        tl: th.Tensor,
-        lft: th.Tensor,
-        bl: th.Tensor,
-        b: th.Tensor,
-        br: th.Tensor,
-        rgt: th.Tensor,
-        tr: th.Tensor,
-    ) -> th.Tensor:
+        c: torch.Tensor,
+        t: torch.Tensor,
+        tl: torch.Tensor,
+        lft: torch.Tensor,
+        bl: torch.Tensor,
+        b: torch.Tensor,
+        br: torch.Tensor,
+        rgt: torch.Tensor,
+        tr: torch.Tensor,
+    ) -> torch.Tensor:
         """
         Applies padding to an equatorial face c under consideration of its given
         neighbors.
@@ -521,24 +521,24 @@ class HEALPixPadding(th.nn.Module):
         """
         p = self.p
 
-        c = th.cat((t[..., -p:, :], c, b[..., :p, :]), dim=-2)
-        left = th.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
-        right = th.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
+        c = torch.cat((t[..., -p:, :], c, b[..., :p, :]), dim=-2)
+        left = torch.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
+        right = torch.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
 
-        return th.cat((left, c, right), dim=-1)
+        return torch.cat((left, c, right), dim=-1)
 
     def ps(
         self,
-        c: th.Tensor,
-        t: th.Tensor,
-        tl: th.Tensor,
-        lft: th.Tensor,
-        bl: th.Tensor,
-        b: th.Tensor,
-        br: th.Tensor,
-        rgt: th.Tensor,
-        tr: th.Tensor,
-    ) -> th.Tensor:
+        c: torch.Tensor,
+        t: torch.Tensor,
+        tl: torch.Tensor,
+        lft: torch.Tensor,
+        bl: torch.Tensor,
+        b: torch.Tensor,
+        br: torch.Tensor,
+        rgt: torch.Tensor,
+        tr: torch.Tensor,
+    ) -> torch.Tensor:
         """
         Applies padding to a southern hemisphere face c under consideration of
         its given neighbors according to the strategy of Karlbauer et al. (2024).
@@ -572,16 +572,16 @@ class HEALPixPadding(th.nn.Module):
         p = self.p
         d = self.d
 
-        c = th.cat((t[..., -p:, :], c, b.rot90(1, d)[..., :p, :]), dim=-2)
-        left = th.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
-        right = th.cat(
+        c = torch.cat((t[..., -p:, :], c, b.rot90(1, d)[..., :p, :]), dim=-2)
+        left = torch.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
+        right = torch.cat(
             (tr[..., -p:, :p], rgt.rot90(-1, d)[..., :p], br.rot90(2, d)[..., :p, :p]),
             dim=-2,
         )
 
-        return th.cat((left, c, right), dim=-1)
+        return torch.cat((left, c, right), dim=-1)
 
-    def tl(self, top: th.Tensor, lft: th.Tensor) -> th.Tensor:
+    def tl(self, top: torch.Tensor, lft: torch.Tensor) -> torch.Tensor:
         """
         Assembles the top left corner of a center face according to the strategy
         of Karlbauer et al. (2024) in the cases where no according top left face
@@ -600,7 +600,7 @@ class HEALPixPadding(th.nn.Module):
             ``p x p`` top-left corner block for the equatorial ``tl`` slot.
         """
         # Preallocated buffer for the synthetic corner (avoids per-call allocation).
-        ret = th.zeros_like(top)[..., : self.p, : self.p]
+        ret = torch.zeros_like(top)[..., : self.p, : self.p]
 
         # Apex of the corner wedge (average of adjacent edge samples)
         ret[..., -1, -1] = 0.5 * top[..., -1, 0] + 0.5 * lft[..., 0, -1]
@@ -618,7 +618,7 @@ class HEALPixPadding(th.nn.Module):
 
         return ret
 
-    def br(self, b: th.Tensor, r: th.Tensor) -> th.Tensor:
+    def br(self, b: torch.Tensor, r: torch.Tensor) -> torch.Tensor:
         """
         Assembles the bottom right corner of a center face according to the
         strategy of Karlbauer et al. (2024) in the cases where no according
@@ -636,7 +636,7 @@ class HEALPixPadding(th.nn.Module):
         torch.Tensor
             ``p x p`` bottom-right corner block for the equatorial ``br`` slot.
         """
-        ret = th.zeros_like(b)[..., : self.p, : self.p]
+        ret = torch.zeros_like(b)[..., : self.p, : self.p]
 
         ret[..., 0, 0] = 0.5 * b[..., 0, -1] + 0.5 * r[..., -1, 0]
 
@@ -649,7 +649,7 @@ class HEALPixPadding(th.nn.Module):
         return ret
 
 
-class HEALPixPaddingIsolatitude(th.nn.Module):
+class HEALPixPaddingIsolatitude(torch.nn.Module):
     """
     Isolatitude HEALPix padding via **precomputed gather** indices.
 
@@ -693,7 +693,7 @@ class HEALPixPaddingIsolatitude(th.nn.Module):
 
         # Active positions in the 2nd gather source are extremely sparse,
         # get the indices of the active positions
-        pos_v1 = th.nonzero(v1_bool, as_tuple=False).squeeze(1).to(dtype=th.long)
+        pos_v1 = torch.nonzero(v1_bool, as_tuple=False).squeeze(1).to(dtype=torch.long)
         self.register_buffer("_pos_v1", pos_v1, persistent=False)
         self.register_buffer(
             "_index1_pos_v1",
@@ -703,7 +703,7 @@ class HEALPixPaddingIsolatitude(th.nn.Module):
             persistent=False,
         )
 
-    def forward(self, data: th.Tensor) -> th.Tensor:
+    def forward(self, data: torch.Tensor) -> torch.Tensor:
         """
         Gather-based isolatitude pad on folded input.
 
@@ -741,28 +741,28 @@ class HEALPixPaddingIsolatitude(th.nn.Module):
         # and valid1==1 positions are extremely sparse.
         idx0 = (
             self._index0.reshape(-1)
-            .to(device=data.device, dtype=th.long, non_blocking=True)
+            .to(device=data.device, dtype=torch.long, non_blocking=True)
             .clone()
         )
-        g0 = th.index_select(flat, 2, idx0)
+        g0 = torch.index_select(flat, 2, idx0)
 
         pos_v1 = self._pos_v1
         if pos_v1.numel() > 0:
-            p = pos_v1.to(device=data.device, dtype=th.long, non_blocking=True)
+            p = pos_v1.to(device=data.device, dtype=torch.long, non_blocking=True)
             pos_g0 = p.clone()
             pos_out = p.clone()
             g0_sub = g0.index_select(dim=2, index=pos_g0)
 
             idx1 = (
                 self._index1_pos_v1.reshape(-1)
-                .to(device=data.device, dtype=th.long, non_blocking=True)
+                .to(device=data.device, dtype=torch.long, non_blocking=True)
                 .clone()
             )
-            g1_sub = th.index_select(flat, 2, idx1)
+            g1_sub = torch.index_select(flat, 2, idx1)
 
             # out[pos] = g0 + 0.5 * (g1 - g0_sub) at sparse positions
             delta = (g1_sub - g0_sub) * 0.5
-            out_flat = th.index_add(g0, 2, pos_out, delta)
+            out_flat = torch.index_add(g0, 2, pos_out, delta)
         else:
             out_flat = g0
 
@@ -773,7 +773,7 @@ class HEALPixPaddingIsolatitude(th.nn.Module):
             .reshape(BF, C, Hp, Wp)
         )
         if self.enable_nhwc:
-            out = out.to(memory_format=th.channels_last)
+            out = out.to(memory_format=torch.channels_last)
 
         return out
 
@@ -783,7 +783,7 @@ class HEALPixPaddingIsolatitude(th.nn.Module):
 # ------------------------------------------------------------
 
 
-def kth_diag_indices(n: int, k: int) -> tuple[th.Tensor, th.Tensor]:
+def kth_diag_indices(n: int, k: int) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Row and column indices for the ``k``-th diagonal of an ``n x n`` matrix.
 
@@ -799,7 +799,7 @@ def kth_diag_indices(n: int, k: int) -> tuple[th.Tensor, th.Tensor]:
     tuple of torch.Tensor
         ``(rows, cols)`` such that ``matrix[rows, cols]`` selects that diagonal.
     """
-    rows, cols = th.arange(n), th.arange(n)
+    rows, cols = torch.arange(n), torch.arange(n)
     if k < 0:
         return rows[-k:], cols[:k]
     if k > 0:
@@ -810,16 +810,16 @@ def kth_diag_indices(n: int, k: int) -> tuple[th.Tensor, th.Tensor]:
 def _pn_isolat(
     p: int,
     d: tuple[int, int],
-    c: th.Tensor,
-    t: th.Tensor,
-    tl: th.Tensor,
-    lft: th.Tensor,
-    bl: th.Tensor,
-    b: th.Tensor,
-    br: th.Tensor,
-    rgt: th.Tensor,
-    tr: th.Tensor,
-) -> th.Tensor:
+    c: torch.Tensor,
+    t: torch.Tensor,
+    tl: torch.Tensor,
+    lft: torch.Tensor,
+    bl: torch.Tensor,
+    b: torch.Tensor,
+    br: torch.Tensor,
+    rgt: torch.Tensor,
+    tr: torch.Tensor,
+) -> torch.Tensor:
     """
     Isolatitude padding assembly for a **northern** hemisphere face (shared helper).
 
@@ -839,32 +839,32 @@ def _pn_isolat(
     """
     t = t.rot90(1, dims=d)[..., -p:, :]
     for i in range(p):
-        t[..., -i - 1, :] = th.roll(t[..., -i - 1, :], 2 * i + 1, dims=-1)
+        t[..., -i - 1, :] = torch.roll(t[..., -i - 1, :], 2 * i + 1, dims=-1)
         t[..., -i - 1, : 2 * i + 1] = t[..., -i - 1, 2 * i + 1].unsqueeze(-1)
 
     lft = lft.rot90(-1, dims=d)[..., -p:]
     for i in range(p):
-        lft[..., -i - 1] = th.roll(lft[..., -i - 1], 2 * i + 1, dims=-1)
+        lft[..., -i - 1] = torch.roll(lft[..., -i - 1], 2 * i + 1, dims=-1)
         lft[..., : 2 * i + 1, -i - 1] = lft[..., 2 * i + 1, -i - 1].unsqueeze(-1)
 
-    c = th.cat((t, c, b[..., :p, :]), dim=-2)
-    left = th.cat((tl.rot90(2, d)[..., -p:, -p:], lft, bl[..., :p, -p:]), dim=-2)
-    right = th.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
-    return th.cat((left, c, right), dim=-1)
+    c = torch.cat((t, c, b[..., :p, :]), dim=-2)
+    left = torch.cat((tl.rot90(2, d)[..., -p:, -p:], lft, bl[..., :p, -p:]), dim=-2)
+    right = torch.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
+    return torch.cat((left, c, right), dim=-1)
 
 
 def _pe_isolat(
     p: int,
-    c: th.Tensor,
-    t: th.Tensor,
-    tl: th.Tensor,
-    lft: th.Tensor,
-    bl: th.Tensor,
-    b: th.Tensor,
-    br: th.Tensor,
-    rgt: th.Tensor,
-    tr: th.Tensor,
-) -> th.Tensor:
+    c: torch.Tensor,
+    t: torch.Tensor,
+    tl: torch.Tensor,
+    lft: torch.Tensor,
+    bl: torch.Tensor,
+    b: torch.Tensor,
+    br: torch.Tensor,
+    rgt: torch.Tensor,
+    tr: torch.Tensor,
+) -> torch.Tensor:
     """
     Isolatitude padding for an **equatorial** face (no extra rolls on top/bottom
     strips).
@@ -877,25 +877,25 @@ def _pe_isolat(
         Central face and neighbor face tensors (same semantics as
         ``HEALPixPadding.pe``).
     """
-    c = th.cat((t[..., -p:, :], c, b[..., :p, :]), dim=-2)
-    left = th.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
-    right = th.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
-    return th.cat((left, c, right), dim=-1)
+    c = torch.cat((t[..., -p:, :], c, b[..., :p, :]), dim=-2)
+    left = torch.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
+    right = torch.cat((tr[..., -p:, :p], rgt[..., :p], br[..., :p, :p]), dim=-2)
+    return torch.cat((left, c, right), dim=-1)
 
 
 def _ps_isolat(
     p: int,
     d: tuple[int, int],
-    c: th.Tensor,
-    t: th.Tensor,
-    tl: th.Tensor,
-    lft: th.Tensor,
-    bl: th.Tensor,
-    b: th.Tensor,
-    br: th.Tensor,
-    rgt: th.Tensor,
-    tr: th.Tensor,
-) -> th.Tensor:
+    c: torch.Tensor,
+    t: torch.Tensor,
+    tl: torch.Tensor,
+    lft: torch.Tensor,
+    bl: torch.Tensor,
+    b: torch.Tensor,
+    br: torch.Tensor,
+    rgt: torch.Tensor,
+    tr: torch.Tensor,
+) -> torch.Tensor:
     """
     Isolatitude padding assembly for a **southern** hemisphere face.
 
@@ -914,21 +914,23 @@ def _ps_isolat(
     """
     b = b.rot90(1, d)[..., :p, :]
     for i in range(p):
-        b[..., i, :] = th.roll(b[..., i, :], -(2 * i + 1), dims=-1)
+        b[..., i, :] = torch.roll(b[..., i, :], -(2 * i + 1), dims=-1)
         b[..., i, -(2 * i + 1) :] = b[..., i, -(2 * i + 1) - 1].unsqueeze(-1)
 
     rgt = rgt.rot90(-1, d)[..., :p]
     for i in range(p):
-        rgt[..., i] = th.roll(rgt[..., i], -(2 * i + 1), dims=-1)
+        rgt[..., i] = torch.roll(rgt[..., i], -(2 * i + 1), dims=-1)
         rgt[..., -(2 * i + 1) :, i] = rgt[..., -(2 * i + 1) - 1, i].unsqueeze(-1)
 
-    c = th.cat((t[..., -p:, :], c, b), dim=-2)
-    left = th.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
-    right = th.cat((tr[..., -p:, :p], rgt, br.rot90(2, d)[..., :p, :p]), dim=-2)
-    return th.cat((left, c, right), dim=-1)
+    c = torch.cat((t[..., -p:, :], c, b), dim=-2)
+    left = torch.cat((tl[..., -p:, -p:], lft[..., -p:], bl[..., :p, -p:]), dim=-2)
+    right = torch.cat((tr[..., -p:, :p], rgt, br.rot90(2, d)[..., :p, :p]), dim=-2)
+    return torch.cat((left, c, right), dim=-1)
 
 
-def _tl_isolat(p: int, d: tuple[int, int], top: th.Tensor, lft: th.Tensor) -> th.Tensor:
+def _tl_isolat(
+    p: int, d: tuple[int, int], top: torch.Tensor, lft: torch.Tensor
+) -> torch.Tensor:
     """
     Synthesize the missing **top-left** equatorial corner under isolatitude rules.
 
@@ -946,7 +948,7 @@ def _tl_isolat(p: int, d: tuple[int, int], top: th.Tensor, lft: th.Tensor) -> th
     lft : torch.Tensor
         Face left of the equatorial center face.
     """
-    ret = th.zeros_like(top)[..., :p, :p]
+    ret = torch.zeros_like(top)[..., :p, :p]
     n = 2 * p - 1
     if n + 1 > top.shape[-1]:
         raise ValueError(
@@ -958,10 +960,12 @@ def _tl_isolat(p: int, d: tuple[int, int], top: th.Tensor, lft: th.Tensor) -> th
         diag_indices = kth_diag_indices(p, diag_nums[i])
         for j in range(len(diag_indices[0])):
             ret[..., diag_indices[0][j], diag_indices[1][j]] = fill_val
-    return th.rot90(ret, k=-1, dims=d)
+    return torch.rot90(ret, k=-1, dims=d)
 
 
-def _br_isolat(p: int, d: tuple[int, int], b: th.Tensor, r: th.Tensor) -> th.Tensor:
+def _br_isolat(
+    p: int, d: tuple[int, int], b: torch.Tensor, r: torch.Tensor
+) -> torch.Tensor:
     """
     Synthesize the missing **bottom-right** equatorial corner under isolatitude rules.
 
@@ -979,7 +983,7 @@ def _br_isolat(p: int, d: tuple[int, int], b: th.Tensor, r: th.Tensor) -> th.Ten
     r : torch.Tensor
         Face right of the equatorial center face.
     """
-    ret = th.zeros_like(b)[..., :p, :p]
+    ret = torch.zeros_like(b)[..., :p, :p]
     n = 2 * p - 1
     if n + 1 > b.shape[-1]:
         raise ValueError(
@@ -991,10 +995,12 @@ def _br_isolat(p: int, d: tuple[int, int], b: th.Tensor, r: th.Tensor) -> th.Ten
         diag_indices = kth_diag_indices(p, diag_nums[i])
         for j in range(len(diag_indices[0])):
             ret[..., diag_indices[0][j], diag_indices[1][j]] = fill_val
-    return th.rot90(ret, k=1, dims=d)
+    return torch.rot90(ret, k=1, dims=d)
 
 
-def isolatitude_pad_folded(data: th.Tensor, p: int, enable_nhwc: bool) -> th.Tensor:
+def isolatitude_pad_folded(
+    data: torch.Tensor, p: int, enable_nhwc: bool
+) -> torch.Tensor:
     """
     Apply isolatitude HEALPix padding on **folded** face data.
 
@@ -1020,8 +1026,8 @@ def isolatitude_pad_folded(data: th.Tensor, p: int, enable_nhwc: bool) -> th.Ten
     data = data.reshape(-1, 12, c, h, w)
 
     f00, f01, f02, f03, f04, f05, f06, f07, f08, f09, f10, f11 = [
-        th.squeeze(x, dim=1)
-        for x in th.split(tensor=data, split_size_or_sections=1, dim=1)
+        torch.squeeze(x, dim=1)
+        for x in torch.split(tensor=data, split_size_or_sections=1, dim=1)
     ]
 
     p00 = _pn_isolat(p, d, f00, f01, f02, f03, f03, f04, f08, f05, f01)
@@ -1083,17 +1089,19 @@ def isolatitude_pad_folded(data: th.Tensor, p: int, enable_nhwc: bool) -> th.Ten
     p10 = _ps_isolat(p, d, f10, f07, f02, f06, f09, f09, f08, f11, f11)
     p11 = _ps_isolat(p, d, f11, f04, f03, f07, f10, f10, f09, f08, f08)
 
-    res = th.stack((p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p10, p11), dim=1)
+    res = torch.stack(
+        (p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p10, p11), dim=1
+    )
     n, _, _, hpad, wpad = res.shape
     res = res.reshape(n * 12, c, hpad, wpad)
     if enable_nhwc:
-        res = res.to(memory_format=th.channels_last)
+        res = res.to(memory_format=torch.channels_last)
     return res
 
 
 def decode_two_channel_identity_to_linear_indices(
-    y0: th.Tensor, y1: th.Tensor
-) -> tuple[th.Tensor, th.Tensor]:
+    y0: torch.Tensor, y1: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Recover two nonnegative integer indices from a redundant two-channel encoding.
 
@@ -1118,12 +1126,12 @@ def decode_two_channel_identity_to_linear_indices(
     ab = (s * s - ss) / 2.0
     disc = (s * s - 4.0 * ab).clamp_min(0.0)
     root = disc.sqrt()
-    a = ((s + root) / 2.0).round().to(th.int64)
-    b = ((s - root) / 2.0).round().to(th.int64)
+    a = ((s + root) / 2.0).round().to(torch.int64)
+    b = ((s - root) / 2.0).round().to(torch.int64)
     return a, b
 
 
-def build_isolatitude_gather_index(p: int, H: int) -> tuple[th.Tensor, th.Tensor]:
+def build_isolatitude_gather_index(p: int, H: int) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Precompute gather indices that reproduce ``isolatitude_pad_folded`` on flat data.
 
@@ -1149,10 +1157,10 @@ def build_isolatitude_gather_index(p: int, H: int) -> tuple[th.Tensor, th.Tensor
         False when both channels collapsed to the same index).
     """
     Hpad = H + 2 * p
-    ids = th.arange(12 * H * H, dtype=th.float64).reshape(12, H, H)
+    ids = torch.arange(12 * H * H, dtype=torch.float64).reshape(12, H, H)
     ch0 = ids
     ch1 = ids * ids
-    x_folded = th.stack((ch0, ch1), dim=1).unsqueeze(0).reshape(12, 2, H, H)
+    x_folded = torch.stack((ch0, ch1), dim=1).unsqueeze(0).reshape(12, 2, H, H)
 
     y_folded = isolatitude_pad_folded(x_folded, p, False)
     y = y_folded.reshape(1, 12, 2, Hpad, Hpad)
@@ -1160,11 +1168,11 @@ def build_isolatitude_gather_index(p: int, H: int) -> tuple[th.Tensor, th.Tensor
     y1 = y[:, :, 1].reshape(-1)
     a_flat, b_flat = decode_two_channel_identity_to_linear_indices(y0, y1)
     n_out = a_flat.numel()
-    index = th.empty(2, n_out, dtype=th.long)
+    index = torch.empty(2, n_out, dtype=torch.long)
     index[0] = a_flat
     index[1] = b_flat
-    valid = th.ones(2, n_out, dtype=th.bool)
+    valid = torch.ones(2, n_out, dtype=torch.bool)
     same = a_flat == b_flat
-    index[1] = th.where(same, th.tensor(-1, dtype=th.long), index[1])
+    index[1] = torch.where(same, torch.tensor(-1, dtype=torch.long), index[1])
     valid[1] = ~same
     return index, valid

--- a/fme/ace/models/healpix/healpix_unet.py
+++ b/fme/ace/models/healpix/healpix_unet.py
@@ -7,9 +7,10 @@ Adapted from the modulus-uw ``physicsnemo.models.dlwp_healpix.HEALPixUNet``.
 from collections.abc import Sequence
 from typing import Literal
 
-import torch as th
+import torch
 import torch.nn as nn
 
+from .healpix_blocks import HEALPixBuildContext
 from .healpix_decoder import UNetDecoderConfig
 from .healpix_encoder import UNetEncoderConfig
 from .healpix_layers import HEALPixFoldFaces, HEALPixUnfoldFaces
@@ -33,7 +34,6 @@ class HEALPixUNet(nn.Module):
         decoder: UNetDecoderConfig,
         input_channels: int,
         output_channels: int,
-        enable_nhwc: bool = False,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -49,7 +49,6 @@ class HEALPixUNet(nn.Module):
                 size of the channel dimension of the tensor passed to
                 ``forward``).
             output_channels: Number of channels in the output tensor.
-            enable_nhwc: Use NHWC tensor layout for child modules.
             hpx_padding_mode: HEALPix padding backend. One of ``"earth2grid"``,
                 ``"karlbauer"``, or ``"isolatitude"``. Default ``"earth2grid"``.
             nside: Face height/width per UNet level, shallowest to deepest.
@@ -61,7 +60,6 @@ class HEALPixUNet(nn.Module):
 
         self.input_channels = input_channels
         self.output_channels = output_channels
-        self.enable_nhwc = enable_nhwc
         self.hpx_padding_mode = hpx_padding_mode
 
         levels = len(encoder.n_channels)
@@ -89,22 +87,18 @@ class HEALPixUNet(nn.Module):
             nside_resolved = None
         self.nside = nside_resolved
 
-        self.fold = HEALPixFoldFaces(enable_nhwc=enable_nhwc)
-        self.unfold = HEALPixUnfoldFaces(num_faces=12, enable_nhwc=enable_nhwc)
+        build_ctx = HEALPixBuildContext(
+            hpx_padding_mode=hpx_padding_mode,
+            nside_levels=nside_resolved,
+        )
 
-        encoder.input_channels = input_channels
-        encoder.enable_nhwc = enable_nhwc
-        encoder.hpx_padding_mode = self.hpx_padding_mode
-        encoder.nside = self.nside
-        self.encoder = encoder.build()
+        self.fold = HEALPixFoldFaces()
+        self.unfold = HEALPixUnfoldFaces(num_faces=12)
 
-        decoder.output_channels = output_channels
-        decoder.enable_nhwc = enable_nhwc
-        decoder.hpx_padding_mode = self.hpx_padding_mode
-        decoder.nside = self.nside
-        self.decoder = decoder.build()
+        self.encoder = encoder.build(input_channels=input_channels, ctx=build_ctx)
+        self.decoder = decoder.build(output_channels=output_channels, ctx=build_ctx)
 
-    def forward(self, inputs: th.Tensor) -> th.Tensor:
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         """Forward pass.
 
         Args:

--- a/fme/ace/registry/hpx.py
+++ b/fme/ace/registry/hpx.py
@@ -23,16 +23,15 @@ class HEALPixUNetBuilder(ModuleConfig):
     Parameters:
         encoder: UNet encoder configuration.
         decoder: UNet decoder configuration.
-        enable_nhwc: Use NHWC tensor layout for child modules.
-        hpx_padding_mode: HEALPix padding backend (``"earth2grid"``,
-            ``"karlbauer"``, ``"isolatitude"``). Default ``"earth2grid"``.
+        hpx_padding_mode: HEALPix padding backend applied to all child modules
+            (``"earth2grid"``, ``"karlbauer"``, ``"isolatitude"``). Default
+            ``"earth2grid"``.
         nside: Face height/width per UNet level (shallowest to deepest). Required for
             ``isolatitude`` padding.
     """
 
     encoder: UNetEncoderConfig
     decoder: UNetDecoderConfig
-    enable_nhwc: bool = False
     hpx_padding_mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "earth2grid"
     nside: Sequence[int] | None = None
 
@@ -60,7 +59,6 @@ class HEALPixUNetBuilder(ModuleConfig):
             decoder=self.decoder,
             input_channels=n_in_channels,
             output_channels=n_out_channels,
-            enable_nhwc=self.enable_nhwc,
             hpx_padding_mode=self.hpx_padding_mode,
             nside=self.nside,
         )

--- a/fme/ace/registry/test_hpx.py
+++ b/fme/ace/registry/test_hpx.py
@@ -481,7 +481,7 @@ def healpix_padding():
     padding = 2
 
     """Instantiate HEALPixPadding with the specified padding."""
-    return HEALPixPadding(padding=padding, enable_nhwc=False)
+    return HEALPixPadding(padding=padding)
 
 
 def test_healpix_padding_pn(healpix_padding):
@@ -666,10 +666,7 @@ def test_HEALPixPaddingIsolatitude_forward_shape_cuda(padding: int):
 
 @pytest.mark.parametrize("padding", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("hw", [16, 32, 64])
-@pytest.mark.parametrize("enable_nhwc", [False, True])
-def test_healpix_padding_isolatitude_matches_folded_reference(
-    padding: int, hw: int, enable_nhwc: bool
-):
+def test_healpix_padding_isolatitude_matches_folded_reference(padding: int, hw: int):
     """Gather-based HEALPixPaddingIsolatitude must match isolatitude_pad_folded."""
     if 2 * padding > hw:
         pytest.skip("face size too small for padding (isolatitude corner synthesis)")
@@ -680,8 +677,8 @@ def test_healpix_padding_isolatitude_matches_folded_reference(
     c = 3
     x = torch.randn(batch_size * num_faces, c, hw, hw)
 
-    ref = isolatitude_pad_folded(x, padding, enable_nhwc)
-    y = HEALPixPaddingIsolatitude(padding=padding, nside=hw, enable_nhwc=enable_nhwc)(x)
+    ref = isolatitude_pad_folded(x, padding)
+    y = HEALPixPaddingIsolatitude(padding=padding, nside=hw)(x)
 
     # Gather path uses 0.5 * (g0 + g1) in a form that can differ by ~1 ULP from the
     # reference on some output cells.
@@ -690,17 +687,12 @@ def test_healpix_padding_isolatitude_matches_folded_reference(
 
 @pytest.mark.parametrize("padding", [1, 2])
 @pytest.mark.parametrize("hw", [4, 8])
-@pytest.mark.parametrize("enable_nhwc", [False, True])
-def test_healpix_padding_isolatitude_gradcheck_cpu(
-    padding: int, hw: int, enable_nhwc: bool
-):
+def test_healpix_padding_isolatitude_gradcheck_cpu(padding: int, hw: int):
     """Analytic backward matches finite differences (double precision)."""
     if 2 * padding > hw:
         pytest.skip("face size too small for padding")
 
-    pad = HEALPixPaddingIsolatitude(
-        padding=padding, nside=hw, enable_nhwc=enable_nhwc
-    ).double()
+    pad = HEALPixPaddingIsolatitude(padding=padding, nside=hw).double()
 
     batch_size = 1
     c = 2
@@ -799,7 +791,6 @@ def test_healpix_layer_conv_same_geometry(mode):
         kernel_size=3,
         stride=1,
         padding="same",
-        enable_nhwc=False,
         hpx_padding_mode=mode,
     )
     if mode == "isolatitude":
@@ -829,9 +820,9 @@ def test_healpix_layer_earth2grid():
 
 
 def test_make_hpx_padding_factory_types():
-    p = make_hpx_padding_layer(1, "karlbauer", enable_nhwc=False)
+    p = make_hpx_padding_layer(1, "karlbauer")
     assert p is not None
-    p2 = make_hpx_padding_layer(1, "isolatitude", enable_nhwc=False, nside=8)
+    p2 = make_hpx_padding_layer(1, "isolatitude", nside=8)
     assert p2 is not None
 
 

--- a/fme/ace/registry/test_hpx.py
+++ b/fme/ace/registry/test_hpx.py
@@ -3,17 +3,27 @@ import datetime
 import logging
 from typing import Literal
 
+import dacite
 import numpy as np
 import pytest
-import torch as th
+import torch
 import torch.nn as nn
 
 from fme.ace.models.healpix.healpix_activations import CappedGELUConfig
 from fme.ace.models.healpix.healpix_blocks import (
+    AvgPoolDownsamplingBlockConfig,
+    BasicConvBlockConfig,
     ConvBlockConfig,
+    ConvNeXtBlockConfig,
     DealiasedDownsample,
+    DealiasedDownsampleBlockConfig,
     DownsamplingBlockConfig,
+    HEALPixLayerBuildContext,
+    MaxPoolDownsamplingBlockConfig,
+    MultiSymmetricConvNeXtBlockConfig,
     SmoothedInterpolateConv,
+    SmoothedInterpolateConvBlockConfig,
+    TransposedConvUpsampleBlockConfig,
     UpsamplingBlockConfig,
 )
 from fme.ace.models.healpix.healpix_decoder import UNetDecoder
@@ -47,26 +57,49 @@ logger = logging.getLogger("__name__")
 def fix_random_seeds(seed=0):
     """Fix random seeds for reproducibility"""
     np.random.seed(seed)
-    th.manual_seed(seed)
-    th.cuda.manual_seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
 
 
-def conv_next_block_config(in_channels=3, out_channels=1):
+def _layer_ctx(
+    mode: Literal["earth2grid", "karlbauer", "isolatitude"] = "karlbauer",
+    *,
+    nside: int | None = None,
+    nside_after: int | None = None,
+) -> HEALPixLayerBuildContext:
+    return HEALPixLayerBuildContext(
+        hpx_padding_mode=mode,
+        nside=nside,
+        nside_after=nside_after,
+    )
+
+
+def conv_next_block_config():
     activation_block_config = CappedGELUConfig(cap_value=10)
-    conv_next_block_config = ConvBlockConfig(
-        in_channels=in_channels,
-        out_channels=out_channels,
+    return ConvNeXtBlockConfig(
         activation=activation_block_config,
         kernel_size=3,
-        dilation=1,
         upscale_factor=4,
-        block_type="ConvNeXtBlock",
     )
-    return conv_next_block_config
 
 
 def down_sampling_block_config():
-    return DownsamplingBlockConfig(pooling=2, block_type="AvgPool")
+    return AvgPoolDownsamplingBlockConfig(pooling=2)
+
+
+def up_sampling_block_config():
+    activation_block_config = CappedGELUConfig(cap_value=10)
+    return TransposedConvUpsampleBlockConfig(
+        activation=activation_block_config,
+        stride=2,
+    )
+
+
+def output_layer_config():
+    return BasicConvBlockConfig(
+        kernel_size=1,
+        n_layers=1,
+    )
 
 
 def encoder_config(
@@ -78,29 +111,6 @@ def encoder_config(
         n_channels=n_channels,
         dilations=[1, 2, 4],
     )
-
-
-def up_sampling_block_config(in_channels=3, out_channels=1):
-    activation_block_config = CappedGELUConfig(cap_value=10)
-    return UpsamplingBlockConfig(
-        block_type="TransposedConvUpsample",
-        in_channels=in_channels,
-        out_channels=out_channels,
-        activation=activation_block_config,
-        stride=2,
-    )
-
-
-def output_layer_config(in_channels=3, out_channels=2):
-    conv_block_config = ConvBlockConfig(
-        in_channels=in_channels,
-        out_channels=out_channels,
-        kernel_size=1,
-        dilation=1,
-        n_layers=1,
-        block_type="BasicConvBlock",
-    )
-    return conv_block_config
 
 
 def decoder_config(
@@ -136,57 +146,29 @@ def _hpx_unet_configs(
         encoder_n_channels = [8, 16]
     if decoder_n_channels is None:
         decoder_n_channels = list(reversed(encoder_n_channels))
-    n_levels = len(encoder_n_channels)
-    levels = _nside_levels(img, n_levels)
 
-    enc_conv = ConvBlockConfig(
-        block_type="ConvNeXtBlock",
-        latent_channels=4,
-        hpx_padding_mode=padding_mode,
-        nside=img,
-    )
-    down = DownsamplingBlockConfig(
-        block_type="AvgPool",
+    enc_conv = ConvNeXtBlockConfig()
+    down = AvgPoolDownsamplingBlockConfig(
         pooling=2,
-        hpx_padding_mode=padding_mode,
-        nside=img,
     )
     enc = UNetEncoderConfig(
         conv_block=enc_conv,
         down_sampling_block=down,
-        input_channels=3,
         n_channels=encoder_n_channels,
         n_layers=[1] * len(encoder_n_channels),
-        nside=levels,
-        hpx_padding_mode=padding_mode,
     )
-    dec_conv = ConvBlockConfig(
-        block_type="ConvNeXtBlock",
-        latent_channels=4,
-        hpx_padding_mode=padding_mode,
-        nside=img,
-    )
+    dec_conv = ConvNeXtBlockConfig()
     dec = UNetDecoderConfig(
         conv_block=dec_conv,
-        up_sampling_block=UpsamplingBlockConfig(
-            block_type="TransposedConvUpsample",
+        up_sampling_block=TransposedConvUpsampleBlockConfig(
             stride=2,
-            hpx_padding_mode=padding_mode,
-            nside=img // 2,
         ),
-        output_layer=ConvBlockConfig(
-            block_type="BasicConvBlock",
+        output_layer=BasicConvBlockConfig(
             n_layers=1,
             kernel_size=1,
-            out_channels=output_channels,
-            hpx_padding_mode=padding_mode,
-            nside=img,
         ),
         n_channels=decoder_n_channels,
         n_layers=[1] * len(decoder_n_channels),
-        output_channels=output_channels,
-        hpx_padding_mode=padding_mode,
-        nside=levels,
     )
     return enc, dec
 
@@ -195,7 +177,7 @@ def _test_data():
     # create dummy data
     def generate_test_data(batch_size=8, time_dim=1, channels=7, img_size=16):
         device = get_device()
-        test_data = th.randn(batch_size, 12, time_dim * channels, img_size, img_size)
+        test_data = torch.randn(batch_size, 12, time_dim * channels, img_size, img_size)
         return test_data.to(device)
 
     return generate_test_data
@@ -205,7 +187,7 @@ def constant_data():
     # create dummy data
     def generate_constant_data(channels=2, img_size=16):
         device = get_device()
-        constants = th.randn(12, channels, img_size, img_size)
+        constants = torch.randn(12, channels, img_size, img_size)
 
         return constants.to(device)
 
@@ -216,7 +198,7 @@ def insolation_data():
     # create dummy data
     def generate_insolation_data(batch_size=8, time_dim=1, img_size=16):
         device = get_device()
-        insolation = th.randn(batch_size, 12, time_dim, img_size, img_size)
+        insolation = torch.randn(batch_size, 12, time_dim, img_size, img_size)
 
         return insolation.to(device)
 
@@ -241,10 +223,10 @@ def test_hpx_init(shape):
     }
 
     horizontal_coordinates = HEALPixCoordinates(
-        th.arange(12), th.arange(8), th.arange(8)
+        torch.arange(12), torch.arange(8), torch.arange(8)
     )
     vertical_coordinate = HybridSigmaPressureCoordinate(
-        ak=th.arange(7), bk=th.arange(7)
+        ak=torch.arange(7), bk=torch.arange(7)
     ).to(device)
     stepper_config = StepperConfig(
         step=StepSelector(
@@ -282,13 +264,8 @@ def test_UNetEncoder_initialize():
     n_channels = (16, 32, 64)
 
     # Dicts for block configs used by encoder
-    conv_block_config = ConvBlockConfig(
-        in_channels=channels,
-        block_type="ConvNeXtBlock",
-    )
-    down_sampling_block_config = DownsamplingBlockConfig(
-        pooling=2, block_type="MaxPool"
-    )
+    conv_block_config = ConvNeXtBlockConfig()
+    down_sampling_block_config = MaxPoolDownsamplingBlockConfig(pooling=2)
 
     encoder = UNetEncoder(
         conv_block=conv_block_config,
@@ -318,13 +295,8 @@ def test_UNetEncoder_forward():
     device = get_device()
 
     # block configs used by encoder
-    conv_block_config = ConvBlockConfig(
-        in_channels=channels,
-        block_type="ConvNeXtBlock",
-    )
-    down_sampling_block_config = DownsamplingBlockConfig(
-        pooling=2, block_type="MaxPool"
-    )
+    conv_block_config = ConvNeXtBlockConfig()
+    down_sampling_block_config = MaxPoolDownsamplingBlockConfig(pooling=2)
     encoder = UNetEncoder(
         conv_block=conv_block_config,
         down_sampling_block=down_sampling_block_config,
@@ -333,7 +305,7 @@ def test_UNetEncoder_forward():
     ).to(device)
 
     tensor_size = [b_size, channels, hw_size, hw_size]
-    invar = th.rand(tensor_size).to(device)
+    invar = torch.rand(tensor_size).to(device)
     outvar = encoder(invar)
 
     # outvar is a module list
@@ -346,29 +318,15 @@ def test_UNetEncoder_forward():
 
 @pytest.mark.skipif(not have_earth2grid, reason="earth2grid not installed")
 def test_UNetDecoder_initilization():
-    in_channels = 2
-    out_channels = 1
     n_channels = (64, 32, 16)
     device = get_device()
 
     # Dicts for block configs used by decoder
-    conv_block_config = ConvBlockConfig(
-        in_channels=in_channels, out_channels=out_channels, block_type="ConvNeXtBlock"
-    )
-    up_sampling_block_config = UpsamplingBlockConfig(
-        block_type="TransposedConvUpsample",
-        in_channels=in_channels,
-        out_channels=out_channels,
-        stride=2,
-    )
+    conv_block_config = ConvNeXtBlockConfig()
+    up_sampling_block_config = TransposedConvUpsampleBlockConfig(stride=2)
 
-    output_layer_config = ConvBlockConfig(
-        in_channels=in_channels,
-        out_channels=out_channels,
+    output_layer_config = ConvNeXtBlockConfig(
         kernel_size=1,
-        dilation=1,
-        n_layers=1,
-        block_type="ConvNeXtBlock",
     )
 
     decoder = UNetDecoder(
@@ -392,7 +350,6 @@ def test_UNetDecoder_initilization():
 
 @pytest.mark.skipif(not have_earth2grid, reason="earth2grid not installed")
 def test_UNetDecoder_forward():
-    in_channels = 2
     out_channels = 1
     hw_size = 32
     b_size = 12
@@ -400,22 +357,11 @@ def test_UNetDecoder_forward():
     device = get_device()
 
     # Dicts for block configs used by decoder
-    conv_block_config = ConvBlockConfig(
-        in_channels=in_channels, out_channels=out_channels, block_type="ConvNeXtBlock"
-    )
-    up_sampling_block_config = UpsamplingBlockConfig(
-        block_type="TransposedConvUpsample",
-        in_channels=in_channels,
-        out_channels=out_channels,
-        stride=2,
-    )
-    output_layer_config = ConvBlockConfig(
-        in_channels=in_channels,
-        out_channels=out_channels,
+    conv_block_config = ConvNeXtBlockConfig()
+    up_sampling_block_config = TransposedConvUpsampleBlockConfig(stride=2)
+    output_layer_config = BasicConvBlockConfig(
         kernel_size=1,
-        dilation=1,
         n_layers=1,
-        block_type="BasicConvBlock",
     )
     decoder = UNetDecoder(
         conv_block=conv_block_config,
@@ -424,14 +370,14 @@ def test_UNetDecoder_forward():
         n_channels=n_channels,
     ).to(device)
 
-    output_2_size = th.Size([b_size, out_channels, hw_size, hw_size])
+    output_2_size = torch.Size([b_size, out_channels, hw_size, hw_size])
 
     # build the list of tensors for the decoder
     invars = []
     # decoder has an algorithm that goes back to front
     for idx in range(len(n_channels) - 1, -1, -1):
         tensor_size = [b_size, n_channels[idx], hw_size, hw_size]
-        invars.append(th.rand(tensor_size).to(device))
+        invars.append(torch.rand(tensor_size).to(device))
         hw_size = hw_size // 2
 
     outvar = decoder(invars)
@@ -453,8 +399,8 @@ def test_UNetDecoder_forward():
 
 
 def compare_output(
-    output_1: th.Tensor | tuple[th.Tensor, ...],
-    output_2: th.Tensor | tuple[th.Tensor, ...],
+    output_1: torch.Tensor | tuple[torch.Tensor, ...],
+    output_2: torch.Tensor | tuple[torch.Tensor, ...],
     rtol: float = 1e-5,
     atol: float = 1e-5,
 ) -> bool:
@@ -470,17 +416,19 @@ def compare_output(
         If outputs are the same
     """
     # Output of tensor
-    if isinstance(output_1, th.Tensor):
-        return th.allclose(output_1, output_2, rtol, atol)
+    if isinstance(output_1, torch.Tensor):
+        return torch.allclose(output_1, output_2, rtol, atol)
     # Output of tuple of tensors
     elif isinstance(output_1, tuple):
         # Loop through tuple of outputs
         for i, (out_1, out_2) in enumerate(zip(output_1, output_2)):
             # If tensor use allclose
-            if isinstance(out_1, th.Tensor):
-                if not th.allclose(out_1, out_2, rtol, atol):
+            if isinstance(out_1, torch.Tensor):
+                if not torch.allclose(out_1, out_2, rtol, atol):
                     logger.warning(f"Failed comparison between outputs {i}")
-                    logger.warning(f"Max Difference: {th.amax(th.abs(out_1 - out_2))}")
+                    logger.warning(
+                        f"Max Difference: {torch.amax(torch.abs(out_1 - out_2))}"
+                    )
                     logger.warning(f"Difference: {out_1 - out_2}")
                     return False
             # Otherwise assume primative
@@ -512,7 +460,7 @@ def compare_output(
     else:
         logger.error(
             "Model returned invalid type for unit test, \
-            should be th.Tensor or Tuple[th.Tensor]"
+            should be torch.Tensor or Tuple[torch.Tensor]"
         )
         return False
     return True
@@ -525,7 +473,7 @@ def mock_data():
     Shape: [B=1, F=12, C=1, H=4, W=4] - a single batch with 12 faces, one channel,
         4x4 grid
     """
-    return th.arange(1, 12 * 4 * 4 + 1, dtype=th.float32).reshape((12, 1, 4, 4))
+    return torch.arange(1, 12 * 4 * 4 + 1, dtype=torch.float32).reshape((12, 1, 4, 4))
 
 
 @pytest.fixture
@@ -544,7 +492,7 @@ def test_healpix_padding_pn(healpix_padding):
     padding = 2
 
     # Mock the neighbor faces, assuming they are 4x4 for simplicity.
-    face = th.ones((1, 1, 4, 4))
+    face = torch.ones((1, 1, 4, 4))
     top = face
     top_left = face * 2
     left = face * 3
@@ -562,13 +510,13 @@ def test_healpix_padding_pn(healpix_padding):
     # Check if padding applied matches expected size: 4 + 2*padding in each dimension
     assert padded.shape[-2:] == (4 + 2 * padding, 4 + 2 * padding)
     # North padding (top two rows) should match `top`
-    assert th.all(padded[..., :padding, padding:-padding] == top[..., -padding:, :])
+    assert torch.all(padded[..., :padding, padding:-padding] == top[..., -padding:, :])
     # Northwest corner padding should match `top_left`
-    assert th.all(
+    assert torch.all(
         padded[..., :padding, :padding] == top_left[..., -padding:, -padding:]
     )
     # Northeast corner padding should match `top_right`
-    assert th.all(
+    assert torch.all(
         padded[..., :padding, -padding:] == top_right[..., -padding:, :padding]
     )
 
@@ -581,7 +529,7 @@ def test_healpix_padding_pe(healpix_padding):
     padding = 2
 
     # Mock the neighbor faces, assuming they are 4x4 for simplicity.
-    face = th.ones((1, 1, 4, 4))
+    face = torch.ones((1, 1, 4, 4))
     top = face
     top_left = face * 2
     left = face * 3
@@ -599,9 +547,11 @@ def test_healpix_padding_pe(healpix_padding):
     # Check if padding applied matches expected size: 4 + 2*padding in each dimension
     assert padded.shape[-2:] == (4 + 2 * padding, 4 + 2 * padding)
     # Left padding (left two columns) should match `left`
-    assert th.all(padded[..., padding:-padding, :padding] == left[..., :, -padding:])
+    assert torch.all(padded[..., padding:-padding, :padding] == left[..., :, -padding:])
     # Right padding (right two columns) should match `right`
-    assert th.all(padded[..., padding:-padding, -padding:] == right[..., :, :padding])
+    assert torch.all(
+        padded[..., padding:-padding, -padding:] == right[..., :, :padding]
+    )
 
 
 def test_healpix_padding_ps(healpix_padding):
@@ -612,7 +562,7 @@ def test_healpix_padding_ps(healpix_padding):
     padding = 2
 
     # Mock the neighbor faces, assuming they are 4x4 for simplicity.
-    face = th.ones((1, 1, 4, 4))
+    face = torch.ones((1, 1, 4, 4))
     top = face
     top_left = face * 2
     left = face * 3
@@ -630,13 +580,15 @@ def test_healpix_padding_ps(healpix_padding):
     # Check if padding applied matches expected size: 4 + 2*padding in each dimension
     assert padded.shape[-2:] == (4 + 2 * padding, 4 + 2 * padding)
     # South padding (bottom two rows) should match `bottom`
-    assert th.all(padded[..., -padding:, padding:-padding] == bottom[..., :padding, :])
+    assert torch.all(
+        padded[..., -padding:, padding:-padding] == bottom[..., :padding, :]
+    )
     # Southwest corner padding should match `bottom_left`
-    assert th.all(
+    assert torch.all(
         padded[..., -padding:, :padding] == bottom_left[..., :padding, -padding:]
     )
     # Southeast corner padding should match `bottom_right`
-    assert th.all(
+    assert torch.all(
         padded[..., -padding:, -padding:] == bottom_right[..., :padding, :padding]
     )
 
@@ -689,13 +641,13 @@ def test_HEALPixPaddingIsolatitude_forward_shape_cpu(padding: int):
         pytest.skip("face size too small for padding (isolatitude corner synthesis)")
 
     pad_mod = HEALPixPaddingIsolatitude(padding=padding, nside=hw)
-    invar = th.rand(batch_size * num_faces, c, hw, hw)
+    invar = torch.rand(batch_size * num_faces, c, hw, hw)
     outvar = pad_mod(invar)
     hw_p = hw + 2 * padding
     assert outvar.shape == (batch_size * num_faces, c, hw_p, hw_p)
 
 
-@pytest.mark.skipif(not th.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("padding", [1, 2, 3])
 def test_HEALPixPaddingIsolatitude_forward_shape_cuda(padding: int):
     num_faces = 12
@@ -704,9 +656,9 @@ def test_HEALPixPaddingIsolatitude_forward_shape_cuda(padding: int):
     c = 2
     if 2 * padding > hw:
         pytest.skip("face size too small for padding")
-    th.cuda.empty_cache()
+    torch.cuda.empty_cache()
     pad_mod = HEALPixPaddingIsolatitude(padding=padding, nside=hw).cuda()
-    invar = th.rand(batch_size * num_faces, c, hw, hw, device="cuda")
+    invar = torch.rand(batch_size * num_faces, c, hw, hw, device="cuda")
     outvar = pad_mod(invar)
     hw_p = hw + 2 * padding
     assert outvar.shape == (batch_size * num_faces, c, hw_p, hw_p)
@@ -722,18 +674,18 @@ def test_healpix_padding_isolatitude_matches_folded_reference(
     if 2 * padding > hw:
         pytest.skip("face size too small for padding (isolatitude corner synthesis)")
 
-    th.manual_seed(0)
+    torch.manual_seed(0)
     batch_size = 2
     num_faces = 12
     c = 3
-    x = th.randn(batch_size * num_faces, c, hw, hw)
+    x = torch.randn(batch_size * num_faces, c, hw, hw)
 
     ref = isolatitude_pad_folded(x, padding, enable_nhwc)
     y = HEALPixPaddingIsolatitude(padding=padding, nside=hw, enable_nhwc=enable_nhwc)(x)
 
     # Gather path uses 0.5 * (g0 + g1) in a form that can differ by ~1 ULP from the
     # reference on some output cells.
-    th.testing.assert_close(y, ref, rtol=1.0e-5, atol=1.0e-6)
+    torch.testing.assert_close(y, ref, rtol=1.0e-5, atol=1.0e-6)
 
 
 @pytest.mark.parametrize("padding", [1, 2])
@@ -752,19 +704,19 @@ def test_healpix_padding_isolatitude_gradcheck_cpu(
 
     batch_size = 1
     c = 2
-    x = th.randn(
+    x = torch.randn(
         batch_size * 12,
         c,
         hw,
         hw,
-        dtype=th.double,
+        dtype=torch.double,
         requires_grad=True,
     )
 
-    def fn(t: th.Tensor) -> th.Tensor:
+    def fn(t: torch.Tensor) -> torch.Tensor:
         return pad(t).sum()
 
-    assert th.autograd.gradcheck(
+    assert torch.autograd.gradcheck(
         fn,
         (x,),
         eps=1e-6,
@@ -773,28 +725,28 @@ def test_healpix_padding_isolatitude_gradcheck_cpu(
     )
 
 
-@pytest.mark.skipif(not th.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("padding", [1, 2])
 @pytest.mark.parametrize("hw", [8, 16])
 def test_healpix_padding_isolatitude_gradcheck_cuda(padding: int, hw: int):
     if 2 * padding > hw:
         pytest.skip("face size too small for padding")
-    th.cuda.empty_cache()
+    torch.cuda.empty_cache()
     pad = HEALPixPaddingIsolatitude(padding=padding, nside=hw).double().cuda()
-    x = th.randn(
+    x = torch.randn(
         1 * 12,
         2,
         hw,
         hw,
-        dtype=th.double,
+        dtype=torch.double,
         device="cuda",
         requires_grad=True,
     )
 
-    def fn(t: th.Tensor) -> th.Tensor:
+    def fn(t: torch.Tensor) -> torch.Tensor:
         return pad(t).sum()
 
-    assert th.autograd.gradcheck(
+    assert torch.autograd.gradcheck(
         fn,
         (x,),
         eps=1e-5,
@@ -806,11 +758,11 @@ def test_healpix_padding_isolatitude_gradcheck_cuda(padding: int, hw: int):
 def test_healpix_padding_isolatitude_backward_grad_matches_finite_diff():
     """Spot-check gradient vs central difference on a few entries (float32, CPU)."""
     padding, hw = 1, 16
-    th.manual_seed(42)
+    torch.manual_seed(42)
     pad = HEALPixPaddingIsolatitude(padding=padding, nside=hw)
-    x0 = th.randn(12, 2, hw, hw)
+    x0 = torch.randn(12, 2, hw, hw)
     x = x0.clone().requires_grad_(True)
-    (g_analytic,) = th.autograd.grad(pad(x).sum(), x)
+    (g_analytic,) = torch.autograd.grad(pad(x).sum(), x)
 
     eps = 1e-3
     indices = [(0, 0, 0, 0), (3, 1, 7, 7), (11, 0, 15, 15), (5, 1, 8, 8)]
@@ -820,7 +772,7 @@ def test_healpix_padding_isolatitude_backward_grad_matches_finite_diff():
         xm = x0.clone()
         xm[b, c, h, w] -= eps
         g_fd_ij = (pad(xp).sum() - pad(xm).sum()) / (2 * eps)
-        th.testing.assert_close(
+        torch.testing.assert_close(
             g_analytic[b, c, h, w],
             g_fd_ij,
             rtol=0.02,
@@ -829,11 +781,11 @@ def test_healpix_padding_isolatitude_backward_grad_matches_finite_diff():
 
 
 def _folded_padding_dealias(
-    batch: int = 2, channels: int = 3, h: int = 16, device=None, dtype=th.float32
+    batch: int = 2, channels: int = 3, h: int = 16, device=None, dtype=torch.float32
 ):
     if device is None:
-        device = th.device("cpu")
-    return th.randn(batch * 12, channels, h, h, device=device, dtype=dtype)
+        device = torch.device("cpu")
+    return torch.randn(batch * 12, channels, h, h, device=device, dtype=dtype)
 
 
 @pytest.mark.parametrize("mode", ["karlbauer", "isolatitude"])
@@ -855,7 +807,7 @@ def test_healpix_layer_conv_same_geometry(mode):
     layer = HEALPixLayer(**kwargs)
     y = layer(x)
     assert y.shape == x.shape
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
 
 
 @pytest.mark.skipif(not have_earth2grid, reason="earth2grid not installed")
@@ -873,7 +825,7 @@ def test_healpix_layer_earth2grid():
     )
     y = layer(x)
     assert y.shape == x.shape
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
 
 
 def test_make_hpx_padding_factory_types():
@@ -951,95 +903,66 @@ def test_smoothed_interpolate_conv_forward(mode):
     assert y.shape[1] == 5
 
 
-def test_dealiased_downsample_config_uses_stride():
-    cfg = DownsamplingBlockConfig(
-        block_type="DealiasedDownsample",
-        in_channels=3,
-        stride=4,
+def test_dealiased_downsample_config_uses_pooling():
+    cfg = DealiasedDownsampleBlockConfig(
+        pooling=4,
         resample_filter=(1.0, 2.0, 1.0),
-        hpx_padding_mode="karlbauer",
     )
     assert cfg.downsample_spatial_factor() == 4
-    module = cfg.build()
+    module = cfg.build(in_channels=3, ctx=_layer_ctx())
     assert isinstance(module, DealiasedDownsample)
 
 
 def test_dealiased_downsample_config_accepts_list_filter():
-    cfg = DownsamplingBlockConfig(
-        block_type="DealiasedDownsample",
-        in_channels=3,
-        stride=2,
+    cfg = DealiasedDownsampleBlockConfig(
+        pooling=2,
         resample_filter=[1.0, 2.0, 1.0],
-        hpx_padding_mode="karlbauer",
     )
-    module = cfg.build()
+    module = cfg.build(in_channels=3, ctx=_layer_ctx())
     assert isinstance(module, DealiasedDownsample)
 
 
 def test_smoothed_interpolate_conv_config_builds():
-    cfg = UpsamplingBlockConfig(
-        block_type="SmoothedInterpolateConv",
-        in_channels=3,
-        out_channels=5,
+    cfg = SmoothedInterpolateConvBlockConfig(
         kernel_size=3,
         stride=2,
         upsample_mode="nearest",
-        hpx_padding_mode="karlbauer",
     )
-    module = cfg.build()
+    module = cfg.build(
+        in_channels=3,
+        out_channels=5,
+        ctx=_layer_ctx(),
+    )
     assert isinstance(module, SmoothedInterpolateConv)
 
 
 def test_healpix_unet_dealias_smoothed():
     img = 16
-    conv = ConvBlockConfig(
-        block_type="ConvNeXtBlock",
-        latent_channels=4,
-        hpx_padding_mode="karlbauer",
-        nside=img,
+    conv = ConvNeXtBlockConfig()
+    down = DealiasedDownsampleBlockConfig(
+        pooling=2,
     )
-    down = DownsamplingBlockConfig(
-        block_type="DealiasedDownsample",
-        stride=2,
-        hpx_padding_mode="karlbauer",
-        nside=img,
-    )
-    levels = _nside_levels(img, 2)
     enc = UNetEncoderConfig(
         conv_block=conv,
         down_sampling_block=down,
-        input_channels=3,
         n_channels=[8, 16],
         n_layers=[1, 1],
-        nside=levels,
-        hpx_padding_mode="karlbauer",
     )
-    up = UpsamplingBlockConfig(
-        block_type="SmoothedInterpolateConv",
+    up = SmoothedInterpolateConvBlockConfig(
         stride=2,
         upsample_mode="nearest",
-        hpx_padding_mode="karlbauer",
-        nside=levels[1],
-        nside_after=levels[0],
     )
     dec = UNetDecoderConfig(
         conv_block=conv,
         up_sampling_block=up,
-        output_layer=ConvBlockConfig(
-            block_type="BasicConvBlock",
+        output_layer=BasicConvBlockConfig(
             n_layers=1,
             kernel_size=1,
-            out_channels=4,
-            hpx_padding_mode="karlbauer",
-            nside=img,
         ),
         n_channels=[16, 8],
         n_layers=[1, 1],
-        output_channels=4,
-        hpx_padding_mode="karlbauer",
-        nside=levels,
     )
-    device = th.device("cuda" if th.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     # Channel count matches prior stacked layout:
     # 2*(3+1) prognostic+decoder + 1 constant
     in_ch = 9
@@ -1052,117 +975,94 @@ def test_healpix_unet_dealias_smoothed():
         nside=_nside_levels(img, len(enc.n_channels)),
     ).to(device)
     b = 2
-    x = th.randn(b, 12, 2 * 3, img, img, device=device)
-    dec_in = th.randn(b, 12, 2, img, img, device=device)
-    const = th.randn(b, 12, 1, img, img, device=device)
-    inp = th.cat([x, dec_in, const], dim=2)
+    x = torch.randn(b, 12, 2 * 3, img, img, device=device)
+    dec_in = torch.randn(b, 12, 2, img, img, device=device)
+    const = torch.randn(b, 12, 1, img, img, device=device)
+    inp = torch.cat([x, dec_in, const], dim=2)
     out = m(inp)
     assert out.shape[0] == b
-    assert th.isfinite(out).all()
+    assert torch.isfinite(out).all()
 
 
 def test_multi_symmetric_convnext_block_forward():
-    cfg = ConvBlockConfig(
-        block_type="Multi_SymmetricConvNeXtBlock",
+    cfg = MultiSymmetricConvNeXtBlockConfig(
+        kernel_size=3,
+        upscale_factor=4,
+        n_layers=2,
+    )
+    layer = cfg.build(
         in_channels=3,
         out_channels=5,
         latent_channels=4,
-        kernel_size=3,
-        dilation=1,
-        upscale_factor=4,
-        n_layers=2,
-        hpx_padding_mode="karlbauer",
-        nside=16,
+        ctx=_layer_ctx(nside=16),
     )
-    layer = cfg.build()
     x = _folded_padding_dealias(channels=3, h=16)
     y = layer(x)
     assert y.shape == (x.shape[0], 5, 16, 16)
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
 
 
 def test_multi_symmetric_isolatitude_forward():
     img = 16
-    conv = ConvBlockConfig(
-        block_type="Multi_SymmetricConvNeXtBlock",
+    conv = MultiSymmetricConvNeXtBlockConfig(
+        n_layers=2,
+        activation=CappedGELUConfig(cap_value=10),
+    ).build(
         in_channels=3,
         out_channels=3,
         latent_channels=4,
-        n_layers=2,
-        hpx_padding_mode="isolatitude",
-        nside=img,
-        activation=CappedGELUConfig(cap_value=10),
-    ).build()
+        ctx=_layer_ctx("isolatitude", nside=img),
+    )
     x = _folded_padding_dealias(channels=3, h=img)
     y = conv(x)
     assert y.shape == x.shape
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
 
 
 def test_smoothed_interpolate_isolatitude_forward():
     img = 16
     x = _folded_padding_dealias(channels=3, h=img)
-    up = UpsamplingBlockConfig(
-        block_type="SmoothedInterpolateConv",
-        in_channels=3,
-        out_channels=3,
+    up = SmoothedInterpolateConvBlockConfig(
         stride=2,
         upsample_mode="nearest",
         activation=CappedGELUConfig(cap_value=10),
-        hpx_padding_mode="isolatitude",
-        nside=img,
-        nside_after=img * 2,
-    ).build()
+    ).build(
+        in_channels=3,
+        out_channels=3,
+        ctx=_layer_ctx("isolatitude", nside=img, nside_after=img * 2),
+    )
     y_up = up(x)
     assert y_up.shape[-2:] == (img * 2, img * 2)
-    assert th.isfinite(y_up).all()
+    assert torch.isfinite(y_up).all()
 
 
 def test_healpix_unet_isolatitude_nside_sequence():
-    conv_cfg = ConvBlockConfig(
-        block_type="ConvNeXtBlock",
-        in_channels=3,
-        out_channels=3,
-        latent_channels=2,
+    conv_cfg = ConvNeXtBlockConfig(
         kernel_size=3,
-        dilation=1,
         activation=CappedGELUConfig(cap_value=10),
     )
     encoder = UNetEncoderConfig(
         conv_block=conv_cfg,
-        down_sampling_block=DownsamplingBlockConfig(block_type="AvgPool", pooling=2),
-        input_channels=5,
+        down_sampling_block=AvgPoolDownsamplingBlockConfig(pooling=2),
         n_channels=[8, 8, 8],
         n_layers=[1, 1, 1],
         dilations=[1, 1, 1],
     )
     decoder = UNetDecoderConfig(
-        conv_block=ConvBlockConfig(
-            block_type="ConvNeXtBlock",
-            in_channels=3,
-            out_channels=3,
-            latent_channels=2,
+        conv_block=ConvNeXtBlockConfig(
             kernel_size=3,
-            dilation=1,
             activation=CappedGELUConfig(cap_value=10),
         ),
-        up_sampling_block=UpsamplingBlockConfig(
-            block_type="TransposedConvUpsample",
-            in_channels=3,
-            out_channels=3,
+        up_sampling_block=TransposedConvUpsampleBlockConfig(
             stride=2,
             activation=CappedGELUConfig(cap_value=10),
         ),
-        output_layer=ConvBlockConfig(
-            block_type="BasicConvBlock",
-            in_channels=3,
-            out_channels=4,
+        output_layer=BasicConvBlockConfig(
             kernel_size=1,
             n_layers=1,
         ),
         n_channels=[8, 8, 8],
         n_layers=[1, 1, 1],
-        output_channels=4,
         dilations=[1, 1, 1],
     )
     model = HEALPixUNet(
@@ -1173,10 +1073,32 @@ def test_healpix_unet_isolatitude_nside_sequence():
         hpx_padding_mode="isolatitude",
         nside=[64, 32, 16],
     )
-    x = th.randn(1, 12, 5, 64, 64)
+    x = torch.randn(1, 12, 5, 64, 64)
     y = model(x)
     assert y.shape == (1, 12, 4, 64, 64)
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
+
+
+def test_healpix_block_configs_resolve_via_dacite():
+    @dataclasses.dataclass
+    class Container:
+        down: DownsamplingBlockConfig
+        up: UpsamplingBlockConfig
+        conv: ConvBlockConfig
+
+    data = {
+        "down": {"block_type": "DealiasedDownsample", "pooling": 2},
+        "up": {
+            "block_type": "SmoothedInterpolateConv",
+            "stride": 2,
+            "kernel_size": 3,
+        },
+        "conv": {"block_type": "ConvNeXtBlock", "upscale_factor": 4},
+    }
+    loaded = dacite.from_dict(Container, data, dacite.Config(strict=True))
+    assert isinstance(loaded.down, DealiasedDownsampleBlockConfig)
+    assert isinstance(loaded.up, SmoothedInterpolateConvBlockConfig)
+    assert isinstance(loaded.conv, ConvNeXtBlockConfig)
 
 
 # pragma mark - HEALPixUNet
@@ -1219,10 +1141,10 @@ def test_HEALPixUNet_forward_shape():
         nside=_nside_levels(img, len(enc.n_channels)),
     ).to(device)
 
-    x = th.randn(batch, 12, in_channels, img, img, device=device)
+    x = torch.randn(batch, 12, in_channels, img, img, device=device)
     y = model(x)
     assert y.shape == (batch, 12, out_channels, img, img)
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
 
 
 def test_HEALPixUNet_input_channel_validation():
@@ -1241,13 +1163,13 @@ def test_HEALPixUNet_input_channel_validation():
         nside=_nside_levels(img, len(enc.n_channels)),
     ).to(device)
 
-    bad_input = th.randn(1, 12, in_channels + 1, img, img, device=device)
+    bad_input = torch.randn(1, 12, in_channels + 1, img, img, device=device)
     with pytest.raises(
         ValueError, match=f"Expected input to have {in_channels} channels"
     ):
         model(bad_input)
 
-    bad_ndim = th.randn(1, 12, in_channels, img, img, img, device=device)
+    bad_ndim = torch.randn(1, 12, in_channels, img, img, img, device=device)
     with pytest.raises(ValueError, match="5D input"):
         model(bad_ndim)
 
@@ -1262,7 +1184,7 @@ def test_HEALPixUNet_forward_padding_mode(mode):
         img=img, output_channels=out_channels, padding_mode=mode
     )
 
-    device = th.device("cuda" if th.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = HEALPixUNet(
         encoder=enc,
         decoder=dec,
@@ -1272,10 +1194,10 @@ def test_HEALPixUNet_forward_padding_mode(mode):
         nside=_nside_levels(img, len(enc.n_channels)),
     ).to(device)
 
-    x = th.randn(batch, 12, in_channels, img, img, device=device)
+    x = torch.randn(batch, 12, in_channels, img, img, device=device)
     y = model(x)
     assert y.shape == (batch, 12, out_channels, img, img)
-    assert th.isfinite(y).all()
+    assert torch.isfinite(y).all()
 
 
 @pytest.mark.skipif(not have_earth2grid, reason="earth2grid not installed")
@@ -1303,11 +1225,11 @@ def test_HEALPixUNet_in_stepper():
     }
 
     horizontal_coordinates = HEALPixCoordinates(
-        th.arange(12), th.arange(img), th.arange(img)
+        torch.arange(12), torch.arange(img), torch.arange(img)
     )
     device = get_device()
     vertical_coordinate = HybridSigmaPressureCoordinate(
-        ak=th.arange(in_channels), bk=th.arange(in_channels)
+        ak=torch.arange(in_channels), bk=torch.arange(in_channels)
     ).to(device)
     stepper_config = StepperConfig(
         step=StepSelector(

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -172,8 +172,7 @@ def _get_test_yaml_files(
     if derived_forcings is None:
         derived_forcings = DerivedForcingsConfig()
     if nettype == "HEALPixUNet":
-        in_channels = len(in_variable_names)
-        conv_next_block = conv_next_block_config(in_channels=in_channels)
+        conv_next_block = conv_next_block_config()
         down_sampling_block = down_sampling_block_config()
         encoder = encoder_config(
             conv_next_block, down_sampling_block, n_channels=[16, 8, 4]

--- a/fme/core/test_coordinates.py
+++ b/fme/core/test_coordinates.py
@@ -395,7 +395,7 @@ def test_healpix_coordinates_xyz(pad: bool):
     # Apply HEALPix padding
     if pad:
         padding = 2
-        healpix_padding = HEALPixPadding(padding=padding, enable_nhwc=False)
+        healpix_padding = HEALPixPadding(padding=padding)
         padded_x = healpix_padding(torch.Tensor(x).unsqueeze(1)).squeeze(1)
         padded_y = healpix_padding(torch.Tensor(y).unsqueeze(1)).squeeze(1)
         padded_z = healpix_padding(torch.Tensor(z).unsqueeze(1)).squeeze(1)


### PR DESCRIPTION
Several HEALPix settings were duplicated across YAML configs, mutated at build time, or lived on monolithic dataclasses where variant-specific fields were silently ignored. This PR makes configs easier to load from YAML, reason about, and extend. It refactors HEALPix UNet configuration and build path to address feedback from [a previous HEALPix PR](https://github.com/ai2cm/ace/pull/1156), namely

> ...generally speaking it would be nice to move "build" type arguments out of the dataclass, and instead as arguments to `.build`. Specifically, the number of input and output channels comes to mind. Anything that you wouldn't want the user to configure in a yaml file, but should instead be determined at build time from other variables in the runtime.
> 
> The fact that you have to `.replace` attributes of something we've specified in a yaml is a bit scary in this respect, those things should probably not be configurable rather than being silently ignored.

Additionally, block configs are split into dacite discriminated unions and runtime/build-time concerns are separated.

Changes:
Build-time vs config-time separation
- Channel counts (`input_channels` / `output_channels`) have been removed from `UNetEncoderConfig`, `UNetDecoderConfig`, and conv/downsample/upsample block configs. Insteady, they are now passed explicitly to `.build()` from `HEALPixUNet` / `HEALPixUNetBuilder`.
- Config objects are no longer mutated (e.g. via `.replace`) when constructing the model.

Shared build context
- Added `HEALPixBuildContext` and `HEALPixLayerBuildContext` for model-level settings (`hpx_padding_mode`, `nside` per level). They are configured once on `HEALPixUNet` / `HEALPixUNetBuilder`, then the encoder, decoder, and blocks receive per-level views via `ctx.layer(level)`.

Discriminated union block configs
- Monolithic block configs have been split into one dataclass per `block_type`, each with a `Literal[...]` discriminator for dacite union resolution. For example, the union alias `DownSamplingBlockConfig` has variants `MaxPoolDownsamplingBlockConfig`, `AvgPoolDownsamplingBlockConfig`, and `DealiasedDownsampleBlockConfig`. Each variant exposes only fields relevant to that block type.

Other
- `enable_nhwc` option removed. Memory format of inputs is already hard coded.
- Replace `th` calls with `torch` for clarity.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated