### PR TITLE
Add L1 (CRPS-consistent) ssr_bias_l1 metric to one-step ensemble aggregator

### DIFF
--- a/docs/default-aggregator-config.yaml
+++ b/docs/default-aggregator-config.yaml
@@ -34,6 +34,7 @@ aggregator:
     strict: false
     target: denorm
     channel_mean_names: null
+    enable_ssr_bias_l1: false
   power_spectrum:
     variables: null
     name: power_spectrum

--- a/fme/ace/aggregator/one_step/ensemble.py
+++ b/fme/ace/aggregator/one_step/ensemble.py
@@ -36,6 +36,7 @@ def get_one_step_ensemble_aggregator(
     target: Literal["norm", "denorm"] = "denorm",
     channel_mean_names: Sequence[str] | None = None,
     report_variables: Sequence[str] | None = None,
+    enable_ssr_bias_l1: bool = False,
 ) -> "SelectStepEnsembleAggregator":
     return SelectStepEnsembleAggregator(
         aggregator=_EnsembleAggregator(
@@ -45,6 +46,7 @@ def get_one_step_ensemble_aggregator(
             target=target,
             channel_mean_names=channel_mean_names,
             report_variables=report_variables,
+            enable_ssr_bias_l1=enable_ssr_bias_l1,
         ),
         i_target_time=target_time,
     )
@@ -173,6 +175,75 @@ class SSRBiasMetric(ReducedMetric):
         return torch.where(prescribed, torch.zeros_like(spread), ssr_bias)
 
 
+class SSRBiasL1Metric(ReducedMetric):
+    """
+    Computes the L1 (CRPS-consistent) spread-skill ratio bias.
+
+    The bias is ``spread_L1 / skill_L1 - 1`` (target 0 at calibration, same
+    convention as the L2 :class:`SSRBiasMetric`). The two terms are the two
+    CRPS terms:
+
+    - ``spread_L1`` is the *fair* mean pairwise absolute difference,
+      ``1/(N(N-1)) * sum_{i!=j} |x_i - x_j|``. The ``i!=j`` normalization plays
+      the role that unbiased variance plays for the L2 spread.
+    - ``skill_L1`` is the *member* MAE, ``mean_i |x_i - y|`` (member-vs-obs, not
+      ensemble-mean-vs-obs). It is the CRPS skill term and needs no finite-N
+      correction: ``E|X - y|`` is already unbiased, so nothing is subtracted
+      from it (there is no L2-style ``- var/N`` analog for L1).
+
+    At calibration ``E|X - X'| = E|X - y|`` so the ratio -> 1 and the bias -> 0.
+    """
+
+    def __init__(self):
+        self._total_spread = None
+        self._total_skill = None
+        self._n_batches = 0
+
+    def record(self, target: torch.Tensor, gen: torch.Tensor):
+        num_ensemble = gen.shape[1]
+        # fair mean pairwise absolute difference over the ensemble dimension:
+        # sum over i, j of |x_i - x_j| (the i == j terms are 0, so this equals
+        # the i != j sum) divided by N(N-1), then averaged over batch and time.
+        pairwise = (gen.unsqueeze(2) - gen.unsqueeze(1)).abs().sum(dim=(1, 2))
+        spread = (pairwise / (num_ensemble * (num_ensemble - 1))).mean(dim=(0, 1))
+        # member MAE: |x_i - y| averaged over members, batch and time.
+        skill = (gen - target).abs().mean(dim=(0, 1, 2))
+        self._add_spread(spread)
+        self._add_skill(skill)
+        self._n_batches += 1
+
+    def _add_spread(self, spread: torch.Tensor):
+        if self._total_spread is None:
+            self._total_spread = torch.zeros_like(spread)
+        self._total_spread += spread
+
+    def _add_skill(self, skill: torch.Tensor):
+        if self._total_skill is None:
+            self._total_skill = torch.zeros_like(skill)
+        self._total_skill += skill
+
+    def get(self) -> torch.Tensor:
+        if self._total_spread is None or self._total_skill is None:
+            raise ValueError("No batches have been recorded.")
+        spread = self._total_spread
+        skill = self._total_skill
+        # Zero skill with nonzero spread is undefined; use -1 by convention
+        # (also the limit of spread / skill - 1 as spread -> 0 at nonzero skill).
+        ssr_bias = torch.where(
+            skill > 0, spread / skill - 1, torch.full_like(spread, -1.0)
+        )
+        # Prescribed cells (every member equals the target, e.g. SST over ocean)
+        # are a genuine 0/0: zero spread and zero error. Report 0 (perfectly
+        # calibrated) rather than the -1 floor, which would otherwise dominate
+        # the global mean of a mostly-prescribed field. Both terms are exactly 0
+        # there (identical members give |x_i - x_j| = 0 and |x_i - y| = 0), but
+        # test skill against a small fraction of the field's largest value to
+        # match the L2 metric's tolerance to rounding residue.
+        skill_floor = _PRESCRIBED_MSE_RTOL * skill.max()
+        prescribed = (self._total_spread == 0) & (self._total_skill <= skill_floor)
+        return torch.where(prescribed, torch.zeros_like(spread), ssr_bias)
+
+
 class _EnsembleAggregator:
     """
     Aggregator for ensemble-based metrics.
@@ -186,6 +257,7 @@ class _EnsembleAggregator:
         target: Literal["norm", "denorm"] = "denorm",
         channel_mean_names: Sequence[str] | None = None,
         report_variables: Sequence[str] | None = None,
+        enable_ssr_bias_l1: bool = False,
     ):
         """
         Args:
@@ -206,6 +278,9 @@ class _EnsembleAggregator:
                 variables will appear in logs and datasets. Aggregate entries
                 like ``channel_mean`` are always included. All variables are
                 still used for channel-mean computation.
+            enable_ssr_bias_l1: Whether to additionally compute the L1
+                (CRPS-consistent) spread-skill ratio bias (``ssr_bias_l1``).
+                Off by default, so existing runs' logged keys are unchanged.
         """
         self._gridded_operations = gridded_operations
         self._n_batches = 0
@@ -213,8 +288,9 @@ class _EnsembleAggregator:
         self._dist = Distributed.get_instance()
         self._log_mean_maps = log_mean_maps
         self._metadata = metadata
-        self._diverging_metrics = {"ssr_bias"}
+        self._diverging_metrics = {"ssr_bias", "ssr_bias_l1"}
         self._target = target
+        self._enable_ssr_bias_l1 = enable_ssr_bias_l1
         self._channel_mean_names = channel_mean_names
         self._report_variables = (
             frozenset(report_variables) if report_variables is not None else None
@@ -231,12 +307,16 @@ class _EnsembleAggregator:
                 "ssr_bias": {},
                 "ensemble_mean_rmse": {},
             }
+            if self._enable_ssr_bias_l1:
+                self._variable_metrics["ssr_bias_l1"] = {}
             for key in gen_data:
                 self._variable_metrics["crps"][key] = CRPSMetric()
                 self._variable_metrics["ssr_bias"][key] = SSRBiasMetric()
                 self._variable_metrics["ensemble_mean_rmse"][key] = (
                     EnsembleMeanRMSEMetric()
                 )
+                if self._enable_ssr_bias_l1:
+                    self._variable_metrics["ssr_bias_l1"][key] = SSRBiasL1Metric()
         return self._variable_metrics
 
     @torch.no_grad()
@@ -464,6 +544,9 @@ class EnsembleMetricConfig:
             via the build context, and finally to all variables present in
             the data when that is also None. Names not present in the data
             raise KeyError. Ignored when ``target="denorm"``.
+        enable_ssr_bias_l1: Whether to additionally compute the L1
+            (CRPS-consistent) spread-skill ratio bias (``ssr_bias_l1``). Off by
+            default, so existing runs' logged keys are unchanged.
     """
 
     step: int = 20
@@ -473,6 +556,7 @@ class EnsembleMetricConfig:
     strict: bool = False
     target: Literal["norm", "denorm"] = "denorm"
     channel_mean_names: list[str] | None = None
+    enable_ssr_bias_l1: bool = False
 
     def __post_init__(self):
         if self.name is None:
@@ -501,6 +585,7 @@ class EnsembleMetricConfig:
                     if is_norm
                     else None
                 ),
+                enable_ssr_bias_l1=self.enable_ssr_bias_l1,
             )
         )
 
@@ -527,6 +612,9 @@ class OneStepEnsembleMetricConfig:
             via the build context, and finally to all variables present in
             the data when that is also None. Names not present in the data
             raise KeyError. Ignored when ``target="denorm"``.
+        enable_ssr_bias_l1: Whether to additionally compute the L1
+            (CRPS-consistent) spread-skill ratio bias (``ssr_bias_l1``). Off by
+            default, so existing runs' logged keys are unchanged.
     """
 
     name: str | None = None
@@ -535,6 +623,7 @@ class OneStepEnsembleMetricConfig:
     strict: bool = False
     target: Literal["norm", "denorm"] = "denorm"
     channel_mean_names: list[str] | None = None
+    enable_ssr_bias_l1: bool = False
 
     def __post_init__(self):
         if self.name is None:
@@ -557,5 +646,6 @@ class OneStepEnsembleMetricConfig:
                     if is_norm
                     else None
                 ),
+                enable_ssr_bias_l1=self.enable_ssr_bias_l1,
             )
         )

--- a/fme/ace/aggregator/one_step/test_ensemble.py
+++ b/fme/ace/aggregator/one_step/test_ensemble.py
@@ -6,6 +6,7 @@ import torch
 from fme.ace.aggregator.one_step.ensemble import (
     CRPSMetric,
     EnsembleMeanRMSEMetric,
+    SSRBiasL1Metric,
     SSRBiasMetric,
     _EnsembleAggregator,
 )
@@ -200,6 +201,148 @@ def test_aggregator_ssr_bias_prescribed_cells_do_not_pull_scalar_to_negative_one
         scalar,
         expected,
     )
+
+
+def test_ssr_bias_l1_metric_gives_correct_shape():
+    torch.manual_seed(0)
+    metric = SSRBiasL1Metric()
+    n_batch, n_sample, n_time, n_y, n_x = 10, 3, 3, 4, 5
+    target = get_tensor((n_batch, 1, n_time, n_y, n_x))
+    gen = get_tensor((n_batch, n_sample, n_time, n_y, n_x))
+    metric.record(target=target, gen=gen)
+    got = metric.get()
+    assert isinstance(got, torch.Tensor)
+    assert got.shape == (n_y, n_x)
+
+
+@pytest.mark.parametrize("n_sample", [2, 5, 10])
+def test_ssr_bias_l1_metric_calibrated_is_zero(n_sample):
+    """A calibrated ensemble (members and target from the same distribution)
+    has E|X - X'| = E|X - y|, so ssr_bias_l1 -> 0."""
+    torch.manual_seed(0)
+    metric = SSRBiasL1Metric()
+    n_batch, n_time, n_y, n_x = 5000, 3, 4, 5
+    target = get_tensor((n_batch, 1, n_time, n_y, n_x))
+    gen = get_tensor((n_batch, n_sample, n_time, n_y, n_x))
+    metric.record(target=target, gen=gen)
+    got = metric.get()
+    assert got.shape == (n_y, n_x)
+    torch.testing.assert_close(got.mean(), torch.tensor(0.0), atol=1e-2, rtol=0.0)
+
+
+@pytest.mark.parametrize("n_sample", [2, 5, 10])
+def test_ssr_bias_l1_metric_underdispersed_is_negative(n_sample):
+    """Members clustered far more tightly than they are from the target:
+    spread_L1 << skill_L1, so ssr_bias_l1 < 0."""
+    torch.manual_seed(0)
+    metric = SSRBiasL1Metric()
+    n_batch, n_time, n_y, n_x = 5000, 3, 4, 5
+    target = get_tensor((n_batch, 1, n_time, n_y, n_x))
+    gen = get_tensor((n_batch, n_sample, n_time, n_y, n_x)) * 0.1
+    metric.record(target=target, gen=gen)
+    got = metric.get()
+    assert torch.isfinite(got).all()
+    assert (got < 0).all(), f"ssr_bias_l1 not under-dispersed: {got}"
+
+
+def test_ssr_bias_l1_metric_forms_ratio_at_end_not_per_batch():
+    """The spread and skill numerators/denominators accumulate across batches
+    and the ratio forms once in get() -- distinct from averaging per-batch
+    ratios. Two single-cell batches with known spread/skill make the two
+    orderings numerically distinguishable."""
+    metric = SSRBiasL1Metric()
+
+    def _cell(members, obs):
+        gen = torch.tensor(members, dtype=torch.float32).reshape(1, -1, 1, 1, 1)
+        target = torch.tensor([[[[[float(obs)]]]]])
+        return target, gen
+
+    # batch 1: members {0, 2}, obs 5 -> spread=|0-2|=2, skill=(5+3)/2=4
+    metric.record(*_cell([0.0, 2.0], 5.0))
+    # batch 2: members {0, 10}, obs 0 -> spread=|0-10|=10, skill=(0+10)/2=5
+    metric.record(*_cell([0.0, 10.0], 0.0))
+    got = float(metric.get().reshape(()))
+    # ratio of the summed terms: (2+10)/(4+5) - 1, NOT the mean of per-batch
+    # ratios 0.5 * ((2/4 - 1) + (10/5 - 1)) = 0.25.
+    expected = (2.0 + 10.0) / (4.0 + 5.0) - 1.0
+    assert math.isclose(got, expected, rel_tol=1e-6, abs_tol=1e-6), got
+    assert not math.isclose(got, 0.25, rel_tol=1e-6, abs_tol=1e-6)
+
+
+def test_ssr_bias_l1_prescribed_cell_is_zero_but_zero_spread_with_error_negative():
+    """A prescribed cell (members identical and equal to the target) is a 0/0
+    and reports 0; a zero-spread cell with nonzero error still gives -1."""
+    torch.manual_seed(0)
+    metric = SSRBiasL1Metric()
+    n_batch, n_sample, n_time, n_y, n_x = 10, 3, 1, 2, 2
+    target = get_tensor((n_batch, 1, n_time, n_y, n_x))
+    # zero spread everywhere: every ensemble member identical
+    single_pred = get_tensor((n_batch, 1, n_time, n_y, n_x))
+    gen = single_pred.expand(n_batch, n_sample, n_time, n_y, n_x).clone()
+    # left column: members also equal the target -> zero skill too (prescribed)
+    gen[..., 0] = target[..., 0]
+    metric.record(target=target, gen=gen)
+    got = metric.get()
+    torch.testing.assert_close(
+        got[..., 0], torch.zeros_like(got[..., 0]), atol=1e-6, rtol=0.0
+    )
+    torch.testing.assert_close(
+        got[..., 1], torch.full_like(got[..., 1], -1.0), atol=1e-6, rtol=0.0
+    )
+
+
+def test_aggregator_ssr_bias_l1_disabled_by_default():
+    """With enable_ssr_bias_l1 unset, no ssr_bias_l1 keys appear in the logs or
+    dataset, and the other families are unchanged."""
+    torch.manual_seed(0)
+    area_weights = torch.ones([4, 4], device=get_device())
+    agg = _EnsembleAggregator(
+        gridded_operations=LatLonOperations(area_weights),
+        log_mean_maps=True,
+        target="norm",
+    )
+    names = ["a", "b"]
+    target = _make_ensemble_batch(names)
+    gen = _make_ensemble_batch(names)
+    agg.record_batch(
+        target_data=target,
+        gen_data=gen,
+        target_data_norm=target,
+        gen_data_norm=gen,
+    )
+    logs = agg.get_logs(label="metrics")
+    assert not any("ssr_bias_l1" in key for key in logs)
+    dataset = agg.get_dataset()
+    assert not any("ssr_bias_l1" in str(key) for key in dataset.data_vars)
+    # the L2 family is still present
+    assert "metrics/ssr_bias/a" in logs
+
+
+def test_aggregator_ssr_bias_l1_enabled_emits_all_shapes():
+    """When enabled, ssr_bias_l1 emits per-variable, mean_map, and (for
+    target='norm') channel_mean entries, matching the other families."""
+    torch.manual_seed(0)
+    area_weights = torch.ones([4, 4], device=get_device())
+    agg = _EnsembleAggregator(
+        gridded_operations=LatLonOperations(area_weights),
+        log_mean_maps=True,
+        target="norm",
+        enable_ssr_bias_l1=True,
+    )
+    names = ["a", "b"]
+    target = _make_ensemble_batch(names)
+    gen = _make_ensemble_batch(names)
+    agg.record_batch(
+        target_data=target,
+        gen_data=gen,
+        target_data_norm=target,
+        gen_data_norm=gen,
+    )
+    logs = agg.get_logs(label="metrics")
+    for name in names:
+        assert f"metrics/ssr_bias_l1/{name}" in logs
+        assert f"metrics/ssr_bias_l1/mean_map/{name}" in logs
+    assert "metrics/ssr_bias_l1/channel_mean" in logs
 
 
 @pytest.mark.parametrize("n_sample", [2, 10])

