### PR TITLE
[Feature] Add probability gate to variable masking configs

### DIFF
--- a/fme/core/test_var_masking.py
+++ b/fme/core/test_var_masking.py
@@ -35,6 +35,18 @@ def test_group_rate_validation():
         BernoulliMaskingConfig(rate=1.1)
 
 
+def test_probability_validation():
+    with pytest.raises(ValueError, match="probability must be in"):
+        UniformMaskingConfig(max_masked_vars=1, probability=-0.1)
+    with pytest.raises(ValueError, match="probability must be in"):
+        UniformMaskingConfig(max_masked_vars=1, probability=1.1)
+    # bool is a subclass of int; reject it rather than coerce to 0.0/1.0.
+    with pytest.raises(ValueError, match="probability must be in"):
+        UniformMaskingConfig(max_masked_vars=1, probability=True)
+    with pytest.raises(ValueError, match="probability must be in"):
+        UniformMaskingConfig(max_masked_vars=1, probability=False)
+
+
 def test_empty_group_validation():
     with pytest.raises(ValueError, match="non-empty"):
         _group([], 0.5)
@@ -266,6 +278,104 @@ def test_masks_are_reproducible_for_fixed_seed_and_rank(monkeypatch):
         ]
 
     assert _sample_sequence() == _sample_sequence()
+
+
+def _sequence(config: VariableMaskingConfig, n: int, trials: int):
+    masking = _build(config, n)
+    return [
+        tuple(bool(x) for x in masking.sample_mask(DEVICE)[0].tolist())
+        for _ in range(trials)
+    ]
+
+
+def test_probability_one_matches_omitted():
+    """probability=1.0 short-circuits the gate, leaving the RNG stream intact.
+
+    An explicit probability=1.0 must replay exactly the same sequence as a config
+    that omits the field, proving no gate draw is taken at 1.0 (so pre-field
+    regression baselines are unchanged).
+    """
+    omitted = VariableMaskingConfig(default=UniformMaskingConfig(max_masked_vars=3))
+    explicit = VariableMaskingConfig(
+        default=UniformMaskingConfig(max_masked_vars=3, probability=1.0)
+    )
+    assert _sequence(omitted, 5, 64) == _sequence(explicit, 5, 64)
+
+
+def test_probability_zero_never_drops():
+    """probability=0.0 gates every step, so nothing is ever dropped."""
+    masking = _build(
+        VariableMaskingConfig(
+            default=UniformMaskingConfig(max_masked_vars=5, probability=0.0)
+        ),
+        5,
+    )
+    for _ in range(64):
+        assert masking.sample_mask(DEVICE).all()
+
+
+def test_probability_gates_uniform_marginal():
+    """No-drop frequency matches ``(1 - p) + p / (n + 1)`` for a gated uniform.
+
+    With ``max_masked_vars == n`` a fired scheme draws ``k`` uniform in
+    ``[0, n]``, so it drops nothing with probability ``1 / (n + 1)``. Folding in
+    the gate gives an overall no-drop frequency of ``(1 - p) + p / (n + 1)``.
+    """
+    n = 4
+    probability = 0.5
+    masking = _build(
+        VariableMaskingConfig(
+            default=UniformMaskingConfig(max_masked_vars=n, probability=probability)
+        ),
+        n,
+    )
+    trials = 4000
+    nodrop = sum(
+        int(bool(masking.sample_mask(DEVICE).all().item())) for _ in range(trials)
+    )
+    freq = nodrop / trials
+    expected = (1 - probability) + probability / (n + 1)
+    assert abs(freq - expected) < 0.05, f"expected ~{expected}, got {freq}"
+
+
+def test_uniform_probability_raises_nodrop_fraction():
+    """Gating a uniform scheme increases the fraction of no-drop steps."""
+    n = 6
+    trials = 4000
+
+    def _nodrop_fraction(probability: float) -> float:
+        masking = _build(
+            VariableMaskingConfig(
+                default=UniformMaskingConfig(max_masked_vars=n, probability=probability)
+            ),
+            n,
+        )
+        nodrop = sum(
+            int(bool(masking.sample_mask(DEVICE).all().item())) for _ in range(trials)
+        )
+        return nodrop / trials
+
+    assert _nodrop_fraction(0.5) > _nodrop_fraction(1.0)
+
+
+def test_probability_gates_override_group():
+    """probability threads through override_groups, not just the default pool."""
+    masking = _build(
+        VariableMaskingConfig(
+            default=UniformMaskingConfig(max_masked_vars=0),
+            override_groups=[
+                MaskingGroupConfig(
+                    variables=["var_0", "var_1"],
+                    masking=UniformMaskingConfig(max_masked_vars=2, probability=0.0),
+                )
+            ],
+        ),
+        3,
+    )
+    # default masks nothing (max=0) and the group is gated off, so no channel
+    # is ever dropped.
+    for _ in range(64):
+        assert masking.sample_mask(DEVICE).all()
 
 
 def test_multiple_groups_fire_independently():

--- a/fme/core/var_masking.py
+++ b/fme/core/var_masking.py
@@ -75,13 +75,6 @@ class UniformMaskingGenerator(MaskingGenerator):
         return [self._names[i] for i in perm.tolist()]
 
 
-def _validate_probability(probability: float) -> None:
-    # bool is a subclass of int, so reject it explicitly to avoid a
-    # silently-coerced True/False being treated as a probability.
-    if isinstance(probability, bool) or not 0.0 <= probability <= 1.0:
-        raise ValueError(f"probability must be in [0, 1], got {probability!r}")
-
-
 @dataclasses.dataclass(frozen=True)
 class BernoulliMaskingConfig:
     """All-or-nothing Bernoulli masking of a channel pool.
@@ -131,7 +124,10 @@ class UniformMaskingConfig:
                 "max_masked_vars must be a non-negative int, got "
                 f"{self.max_masked_vars!r}"
             )
-        _validate_probability(self.probability)
+        # bool is a subclass of int, so reject it explicitly to avoid a
+        # silently-coerced True/False being treated as a probability.
+        if isinstance(self.probability, bool) or not 0.0 <= self.probability <= 1.0:
+            raise ValueError(f"probability must be in [0, 1], got {self.probability!r}")
 
     def build(self, names: list[str]) -> UniformMaskingGenerator:
         return UniformMaskingGenerator(names, self.max_masked_vars, self.probability)

--- a/fme/core/var_masking.py
+++ b/fme/core/var_masking.py
@@ -46,13 +46,26 @@ class UniformMaskingGenerator(MaskingGenerator):
 
     ``k`` is drawn uniformly from ``[0, min(max_masked_vars, n)]`` where ``n``
     is the pool size, so a draw may drop nothing.
+
+    Gated by ``probability``: with probability ``1 - probability`` the scheme
+    fires no draw and drops nothing on a step. When ``probability == 1.0`` the
+    gate is short-circuited so no gate draw is taken, keeping the RNG stream
+    identical to configs that predate this field.
     """
 
-    def __init__(self, names: list[str], max_masked_vars: int):
+    def __init__(
+        self, names: list[str], max_masked_vars: int, probability: float = 1.0
+    ):
         self._names = list(names)
         self._max_masked_vars = max_masked_vars
+        self._probability = probability
 
     def sample(self, generator: torch.Generator) -> list[str]:
+        if (
+            self._probability < 1.0
+            and torch.rand(1, generator=generator).item() >= self._probability
+        ):
+            return []
         n = len(self._names)
         max_n = min(self._max_masked_vars, n)
         k = int(torch.randint(0, max_n + 1, (1,), generator=generator).item())
@@ -62,13 +75,22 @@ class UniformMaskingGenerator(MaskingGenerator):
         return [self._names[i] for i in perm.tolist()]
 
 
+def _validate_probability(probability: float) -> None:
+    # bool is a subclass of int, so reject it explicitly to avoid a
+    # silently-coerced True/False being treated as a probability.
+    if isinstance(probability, bool) or not 0.0 <= probability <= 1.0:
+        raise ValueError(f"probability must be in [0, 1], got {probability!r}")
+
+
 @dataclasses.dataclass(frozen=True)
 class BernoulliMaskingConfig:
     """All-or-nothing Bernoulli masking of a channel pool.
 
     Parameters:
         rate: Bernoulli masking rate in ``[0, 1]``; the marginal probability
-            the pool is dropped on any step.
+            the pool is dropped on any step. (No ``probability`` gate is offered
+            here: it would be redundant, since gating a Bernoulli pool at
+            ``probability`` is identical to scaling ``rate`` by ``probability``.)
     """
 
     rate: float
@@ -89,9 +111,13 @@ class UniformMaskingConfig:
         max_masked_vars: Maximum number of masked channels. The count is
             sampled uniformly from ``[0, min(max_masked_vars, n)]`` where ``n``
             is the pool size, so a draw may mask no variables.
+        probability: Probability in ``[0, 1]`` that this masking scheme fires on
+            any step. When it does not fire, nothing is dropped. Defaults to
+            ``1.0`` (always fires).
     """
 
     max_masked_vars: int
+    probability: float = 1.0
 
     def __post_init__(self):
         # bool is a subclass of int, so reject it explicitly to avoid a
@@ -105,9 +131,10 @@ class UniformMaskingConfig:
                 "max_masked_vars must be a non-negative int, got "
                 f"{self.max_masked_vars!r}"
             )
+        _validate_probability(self.probability)
 
     def build(self, names: list[str]) -> UniformMaskingGenerator:
-        return UniformMaskingGenerator(names, self.max_masked_vars)
+        return UniformMaskingGenerator(names, self.max_masked_vars, self.probability)
 
 
 # Disjoint required fields (`rate` vs `max_masked_vars`) let dacite discriminate


### PR DESCRIPTION
Variable masking (#1329) drops input channels during training, but a `UniformMaskingConfig` scheme fired on every step. This PR adds a `probability` gate to `UniformMaskingConfig` so a uniform scheme can leave all channels intact on a fraction of steps.

At `probability=1.0` (default) the gate always fires the draw, preserving current behavior. At `0.5` the scheme drops nothing on half the steps. The gate short-circuits at `probability=1.0` so no gate draw is taken, keeping the RNG stream (and existing regression baselines) identical for configs that omit the field.

No `probability` gate is offered on `BernoulliMaskingConfig`: gating a Bernoulli pool at `probability` is identical to scaling `rate` by `probability`, so it would be redundant.

Changes:
- `fme.core.var_masking.UniformMaskingConfig` / `UniformMaskingGenerator`: add `probability: float = 1.0` field (gate), validated in `[0, 1]` via `_validate_probability`, threaded through `build()`. `_validate_probability` rejects `bool` explicitly, since `bool` is an `int` subclass that would otherwise coerce to `0.0`/`1.0`.
- `fme.core.var_masking.BernoulliMaskingConfig`: no gate (redundant with `rate`).

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

