### PR TITLE
v2-era5-only recipe on single SHiELD AMIP member ic_0001 (with-CO2 + no-CO2)

### DIFF
--- a/configs/baselines/ace2s-shield-plus-like/run-train-shield-amip-only.sh
+++ b/configs/baselines/ace2s-shield-plus-like/run-train-shield-amip-only.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+#
+# Reference ACE training launcher. Canonical source:
+#   research/.claude/skills/launching-runs/run-train.reference.sh
+#
+# Baseline branches ADOPT this by copying it to
+# configs/<baseline>/run-train.sh and editing ONLY:
+#   (a) the BASELINE-SPECIFIC gantry block inside run_training(), and
+#   (b) the run_training() calls at the bottom.
+# Keep the GUARDRAILS block verbatim so it does not drift between baselines —
+# that is the whole point of having a canonical reference. `git grep` for the
+# block markers detects drift. The guardrails are mcgibbon-specific (wandb
+# attribution) and deliberately live in research/, NOT in the ace repo.
+#
+# Usage (run FROM the configs directory that contains this script):
+#   ./run-train.sh                  # launch every run_training call below
+#   ./run-train.sh no-residual      # launch only calls whose config filename
+#                                   # or job name contains "no-residual"
+#   ./run-train.sh seed1 seed2      # multiple substrings = OR
+#
+# The config filter lets you add a new arm to an existing baseline's script
+# and launch only that arm, without commenting out / relaunching the runs that
+# are already live.
+
+set -euo pipefail
+
+# === GUARDRAILS (copy verbatim from the reference; do not hand-edit) =========
+WANDB_IDENTITY="mcgibbon"   # the wandb username every run must attribute to
+
+SCRIPT_PATH=$(git rev-parse --show-prefix)   # repo-root-relative dir of this script
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BEAKER_USERNAME=$(beaker account whoami --format=json | jq -r '.[0].name')
+
+# WANDB attribution guard. The beaker job env does not carry WANDB_USERNAME, and
+# the beaker account (jeremym) makes wandb fall back to the API-key service
+# account, so an unset/null/jeremym value silently misattributes the run. Beaker
+# specs are immutable, so a miss costs a full stop+relaunch+rewrite-every-record
+# cycle — fail loud, before submit.
+WANDB_USERNAME=${WANDB_USERNAME:-$WANDB_IDENTITY}
+if [[ "$WANDB_USERNAME" != "$WANDB_IDENTITY" ]]; then
+  echo "ERROR: WANDB_USERNAME='$WANDB_USERNAME' but runs must attribute to '$WANDB_IDENTITY'." >&2
+  echo "       (BEAKER_USERNAME='$BEAKER_USERNAME' would misattribute to the wandb service account.)" >&2
+  echo "       Run:  export WANDB_USERNAME=$WANDB_IDENTITY   before launching." >&2
+  exit 1
+fi
+
+# cwd / path guard. An empty SCRIPT_PATH means the script was run from the repo
+# root (or outside the configs dir): CONFIG_PATH would become "/<config>.yaml"
+# and gantry would submit a doomed job even after local validate_config fails.
+if [[ -z "$SCRIPT_PATH" ]]; then
+  echo "ERROR: SCRIPT_PATH (git rev-parse --show-prefix) is empty." >&2
+  echo "       Invoke run-train.sh FROM its own configs directory, not the repo root." >&2
+  exit 1
+fi
+
+# Config-line filter. With no args every run_training call runs; with args, only
+# calls whose config filename OR job name contains one of the substrings.
+LAUNCH_FILTERS=("$@")
+should_run() {  # should_run <config_filename> <job_name>
+  [[ ${#LAUNCH_FILTERS[@]} -eq 0 ]] && return 0
+  local f
+  for f in "${LAUNCH_FILTERS[@]}"; do
+    [[ "$1" == *"$f"* || "$2" == *"$f"* ]] && return 0
+  done
+  return 1
+}
+
+# Post-launch attribution assertion. gantry submits asynchronously, so the wandb
+# run may not exist at submit time; call this once the run has registered (or as
+# a standalone follow-up check) to confirm wandb really recorded it under
+# WANDB_IDENTITY before you write records / move on.
+#   assert_wandb_attribution <wandb_run_id> [wandb_project]   # default ai2cm/ace
+assert_wandb_attribution() {
+  local run_id="$1" project="${2:-ai2cm/ace}"
+  python - "$run_id" "$project" "$WANDB_IDENTITY" <<'PY'
+import sys
+import wandb
+run_id, project, expected = sys.argv[1], sys.argv[2], sys.argv[3]
+got = wandb.Api().run(f"{project}/{run_id}").user.username
+assert got == expected, f"wandb run {run_id} attributed to {got!r}, expected {expected!r}"
+print(f"OK: wandb run {run_id} attributed to {got}")
+PY
+}
+# === END GUARDRAILS =========================================================
+
+cd "$REPO_ROOT"
+
+run_training() {
+  local config_filename="$1"
+  local job_name="$2"
+  local N_GPUS="${3:-1}"
+  local CONFIG_PATH="$SCRIPT_PATH/$config_filename"
+
+  should_run "$config_filename" "$job_name" || { echo "skip (filter): $job_name"; return 0; }
+
+  # path guard: the resolved local config must exist before we pay for gantry.
+  # (cwd is REPO_ROOT here, so CONFIG_PATH is the repo-relative path.)
+  if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "ERROR: config not found: $REPO_ROOT/$CONFIG_PATH" >&2
+    echo "       Check the filename and that you launched from the configs dir." >&2
+    exit 1
+  fi
+
+  echo "launching: $job_name  ($CONFIG_PATH)"
+
+  # --- BASELINE-SPECIFIC: edit only the block below for this baseline ---------
+  # Validate locally to fail fast on config bugs before paying for GPU spin-up.
+  # (Swap fme.ace -> fme.diffusion etc. as the baseline requires.)
+  python -m fme.ace.validate_config --config_type train "$CONFIG_PATH"
+
+  # Extract additional gantry flags from "# arg: ..." headers in the YAML.
+  local extra_args=()
+  while IFS= read -r line; do
+    [[ "$line" =~ ^#\ arg:\ (.*) ]] && extra_args+=(${BASH_REMATCH[1]})
+  done < "$CONFIG_PATH"
+
+  gantry run \
+    --name "$job_name" \
+    --description 'Run ACE training (4deg daily ACE2S-SHiELD+ analog baseline)' \
+    --beaker-image "$(cat "$REPO_ROOT/latest_deps_only_image.txt")" \
+    --workspace ai2/ace \
+    --priority high \
+    --cluster ai2/jupiter \
+    --cluster ai2/titan \
+    --env WANDB_USERNAME="$WANDB_USERNAME" \
+    --env WANDB_NAME="$job_name" \
+    --env WANDB_JOB_TYPE=training \
+    --env WANDB_RUN_GROUP= \
+    --env GOOGLE_APPLICATION_CREDENTIALS=/tmp/google_application_credentials.json \
+    --env-secret WANDB_API_KEY=wandb-api-key-ai2cm-sa \
+    --dataset-secret google-credentials:/tmp/google_application_credentials.json \
+    --gpus "$N_GPUS" \
+    --shared-memory "$((N_GPUS * 50))GiB" \
+    --weka climate-default:/climate-default \
+    --budget ai2/atec-climate \
+    --allow-dirty \
+    --system-python \
+    --install "pip install --no-deps ." \
+    "${extra_args[@]}" \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.ace.train "$CONFIG_PATH"
+  # --- END BASELINE-SPECIFIC --------------------------------------------------
+}
+
+# =============================================================================
+# v2-era5-only recipe on a single SHiELD AMIP member (ic_0001).
+#
+# The ERA5 v2-era5-only recipe (shared-temperature global-mean removal +
+# latent-global-mean clip, residual prediction, 120 epochs, single-step
+# EnsembleLoss) trained on the historical SHiELD AMIP member ic_0001 instead of
+# ERA5, with an ERA5-style held-out-year split (train 1979-2013 minus 1994;
+# validate on 1994 + 2014) and AMIP-historical normalization stats. For the
+# land-amplification +4K SST-response evaluation (later run through the
+# +0/+4K constant-SST-perturbation harness, scored against a direct GCM +4K
+# SHiELD target).
+#
+# Two arms, launched together — a with-CO2 / no-CO2 pair (the no-CO2 arm drops
+# global_mean_co2 from in_names + next_step_forcing_names, mirroring the ERA5 v2
+# with-CO2 znnaox7t -> no-CO2 im4ecamc precedent).
+# 1 GPU each; batch_size 8 is global, matching the ERA5 v2 baselines.
+# =============================================================================
+
+# --- with-CO2 arm, seed 0 (1 GPU) ---
+run_training "train-4deg-daily-v2-shield-amip-only.yaml"        "train-4deg-daily-v2-shield-amip-only-rs0"        1
+
+# --- no-CO2 arm, seed 0 (1 GPU) ---
+run_training "train-4deg-daily-v2-shield-amip-only-no-co2.yaml" "train-4deg-daily-v2-shield-amip-only-no-co2-rs0" 1

--- a/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only-no-co2.yaml
+++ b/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only-no-co2.yaml
@@ -1,0 +1,321 @@
+# v2-era5-only recipe (shared-temperature global-mean removal + latent-global-
+# mean clip, residual prediction, 120 epochs, single-step EnsembleLoss) trained
+# on a SINGLE SHiELD AMIP member (ic_0001) instead of ERA5. Built from the
+# ACE2S-SHiELD+ v2arch config (SHiELD variable lists, corrector, ocean, and v2
+# builder) with the v2-era5-only recipe knobs spliced in and the training data
+# reduced to the historical AMIP member with an ERA5-style held-out-year split
+# (train 1979-2013 minus 1994; validate on 1994 + 2014). NO-CO2 arm: this is
+# the with-CO2 sibling (...-v2-shield-amip-only.yaml) with global_mean_co2
+# removed from in_names and next_step_forcing_names — the only delta. This
+# mirrors the ERA5 v2 no-CO2 precedent (with-CO2 znnaox7t -> no-CO2 im4ecamc,
+# same single CO2-removal delta).
+#
+# For the land-amplification +4K SST-response evaluation: this model is later
+# run through the +0/+4K constant-SST-perturbation harness and scored against a
+# direct GCM +4K SHiELD target.
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 120
+ema:
+  decay: 0.999
+train_aggregator:
+  ensemble_metrics: true
+inference:
+  - name: insample_10year
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T00:00:00'
+          - '1995-01-02T00:00:00'
+          - '1995-01-03T00:00:00'
+          - '1995-01-04T00:00:00'
+          - '1995-01-05T00:00:00'
+          - '1995-01-06T00:00:00'
+          - '1995-01-07T00:00:00'
+          - '1995-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+        file_pattern: ic_0001.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - total_frozen_precipitation_rate
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 4
+  prefetch_factor: 4
+  time_buffer: 8
+  time_buffer_pool_size: 32
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+        file_pattern: ic_0001.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1993-12-31'
+      - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+        file_pattern: ic_0001.zarr
+        engine: zarr
+        subset:
+          start_time: '1995-01-01'
+          stop_time: '2013-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 16
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+          file_pattern: ic_0001.zarr
+          engine: zarr
+          subset:
+            start_time: '1994-01-01'
+            stop_time: '1994-12-31'
+        - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+          file_pattern: ic_0001.zarr
+          engine: zarr
+          subset:
+            start_time: '2014-01-01'
+            stop_time: '2014-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/centering.nc
+          global_stds_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/centering.nc
+          global_stds_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+        interpolate: true
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        force_positive_names:
+          - specific_total_water_0
+          - specific_total_water_1
+          - specific_total_water_2
+          - specific_total_water_3
+          - specific_total_water_4
+          - specific_total_water_5
+          - specific_total_water_6
+          - specific_total_water_7
+          - Q2m
+          - PRATEsfc
+          - ULWRFsfc
+          - ULWRFtoa
+          - DLWRFsfc
+          - DSWRFsfc
+          - USWRFsfc
+          - USWRFtoa
+          - total_frozen_precipitation_rate
+      next_step_forcing_names:
+        - DSWRFtoa
+      in_names:
+        - land_fraction
+        - ocean_fraction
+        - sea_ice_fraction
+        - DSWRFtoa
+        - HGTsfc
+        - PRESsfc
+        - surface_temperature
+        - TMP2m
+        - Q2m
+        - UGRD10m
+        - VGRD10m
+        - air_temperature_0
+        - air_temperature_1
+        - air_temperature_2
+        - air_temperature_3
+        - air_temperature_4
+        - air_temperature_5
+        - air_temperature_6
+        - air_temperature_7
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - eastward_wind_0
+        - eastward_wind_1
+        - eastward_wind_2
+        - eastward_wind_3
+        - eastward_wind_4
+        - eastward_wind_5
+        - eastward_wind_6
+        - eastward_wind_7
+        - northward_wind_0
+        - northward_wind_1
+        - northward_wind_2
+        - northward_wind_3
+        - northward_wind_4
+        - northward_wind_5
+        - northward_wind_6
+        - northward_wind_7
+      out_names:
+        - PRESsfc
+        - surface_temperature
+        - TMP2m
+        - Q2m
+        - UGRD10m
+        - VGRD10m
+        - air_temperature_0
+        - air_temperature_1
+        - air_temperature_2
+        - air_temperature_3
+        - air_temperature_4
+        - air_temperature_5
+        - air_temperature_6
+        - air_temperature_7
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - eastward_wind_0
+        - eastward_wind_1
+        - eastward_wind_2
+        - eastward_wind_3
+        - eastward_wind_4
+        - eastward_wind_5
+        - eastward_wind_6
+        - eastward_wind_7
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+        - tendency_of_total_water_path_due_to_advection
+        - TMP850
+        - h500
+        - total_frozen_precipitation_rate
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only-no-co2.yaml
+++ b/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only-no-co2.yaml
@@ -303,6 +303,14 @@ stepper:
         - eastward_wind_5
         - eastward_wind_6
         - eastward_wind_7
+        - northward_wind_0
+        - northward_wind_1
+        - northward_wind_2
+        - northward_wind_3
+        - northward_wind_4
+        - northward_wind_5
+        - northward_wind_6
+        - northward_wind_7
         - LHTFLsfc
         - SHTFLsfc
         - PRATEsfc

--- a/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only.yaml
+++ b/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only.yaml
@@ -1,0 +1,321 @@
+# v2-era5-only recipe (shared-temperature global-mean removal + latent-global-
+# mean clip, residual prediction, 120 epochs, single-step EnsembleLoss) trained
+# on a SINGLE SHiELD AMIP member (ic_0001) instead of ERA5. Built from the
+# ACE2S-SHiELD+ v2arch config (SHiELD variable lists, corrector, ocean, and v2
+# builder) with the v2-era5-only recipe knobs spliced in and the training data
+# reduced to the historical AMIP member with an ERA5-style held-out-year split
+# (train 1979-2013 minus 1994; validate on 1994 + 2014). WITH-CO2 arm:
+# global_mean_co2 is retained in in_names / next_step_forcing_names.
+#
+# For the land-amplification +4K SST-response evaluation: this model is later
+# run through the +0/+4K constant-SST-perturbation harness and scored against a
+# direct GCM +4K SHiELD target. The paired no-CO2 arm is in the sibling
+# ...-no-co2.yaml config.
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 120
+ema:
+  decay: 0.999
+train_aggregator:
+  ensemble_metrics: true
+inference:
+  - name: insample_10year
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T00:00:00'
+          - '1995-01-02T00:00:00'
+          - '1995-01-03T00:00:00'
+          - '1995-01-04T00:00:00'
+          - '1995-01-05T00:00:00'
+          - '1995-01-06T00:00:00'
+          - '1995-01-07T00:00:00'
+          - '1995-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+        file_pattern: ic_0001.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - total_frozen_precipitation_rate
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 4
+  prefetch_factor: 4
+  time_buffer: 8
+  time_buffer_pool_size: 32
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+        file_pattern: ic_0001.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1993-12-31'
+      - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+        file_pattern: ic_0001.zarr
+        engine: zarr
+        subset:
+          start_time: '1995-01-01'
+          stop_time: '2013-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 16
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+          file_pattern: ic_0001.zarr
+          engine: zarr
+          subset:
+            start_time: '1994-01-01'
+            stop_time: '1994-12-31'
+        - data_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset
+          file_pattern: ic_0001.zarr
+          engine: zarr
+          subset:
+            start_time: '2014-01-01'
+            stop_time: '2014-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/centering.nc
+          global_stds_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/centering.nc
+          global_stds_path: /climate-default/2026-01-28-vertically-resolved-c96-4deg-daily-shield-amip-ensemble-dataset-stats/combined/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+        interpolate: true
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        force_positive_names:
+          - specific_total_water_0
+          - specific_total_water_1
+          - specific_total_water_2
+          - specific_total_water_3
+          - specific_total_water_4
+          - specific_total_water_5
+          - specific_total_water_6
+          - specific_total_water_7
+          - Q2m
+          - PRATEsfc
+          - ULWRFsfc
+          - ULWRFtoa
+          - DLWRFsfc
+          - DSWRFsfc
+          - USWRFsfc
+          - USWRFtoa
+          - total_frozen_precipitation_rate
+      next_step_forcing_names:
+        - DSWRFtoa
+        - global_mean_co2
+      in_names:
+        - land_fraction
+        - ocean_fraction
+        - sea_ice_fraction
+        - DSWRFtoa
+        - HGTsfc
+        - PRESsfc
+        - surface_temperature
+        - TMP2m
+        - Q2m
+        - UGRD10m
+        - VGRD10m
+        - air_temperature_0
+        - air_temperature_1
+        - air_temperature_2
+        - air_temperature_3
+        - air_temperature_4
+        - air_temperature_5
+        - air_temperature_6
+        - air_temperature_7
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - eastward_wind_0
+        - eastward_wind_1
+        - eastward_wind_2
+        - eastward_wind_3
+        - eastward_wind_4
+        - eastward_wind_5
+        - eastward_wind_6
+        - eastward_wind_7
+        - northward_wind_0
+        - northward_wind_1
+        - northward_wind_2
+        - northward_wind_3
+        - northward_wind_4
+        - northward_wind_5
+        - northward_wind_6
+        - northward_wind_7
+        - global_mean_co2
+      out_names:
+        - PRESsfc
+        - surface_temperature
+        - TMP2m
+        - Q2m
+        - UGRD10m
+        - VGRD10m
+        - air_temperature_0
+        - air_temperature_1
+        - air_temperature_2
+        - air_temperature_3
+        - air_temperature_4
+        - air_temperature_5
+        - air_temperature_6
+        - air_temperature_7
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - eastward_wind_0
+        - eastward_wind_1
+        - eastward_wind_2
+        - eastward_wind_3
+        - eastward_wind_4
+        - eastward_wind_5
+        - eastward_wind_6
+        - eastward_wind_7
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+        - tendency_of_total_water_path_due_to_advection
+        - TMP850
+        - h500
+        - total_frozen_precipitation_rate
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only.yaml
+++ b/configs/baselines/ace2s-shield-plus-like/train-4deg-daily-v2-shield-amip-only.yaml
@@ -303,6 +303,14 @@ stepper:
         - eastward_wind_5
         - eastward_wind_6
         - eastward_wind_7
+        - northward_wind_0
+        - northward_wind_1
+        - northward_wind_2
+        - northward_wind_3
+        - northward_wind_4
+        - northward_wind_5
+        - northward_wind_6
+        - northward_wind_7
         - LHTFLsfc
         - SHTFLsfc
         - PRATEsfc


### PR DESCRIPTION
Adds ACE training **and** prescribed-SST inference configs (with launchers) that apply the ERA5 **v2-era5-only** recipe to a single SHiELD AMIP member (`ic_0001`), for the land-amplification **+4K SST-response** evaluation. The trained models are run forced by the real +2K/+4K GCM target SST and scored against the direct GCM +4K SHiELD target.

## Training configs

Both configs are built from the ACE2S-SHiELD+ **v2arch** config (correct SHiELD `in_names`/`out_names`/`next_step_forcing_names`, SHiELD `corrector`, `ocean` with `interpolate: true`, v2 `NoiseConditionedSFNO` builder with `clip_latent_global_means`) with the v2-era5-only recipe knobs spliced in:
- `max_epochs: 120`, `ema_checkpoint_save_epochs {start: 5, step: 5}`, no full-checkpoint fine-tune save.
- Single-step `stepper_training` (`n_forward_steps: 1`, `optimize_last_step_only`, `EnsembleLoss` crps 0.9 / energy_score 0.1) — replaces v2arch's epoch-scheduled multi-step.
- `stepper.step.config.global_mean_removal {kind: shared, append_as_input: true}` and `residual_prediction: true`.
- AMIP-historical normalization stats (network + residual).
- `train_loader`: AMIP member `ic_0001` with an ERA5-style held-out-year split — train 1979-2013 minus 1994 (no stitch-boundary splits; SHiELD has none). `validation`: held-out 1994 + 2014.
- One in-sample 10-year AMIP rollout inference block (`insample_10year`, weight 1.0) for checkpoint selection, mirroring the ERA5 `10year_insample` aggregator.

The with-CO2 / no-CO2 pair differs only by dropping `global_mean_co2` from `in_names` + `next_step_forcing_names` in the no-CO2 arm, mirroring the ERA5 v2 precedent (with-CO2 `znnaox7t` -> no-CO2 `im4ecamc`).

- `train-4deg-daily-v2-shield-amip-only.yaml` - with-CO2 arm.
- `train-4deg-daily-v2-shield-amip-only-no-co2.yaml` - no-CO2 arm (single CO2-removal delta).
- `run-train-shield-amip-only.sh` - launcher for both arms (1 GPU each), copied from the SHiELD `run-train.sh` guardrail launcher.

## Inference configs (+4K response)

Prescribed-SST inference that runs each trained checkpoint forced by the real GCM target SST. SST is prescribed from the forcing dataset's `surface_temperature` over ocean via the checkpoint's `ocean {interpolate: true}` config — there is **no** `perturbations` block; the +2K/+4K warming comes entirely from pointing the forcing loader at the matched c96 X-SHiELD AMIP +2K/+4K target datasets. Normalization and all variable lists come from the mounted checkpoint (`/ckpt.tar`), so one forcing config serves both the with-CO2 and no-CO2 checkpoints (the no-CO2 stepper simply does not request `global_mean_co2` from the loader).

Runs over the full matched **1979-2020** window (start `1979-01-02`, the first day present in the p2k/p4k targets; `n_forward_steps: 15339` daily steps land on 2020-12-31), identical across all six jobs. The default inference aggregator emits denormalized time-means (for Δ = warmed − control: global-mean column warming, land/ocean near-surface ratio, per-level profile).

- `ace-inference-shield-amip-control.yaml` - 0K control (observed-SST AMIP member `ic_0001`).
- `ace-inference-shield-amip-p2k.yaml` - +2K target forcing.
- `ace-inference-shield-amip-p4k.yaml` - +4K target forcing.
- `run-inference-4k-response.sh` - launches the 6 jobs (2 checkpoints × 3 forcings, 1 GPU each), with the mcgibbon wandb-attribution guardrail.

All configs pass `python -m fme.ace.validate_config` (`--config_type train` / `inference`).

- [ ] Tests added (config-only; no code changes)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (no dependency changes)