--- a/fme/ace/aggregator/test_train.py
+++ b/fme/ace/aggregator/test_train.py
@@ -258,9 +258,92 @@ def test_aggregator_ensemble_metrics():
     assert "train/ensemble/crps/a" in logs
     assert "train/ensemble/ssr_bias/a" in logs
     assert "train/ensemble/ensemble_mean_rmse/a" in logs
+    # enable_ssr_bias_l1 defaults to False, so no ssr_bias_l1 key is logged.
+    assert not any("ssr_bias_l1" in key for key in logs)
     for key in logs:
         if key != "train/mean/loss":
             assert not np.isnan(float(logs[key])), f"{key} is NaN"
+
+
+def test_aggregator_ensemble_metrics_ssr_bias_l1():
+    """When ensemble_metrics=True and enable_ssr_bias_l1=True, logs include the
+    L1 (CRPS-consistent) ssr_bias_l1 key alongside the other ensemble metrics."""
+    batch_size = 10
+    n_ensemble = 2
+    n_time = 1
+    nx, ny = 2, 2
+    device = get_device()
+    gridded_operations = LatLonOperations(
+        area_weights=torch.ones(nx, ny, device=device)
+    )
+    config = TrainAggregatorConfig(
+        spherical_power_spectrum=False,
+        weighted_rmse=False,
+        ensemble_metrics=True,
+        enable_ssr_bias_l1=True,
+    )
+    agg = TrainAggregator(config=config, operations=gridded_operations)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="train")
+    assert "train/ensemble/ssr_bias/a" in logs
+    assert "train/ensemble/ssr_bias_l1/a" in logs
+    # The train aggregator builds the ensemble aggregator with log_mean_maps=False,
+    # so no mean-of-map key is emitted.
+    assert not any("mean_map" in key for key in logs)
+    for key in logs:
+        if key != "train/mean/loss":
+            assert not np.isnan(float(logs[key])), f"{key} is NaN"
+
+
+def test_aggregator_ensemble_metrics_ssr_bias_l1_disabled_by_default():
+    """ssr_bias_l1 is absent when enable_ssr_bias_l1 is left at its default even
+    with ensemble_metrics=True."""
+    batch_size = 10
+    n_ensemble = 2
+    n_time = 1
+    nx, ny = 2, 2
+    device = get_device()
+    gridded_operations = LatLonOperations(
+        area_weights=torch.ones(nx, ny, device=device)
+    )
+    config = TrainAggregatorConfig(
+        spherical_power_spectrum=False,
+        weighted_rmse=False,
+        ensemble_metrics=True,
+    )
+    agg = TrainAggregator(config=config, operations=gridded_operations)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+        ),
+    )
+    logs = agg.get_logs(label="train")
+    assert "train/ensemble/ssr_bias/a" in logs
+    assert not any("ssr_bias_l1" in key for key in logs)
 
 
 def test_aggregator_ensemble_metrics_disabled_by_default():

