### PR TITLE
Mark test_lr_tuning_with_loss_schedule as medium_duration

### DIFF
--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -1095,6 +1095,7 @@ def test_train_without_inline_inference(tmp_path):
     assert val_extra_output.exists()
 
 
+@pytest.mark.medium_duration
 def test_lr_tuning_with_loss_schedule(tmp_path):
     """LR tuning combined with an epoch-based loss schedule trains without error.
 


### PR DESCRIPTION
`test_lr_tuning_with_loss_schedule` (the ace#1275 regression test) runs a full SFNO training run — ~6s on CPU — but was added without a duration marker. Unmarked tests are selected in the `--very-fast` job (`cpu-very-fast-no-healpix`), whose per-test timeout is 3s, where it can never pass; this surfaces as an intermittent `conftest.TimeoutException: Test took too long`.

Adding `@pytest.mark.medium_duration` deselects it from `--very-fast` (3s) while keeping it in `--fast` (30s, ~5x headroom) and the default suite (90s). This matches the sibling training tests in the same file (`test_train_without_inline_inference`, `test_train_and_inference_with_derived_forcings`).

Measured on CPU (`FME_FORCE_CPU=1`): call ~5.6–6.9s. Verified after the change: `--very-fast` now deselects the test (no failure) and `--fast` passes in ~6.7s.

Changes:
- `fme/ace/test_train.py::test_lr_tuning_with_loss_schedule` — add `@pytest.mark.medium_duration`

- [x] Tests added (marker on existing test)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
