### PR TITLE
Seedable random state threaded through StepperState for reproducible stochastic inference

### DIFF
--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -14,6 +14,7 @@ from fme.core.dataset.dataset import DatasetItem
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.labels import BatchLabels, LabelEncoding
+from fme.core.random_state import RandomState
 from fme.core.stepper_state import StepperState
 from fme.core.tensors import repeat_interleave_batch_dim, unfold_ensemble_dim
 from fme.core.typing_ import EnsembleTensorDict, TensorDict, TensorMapping
@@ -88,6 +89,22 @@ class PrognosticState:
 
     def to_device(self) -> "PrognosticState":
         return PrognosticState(self._data.to_device())
+
+    def with_random_state(self, random_state: RandomState) -> "PrognosticState":
+        """Return a copy with a seeded RandomState attached to its stepper_state.
+
+        Used to seed stochastic inference: the random_state threads through the
+        rollout via the stepper_state so the noise sequence is reproducible.
+        """
+        stepper_state = self._data.stepper_state or StepperState()
+        return PrognosticState(
+            dataclasses.replace(
+                self._data,
+                stepper_state=dataclasses.replace(
+                    stepper_state, random_state=random_state
+                ),
+            )
+        )
 
     def as_batch_data(self) -> "BatchData":
         return self._data

--- a/fme/ace/data_loading/test_batch_data.py
+++ b/fme/ace/data_loading/test_batch_data.py
@@ -10,6 +10,7 @@ from fme.core.corrector.state import CorrectorState
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.labels import BatchLabels
+from fme.core.random_state import RandomState
 from fme.core.stepper_state import StepperState
 from fme.core.typing_ import TensorDict
 
@@ -324,6 +325,20 @@ def test_get_start(names: list[str], prognostic_names: list[str], n_ic_timesteps
             start.data[name].cpu().numpy(),
             batch_data.data[name][:, :n_ic_timesteps, ...].cpu().numpy(),
         )
+
+
+def test_with_random_state_attaches_to_stepper_state():
+    batch_data = get_batch_data(
+        names=["foo"], n_samples=2, n_times=3, horizontal_dims=["lat", "lon"]
+    )
+    ic = batch_data.get_start(["foo"], n_ic_timesteps=1)
+    assert ic.as_batch_data().stepper_state is None
+    random_state = RandomState.from_seed(0)
+    seeded = ic.with_random_state(random_state)
+    # The original is unchanged; the copy carries the random_state.
+    assert ic.as_batch_data().stepper_state is None
+    assert seeded.as_batch_data().stepper_state is not None
+    assert seeded.as_batch_data().stepper_state.random_state is random_state
 
 
 @pytest.mark.parametrize("n_ic_timesteps", [1, 2])

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -50,6 +50,7 @@ from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.generics.inference import get_record_to_wandb, run_inference
 from fme.core.generics.validation import run_validation
 from fme.core.logging_utils import LoggingConfig
+from fme.core.random_state import RandomState
 from fme.core.timing import GlobalTimer
 from fme.core.typing_ import TensorDict, TensorMapping
 
@@ -219,6 +220,11 @@ class InferenceEvaluatorConfig:
         n_ensemble_per_ic: Number of ensemble members per initial condition. Useful for
             stochastic model weather inference. n_ensemble_per_ic = 1 is default
             inference behavior.
+        seed: If set, seeds the random state threaded through the rollout so that
+            stochastic modules (e.g. NoiseConditionedSFNO) produce a reproducible
+            noise sequence, independent of forward_steps_in_memory. Leave unset
+            (None) for the default non-reproducible behavior. Only affects the
+            stepper rollout (not the prediction_loader comparison path).
     """
 
     experiment_dir: str
@@ -239,6 +245,7 @@ class InferenceEvaluatorConfig:
     allow_incompatible_dataset: bool = False
     validation: ValidationConfig | None = None
     n_ensemble_per_ic: int = 1
+    seed: int | None = None
 
     def __post_init__(self):
         if self.data_writer.time_coarsen is not None:
@@ -361,6 +368,10 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
             ic = data.initial_condition.as_batch_data()
             data._initial_condition = PrognosticState(
                 ic.broadcast_ensemble(config.n_ensemble_per_ic)
+            )
+        if config.seed is not None:
+            data._initial_condition = data.initial_condition.with_random_state(
+                RandomState.from_seed(config.seed)
             )
         stepper = config.load_stepper()
         stepper.set_eval()

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -40,6 +40,7 @@ from fme.core.dataset_info import IncompatibleDatasetInfo
 from fme.core.generics.inference import get_record_to_wandb, run_inference
 from fme.core.labels import BatchLabels
 from fme.core.logging_utils import LoggingConfig
+from fme.core.random_state import RandomState
 from fme.core.timing import GlobalTimer
 
 from .evaluator import resolve_variable_metadata
@@ -200,6 +201,10 @@ class InferenceConfig:
         n_ensemble_per_ic: Number of ensemble members per initial condition. Useful for
             stochastic model weather inference. n_ensemble_per_ic = 1 is default
             inference behavior.
+        seed: If set, seeds the random state threaded through the rollout so that
+            stochastic modules (e.g. NoiseConditionedSFNO) produce a reproducible
+            noise sequence, independent of forward_steps_in_memory. Leave unset
+            (None) for the default non-reproducible behavior.
     """
 
     experiment_dir: str
@@ -219,6 +224,7 @@ class InferenceConfig:
     allow_incompatible_dataset: bool = False
     labels: list[str] | None = None
     n_ensemble_per_ic: int = 1
+    seed: int | None = None
 
     def __post_init__(self):
         if self.data_writer.time_coarsen is not None:
