### PR TITLE
Serialize ModuleConfig defaults in ModuleSelector.config

### DIFF
--- a/fme/core/registry/module.py
+++ b/fme/core/registry/module.py
@@ -156,6 +156,10 @@ class ModuleSelector:
                 f"got {self.type} (available: {CONDITIONAL_BUILDERS})"
             )
         self._instance = self.registry.get(self.type, self.config)
+        # Normalize config to include the built ModuleConfig's default values,
+        # so that defaults are captured when the config is serialized (e.g.
+        # logged to Weights & Biases). See issue #596.
+        self.config = dataclasses.asdict(self._instance)
 
     @property
     def module_config(self) -> ModuleConfig:

--- a/fme/core/registry/test_module_registry.py
+++ b/fme/core/registry/test_module_registry.py
@@ -46,6 +46,28 @@ class MockModuleBuilder(ModuleConfig):
         }
 
 
+@ModuleSelector.register("mock_with_default")
+@dataclasses.dataclass
+class MockModuleBuilderWithDefault(ModuleConfig):
+    param_shapes: list[tuple[int, ...]]
+    pad: str = "reflect"
+
+    def build(self, n_in_channels, n_out_channels, dataset_info):
+        return MockModule(self.param_shapes)
+
+
+def test_module_selector_config_includes_defaults():
+    """ModuleSelector.config should be normalized to include the default
+    values of the built ModuleConfig, so that defaults are captured when the
+    config is serialized (e.g. logged to wandb). See issue #596.
+    """
+    selector = ModuleSelector(
+        type="mock_with_default", config={"param_shapes": [(1, 2, 3)]}
+    )
+    serialized_config = dataclasses.asdict(selector)["config"]
+    assert serialized_config["pad"] == "reflect"
+
+
 def test_register():
     """Make sure that the registry is working as expected."""
     selector = ModuleSelector(type="mock", config={"param_shapes": [(1, 2, 3)]})


### PR DESCRIPTION
When a run is logged to Weights & Biases, only the config values explicitly set in the yaml file were captured. Default field values defined on the `ModuleConfig` dataclass were silently omitted, because `ModuleSelector` kept the raw yaml dict in its `config` field and never serialized the defaults that Python fills in when the `ModuleConfig` is instantiated. This PR normalizes `ModuleSelector.config` to the built instance's fully-defaulted values so defaults are captured wherever the config is serialized (wandb, checkpoints, logs).

Changes:
- `fme.core.registry.module.ModuleSelector.__post_init__`: after building the ModuleConfig instance, set `self.config = dataclasses.asdict(self._instance)` so default values are included in the serialized config.
- `fme.core.registry.test_module_registry`: add a mock builder with a default field and a test asserting the default appears in the serialized config (fails before the change, passes after).

Backwards compatibility: loading is unaffected. `ModuleConfig.from_state` uses `dacite(strict=True)` and every added key is a valid field of the target dataclass, so both older (partial) and newer (full) configs load correctly; the frozen/latest module backwards-compatibility tests still pass.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #596