### PR TITLE
Guide agents to keep PR descriptions self-contained

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- This description becomes the squash-and-merge commit message: keep it self-contained and describe the final state from main. Put PR-process notes (stacking/rebase, review responses, commit-by-commit narratives) in a PR comment, not here. -->
 Short description of why the PR is needed and how it satisfies those requirements, in sentence form.
 
 Changes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ When amending a PR description, make sure it still reflects the change _from mai
 
 When making PRs, use the template that exists in the repo under .github/pull_request_template.md, if one exists.
 
+The PR description becomes the squash-and-merge commit message, so keep it self-contained and describe the final state of the change from main. Keep PR-process and agent-iteration content out of it: commit-by-commit narratives (stale after squash), "review response" notes, stacking/rebase instructions, and review attributions belong in PR comments, not the description. Prefer posting such context as a PR comment rather than folding it into the description.
+
 ### Commit/PR process
 
 Changes that will go to main should be made in branches so that PRs can be made for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ When amending a PR description, make sure it still reflects the change _from mai
 
 When making PRs, use the template that exists in the repo under .github/pull_request_template.md, if one exists.
 
-The PR description becomes the squash-and-merge commit message, so keep it self-contained and describe the final state of the change from main. Keep PR-process and agent-iteration content out of it: commit-by-commit narratives (stale after squash), "review response" notes, stacking/rebase instructions, and review attributions belong in PR comments, not the description. Prefer posting such context as a PR comment rather than folding it into the description.
+The PR description becomes the squash-and-merge commit message, so keep it self-contained and describe the final state of the change from main. PR-process information belongs in PR comments, not the description.
 
 ### Commit/PR process
 


### PR DESCRIPTION
PR descriptions are squash-and-merged into the commit message on main, but agents tend to fill them with PR-process and agent-iteration content that goes stale or reads as noise in that commit (commit-by-commit narratives, "review response" notes, stacking/rebase instructions, review attributions). This adds guidance to keep descriptions self-contained and route that content to PR comments instead.

Changes:
- `AGENTS.md` (`### PR description template`): the description feeds the squash-merge commit message, so it must be self-contained and describe the final state from main; PR-process/agent-iteration content belongs in PR comments.
- `.github/pull_request_template.md`: inline HTML-comment reminder of the same rule at the top of the template.

- [x] Tests added (n/a — docs only)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated