### PR TITLE
Add optional prediction_names to filter prediction files independently

### DIFF
--- a/fme/ace/inference/data_writer/main.py
+++ b/fme/ace/inference/data_writer/main.py
@@ -41,6 +41,12 @@ class DataWriterConfig:
             containing the monthly predictions and target values.
         names: Names of variables to save in the prediction and monthly
             netCDF files.
+        prediction_names: Names of variables to save in the prediction netCDF
+            files. When set, this overrides ``names`` for the prediction files
+            only (the monthly files continue to use ``names``); when None, the
+            prediction files fall back to ``names``. Useful for saving a small
+            subset in the high-frequency prediction files while retaining all
+            variables in the monthly aggregates.
         time_coarsen: Configuration for time coarsening of written outputs to the
             raw data writer.
         files: Configuration for a sequence of individual data writers. Each data
@@ -50,6 +56,7 @@ class DataWriterConfig:
     save_prediction_files: bool = True
     save_monthly_files: bool = True
     names: Sequence[str] | None = None
+    prediction_names: Sequence[str] | None = None
     time_coarsen: TimeCoarsenConfig | None = None
     files: list[FileWriterConfig] | None = None
 
@@ -61,6 +68,10 @@ class DataWriterConfig:
             warnings.warn(
                 "names provided but all options to "
                 "save subsettable output files are False."
+            )
+        if self.prediction_names is not None and not self.save_prediction_files:
+            warnings.warn(
+                "prediction_names provided but save_prediction_files is False."
             )
         all_filenames = self._get_all_filenames()
         if len(set(all_filenames)) != len(all_filenames):
@@ -74,6 +85,13 @@ class DataWriterConfig:
         for file in self.files or []:
             filenames.extend(file.filenames)
         return filenames
+
+    @property
+    def _prediction_save_names(self) -> Sequence[str] | None:
+        """Names to save in the prediction files, falling back to ``names``."""
+        if self.prediction_names is not None:
+            return self.prediction_names
+        return self.names
 
     def validate_time_coarsen(self, forward_steps_in_memory: int, n_forward_steps: int):
         """Validate time coarsening (top-level and per-file) against the schedule."""
@@ -97,7 +115,7 @@ class DataWriterConfig:
             raw_writer: PairedSubwriter = PairedRawDataWriter(
                 path=experiment_dir,
                 initial_condition_times=initial_condition_times,
-                save_names=self.names,
+                save_names=self._prediction_save_names,
                 variable_metadata=variable_metadata,
                 coords=coords,
                 dataset_metadata=dataset_metadata,
@@ -157,7 +175,7 @@ class DataWriterConfig:
                     path=experiment_dir,
                     label="autoregressive_predictions",
                     initial_condition_times=initial_condition_times,
-                    save_names=self.names,
+                    save_names=self._prediction_save_names,
                     variable_metadata=variable_metadata,
                     coords=coords,
                     dataset_metadata=dataset_metadata,

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -71,6 +71,15 @@ def test_data_writer_config_save_names():
         DataWriterConfig(names=variable_names, **kwargs_copy)  # type: ignore
 
 
+def test_data_writer_config_prediction_names_warns_when_predictions_disabled():
+    with pytest.warns(UserWarning, match="prediction_names provided"):
+        DataWriterConfig(
+            save_prediction_files=False,
+            save_monthly_files=True,
+            prediction_names=["temp"],
+        )
+
+
 def get_paired_data(
     prediction: TensorMapping, reference: TensorMapping, time: xr.DataArray
 ) -> PairedData:
@@ -409,6 +418,79 @@ class TestDataWriter:
             else set(sample_target_data.keys())
         )
         assert set(dataset.variables.keys()) == expected_prediction_variables.union(
+            {
+                "init_time",
+                "time",
+                "valid_time",
+                "counts",
+                "lat",
+                "lon",
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "sample_target_data, sample_prediction_data",
+        [pytest.param((2, 3, 4, 5), (2, 3, 4, 5), id="LatLon")],
+        indirect=True,
+    )
+    def test_append_batch_prediction_names_override(
+        self,
+        sample_metadata,
+        sample_target_data,
+        sample_prediction_data,
+        tmp_path,
+    ):
+        """prediction_names subsets prediction files while monthly saves all."""
+        n_samples = 2
+        calendar = "julian"
+        start_time = (2020, 1, 1, 0, 0, 0)
+        initial_condition_times = get_initial_condition_times(
+            start_time, calendar, n_samples
+        )
+        writer = DataWriterConfig(
+            save_prediction_files=True,
+            save_monthly_files=True,
+            names=None,  # save all variables in monthly files
+            prediction_names=["temp"],  # only a subset in prediction files
+        ).build_paired(
+            experiment_dir=str(tmp_path),
+            initial_condition_times=initial_condition_times,
+            n_timesteps=4,  # unused
+            timestep=TIMESTEP,
+            variable_metadata=sample_metadata,
+            coords={"lat": np.arange(4), "lon": np.arange(5)},
+            dataset_metadata=DatasetMetadata(),
+        )
+        end_time = (2020, 1, 1, 12, 0, 0)
+        batch_time = self.get_batch_time(
+            start_time=start_time,
+            end_time=end_time,
+            freq="6h",
+            n_initial_conditions=n_samples,
+        )
+        writer.append_batch(
+            batch=get_paired_data(
+                prediction=sample_prediction_data,
+                reference=sample_target_data,
+                time=batch_time,
+            ),
+        )
+        writer.finalize()
+
+        prediction_dataset = Dataset(tmp_path / "autoregressive_predictions.nc", "r")
+        assert set(prediction_dataset.variables.keys()) == {
+            "temp",
+            "init_time",
+            "time",
+            "lat",
+            "lon",
+            "valid_time",
+        }
+
+        monthly_dataset = Dataset(tmp_path / "monthly_mean_predictions.nc", "r")
+        assert set(monthly_dataset.variables.keys()) == set(
+            sample_prediction_data.keys()
+        ).union(
             {
                 "init_time",
                 "time",


### PR DESCRIPTION
`DataWriterConfig.names` applies to both prediction and monthly netCDF files. Add an optional `prediction_names` field that, when set, overrides `names` for the prediction (autoregressive) files only, so a small subset can be saved at high frequency while the monthly aggregates retain all variables. Falls back to `names` when unset, so existing configs are unaffected.

Changes:
- `fme.ace.inference.data_writer.main.DataWriterConfig`: add optional `prediction_names` field; new private `_prediction_save_names` property returning `prediction_names` if set else `names`; both `build` and `build_paired` pass it as `save_names` to the raw/prediction writers while the monthly writers keep `names`. Adds a `__post_init__` warning when `prediction_names` is set but `save_prediction_files` is False.
- `test_data_writer.py`: add a warning test and an end-to-end test asserting the prediction file is subset to `prediction_names` while the monthly file still saves all variables.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
