### PR TITLE
Add configuration for processing 4-degree AMIP constant CO2 data

### DIFF
--- a/scripts/data_process/Makefile
+++ b/scripts/data_process/Makefile
@@ -366,4 +366,4 @@ cm4_like_am4_random_co2_ensemble_coupled:
 
 .PHONY: shield_amip_constant_co2_c96_dataset
 shield_amip_constant_co2_c96_dataset:
-	./compute_dataset.sh --config configs/shield-amip-constant-co2-c96-1deg-8layer.yaml
+	./compute_dataset.sh --dataset --stats --time-coarsen --config configs/shield-amip-constant-co2-c96-$(RESOLUTION)-$(LAYERS).yaml

--- a/scripts/data_process/configs/shield-amip-constant-co2-c96-4deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-amip-constant-co2-c96-4deg-8layer.yaml
@@ -1,0 +1,182 @@
+runs:
+  AMIP-constant-CO2: gs://vcm-ml-raw-flexible-retention/2025-12-16-C96-SHiELD-AMIP-constant-CO2/regridded-zarrs/gaussian_grid_45_by_90/AMIP-constant-CO2
+data_output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset
+stats:
+  output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats
+  beaker_dataset: 2026-06-30-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats
+  start_date: "1979-01-01T06:00:00"
+  end_date: "2021-01-01T00:00:00"  # Only use whole years for computing the stats
+  data_type: FV3GFS
+dataset_computation:
+  reference_vertical_coordinate_file: gs://vcm-ml-raw-flexible-retention/2024-03-10-C96-SHiELD-FME-reference/vertical-coordinate-file/fv_core.res.nc
+  vertical_coarsening_indices:
+    - [0, 11]
+    - [11, 21]
+    - [21, 30]
+    - [30, 39]
+    - [39, 49]
+    - [49, 58]
+    - [58, 67]
+    - [67, 79]
+  renaming:
+    specific_humidity_at_two_meters: Q2m
+    air_temperature_at_two_meters: TMP2m
+    eastward_wind_at_ten_meters: UGRD10m
+    northward_wind_at_ten_meters: VGRD10m
+  variable_sources:
+    fluxes_2d.zarr:
+      - PRATEsfc
+      - LHTFLsfc
+      - SHTFLsfc
+      - DLWRFsfc
+      - DSWRFsfc
+      - DSWRFtoa
+      - ULWRFsfc
+      - ULWRFtoa
+      - USWRFsfc
+      - USWRFtoa
+      - precipitable_water_path
+      - GRAUPELsfc
+      - ICEsfc
+      - SNOWsfc
+    full_state.zarr:
+      - PRESsfc
+      - HGTsfc
+      - RH200
+      - RH500
+      - RH850
+      - TMP200
+      - TMP500
+      - TMP850
+      - UGRD200
+      - UGRD500
+      - UGRD850
+      - UGRD1000
+      - VGRD200
+      - VGRD500
+      - VGRD850
+      - VGRD1000
+      - h50
+      - h500
+      - h850
+      - h1000
+      - air_temperature_at_two_meters
+      - eastward_wind_at_ten_meters
+      - northward_wind_at_ten_meters
+      - surface_temperature
+      - air_temperature
+      - specific_humidity
+      - cloud_water_mixing_ratio
+      - cloud_ice_mixing_ratio
+      - graupel_mixing_ratio
+      - rain_mixing_ratio
+      - snow_mixing_ratio
+      - northward_wind
+      - eastward_wind
+      - pressure_thickness_of_atmospheric_layer
+      - soil_moisture_0
+      - soil_moisture_1
+      - soil_moisture_2
+      - soil_moisture_3
+      - snow_cover_fraction
+      - specific_humidity_at_two_meters
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - PRMSL
+    scalar.zarr:
+      - global_mean_co2
+  standard_names:
+    total_frozen_precip_rate: None
+time_coarsen:
+  factor: 4
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset-stats
+  snapshot_names:
+    - PRESsfc
+    - PRMSL
+    - Q2m
+    - RH200
+    - RH500
+    - RH850
+    - TMP200
+    - TMP2m
+    - TMP500
+    - TMP850
+    - UGRD1000
+    - UGRD10m
+    - UGRD200
+    - UGRD500
+    - UGRD850
+    - VGRD1000
+    - VGRD10m
+    - VGRD200
+    - VGRD500
+    - VGRD850
+    - air_temperature_0
+    - air_temperature_1
+    - air_temperature_2
+    - air_temperature_3
+    - air_temperature_4
+    - air_temperature_5
+    - air_temperature_6
+    - air_temperature_7
+    - eastward_wind_0
+    - eastward_wind_1
+    - eastward_wind_2
+    - eastward_wind_3
+    - eastward_wind_4
+    - eastward_wind_5
+    - eastward_wind_6
+    - eastward_wind_7
+    - global_mean_co2
+    - h1000
+    - h50
+    - h500
+    - h850
+    - land_fraction
+    - northward_wind_0
+    - northward_wind_1
+    - northward_wind_2
+    - northward_wind_3
+    - northward_wind_4
+    - northward_wind_5
+    - northward_wind_6
+    - northward_wind_7
+    - ocean_fraction
+    - sea_ice_fraction
+    - snow_cover_fraction
+    - soil_moisture_0
+    - soil_moisture_1
+    - soil_moisture_2
+    - soil_moisture_3
+    - specific_total_water_0
+    - specific_total_water_1
+    - specific_total_water_2
+    - specific_total_water_3
+    - specific_total_water_4
+    - specific_total_water_5
+    - specific_total_water_6
+    - specific_total_water_7
+    - surface_temperature
+    - total_water_path
+  window_names:
+    - DLWRFsfc
+    - DSWRFsfc
+    - DSWRFtoa
+    - LHTFLsfc
+    - PRATEsfc
+    - SHTFLsfc
+    - ULWRFsfc
+    - ULWRFtoa
+    - USWRFsfc
+    - USWRFtoa
+    - tendency_of_total_water_path
+    - tendency_of_total_water_path_due_to_advection
+    - total_frozen_precipitation_rate
+  constant_prefixes:
+    - ak_
+    - bk_
+    - HGTsfc
+    - grid_xt
+    - grid_yt

--- a/scripts/data_process/configs/shield-amip-constant-co2-c96-4deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-amip-constant-co2-c96-4deg-8layer.yaml
@@ -2,8 +2,8 @@ runs:
   AMIP-constant-CO2: gs://vcm-ml-raw-flexible-retention/2025-12-16-C96-SHiELD-AMIP-constant-CO2/regridded-zarrs/gaussian_grid_45_by_90/AMIP-constant-CO2
 data_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats-1979-2021
-  beaker_dataset: 2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats-1979-2021
+  output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats-1979-2020
+  beaker_dataset: 2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats-1979-2020
   start_date: "1979-01-01T06:00:00"
   end_date: "2021-01-01T00:00:00"  # Only use whole years for computing the stats
   data_type: FV3GFS
@@ -91,7 +91,7 @@ dataset_computation:
 time_coarsen:
   factor: 4
   data_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset
-  stats_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset-stats-1979-2021
+  stats_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset-stats-1979-2020
   snapshot_names:
     - PRESsfc
     - PRMSL

--- a/scripts/data_process/configs/shield-amip-constant-co2-c96-4deg-8layer.yaml
+++ b/scripts/data_process/configs/shield-amip-constant-co2-c96-4deg-8layer.yaml
@@ -1,9 +1,9 @@
 runs:
   AMIP-constant-CO2: gs://vcm-ml-raw-flexible-retention/2025-12-16-C96-SHiELD-AMIP-constant-CO2/regridded-zarrs/gaussian_grid_45_by_90/AMIP-constant-CO2
-data_output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset
+data_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset
 stats:
-  output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats
-  beaker_dataset: 2026-06-30-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats
+  output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats-1979-2021
+  beaker_dataset: 2026-07-01-vertically-resolved-c96-4deg-shield-amip-constant-co2-dataset-stats-1979-2021
   start_date: "1979-01-01T06:00:00"
   end_date: "2021-01-01T00:00:00"  # Only use whole years for computing the stats
   data_type: FV3GFS
@@ -90,8 +90,8 @@ dataset_computation:
     total_frozen_precip_rate: None
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset
-  stats_output_directory: gs://vcm-ml-intermediate/2026-06-30-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset-stats
+  data_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset
+  stats_output_directory: gs://vcm-ml-intermediate/2026-07-01-vertically-resolved-c96-4deg-daily-shield-amip-constant-co2-dataset-stats-1979-2021
   snapshot_names:
     - PRESsfc
     - PRMSL
@@ -129,7 +129,6 @@ time_coarsen:
     - eastward_wind_5
     - eastward_wind_6
     - eastward_wind_7
-    - global_mean_co2
     - h1000
     - h50
     - h500
@@ -171,6 +170,7 @@ time_coarsen:
     - ULWRFtoa
     - USWRFsfc
     - USWRFtoa
+    - global_mean_co2
     - tendency_of_total_water_path
     - tendency_of_total_water_path_due_to_advection
     - total_frozen_precipitation_rate


### PR DESCRIPTION
This PR adds a configuration for processing 4-degree AMIP constant CO2 data, which I produced and uploaded today.  It includes a configuration for a daily coarsened dataset.

An argo job is in progress here: `compute-fme-dataset-ensemble-j2kmq`.