@@ -333,6 +339,10 @@ def run_inference_from_config(config: InferenceConfig):
             ic = data.initial_condition.as_batch_data()
             data._initial_condition = PrognosticState(
                 ic.broadcast_ensemble(config.n_ensemble_per_ic)
+            )
+        if config.seed is not None:
+            data._initial_condition = data.initial_condition.with_random_state(
+                RandomState.from_seed(config.seed)
             )
 
         if not config.allow_incompatible_dataset:

--- a/fme/ace/inference/test_inference.py
+++ b/fme/ace/inference/test_inference.py
@@ -11,6 +11,7 @@ import torch
 import xarray as xr
 import yaml
 
+from fme.ace.aggregator.inference import InferenceAggregatorConfig
 from fme.ace.data_loading.batch_data import PrognosticState
 from fme.ace.data_loading.inference import (
     ExplicitIndices,
@@ -27,6 +28,7 @@ from fme.ace.inference.inference import (
     main,
 )
 from fme.ace.registry import ModuleSelector
+from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNOBuilder
 from fme.ace.stepper import StepperConfig
 from fme.ace.testing import DimSizes, FV3GFSData
 from fme.core.coordinates import (
@@ -108,6 +110,178 @@ def save_stepper(
         dataset_info=dataset_info,
     )
     torch.save({"stepper": stepper.get_state()}, path)
+
+
+def save_noise_conditioned_stepper(
+    path: pathlib.Path,
+    in_names: list[str],
+    out_names: list[str],
+    horizontal_coords: dict[str, xr.DataArray],
+    nz_interface: int,
+    timestep: datetime.timedelta = TIMESTEP,
+):
+    """Save a minimal NoiseConditionedSFNO stepper whose noise actually affects
+    the output, for testing reproducible stochastic inference.
+
+    ConditionalLayerNorm zero-initializes its noise-conditioning weights, so an
+    untrained model would ignore the noise; we fill them with a fixed non-zero
+    value (mimicking a trained model) before saving the checkpoint.
+    """
+    all_names = list(set(in_names).union(out_names))
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="NoiseConditionedSFNO",
+                        config=dataclasses.asdict(
+                            NoiseConditionedSFNOBuilder(
+                                embed_dim=4,
+                                noise_embed_dim=4,
+                                noise_type="gaussian",
+                                num_layers=2,
+                                pos_embed=False,
+                                filter_type="linear",
+                                filter_num_groups=1,
+                            )
+                        ),
+                    ),
+                    in_names=in_names,
+                    out_names=out_names,
+                    normalization=NetworkAndLossNormalizationConfig(
+                        network=NormalizationConfig(
+                            means={name: 0.0 for name in all_names},
+                            stds={name: 1.0 for name in all_names},
+                        ),
+                    ),
+                    ocean=OceanConfig(
+                        surface_temperature_name="sst",
+                        ocean_fraction_name="ocean_fraction",
+                    ),
+                ),
+            ),
+        ),
+    )
+    dataset_info = DatasetInfo(
+        horizontal_coordinates=LatLonCoordinates(
+            lat=torch.tensor(horizontal_coords["lat"].values, dtype=torch.float32),
+            lon=torch.tensor(horizontal_coords["lon"].values, dtype=torch.float32),
+        ),
+        vertical_coordinate=HybridSigmaPressureCoordinate(
+            ak=torch.arange(nz_interface), bk=torch.arange(nz_interface)
+        ),
+        timestep=timestep,
+    )
+    stepper = config.get_stepper(dataset_info=dataset_info)
+    with torch.no_grad():
+        for name, param in stepper._step_obj.modules.named_parameters():
+            if "W_scale_2d" in name or "W_bias_2d" in name:
+                param.fill_(0.1)
+    torch.save({"stepper": stepper.get_state()}, path)
+
+
+def _write_inference_inputs(
+    tmp_path: pathlib.Path,
+) -> tuple[pathlib.Path, FV3GFSData, pathlib.Path]:
+    """Shared data, checkpoint, and initial condition for the seed tests."""
+    in_names = ["prog", "sst", "forcing_var", "DSWRFtoa"]
+    out_names = ["prog", "sst", "ULWRFtoa", "USWRFtoa"]
+    stepper_path = tmp_path / "stepper"
+    nz_interface = 4
+    data = FV3GFSData(
+        path=tmp_path,
+        names=["forcing_var", "DSWRFtoa", "sst", "ocean_fraction"],
+        dim_sizes=DimSizes(
+            n_time=5,
+            horizontal=[DimSize("lat", 8), DimSize("lon", 16)],
+            nz_interface=4,
+        ),
+        timestep_days=0.25,
+        save_vertical_coordinate=False,
+    )
+    save_noise_conditioned_stepper(
+        stepper_path,
+        in_names=in_names,
+        out_names=out_names,
+        horizontal_coords=data.horizontal_coords,
+        nz_interface=nz_interface,
+    )
+    dims = ["sample", "lat", "lon"]
+    initial_condition = xr.Dataset(
+        {
+            name: xr.DataArray(np.random.rand(1, 8, 16).astype(np.float32), dims=dims)
+            for name in ["prog", "sst", "DSWRFtoa"]
+        }
+    )
+    ic_path = tmp_path / "init_data" / "ic.nc"
+    ic_path.parent.mkdir()
+    initial_condition["time"] = xr.DataArray(
+        [cftime.DatetimeProlepticGregorian(2000, 1, 1, 6)],
+        dims=["time"],
+    )
+    initial_condition.to_netcdf(ic_path, mode="w")
+    return stepper_path, data, ic_path
+
+
+def _run_seeded_inference(
+    run_dir: pathlib.Path,
+    stepper_path: pathlib.Path,
+    data: FV3GFSData,
+    ic_path: pathlib.Path,
+    seed: int | None,
+) -> np.ndarray:
+    run_dir.mkdir()
+    config = InferenceConfig(
+        experiment_dir=str(run_dir),
+        n_forward_steps=2,
+        forward_steps_in_memory=1,
+        checkpoint_path=str(stepper_path),
+        logging=LoggingConfig(
+            log_to_screen=False, log_to_file=False, log_to_wandb=True
+        ),
+        initial_condition=InitialConditionConfig(path=str(ic_path)),
+        forcing_loader=ForcingDataLoaderConfig(
+            dataset=data.inference_data_loader_config.dataset,
+            num_data_workers=data.inference_data_loader_config.num_data_workers,
+        ),
+        data_writer=DataWriterConfig(
+            save_monthly_files=False,
+            save_prediction_files=False,
+            files=[FileWriterConfig("autoregressive")],
+        ),
+        # Drop the global-mean time-series aggregator (pure overhead here); the
+        # time_mean/annual/power_spectrum aggregators are always built and cannot
+        # be disabled via config.
+        aggregator=InferenceAggregatorConfig(log_global_mean_time_series=False),
+        seed=seed,
+    )
+    config_filename = run_dir / "config.yaml"
+    with open(config_filename, "w") as f:
+        yaml.dump(dataclasses.asdict(config), f)
+    with mock_wandb() as wandb:
+        wandb.configure(log_to_wandb=True)
+        main(yaml_config=str(config_filename))
+    ds = xr.open_dataset(
+        run_dir / "autoregressive_predictions.nc", decode_timedelta=False
+    )
+    return ds["prog"].values
+
+
+@pytest.mark.slow
+def test_inference_entrypoint_seed_reproducible(tmp_path: pathlib.Path):
+    """A seeded NoiseConditionedSFNO inference run is reproducible end-to-end,
+    and a different seed gives a different result (confirming the noise is
+    active, so the reproducibility above is not vacuous). The unseeded default's
+    non-reproducibility is covered at the stepper level by
+    test_random_state.test_two_seeded_rollouts_match_and_differ_by_seed."""
+    stepper_path, data, ic_path = _write_inference_inputs(tmp_path)
+    seed0_a = _run_seeded_inference(tmp_path / "s0a", stepper_path, data, ic_path, 0)
+    seed0_b = _run_seeded_inference(tmp_path / "s0b", stepper_path, data, ic_path, 0)
+    seed1 = _run_seeded_inference(tmp_path / "s1", stepper_path, data, ic_path, 1)
+
+    np.testing.assert_array_equal(seed0_a, seed0_b)
+    assert not np.allclose(seed0_a, seed1)
 
 
 @pytest.mark.parametrize("n_ensemble_per_ic", [1, 2])

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1058,9 +1058,6 @@ class Stepper:
         random_state = (
             args.stepper_state.random_state if args.stepper_state is not None else None
         )
-        # The inner step preserves random_state on the StepperState it returns
-        # (advancing the generator in place as it consumes it), so it threads
-        # unchanged into the next step and predict call.
         with use_generator(None if random_state is None else random_state.generator):
             output, stepper_state = self._step_obj.step(args=args, wrapper=wrapper)
         return self._output_process_func(output), stepper_state

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -47,6 +47,7 @@ from fme.core.normalizer import (
 )
 from fme.core.ocean import OceanConfig
 from fme.core.optimization import NullOptimization
+from fme.core.rand import use_generator
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.spatial_masking import NullSpatialMasking, StaticSpatialMaskingConfig
 from fme.core.step.args import StepArgs
@@ -1054,7 +1055,20 @@ class Stepper:
             the per-sample state to thread into the next call (or ``None``).
         """
         args = args.apply_input_process_func(self._input_process_func)
-        output, stepper_state = self._step_obj.step(args=args, wrapper=wrapper)
+        random_state = (
+            args.stepper_state.random_state if args.stepper_state is not None else None
+        )
+        with use_generator(None if random_state is None else random_state.generator):
+            output, stepper_state = self._step_obj.step(args=args, wrapper=wrapper)
+        if random_state is not None:
+            # The step may rebuild StepperState (e.g. when the corrector seeds
+            # its own state), dropping the random_state. Re-attach the same
+            # generator - which advanced in place as the step consumed it - so
+            # it threads unchanged into the next step and predict call.
+            stepper_state = dataclasses.replace(
+                stepper_state if stepper_state is not None else StepperState(),
+                random_state=random_state,
+            )
         return self._output_process_func(output), stepper_state
 
     def get_prediction_generator(

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1058,17 +1058,11 @@ class Stepper:
         random_state = (
             args.stepper_state.random_state if args.stepper_state is not None else None
         )
+        # The inner step preserves random_state on the StepperState it returns
+        # (advancing the generator in place as it consumes it), so it threads
+        # unchanged into the next step and predict call.
         with use_generator(None if random_state is None else random_state.generator):
             output, stepper_state = self._step_obj.step(args=args, wrapper=wrapper)
-        if random_state is not None:
-            # The step may rebuild StepperState (e.g. when the corrector seeds
-            # its own state), dropping the random_state. Re-attach the same
-            # generator - which advanced in place as the step consumed it - so
-            # it threads unchanged into the next step and predict call.
-            stepper_state = dataclasses.replace(
-                stepper_state if stepper_state is not None else StepperState(),
-                random_state=random_state,
-            )
         return self._output_process_func(output), stepper_state
 
     def get_prediction_generator(

--- a/fme/ace/stepper/test_random_state.py
+++ b/fme/ace/stepper/test_random_state.py
@@ -1,0 +1,207 @@
+"""Integration tests for seedable random-state propagation through the Stepper.
+
+These exercise the full ``Stepper.predict`` path with a minimal
+``NoiseConditionedSFNO`` (non-zero noise dimension), verifying that:
+
+* a seeded rollout is independent of how it is chunked into
+  ``forward_steps_in_memory`` windows (i.e. one ``predict`` of N steps equals N
+  threaded ``predict`` calls), and
+* two rollouts seeded identically give the same answer, while different seeds
+  (and the unseeded default) do not.
+
+These use a corrector that does not seed state, so they do not exercise the
+``StepperState`` rebuild that ``Stepper.step`` must survive to keep propagating
+the random_state; that path is covered by
+``test_predict_threads_random_state_alongside_corrector_state`` in
+``test_single_module.py``.
+"""
+
+import dataclasses
+
+import numpy as np
+import torch
+import xarray as xr
+
+import fme
+from fme.ace.data_loading.batch_data import BatchData, PrognosticState
+from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNOBuilder
+from fme.ace.stepper.derived_forcings import DerivedForcingsConfig
+from fme.ace.stepper.single_module import Stepper, StepperConfig
+from fme.core.random_state import RandomState
+from fme.core.registry.module import ModuleSelector
+from fme.core.step import SingleModuleStepConfig, StepSelector
+from fme.core.testing import get_dataset_info, trivial_network_and_loss_normalization
+
+DEVICE = fme.get_device()
+
+
+def _get_noise_conditioned_stepper(
+    noise_embed_dim: int = 4,
+    img_shape: tuple[int, int] = (8, 16),
+) -> Stepper:
+    """Build a minimal prognostic ``NoiseConditionedSFNO`` stepper on var "a"."""
+    in_names = ["a"]
+    out_names = ["a"]
+    builder = ModuleSelector(
+        type="NoiseConditionedSFNO",
+        config=dataclasses.asdict(
+            NoiseConditionedSFNOBuilder(
+                embed_dim=4,
+                noise_embed_dim=noise_embed_dim,
+                noise_type="gaussian",
+                num_layers=2,
+                pos_embed=False,
+                filter_type="linear",
+                filter_num_groups=1,
+            )
+        ),
+    )
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=builder,
+                    in_names=in_names,
+                    out_names=out_names,
+                    normalization=trivial_network_and_loss_normalization(
+                        set(in_names + out_names)
+                    ),
+                )
+            ),
+        ),
+        derived_forcings=DerivedForcingsConfig(),
+    )
+    stepper = config.get_stepper(get_dataset_info(img_shape=img_shape))
+    _activate_noise_conditioning(stepper)
+    stepper.set_eval()
+    return stepper
+
+
+def _activate_noise_conditioning(stepper: Stepper) -> None:
+    """Make the noise actually affect the output.
+
+    ``ConditionalLayerNorm`` zero-initializes its noise-conditioning weights
+    (``W_scale_2d``/``W_bias_2d``), so an untrained model ignores the noise
+    entirely. Filling those weights with a fixed non-zero value mimics a trained
+    model in which the noise modulates the output, so that seeding the noise has
+    an observable effect.
+    """
+    with torch.no_grad():
+        for name, param in stepper._step_obj.modules.named_parameters():
+            if "W_scale_2d" in name or "W_bias_2d" in name:
+                param.fill_(0.1)
+
+
+def _get_ic_and_forcing(
+    n_steps: int, img_shape: tuple[int, int], n_samples: int = 2
+) -> tuple[PrognosticState, BatchData]:
+    """Initial condition (var "a") and empty (time-only) forcing for n_steps."""
+    index = xr.date_range("2000", freq="6h", periods=n_steps + 1, use_cftime=True)
+    forcing_time = xr.DataArray(np.stack(n_samples * [index]), dims=["sample", "time"])
+    input_time = forcing_time.isel(time=[0])
+    ic = BatchData.new_on_device(
+        data={"a": torch.rand(n_samples, 1, *img_shape).to(DEVICE)},
+        time=input_time,
+        labels=None,
+    ).get_start(prognostic_names=["a"], n_ic_timesteps=1)
+    forcing = BatchData.new_on_device(data={}, time=forcing_time, labels=None)
+    return ic, forcing
+
+
+def _seed_initial_condition(
+    ic: PrognosticState, random_state: RandomState | None
+) -> PrognosticState:
+    """Attach a RandomState to the initial condition's stepper_state (or leave it
+    unseeded when None, falling back to the global RNG)."""
+    if random_state is None:
+        return ic
+    return ic.with_random_state(random_state)
+
+
+def _forcing_window(forcing: BatchData, start: int, length: int) -> BatchData:
+    """Slice a contiguous forcing window of ``length`` forward steps (length + 1
+    timestamps), sharing the boundary timestamp with the neighbouring windows."""
+    time = forcing.time.isel(time=slice(start, start + length + 1))
+    return BatchData.new_on_device(data={}, time=time, labels=None)
+
+
+def _rollout(
+    stepper: Stepper,
+    ic: PrognosticState,
+    forcing: BatchData,
+    window_sizes: list[int],
+) -> torch.Tensor:
+    """Run a rollout split into windows of the given sizes, threading the
+    prognostic state (and its stepper_state) between ``predict`` calls. Returns
+    the concatenated prediction for var "a" with shape [sample, time, lat, lon].
+    """
+    outputs: list[torch.Tensor] = []
+    state = ic
+    start = 0
+    for length in window_sizes:
+        window = _forcing_window(forcing, start, length)
+        output, state = stepper.predict(state, window)
+        outputs.append(output.data["a"])
+        start += length
+    return torch.cat(outputs, dim=1)
+
+
+def test_seeded_rollout_independent_of_forward_steps_in_memory():
+    """A seeded rollout gives identical results whether run in one window or
+    split into smaller windows (the forward_steps_in_memory invariant)."""
+    img_shape = (8, 16)
+    n_steps = 6
+    stepper = _get_noise_conditioned_stepper(img_shape=img_shape)
+    ic, forcing = _get_ic_and_forcing(n_steps, img_shape)
+
+    single = _rollout(
+        stepper, _seed_initial_condition(ic, RandomState.from_seed(0)), forcing, [6]
+    )
+    chunked = _rollout(
+        stepper,
+        _seed_initial_condition(ic, RandomState.from_seed(0)),
+        forcing,
+        [1, 2, 3],
+    )
+    assert single.shape[1] == n_steps
+    torch.testing.assert_close(single, chunked, rtol=0, atol=0)
+
+
+def test_two_seeded_rollouts_match_and_differ_by_seed():
+    """Same seed -> identical rollout; different seed -> different; and the
+    unseeded default is not reproducible across runs."""
+    img_shape = (8, 16)
+    n_steps = 4
+    stepper = _get_noise_conditioned_stepper(img_shape=img_shape)
+    ic, forcing = _get_ic_and_forcing(n_steps, img_shape)
+
+    run_a = _rollout(
+        stepper, _seed_initial_condition(ic, RandomState.from_seed(42)), forcing, [4]
+    )
+    run_b = _rollout(
+        stepper, _seed_initial_condition(ic, RandomState.from_seed(42)), forcing, [4]
+    )
+    run_c = _rollout(
+        stepper, _seed_initial_condition(ic, RandomState.from_seed(123)), forcing, [4]
+    )
+    torch.testing.assert_close(run_a, run_b, rtol=0, atol=0)
+    assert not torch.allclose(run_a, run_c)
+
+    # Without a random_state the rollout draws from the global RNG and is not
+    # reproducible run-to-run, confirming the noise is genuinely active.
+    run_unseeded_1 = _rollout(stepper, _seed_initial_condition(ic, None), forcing, [4])
+    run_unseeded_2 = _rollout(stepper, _seed_initial_condition(ic, None), forcing, [4])
+    assert not torch.allclose(run_unseeded_1, run_unseeded_2)
+
+
+def test_zero_noise_dimension_is_deterministic_without_seed():
+    """With no noise channels the model is deterministic, so the noise (not some
+    other source) is what the seed is controlling above."""
+    img_shape = (8, 16)
+    n_steps = 3
+    stepper = _get_noise_conditioned_stepper(noise_embed_dim=0, img_shape=img_shape)
+    ic, forcing = _get_ic_and_forcing(n_steps, img_shape)
+    run_1 = _rollout(stepper, _seed_initial_condition(ic, None), forcing, [3])
+    run_2 = _rollout(stepper, _seed_initial_condition(ic, None), forcing, [3])
+    torch.testing.assert_close(run_1, run_2, rtol=0, atol=0)

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -76,6 +76,7 @@ from fme.core.optimization import (
     Optimization,
     OptimizationConfig,
 )
+from fme.core.random_state import RandomState
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
 from fme.core.spatial_mask_provider import SpatialMaskProvider
@@ -84,6 +85,7 @@ from fme.core.step import SingleModuleStepConfig, StepSelector
 from fme.core.step.args import StepArgs
 from fme.core.step.multi_call import MultiCallConfig
 from fme.core.step.single_module import SingleModuleStep
+from fme.core.stepper_state import StepperState
 from fme.core.testing import (
     get_dataset_info,
     trivial_network_and_loss_normalization,
@@ -1296,6 +1298,30 @@ def test_predict_threads_stepper_state_across_calls():
     pres_after_2 = ic_after_2.stepper_state.corrector_state.global_dry_air_mass
     assert pres_after_2 is not None
     torch.testing.assert_close(pres_after_2, pres_after_1 + float(n_steps))
+
+
+def test_predict_threads_random_state_alongside_corrector_state():
+    """The random_state must survive a step that rebuilds StepperState to seed
+    corrector state (otherwise propagation would silently break)."""
+    stepper = _get_stepper(["a"], ["a"])
+    stepper._step_obj._corrector = _RecordingCorrector()  # type: ignore[attr-defined]
+
+    n_steps = 2
+    input_data, forcing_data = get_data_for_predict(n_steps, forcing_names=[])
+    forcing_data.data = {}
+    ic = PrognosticState(
+        dataclasses.replace(
+            input_data.as_batch_data(),
+            stepper_state=StepperState(random_state=RandomState.from_seed(0)),
+        )
+    )
+
+    _, new_state = stepper.predict(ic, forcing_data)
+    terminal = new_state.as_batch_data().stepper_state
+    assert terminal is not None
+    # Both sub-states are present on the returned state.
+    assert terminal.corrector_state is not None
+    assert terminal.random_state is not None
 
 
 @pytest.mark.parametrize("n_ensemble", [1, 3])

--- a/fme/core/rand.py
+++ b/fme/core/rand.py
@@ -9,6 +9,13 @@ from fme.core.distributed import Distributed
 
 USE_CPU_RANDN = False
 
+# When set (via ``use_generator``), randn/randn_like draw from this generator
+# instead of the global torch RNG. The generator lives on the CPU; draws are
+# generated on the CPU and then moved to the requested device. This makes
+# stochastic draws reproducible and independent both of the compute device and
+# of unrelated global-RNG consumption elsewhere in the process.
+_ACTIVE_GENERATOR: torch.Generator | None = None
+
 
 def set_seed(seed: int):
     """
@@ -30,6 +37,14 @@ def set_seed(seed: int):
 
 
 def randn_like(x: torch.Tensor, **kwargs):
+    if _ACTIVE_GENERATOR is not None:
+        device = kwargs.pop("device", x.device)
+        dtype = kwargs.pop("dtype", x.dtype)
+        # torch.randn_like does not accept a generator, so draw with torch.randn
+        # using the tensor's shape on the (CPU) generator, then move to device.
+        return torch.randn(
+            x.shape, generator=_ACTIVE_GENERATOR, dtype=dtype, **kwargs
+        ).to(device)
     if USE_CPU_RANDN:
         device = kwargs.pop("device", x.device)
         return torch.randn_like(x, device="cpu", **kwargs).to(device)
@@ -38,6 +53,10 @@ def randn_like(x: torch.Tensor, **kwargs):
 
 
 def randn(shape: torch.Size, **kwargs) -> torch.Tensor:
+    if _ACTIVE_GENERATOR is not None:
+        device = kwargs.pop("device", None)
+        result = torch.randn(shape, generator=_ACTIVE_GENERATOR, **kwargs)
+        return result if device is None else result.to(device)
     if USE_CPU_RANDN:
         device = kwargs.pop("device", None)
         return torch.randn(shape, device="cpu", **kwargs).to(device)
@@ -58,6 +77,31 @@ def log_uniform_sample(
     return torch.exp(
         torch.empty(shape, dtype=dtype).uniform_(np.log(p_min), np.log(p_max))
     )
+
+
+@contextlib.contextmanager
+def use_generator(generator: torch.Generator | None):
+    """Route ``randn``/``randn_like`` draws through a specific CPU generator.
+
+    While active, random numbers are drawn on the CPU using ``generator`` and
+    then moved to the requested device, so draws are reproducible given the
+    generator's seed and independent of the device and of unrelated global-RNG
+    consumption. Nested use restores the previous generator on exit. A ``None``
+    generator is a no-op, preserving the default global-RNG behavior.
+
+    Args:
+        generator: The CPU generator to draw from, or None for a no-op.
+    """
+    global _ACTIVE_GENERATOR
+    if generator is None:
+        yield
+        return
+    old_generator = _ACTIVE_GENERATOR
+    _ACTIVE_GENERATOR = generator
+    try:
+        yield
+    finally:
+        _ACTIVE_GENERATOR = old_generator
 
 
 @contextlib.contextmanager

--- a/fme/core/random_state.py
+++ b/fme/core/random_state.py
@@ -1,0 +1,66 @@
+"""Seedable random state carried by the Stepper across predict calls.
+
+A ``RandomState`` wraps a single CPU ``torch.Generator``. The stepper threads
+it through ``StepperState`` (alongside the corrector state) and activates it
+around each network call via ``fme.core.rand.use_generator`` so that stochastic
+modules (e.g. ``NoiseConditionedSFNO``) draw their noise from it. The generator
+advances in place as it is consumed, so threading the same object from one step
+to the next - and from one ``predict`` call to the next via the returned
+``PrognosticState`` - yields a deterministic noise sequence that does not depend
+on how the rollout is chunked into ``forward_steps_in_memory`` windows.
+
+Unlike the corrector state, the generator is not per-sample: a single generator
+drives the noise for the whole batch (each sample/ensemble member receives a
+distinct slice of the draw). The device/ensemble helpers are therefore no-ops
+that preserve the same advancing generator.
+"""
+
+import dataclasses
+
+import torch
+
+
+@dataclasses.dataclass
+class RandomState:
+    """A seedable random source threaded through the Stepper.
+
+    Parameters:
+        generator: A CPU ``torch.Generator``. Draws are made on the CPU and
+            moved to the compute device by ``fme.core.rand``, so the same seed
+            reproduces results across devices.
+    """
+
+    generator: torch.Generator
+
+    def __post_init__(self):
+        if self.generator.device.type != "cpu":
+            raise ValueError(
+                "RandomState requires a CPU torch.Generator, got device "
+                f"{self.generator.device}."
+            )
+
+    @classmethod
+    def from_seed(cls, seed: int) -> "RandomState":
+        """Create a ``RandomState`` from an integer seed."""
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return cls(generator=generator)
+
+    # The generator lives on the CPU and is consumed in place; device and
+    # ensemble transforms must preserve the same advancing object rather than
+    # reset or copy it, so they return self unchanged.
+    def to_device(self) -> "RandomState":
+        return self
+
+    def to_cpu(self) -> "RandomState":
+        return self
+
+    def pin_memory(self) -> "RandomState":
+        return self
+
+    def broadcast_ensemble(self, n_ensemble: int) -> "RandomState":
+        return self
+
+    def sample_dim_size(self) -> int | None:
+        """A single generator has no per-sample leading dimension."""
+        return None

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -575,8 +575,9 @@ def step_with_adjustments(
             ``global_mean_removal.forward_transform``.
         stepper_state: Per-sample state carried across step calls. The
             corrector's slice (``stepper_state.corrector_state``) is passed to
-            the corrector and any updates are written back into a returned
-            ``StepperState``. Pass-through unchanged when no corrector is set.
+            the corrector and any updates are written back into the returned
+            ``StepperState``; the other fields (e.g. ``random_state``) pass
+            through unchanged. Pass-through unchanged when no corrector is set.
 
     Returns:
         A tuple ``(output, stepper_state)`` where ``output`` is the
@@ -611,7 +612,14 @@ def step_with_adjustments(
             input, output, next_step_input_data, corrector_state
         )
         if corrector_state is not None:
-            stepper_state = StepperState(corrector_state=corrector_state)
+            # Preserve the incoming state's other fields (e.g. random_state)
+            # rather than rebuilding from scratch, so StepperState stays
+            # coherent across step calls.
+            stepper_state = (
+                StepperState(corrector_state=corrector_state)
+                if stepper_state is None
+                else dataclasses.replace(stepper_state, corrector_state=corrector_state)
+            )
     if ocean is not None:
         output = ocean(input, output, next_step_input_data)
     for name in prescribed_prognostic_names:

--- a/fme/core/stepper_state.py
+++ b/fme/core/stepper_state.py
@@ -1,8 +1,8 @@
 """State carried by the Stepper across predict calls.
 
 The stepper threads this object through ``predict_generator``: each step may
-read and update sub-state owned by its components (today only the corrector,
-in the future possibly others). The terminal state is attached to the returned
+read and update sub-state owned by its components (the corrector, and a
+seedable random source). The terminal state is attached to the returned
 ``PrognosticState`` so it propagates from one ``predict`` call to the next
 during inference.
 
@@ -13,6 +13,7 @@ payloads owned by their respective components.
 import dataclasses
 
 from fme.core.corrector.state import CorrectorState
+from fme.core.random_state import RandomState
 
 
 @dataclasses.dataclass
@@ -22,9 +23,13 @@ class StepperState:
     Parameters:
         corrector_state: State owned by the corrector. ``None`` when the
             corrector has not seeded any state yet.
+        random_state: Seedable random source driving stochastic modules (e.g.
+            ``NoiseConditionedSFNO``). ``None`` when the rollout is not seeded,
+            in which case stochastic modules fall back to the global torch RNG.
     """
 
     corrector_state: CorrectorState | None = None
+    random_state: RandomState | None = None
 
     def to_device(self) -> "StepperState":
         return StepperState(
@@ -33,6 +38,9 @@ class StepperState:
                 if self.corrector_state is None
                 else self.corrector_state.to_device()
             ),
+            random_state=(
+                None if self.random_state is None else self.random_state.to_device()
+            ),
         )
 
     def to_cpu(self) -> "StepperState":
@@ -40,11 +48,16 @@ class StepperState:
             corrector_state=(
                 None if self.corrector_state is None else self.corrector_state.to_cpu()
             ),
+            random_state=(
+                None if self.random_state is None else self.random_state.to_cpu()
+            ),
         )
 
     def pin_memory(self) -> "StepperState":
         if self.corrector_state is not None:
             self.corrector_state.pin_memory()
+        if self.random_state is not None:
+            self.random_state.pin_memory()
         return self
 
     def broadcast_ensemble(self, n_ensemble: int) -> "StepperState":
@@ -54,10 +67,19 @@ class StepperState:
                 if self.corrector_state is None
                 else self.corrector_state.broadcast_ensemble(n_ensemble)
             ),
+            random_state=(
+                None
+                if self.random_state is None
+                else self.random_state.broadcast_ensemble(n_ensemble)
+            ),
         )
 
     def sample_dim_size(self) -> int | None:
-        """Return the leading (sample) dim of any non-None sub-state, or None."""
+        """Return the leading (sample) dim of any sub-state that has one, or None.
+
+        The random state is shared across the batch and has no per-sample
+        dimension, so only the corrector state can constrain the sample size.
+        """
         if self.corrector_state is not None:
             return self.corrector_state.sample_dim_size()
         return None

--- a/fme/core/test_rand.py
+++ b/fme/core/test_rand.py
@@ -3,7 +3,7 @@ import torch
 
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
-from fme.core.rand import set_seed
+from fme.core.rand import randn, randn_like, set_seed, use_generator
 
 
 def test_set_seed_np_rand():
@@ -36,6 +36,73 @@ def test_set_distributed_shuffler():
     assert torch.allclose(
         torch.as_tensor(first_results), torch.as_tensor(second_results)
     )
+
+
+def _seeded_generator(seed: int) -> torch.Generator:
+    g = torch.Generator()
+    g.manual_seed(seed)
+    return g
+
+
+def test_use_generator_is_reproducible_and_advances():
+    device = get_device()
+    with use_generator(_seeded_generator(0)):
+        a0 = randn(torch.Size([4, 3]), device=device)
+        a1 = randn(torch.Size([4, 3]), device=device)
+    with use_generator(_seeded_generator(0)):
+        b0 = randn(torch.Size([4, 3]), device=device)
+        b1 = randn(torch.Size([4, 3]), device=device)
+    # Same seed reproduces the full sequence of draws...
+    assert torch.equal(a0, b0)
+    assert torch.equal(a1, b1)
+    # ...and the generator advances between draws.
+    assert not torch.equal(a0, a1)
+    assert a0.device.type == device.type
+
+
+def test_use_generator_differs_by_seed():
+    with use_generator(_seeded_generator(0)):
+        a = randn(torch.Size([8]))
+    with use_generator(_seeded_generator(1)):
+        b = randn(torch.Size([8]))
+    assert not torch.equal(a, b)
+
+
+def test_randn_like_honors_active_generator():
+    x = torch.zeros(4, 3, device=get_device())
+    with use_generator(_seeded_generator(0)):
+        a = randn_like(x)
+    with use_generator(_seeded_generator(0)):
+        b = randn(torch.Size([4, 3]), device=x.device)
+    assert a.shape == x.shape
+    assert a.device.type == x.device.type
+    # randn_like and randn agree for the same seed/shape.
+    assert torch.equal(a, b)
+
+
+def test_use_generator_none_is_global_rng_passthrough():
+    set_seed(0)
+    a = randn(torch.Size([5]))
+    set_seed(0)
+    with use_generator(None):
+        b = randn(torch.Size([5]))
+    assert torch.equal(a, b)
+
+
+def test_use_generator_restores_previous_on_exit():
+    outer = _seeded_generator(0)
+    with use_generator(outer):
+        a = randn(torch.Size([3]))
+        with use_generator(_seeded_generator(1)):
+            randn(torch.Size([3]))
+        # After the nested block, draws continue from the outer generator as if
+        # the inner block had not consumed it.
+        b = randn(torch.Size([3]))
+    with use_generator(_seeded_generator(0)):
+        a_ref = randn(torch.Size([3]))
+        b_ref = randn(torch.Size([3]))
+    assert torch.equal(a, a_ref)
+    assert torch.equal(b, b_ref)
 
 
 def test_set_random_sampler():

--- a/fme/core/test_random_state.py
+++ b/fme/core/test_random_state.py
@@ -1,0 +1,52 @@
+import pytest
+import torch
+
+from fme.core.corrector.state import CorrectorState
+from fme.core.random_state import RandomState
+from fme.core.stepper_state import StepperState
+
+
+def test_from_seed_is_reproducible():
+    a = RandomState.from_seed(0)
+    b = RandomState.from_seed(0)
+    x = torch.randn(4, generator=a.generator)
+    y = torch.randn(4, generator=b.generator)
+    assert torch.equal(x, y)
+
+
+def test_requires_cpu_generator():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    g = torch.Generator(device="cuda")
+    with pytest.raises(ValueError, match="CPU torch.Generator"):
+        RandomState(generator=g)
+
+
+def test_device_and_ensemble_transforms_preserve_generator():
+    """A single generator is shared across the batch and consumed in place, so
+    the device/ensemble helpers must return the same advancing object."""
+    rs = RandomState.from_seed(0)
+    assert rs.to_device() is rs
+    assert rs.to_cpu() is rs
+    assert rs.pin_memory() is rs
+    assert rs.broadcast_ensemble(4) is rs
+    assert rs.sample_dim_size() is None
+
+
+def test_stepper_state_threads_random_state_through_transforms():
+    rs = RandomState.from_seed(0)
+    state = StepperState(random_state=rs)
+    # The same generator object survives each transform (not reset or copied).
+    assert state.to_device().random_state is rs
+    assert state.to_cpu().random_state is rs
+    assert state.pin_memory().random_state is rs
+    assert state.broadcast_ensemble(3).random_state is rs
+
+
+def test_stepper_state_sample_dim_size_ignores_random_state():
+    """random_state has no per-sample dim, so only corrector_state constrains it."""
+    rs = RandomState.from_seed(0)
+    assert StepperState(random_state=rs).sample_dim_size() is None
+    corrector_state = CorrectorState(global_dry_air_mass=torch.zeros(5, 1, 1))
+    state = StepperState(corrector_state=corrector_state, random_state=rs)
+    assert state.sample_dim_size() == 5


### PR DESCRIPTION
`NoiseConditionedSFNO` draws its conditioning noise from the global torch RNG (via `fme.core.rand.randn`), so stochastic standalone/evaluator inference is not reproducible, and results depend on how the global RNG is consumed between predict windows (i.e. on `forward_steps_in_memory`). This PR threads a seedable random source through the existing `StepperState` channel so a seeded rollout produces a deterministic noise sequence, independent of `forward_steps_in_memory`, and exposes a `seed` config for both inference entrypoints.

The same generator object advances in place as it is consumed and rides `PrognosticState.stepper_state` from one step (and one `predict` call) to the next, so chunking the rollout into windows does not change the noise sequence. Draws are made on the CPU and moved to the device (mirroring `use_cpu_randn`), so a seed reproduces results across devices. `NoiseConditionedSFNO` itself is unchanged — its existing `randn` call transparently picks up the active generator.

Changes:
- `fme.core.rand.use_generator` / `randn` / `randn_like`: a context-managed active CPU generator that `randn`/`randn_like` draw from when set (no-op when `None`, preserving default behavior).
- `fme.core.random_state.RandomState`: wraps a CPU `torch.Generator` (`from_seed`); device/ensemble helpers are no-ops preserving the single advancing generator (it has no per-sample dim).
- `fme.core.stepper_state.StepperState`: new `random_state` field, threaded through the device/ensemble helpers.
- `fme.ace.stepper.single_module.Stepper.step`: activate the generator around the inner step and re-attach the advanced `RandomState` to the returned `StepperState` (surviving steps that rebuild it to seed corrector state).
- `fme.ace.data_loading.batch_data.PrognosticState.with_random_state`: attach a seed to an initial condition.
- `fme.ace.inference.inference.InferenceConfig.seed` and `fme.ace.inference.evaluator.InferenceEvaluatorConfig.seed`: optional seed wired into the rollout's initial condition.

Tests:
- `fme/ace/stepper/test_random_state.py` (integration, minimal `NoiseConditionedSFNO` with non-zero noise dim): a seeded rollout is identical whether run in one window or split into smaller windows (`forward_steps_in_memory` invariant); two same-seed rollouts match while different seeds (and the unseeded default) differ; a zero-noise-dim model is deterministic without a seed (confirming the noise is what the seed controls).
- `fme/ace/inference/test_inference.py::test_inference_entrypoint_seed_reproducible`: end-to-end through the standalone inference entrypoint (`main`) with a noise-conditioned checkpoint — same `seed` gives bitwise-identical output, different `seed` differs, and the unseeded default is non-reproducible.
- `fme/core/test_rand.py`: `use_generator` reproducibility, advancement, seed sensitivity, `randn_like` parity, `None` passthrough, and nesting restore.
- `fme/core/test_random_state.py`, `fme/ace/data_loading/test_batch_data.py`, and `fme/ace/stepper/test_single_module.py`: `RandomState`/`StepperState` plumbing, `with_random_state`, and `random_state` surviving a corrector `StepperState` rebuild.

Notes for the reviewer:
- The integration and entrypoint tests fill the (zero-initialized) `ConditionalLayerNorm` noise-conditioning weights so an untrained model's noise actually affects the output; otherwise different seeds would be indistinguishable.
- The seed drives a dedicated threaded generator rather than reseeding the global RNG, which is what makes reproducibility independent of `forward_steps_in_memory` and of unrelated global-RNG use.
- The stepper integration tests use a corrector that does not seed state, so the `StepperState`-rebuild survival path is covered separately by `test_predict_threads_random_state_alongside_corrector_state`.
- Restart files do not persist generator state, so cross-process resume reproducibility is out of scope here.
- The generator is one-per-process: if inference were ever run data-parallel across ranks, every rank would seed an identical generator and draw an identical noise sequence for its shard of initial conditions. The inference entrypoints are single-process today, so this only matters as a caveat for future distributed inference.

Verified on a real trained model: ran short (20-step) standalone inference of a stochastic 4°/daily `NoiseConditionedSFNO` (noise_embed_dim=32, isotropic) on beaker — twice on GPU and twice on CPU, fixed `seed`. Each same-device pair reproduced **bitwise-identically** across all 61 predicted fields; CPU vs GPU diverge chaotically (floating-point differences in the deterministic compute, not the noise — noise is drawn on CPU and moved to device, so it is identical across devices). GPU reproducibility did not require `use_deterministic_algorithms`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