--- a/fme/ace/aggregator/train.py
+++ b/fme/ace/aggregator/train.py
@@ -35,12 +35,17 @@ class TrainAggregatorConfig:
         ensemble_metrics: Whether to compute ensemble metrics (CRPS, SSR bias, and
             ensemble-mean RMSE) over the training batches. Disabled by default;
             requires the batch to carry an ensemble dimension.
+        enable_ssr_bias_l1: Whether to additionally compute the L1
+            (CRPS-consistent) spread-skill ratio bias (``ssr_bias_l1``) when
+            ensemble_metrics is enabled. Off by default, so existing runs'
+            logged keys are unchanged.
     """
 
     spherical_power_spectrum: bool = True
     weighted_rmse: bool = True
     per_channel_loss: bool = True
     ensemble_metrics: bool = False
+    enable_ssr_bias_l1: bool = False
 
 
 class Aggregator(Protocol):
@@ -117,6 +122,7 @@ class TrainAggregator(AggregatorABC[TrainOutput]):
             self._ensemble_aggregator = _EnsembleAggregator(
                 gridded_operations=operations,
                 log_mean_maps=False,
+                enable_ssr_bias_l1=config.enable_ssr_bias_l1,
             )
 
     @torch.no_grad()


### PR DESCRIPTION
Adds an L1 (CRPS-consistent) analog of the existing L2 `ssr_bias` to the ensemble aggregator, so 1-step ensemble under-dispersion can be read in units that match the fair-CRPS / energy-score training loss rather than MSE. It is exposed on both the one-step ensemble aggregator and the train/val aggregator path.

The metric is `ssr_bias_l1 = spread_L1 / skill_L1 - 1` (target 0 at calibration, same convention as the L2 metric), where the two terms are the two CRPS terms:
- `spread_L1` is the fair mean pairwise absolute difference, `1/(N(N-1)) sum_{i!=j} |x_i - x_j|` (the `i!=j` correction plays the role unbiased variance plays for the L2 spread).
- `skill_L1` is the member MAE, `mean_i |x_i - y|` (member-vs-obs, not ensemble-mean-vs-obs). At calibration `E|X - X'| = E|X - y|`, so the ratio approaches 1. Unlike the L2 skill's `mse - var/N`, the member MAE is already unbiased and gets no finite-N correction: MAE-of-the-ensemble-mean has no closed `/N` decomposition, so there is no L2-style analog to subtract.

The numerator and denominator sums accumulate across batches and the ratio is formed once in `get()`, so it is not a per-batch-averaged ratio. Prescribed cells (every member equals the target: zero spread and zero error) report 0 rather than the -1 floor, matching `SSRBiasMetric`.

Off by default: `enable_ssr_bias_l1` gates building the family, so existing runs' logged keys are unchanged.

Changes:
- `fme.ace.aggregator.one_step.ensemble.SSRBiasL1Metric`: new `ReducedMetric` accumulating the spread and skill sums and forming the ratio in `get()`, with the prescribed-cell 0/0 handling carried over from `SSRBiasMetric`.
- `_EnsembleAggregator`: `enable_ssr_bias_l1` flag builds the `ssr_bias_l1` family (registered in `_get_variable_metrics`, added to `_diverging_metrics`), emitting `ssr_bias_l1/<var>`, `ssr_bias_l1/mean_map/<var>`, and (for `target="norm"`) `ssr_bias_l1/channel_mean` via the existing area-weighted-mean and mean-map plumbing.
- `get_one_step_ensemble_aggregator`, `EnsembleMetricConfig`, `OneStepEnsembleMetricConfig`: gain `enable_ssr_bias_l1: bool = False`.
- `fme.ace.aggregator.train.TrainAggregatorConfig`: gains `enable_ssr_bias_l1: bool = False`, forwarded into the `_EnsembleAggregator` built when `ensemble_metrics` is enabled, so the L1 metric is available on the train/val aggregator path (e.g. `val/ensemble/ssr_bias_l1`).

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated