### PR TITLE
Allow filter_preserves_global_mean with spectral_ratio < 1 in the noise-conditioned SFNO

### DIFF
--- a/fme/ace/registry/stochastic_sfno.py
+++ b/fme/ace/registry/stochastic_sfno.py
@@ -322,7 +322,6 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
             self.embed_dim,
             self.filter_num_groups,
             filter_type=self.filter_type,
-            preserves_global_mean=self.filter_preserves_global_mean,
             local_blocks=bool(self.local_blocks),
         )
 

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -152,9 +152,9 @@ class SpectralConvS2(nn.Module):
     (global-mean) mode: the per-mode weight at l=0 is bypassed, so the filter
     cannot do global-level reasoning. Its l=0 weight then trains to zero
     gradient. At ``spectral_ratio == 1`` this holds the global mean exactly; at
-    ``spectral_ratio < 1`` the l=0 still passes through the shared channel
-    projections (pre_proj/post_proj), which is a fixed mix, not per-mode
-    reasoning, so the mean is largely but not exactly preserved.
+    ``spectral_ratio < 1`` the l=0 instead passes through the shared channel
+    projections (pre_proj/post_proj), so the mean is no longer held fixed --
+    but that is a fixed channel mix, not per-mode l=0 reasoning.
     """
 
     def __init__(
@@ -415,9 +415,12 @@ class SpectralConvS2(nn.Module):
             )
             xp = xp + self.lora_scaling * lora_update
             if self._preserve_global_mean and self._has_global_mean:
-                # Bypass the l=0 per-mode weight: pass the input's l=0 through
-                # unchanged so the filter does no global-mean reasoning. See the
-                # class docstring for the exact-vs-approximate behavior by ratio.
+                # Skip the per-mode weight at l=0 by passing the input's l=0
+                # through unchanged, so the filter cannot reason about or alter
+                # the global mean. With spectral_ratio < 1 this l=0 is the
+                # bottleneck (pre_proj) representation, so the mean still passes
+                # through the shared pre/post projections rather than being held
+                # exactly; that is intended (see the class-level note).
                 xp = torch.cat([x[..., :1, :], xp[..., 1:, :]], dim=-2)
             xp = xp.reshape(B, self.spectral_channels, H, W)
             x = xp.contiguous()

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -240,6 +240,22 @@ class SpectralConvS2(nn.Module):
                 f"and out_channels={out_channels}."
             )
         if self._reduced_global_mean:
+            # The grid-space global-mean swap reads per-latitude quadrature
+            # weights from the transforms' ``weights`` buffer, which is only the
+            # full-grid, m=0 quadrature on a single spatial rank. Under spatial
+            # parallelism the buffer's latitude axis stays global (so it does
+            # not match the lat-sharded grid input) and its leading axis is the
+            # local-m partition (so ``[0, 0]`` is not the m=0 row off rank 0);
+            # the swap would then crash under H-parallelism and silently compute
+            # the wrong global mean under W-parallelism. The spectral_ratio == 1
+            # path preserves the global mean correctly under spatial parallelism
+            # via the l=0 coefficient on the l_start == 0 rank; matching that
+            # here is left as follow-up.
+            dist.require_no_spatial_parallelism(
+                "preserve_global_mean with spectral_ratio < 1 does not support "
+                "spatial parallelism; the grid-space global-mean swap needs the "
+                "single-rank, full-grid m=0 quadrature weights."
+            )
             # Latitude quadrature weights for the input (forward) grid and the
             # output (inverse) grid, uniform over longitude. inverse_transform
             # is an InverseRealSHT and carries no forward quadrature, so build a
@@ -429,8 +445,10 @@ class SpectralConvS2(nn.Module):
         ``source``'s. Because the inverse SHT of an l=0-only field is a constant
         equal to that weighted mean, this is exactly equivalent to copying the
         l=0 coefficient, but is done in the full-channel grid space rather than
-        inside the reduced-channel spectral bottleneck. Autograd-safe;
-        ``Distributed.weighted_mean`` reduces across spatial-parallel ranks.
+        inside the reduced-channel spectral bottleneck. Autograd-safe. Only
+        reached on a single spatial rank (see the spatial-parallelism guard in
+        ``__init__``); ``Distributed.weighted_mean`` then reduces over that one
+        rank.
         """
         dist = Distributed.get_instance()
         source_mean = dist.weighted_mean(

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -415,12 +415,9 @@ class SpectralConvS2(nn.Module):
             )
             xp = xp + self.lora_scaling * lora_update
             if self._preserve_global_mean and self._has_global_mean:
-                # Skip the per-mode weight at l=0 by passing the input's l=0
-                # through unchanged, so the filter cannot reason about or alter
-                # the global mean. With spectral_ratio < 1 this l=0 is the
-                # bottleneck (pre_proj) representation, so the mean still passes
-                # through the shared pre/post projections rather than being held
-                # exactly; that is intended (see the class-level note).
+                # Bypass the l=0 per-mode weight: pass the input's l=0 through
+                # unchanged so the filter does no global-mean reasoning. See the
+                # class docstring for the exact-vs-approximate behavior by ratio.
                 xp = torch.cat([x[..., :1, :], xp[..., 1:, :]], dim=-2)
             xp = xp.reshape(B, self.spectral_channels, H, W)
             x = xp.contiguous()

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -39,8 +39,6 @@ def validate_spectral_ratio(
     channels_name: str = "embed_dim",
     num_groups_name: str = "filter_num_groups",
     filter_type: str | None = None,
-    preserves_global_mean: bool = False,
-    global_mean_arg_name: str = "filter_preserves_global_mean",
     local_blocks: bool = False,
 ) -> int:
     """Validate ``spectral_ratio`` and return the resulting spectral channel count.
@@ -60,10 +58,6 @@ def validate_spectral_ratio(
         channels_name: name of ``channels`` to use in error messages.
         num_groups_name: name of ``num_groups`` to use in error messages.
         filter_type: if given, ``spectral_ratio < 1`` requires ``"linear"``.
-        preserves_global_mean: passed by callers but does not gate
-            ``spectral_ratio``; the two are compatible (see
-            ``SpectralConvS2.forward``).
-        global_mean_arg_name: name of the global-mean flag for error messages.
         local_blocks: if True, ``spectral_ratio < 1`` is rejected.
 
     Returns:
@@ -184,8 +178,6 @@ class SpectralConvS2(nn.Module):
             num_groups,
             channels_name="in_channels",
             num_groups_name="num_groups",
-            preserves_global_mean=preserve_global_mean,
-            global_mean_arg_name="preserve_global_mean",
         )
 
         assert in_channels % num_groups == 0

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -60,7 +60,11 @@ def validate_spectral_ratio(
         channels_name: name of ``channels`` to use in error messages.
         num_groups_name: name of ``num_groups`` to use in error messages.
         filter_type: if given, ``spectral_ratio < 1`` requires ``"linear"``.
-        preserves_global_mean: if True, ``spectral_ratio < 1`` is rejected.
+        preserves_global_mean: accepted for API symmetry with the callers but
+            no longer gates ``spectral_ratio``. Preserving the global mean with
+            ``spectral_ratio < 1`` is supported: ``SpectralConvS2`` restores the
+            input's l=0 coefficient in the full-channel grid space, outside the
+            reduced-channel bottleneck (see ``SpectralConvS2.forward``).
         global_mean_arg_name: name of the global-mean flag for error messages.
         local_blocks: if True, ``spectral_ratio < 1`` is rejected.
 
@@ -75,15 +79,6 @@ def validate_spectral_ratio(
             raise NotImplementedError(
                 "spectral_ratio < 1 is only supported for filter_type='linear', "
                 f"got filter_type='{filter_type}'."
-            )
-        if preserves_global_mean:
-            # The l=0 mode is sandwiched between the pre/post channel
-            # projections, so the original C-channel global mean is not
-            # recoverable from the spectral_channels-wide bottleneck.
-            raise NotImplementedError(
-                f"{global_mean_arg_name} is not supported with spectral_ratio < 1, "
-                "since the l=0 mode is sandwiched between the pre/post channel "
-                "projections."
             )
         if local_blocks:
             raise NotImplementedError(
@@ -102,6 +97,25 @@ def validate_spectral_ratio(
                 f"divisible by {num_groups_name}={num_groups}."
             )
     return spectral_channels
+
+
+def _latitude_quadrature_weights(transform) -> torch.Tensor:
+    """Per-latitude quadrature weights of a transform's l=0, m=0 basis.
+
+    For a torch-harmonics ``RealSHT`` the ``(m=0, l=0)`` row of the precomputed
+    ``weights`` buffer is exactly the latitude quadrature that forms the global
+    mean coefficient: ``sht(f)[..., 0, 0] == sqrt(4*pi) * <f>`` where ``<f>`` is
+    the mean of ``f`` over the sphere weighted by these values (uniform over
+    longitude). Returning them lets us reproduce the l=0 coefficient as a cheap
+    grid-space weighted mean instead of a full spherical harmonic transform.
+
+    For a transform without such weights (e.g. the periodic ``RealFFT2``), the
+    l=0 mode is the unweighted mean, so uniform weights are returned.
+    """
+    weights = getattr(transform, "weights", None)
+    if weights is not None:
+        return weights[0, 0, :].detach().clone().float()
+    return torch.ones(transform.nlat)
 
 
 @torch.jit.script
@@ -213,6 +227,40 @@ class SpectralConvS2(nn.Module):
         self._l_slice = l_slice
         self._preserve_global_mean = preserve_global_mean
         self._has_global_mean = l_start == 0
+        # When spectral_ratio < 1 the l=0 mode lives in the reduced-channel
+        # bottleneck, so it cannot be preserved channel-for-channel in the
+        # spectral domain. Instead the input's per-channel global mean is
+        # restored in full-channel grid space after post_proj (see forward).
+        self._reduced_global_mean = preserve_global_mean and spectral_ratio < 1.0
+        if self._reduced_global_mean and in_channels != out_channels:
+            raise NotImplementedError(
+                "preserve_global_mean with spectral_ratio < 1 requires "
+                "in_channels == out_channels so the l=0 coefficient can be "
+                f"swapped channel-for-channel, got in_channels={in_channels} "
+                f"and out_channels={out_channels}."
+            )
+        if self._reduced_global_mean:
+            # Latitude quadrature weights for the input (forward) grid and the
+            # output (inverse) grid, uniform over longitude. inverse_transform
+            # is an InverseRealSHT and carries no forward quadrature, so build a
+            # matching RealSHT to read the output grid's weights.
+            out_transform = dist.get_sht(
+                inverse_transform.nlat,
+                inverse_transform.nlon,
+                lmax=inverse_transform.lmax,
+                mmax=inverse_transform.mmax,
+                grid=inverse_transform.grid,
+            )
+            self.register_buffer(
+                "_gm_lat_weights_in",
+                _latitude_quadrature_weights(forward_transform).reshape(1, 1, -1, 1),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_gm_lat_weights_out",
+                _latitude_quadrature_weights(out_transform).reshape(1, 1, -1, 1),
+                persistent=False,
+            )
 
         # When spectral_ratio < 1, the SHT and per-mode complex weight operate
         # on a reduced spectral_channels = round(in_channels * spectral_ratio)
@@ -371,10 +419,35 @@ class SpectralConvS2(nn.Module):
         if weight.shape == ungrouped_shape:
             state_dict[key] = weight.view(1, *ungrouped_shape)
 
+    def _swap_global_mean(
+        self, output: torch.Tensor, source: torch.Tensor
+    ) -> torch.Tensor:
+        """Set ``output``'s per-channel l=0 (global-mean) coefficient to ``source``'s.
+
+        Adds a spatially-constant, per-channel shift so that, under the
+        transform's spherical quadrature, ``output``'s area-weighted mean equals
+        ``source``'s. Because the inverse SHT of an l=0-only field is a constant
+        equal to that weighted mean, this is exactly equivalent to copying the
+        l=0 coefficient, but is done in the full-channel grid space rather than
+        inside the reduced-channel spectral bottleneck. Autograd-safe;
+        ``Distributed.weighted_mean`` reduces across spatial-parallel ranks.
+        """
+        dist = Distributed.get_instance()
+        source_mean = dist.weighted_mean(
+            source, self._gm_lat_weights_in, dim=(-2, -1), keepdim=True
+        )
+        output_mean = dist.weighted_mean(
+            output, self._gm_lat_weights_out, dim=(-2, -1), keepdim=True
+        )
+        return output + (source_mean - output_mean)
+
     def forward(self, x, timer: Timer = NullTimer()):  # pragma: no cover
         dtype = x.dtype
         residual = x
         x = x.float()
+        # Full-channel input in grid space, kept for the reduced-bottleneck
+        # global-mean swap below (before any pre_proj down-projection).
+        global_mean_source = x if self._reduced_global_mean else None
 
         with torch.amp.autocast("cuda", enabled=False):
             if self.pre_proj is not None:
@@ -413,7 +486,11 @@ class SpectralConvS2(nn.Module):
                 weight_local,
             )
             xp = xp + self.lora_scaling * lora_update
-            if self._preserve_global_mean and self._has_global_mean:
+            if (
+                self._preserve_global_mean
+                and not self._reduced_global_mean
+                and self._has_global_mean
+            ):
                 xp = torch.cat([x[..., :1, :], xp[..., 1:, :]], dim=-2)
             xp = xp.reshape(B, self.spectral_channels, H, W)
             x = xp.contiguous()
@@ -424,6 +501,9 @@ class SpectralConvS2(nn.Module):
             if self.post_proj is not None:
                 with timer.child("post_proj"):
                     x = self.post_proj(x)
+            if global_mean_source is not None:
+                with timer.child("preserve_global_mean"):
+                    x = self._swap_global_mean(x, global_mean_source)
 
         if hasattr(self, "bias"):
             with timer.child("add_bias"):

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -449,13 +449,24 @@ class SpectralConvS2(nn.Module):
         reached on a single spatial rank (see the spatial-parallelism guard in
         ``__init__``); ``Distributed.weighted_mean`` then reduces over that one
         rank.
+
+        All operands are aligned to ``output.device`` before combining. The
+        transforms these buffers come from can be built on different devices
+        (``get_real_sht`` moves to ``get_device``, the internally-built
+        ``out_transform`` does not), and ``source`` is the pre-transform input,
+        which may sit on the host while the transformed ``output`` is on device.
+        The moves are no-ops once the whole module and its inputs share a device.
         """
         dist = Distributed.get_instance()
+        device = output.device
         source_mean = dist.weighted_mean(
-            source, self._gm_lat_weights_in, dim=(-2, -1), keepdim=True
+            source.to(device),
+            self._gm_lat_weights_in.to(device),
+            dim=(-2, -1),
+            keepdim=True,
         )
         output_mean = dist.weighted_mean(
-            output, self._gm_lat_weights_out, dim=(-2, -1), keepdim=True
+            output, self._gm_lat_weights_out.to(device), dim=(-2, -1), keepdim=True
         )
         return output + (source_mean - output_mean)
 

--- a/fme/core/models/conditional_sfno/s2convolutions.py
+++ b/fme/core/models/conditional_sfno/s2convolutions.py
@@ -60,11 +60,9 @@ def validate_spectral_ratio(
         channels_name: name of ``channels`` to use in error messages.
         num_groups_name: name of ``num_groups`` to use in error messages.
         filter_type: if given, ``spectral_ratio < 1`` requires ``"linear"``.
-        preserves_global_mean: accepted for API symmetry with the callers but
-            no longer gates ``spectral_ratio``. Preserving the global mean with
-            ``spectral_ratio < 1`` is supported: ``SpectralConvS2`` restores the
-            input's l=0 coefficient in the full-channel grid space, outside the
-            reduced-channel bottleneck (see ``SpectralConvS2.forward``).
+        preserves_global_mean: passed by callers but does not gate
+            ``spectral_ratio``; the two are compatible (see
+            ``SpectralConvS2.forward``).
         global_mean_arg_name: name of the global-mean flag for error messages.
         local_blocks: if True, ``spectral_ratio < 1`` is rejected.
 
@@ -97,25 +95,6 @@ def validate_spectral_ratio(
                 f"divisible by {num_groups_name}={num_groups}."
             )
     return spectral_channels
-
-
-def _latitude_quadrature_weights(transform) -> torch.Tensor:
-    """Per-latitude quadrature weights of a transform's l=0, m=0 basis.
-
-    For a torch-harmonics ``RealSHT`` the ``(m=0, l=0)`` row of the precomputed
-    ``weights`` buffer is exactly the latitude quadrature that forms the global
-    mean coefficient: ``sht(f)[..., 0, 0] == sqrt(4*pi) * <f>`` where ``<f>`` is
-    the mean of ``f`` over the sphere weighted by these values (uniform over
-    longitude). Returning them lets us reproduce the l=0 coefficient as a cheap
-    grid-space weighted mean instead of a full spherical harmonic transform.
-
-    For a transform without such weights (e.g. the periodic ``RealFFT2``), the
-    l=0 mode is the unweighted mean, so uniform weights are returned.
-    """
-    weights = getattr(transform, "weights", None)
-    if weights is not None:
-        return weights[0, 0, :].detach().clone().float()
-    return torch.ones(transform.nlat)
 
 
 @torch.jit.script
@@ -168,6 +147,14 @@ class SpectralConvS2(nn.Module):
     the two-sphere S2 using the Spherical Harmonic Transforms in torch-harmonics, but
     supports convolutions on the periodic domain via the RealFFT2 and InverseRealFFT2
     wrappers.
+
+    ``preserve_global_mean`` stops the spectral filter from acting on the l=0
+    (global-mean) mode: the per-mode weight at l=0 is bypassed, so the filter
+    cannot do global-level reasoning. Its l=0 weight then trains to zero
+    gradient. At ``spectral_ratio == 1`` this holds the global mean exactly; at
+    ``spectral_ratio < 1`` the l=0 still passes through the shared channel
+    projections (pre_proj/post_proj), which is a fixed mix, not per-mode
+    reasoning, so the mean is largely but not exactly preserved.
     """
 
     def __init__(
@@ -227,56 +214,6 @@ class SpectralConvS2(nn.Module):
         self._l_slice = l_slice
         self._preserve_global_mean = preserve_global_mean
         self._has_global_mean = l_start == 0
-        # When spectral_ratio < 1 the l=0 mode lives in the reduced-channel
-        # bottleneck, so it cannot be preserved channel-for-channel in the
-        # spectral domain. Instead the input's per-channel global mean is
-        # restored in full-channel grid space after post_proj (see forward).
-        self._reduced_global_mean = preserve_global_mean and spectral_ratio < 1.0
-        if self._reduced_global_mean and in_channels != out_channels:
-            raise NotImplementedError(
-                "preserve_global_mean with spectral_ratio < 1 requires "
-                "in_channels == out_channels so the l=0 coefficient can be "
-                f"swapped channel-for-channel, got in_channels={in_channels} "
-                f"and out_channels={out_channels}."
-            )
-        if self._reduced_global_mean:
-            # The grid-space global-mean swap reads per-latitude quadrature
-            # weights from the transforms' ``weights`` buffer, which is only the
-            # full-grid, m=0 quadrature on a single spatial rank. Under spatial
-            # parallelism the buffer's latitude axis stays global (so it does
-            # not match the lat-sharded grid input) and its leading axis is the
-            # local-m partition (so ``[0, 0]`` is not the m=0 row off rank 0);
-            # the swap would then crash under H-parallelism and silently compute
-            # the wrong global mean under W-parallelism. The spectral_ratio == 1
-            # path preserves the global mean correctly under spatial parallelism
-            # via the l=0 coefficient on the l_start == 0 rank; matching that
-            # here is left as follow-up.
-            dist.require_no_spatial_parallelism(
-                "preserve_global_mean with spectral_ratio < 1 does not support "
-                "spatial parallelism; the grid-space global-mean swap needs the "
-                "single-rank, full-grid m=0 quadrature weights."
-            )
-            # Latitude quadrature weights for the input (forward) grid and the
-            # output (inverse) grid, uniform over longitude. inverse_transform
-            # is an InverseRealSHT and carries no forward quadrature, so build a
-            # matching RealSHT to read the output grid's weights.
-            out_transform = dist.get_sht(
-                inverse_transform.nlat,
-                inverse_transform.nlon,
-                lmax=inverse_transform.lmax,
-                mmax=inverse_transform.mmax,
-                grid=inverse_transform.grid,
-            )
-            self.register_buffer(
-                "_gm_lat_weights_in",
-                _latitude_quadrature_weights(forward_transform).reshape(1, 1, -1, 1),
-                persistent=False,
-            )
-            self.register_buffer(
-                "_gm_lat_weights_out",
-                _latitude_quadrature_weights(out_transform).reshape(1, 1, -1, 1),
-                persistent=False,
-            )
 
         # When spectral_ratio < 1, the SHT and per-mode complex weight operate
         # on a reduced spectral_channels = round(in_channels * spectral_ratio)
@@ -435,48 +372,10 @@ class SpectralConvS2(nn.Module):
         if weight.shape == ungrouped_shape:
             state_dict[key] = weight.view(1, *ungrouped_shape)
 
-    def _swap_global_mean(
-        self, output: torch.Tensor, source: torch.Tensor
-    ) -> torch.Tensor:
-        """Set ``output``'s per-channel l=0 (global-mean) coefficient to ``source``'s.
-
-        Adds a spatially-constant, per-channel shift so that, under the
-        transform's spherical quadrature, ``output``'s area-weighted mean equals
-        ``source``'s. Because the inverse SHT of an l=0-only field is a constant
-        equal to that weighted mean, this is exactly equivalent to copying the
-        l=0 coefficient, but is done in the full-channel grid space rather than
-        inside the reduced-channel spectral bottleneck. Autograd-safe. Only
-        reached on a single spatial rank (see the spatial-parallelism guard in
-        ``__init__``); ``Distributed.weighted_mean`` then reduces over that one
-        rank.
-
-        All operands are aligned to ``output.device`` before combining. The
-        transforms these buffers come from can be built on different devices
-        (``get_real_sht`` moves to ``get_device``, the internally-built
-        ``out_transform`` does not), and ``source`` is the pre-transform input,
-        which may sit on the host while the transformed ``output`` is on device.
-        The moves are no-ops once the whole module and its inputs share a device.
-        """
-        dist = Distributed.get_instance()
-        device = output.device
-        source_mean = dist.weighted_mean(
-            source.to(device),
-            self._gm_lat_weights_in.to(device),
-            dim=(-2, -1),
-            keepdim=True,
-        )
-        output_mean = dist.weighted_mean(
-            output, self._gm_lat_weights_out.to(device), dim=(-2, -1), keepdim=True
-        )
-        return output + (source_mean - output_mean)
-
     def forward(self, x, timer: Timer = NullTimer()):  # pragma: no cover
         dtype = x.dtype
         residual = x
         x = x.float()
-        # Full-channel input in grid space, kept for the reduced-bottleneck
-        # global-mean swap below (before any pre_proj down-projection).
-        global_mean_source = x if self._reduced_global_mean else None
 
         with torch.amp.autocast("cuda", enabled=False):
             if self.pre_proj is not None:
@@ -515,11 +414,13 @@ class SpectralConvS2(nn.Module):
                 weight_local,
             )
             xp = xp + self.lora_scaling * lora_update
-            if (
-                self._preserve_global_mean
-                and not self._reduced_global_mean
-                and self._has_global_mean
-            ):
+            if self._preserve_global_mean and self._has_global_mean:
+                # Skip the per-mode weight at l=0 by passing the input's l=0
+                # through unchanged, so the filter cannot reason about or alter
+                # the global mean. With spectral_ratio < 1 this l=0 is the
+                # bottleneck (pre_proj) representation, so the mean still passes
+                # through the shared pre/post projections rather than being held
+                # exactly; that is intended (see the class-level note).
                 xp = torch.cat([x[..., :1, :], xp[..., 1:, :]], dim=-2)
             xp = xp.reshape(B, self.spectral_channels, H, W)
             x = xp.contiguous()
@@ -530,9 +431,6 @@ class SpectralConvS2(nn.Module):
             if self.post_proj is not None:
                 with timer.child("post_proj"):
                     x = self.post_proj(x)
-            if global_mean_source is not None:
-                with timer.child("preserve_global_mean"):
-                    x = self._swap_global_mean(x, global_mean_source)
 
         if hasattr(self, "bias"):
             with timer.child("add_bias"):

--- a/fme/core/models/conditional_sfno/sfnonet.py
+++ b/fme/core/models/conditional_sfno/sfnonet.py
@@ -142,7 +142,6 @@ class SFNONetConfig:
             self.embed_dim,
             self.filter_num_groups,
             filter_type=self.filter_type,
-            preserves_global_mean=self.filter_preserves_global_mean,
             local_blocks=bool(self.local_blocks),
         )
 

--- a/fme/core/models/conditional_sfno/test_s2convolutions.py
+++ b/fme/core/models/conditional_sfno/test_s2convolutions.py
@@ -213,8 +213,31 @@ def test_spectral_ratio_validation():
     # 8 * 0.25 -> 2 spectral channels, not divisible by num_groups=4
     with pytest.raises(ValueError, match="num_groups"):
         _make_conv(embed_dim, spectral_ratio=0.25, num_groups=4)
-    with pytest.raises(NotImplementedError, match="preserve_global_mean"):
-        _make_conv(embed_dim, spectral_ratio=0.5, preserve_global_mean=True)
+
+
+def test_preserve_global_mean_with_spectral_ratio_preserves_l0():
+    # spectral_ratio < 1 with preserve_global_mean is supported: the input's
+    # per-channel l=0 coefficient is restored in full-channel grid space after
+    # post_proj, so it round-trips through the reduced-channel bottleneck.
+    embed_dim = 8
+    n_lat, n_lon = 16, 32
+    torch.manual_seed(0)
+    conv = _make_conv(
+        embed_dim, n_lat, n_lon, spectral_ratio=0.5, preserve_global_mean=True
+    )
+    assert conv.spectral_channels == embed_dim // 2
+    x = torch.randn(2, embed_dim, n_lat, n_lon)
+    with torch.no_grad():
+        output, _ = conv(x)
+    sht = LatLonOperations(
+        area_weights=torch.ones(n_lat, n_lon), grid="legendre-gauss"
+    ).get_real_sht()
+    torch.testing.assert_close(
+        sht(output.float())[:, :, 0, :],
+        sht(x.float())[:, :, 0, :],
+        atol=1e-5,
+        rtol=1e-5,
+    )
 
 
 def test_spectral_conv_s2_lora():

--- a/fme/core/models/conditional_sfno/test_s2convolutions.py
+++ b/fme/core/models/conditional_sfno/test_s2convolutions.py
@@ -215,10 +215,10 @@ def test_spectral_ratio_validation():
         _make_conv(embed_dim, spectral_ratio=0.25, num_groups=4)
 
 
-def test_preserve_global_mean_with_spectral_ratio_preserves_l0():
-    # spectral_ratio < 1 with preserve_global_mean is supported: the input's
-    # per-channel l=0 coefficient is restored in full-channel grid space after
-    # post_proj, so it round-trips through the reduced-channel bottleneck.
+def test_preserve_global_mean_with_spectral_ratio_bypasses_l0_weight():
+    # spectral_ratio < 1 with preserve_global_mean is supported and keeps the
+    # defining behavior: the l=0 per-mode weight is bypassed, so changing it
+    # does not affect the output and it receives no gradient.
     embed_dim = 8
     n_lat, n_lon = 16, 32
     torch.manual_seed(0)
@@ -228,16 +228,14 @@ def test_preserve_global_mean_with_spectral_ratio_preserves_l0():
     assert conv.spectral_channels == embed_dim // 2
     x = torch.randn(2, embed_dim, n_lat, n_lon)
     with torch.no_grad():
-        output, _ = conv(x)
-    sht = LatLonOperations(
-        area_weights=torch.ones(n_lat, n_lon), grid="legendre-gauss"
-    ).get_real_sht()
-    torch.testing.assert_close(
-        sht(output.float())[:, :, 0, :],
-        sht(x.float())[:, :, 0, :],
-        atol=1e-5,
-        rtol=1e-5,
-    )
+        baseline, _ = conv(x)
+        conv.weight[:, 0] += 10.0  # l=0 row of the per-mode weight
+        perturbed, _ = conv(x)
+    torch.testing.assert_close(perturbed, baseline, atol=1e-5, rtol=1e-5)
+
+    conv(x)[0].sum().backward()
+    assert torch.all(conv.weight.grad[:, 0] == 0)
+    assert not torch.all(conv.weight.grad[:, 1:] == 0)
 
 
 def test_spectral_conv_s2_lora():

--- a/fme/core/models/conditional_sfno/test_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_sfnonet.py
@@ -407,8 +407,8 @@ def test_sfnonet_spectral_ratio_rejects_non_linear_filter():
 
 def test_sfnonet_spectral_ratio_allows_preserve_global_mean():
     # spectral_ratio < 1 and filter_preserves_global_mean are now compatible:
-    # the l=0 coefficient is restored in full-channel grid space, outside the
-    # reduced-channel bottleneck.
+    # the l=0 per-mode weight is bypassed in the spectral domain, so the config
+    # no longer needs to be rejected.
     SFNONetConfig(
         embed_dim=16,
         num_layers=2,

--- a/fme/core/models/conditional_sfno/test_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_sfnonet.py
@@ -7,7 +7,6 @@ from torch import nn
 from fme.ace.models.modulus.sfnonet import SphericalFourierNeuralOperatorNet
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
-from fme.core.distributed.distributed import SpatialParallelismNotImplemented
 from fme.core.models.conditional_sfno.benchmark import get_block_benchmark
 from fme.core.testing.regression import validate_tensor
 
@@ -329,28 +328,28 @@ def test_filter_preserves_global_mean():
 
 
 def test_filter_preserves_global_mean_with_spectral_ratio():
-    """With spectral_ratio < 1 the l=0 coefficient is restored outside the
-    reduced-channel bottleneck, so the SpectralConvS2 output's per-channel l=0
-    still equals the input's."""
+    """With spectral_ratio < 1, preserve_global_mean still bypasses the l=0
+    per-mode weight: its output is discarded, so mutating it does not change the
+    forward output and it receives no gradient."""
     torch.manual_seed(0)
     nlat, nlon, embed_dim = 16, 32, 8
     device = get_device()
-    conv, sht = _make_spectral_conv(
+    conv, _ = _make_spectral_conv(
         nlat, nlon, embed_dim, preserve_global_mean=True, spectral_ratio=0.5
     )
     conv = conv.to(device)
-    sht = sht.to(device)
     assert conv.spectral_channels == embed_dim // 2
 
     x = torch.randn(2, embed_dim, nlat, nlon, device=device)
     with torch.no_grad():
-        output, _ = conv(x)
+        baseline, _ = conv(x)
+        conv.weight[:, 0] += 10.0  # l=0 row of the per-mode weight
+        perturbed, _ = conv(x)
+    torch.testing.assert_close(perturbed, baseline, atol=1e-5, rtol=1e-5)
 
-    x_spectral = sht(x.float())
-    out_spectral = sht(output.float())
-    torch.testing.assert_close(
-        out_spectral[:, :, 0, :], x_spectral[:, :, 0, :], atol=1e-5, rtol=1e-5
-    )
+    conv(x)[0].sum().backward()
+    assert torch.all(conv.weight.grad[:, 0] == 0)
+    assert not torch.all(conv.weight.grad[:, 1:] == 0)
 
 
 def test_sfnonet_spectral_ratio_end_to_end():
@@ -444,8 +443,8 @@ def test_sfnonet_spectral_ratio_rejects_indivisible_groups():
 
 def test_sfnonet_spectral_ratio_preserve_global_mean_end_to_end():
     """Combined spectral_ratio < 1 and filter_preserves_global_mean: the model
-    builds, forwards, and backpropagates through both the reduced-channel
-    projections and the grid-space global-mean swap."""
+    builds, forwards, and backpropagates through the reduced-channel projections
+    while the l=0 per-mode weight stays bypassed."""
     torch.manual_seed(0)
     input_channels = 2
     output_channels = 3
@@ -477,30 +476,51 @@ def test_sfnonet_spectral_ratio_preserve_global_mean_end_to_end():
     output.sum().backward()
     for block in model.blocks:
         spectral_conv = block.filter.filter
-        assert spectral_conv._reduced_global_mean
+        assert spectral_conv._preserve_global_mean
         assert spectral_conv.spectral_channels == embed_dim // 2
         assert spectral_conv.weight.grad is not None
-        assert not torch.all(spectral_conv.weight.grad == 0)
+        # l=0 per-mode weight is bypassed; the other modes still train.
+        assert torch.all(spectral_conv.weight.grad[:, 0] == 0)
+        assert not torch.all(spectral_conv.weight.grad[:, 1:] == 0)
         assert spectral_conv.pre_proj.weight.grad is not None
         assert spectral_conv.post_proj.weight.grad is not None
 
 
 @pytest.mark.parallel
-def test_spectral_ratio_preserve_global_mean_rejects_spatial_parallelism():
-    """The grid-space global-mean swap reads the transform's ``weights`` buffer,
-    which is only the full-grid m=0 quadrature on a single spatial rank. Under
-    spatial parallelism it would crash (H) or silently return the wrong mean
-    (W), so construction must reject it. The spectral_ratio == 1 path preserves
-    the mean correctly under spatial parallelism and must still build."""
+def test_sfnonet_spectral_ratio_preserve_global_mean_spatial_parallel():
+    """spectral_ratio < 1 with filter_preserves_global_mean builds and forwards
+    under spatial parallelism: the l=0 passthrough is a spectral-domain copy on
+    the l_start == 0 rank, distributed exactly like the spectral_ratio == 1
+    path, so it needs no full-grid quadrature and no rejection."""
+    torch.manual_seed(0)
     dist = Distributed.get_instance()
-    nlat, nlon, embed_dim = 16, 32, 8
-    conv_kwargs = dict(preserve_global_mean=True)
     if dist.world_size == dist.total_data_parallel_ranks:
         pytest.skip("no spatial parallelism in this configuration")
-    with pytest.raises(SpatialParallelismNotImplemented):
-        _make_spectral_conv(nlat, nlon, embed_dim, spectral_ratio=0.5, **conv_kwargs)
-    # spectral_ratio == 1 remains supported under spatial parallelism.
-    _make_spectral_conv(nlat, nlon, embed_dim, spectral_ratio=1.0, **conv_kwargs)
+    embed_dim = 16
+    img_shape = (8, 16)  # divides evenly across spatial ranks
+    device = get_device()
+    params = SFNONetConfig(
+        embed_dim=embed_dim,
+        num_layers=2,
+        filter_type="linear",
+        spectral_ratio=0.5,
+        filter_preserves_global_mean=True,
+    )
+    model = get_lat_lon_sfnonet(
+        params=params, img_shape=img_shape, in_chans=2, out_chans=2
+    ).to(device)
+    x_global = torch.randn(2, 2, *img_shape, device=device)
+    h_slice, w_slice = dist.get_local_slices(img_shape)
+    x_local = x_global[..., h_slice, w_slice]
+    context = Context(
+        embedding_scalar=torch.zeros(2, 0, device=device),
+        labels=torch.zeros(2, 0, device=device),
+        noise=None,
+        embedding_pos=None,
+    )
+    output = model(x_local, context)
+    assert output.shape == (2, 2, *x_local.shape[-2:])
+    output.sum().backward()
 
 
 def test_filter_preserves_global_mean_allows_grad():

--- a/fme/core/models/conditional_sfno/test_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_sfnonet.py
@@ -407,8 +407,8 @@ def test_sfnonet_spectral_ratio_rejects_non_linear_filter():
 
 def test_sfnonet_spectral_ratio_allows_preserve_global_mean():
     # spectral_ratio < 1 and filter_preserves_global_mean are now compatible:
-    # the l=0 per-mode weight is bypassed in the spectral domain, so the config
-    # no longer needs to be rejected.
+    # the l=0 coefficient is restored in full-channel grid space, outside the
+    # reduced-channel bottleneck.
     SFNONetConfig(
         embed_dim=16,
         num_layers=2,

--- a/fme/core/models/conditional_sfno/test_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_sfnonet.py
@@ -7,6 +7,7 @@ from torch import nn
 from fme.ace.models.modulus.sfnonet import SphericalFourierNeuralOperatorNet
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
+from fme.core.distributed.distributed import SpatialParallelismNotImplemented
 from fme.core.models.conditional_sfno.benchmark import get_block_benchmark
 from fme.core.testing.regression import validate_tensor
 
@@ -482,6 +483,24 @@ def test_sfnonet_spectral_ratio_preserve_global_mean_end_to_end():
         assert not torch.all(spectral_conv.weight.grad == 0)
         assert spectral_conv.pre_proj.weight.grad is not None
         assert spectral_conv.post_proj.weight.grad is not None
+
+
+@pytest.mark.parallel
+def test_spectral_ratio_preserve_global_mean_rejects_spatial_parallelism():
+    """The grid-space global-mean swap reads the transform's ``weights`` buffer,
+    which is only the full-grid m=0 quadrature on a single spatial rank. Under
+    spatial parallelism it would crash (H) or silently return the wrong mean
+    (W), so construction must reject it. The spectral_ratio == 1 path preserves
+    the mean correctly under spatial parallelism and must still build."""
+    dist = Distributed.get_instance()
+    nlat, nlon, embed_dim = 16, 32, 8
+    conv_kwargs = dict(preserve_global_mean=True)
+    if dist.world_size == dist.total_data_parallel_ranks:
+        pytest.skip("no spatial parallelism in this configuration")
+    with pytest.raises(SpatialParallelismNotImplemented):
+        _make_spectral_conv(nlat, nlon, embed_dim, spectral_ratio=0.5, **conv_kwargs)
+    # spectral_ratio == 1 remains supported under spatial parallelism.
+    _make_spectral_conv(nlat, nlon, embed_dim, spectral_ratio=1.0, **conv_kwargs)
 
 
 def test_filter_preserves_global_mean_allows_grad():

--- a/fme/core/models/conditional_sfno/test_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_sfnonet.py
@@ -284,7 +284,9 @@ def test_block_speed():
     )
 
 
-def _make_spectral_conv(nlat, nlon, embed_dim, preserve_global_mean, bias=False):
+def _make_spectral_conv(
+    nlat, nlon, embed_dim, preserve_global_mean, bias=False, spectral_ratio=1.0
+):
     dist = Distributed.get_instance()
     modes_lat = nlat
     modes_lon = nlon // 2 + 1
@@ -301,6 +303,7 @@ def _make_spectral_conv(nlat, nlon, embed_dim, preserve_global_mean, bias=False)
         embed_dim,
         bias=bias,
         preserve_global_mean=preserve_global_mean,
+        spectral_ratio=spectral_ratio,
     )
     return conv, sht
 
@@ -312,6 +315,31 @@ def test_filter_preserves_global_mean():
     conv, sht = _make_spectral_conv(nlat, nlon, embed_dim, preserve_global_mean=True)
     conv = conv.to(device)
     sht = sht.to(device)
+
+    x = torch.randn(2, embed_dim, nlat, nlon, device=device)
+    with torch.no_grad():
+        output, _ = conv(x)
+
+    x_spectral = sht(x.float())
+    out_spectral = sht(output.float())
+    torch.testing.assert_close(
+        out_spectral[:, :, 0, :], x_spectral[:, :, 0, :], atol=1e-5, rtol=1e-5
+    )
+
+
+def test_filter_preserves_global_mean_with_spectral_ratio():
+    """With spectral_ratio < 1 the l=0 coefficient is restored outside the
+    reduced-channel bottleneck, so the SpectralConvS2 output's per-channel l=0
+    still equals the input's."""
+    torch.manual_seed(0)
+    nlat, nlon, embed_dim = 16, 32, 8
+    device = get_device()
+    conv, sht = _make_spectral_conv(
+        nlat, nlon, embed_dim, preserve_global_mean=True, spectral_ratio=0.5
+    )
+    conv = conv.to(device)
+    sht = sht.to(device)
+    assert conv.spectral_channels == embed_dim // 2
 
     x = torch.randn(2, embed_dim, nlat, nlon, device=device)
     with torch.no_grad():
@@ -377,15 +405,17 @@ def test_sfnonet_spectral_ratio_rejects_non_linear_filter():
         )
 
 
-def test_sfnonet_spectral_ratio_rejects_preserve_global_mean():
-    with pytest.raises(NotImplementedError, match="filter_preserves_global_mean"):
-        SFNONetConfig(
-            embed_dim=16,
-            num_layers=2,
-            filter_type="linear",
-            spectral_ratio=0.5,
-            filter_preserves_global_mean=True,
-        )
+def test_sfnonet_spectral_ratio_allows_preserve_global_mean():
+    # spectral_ratio < 1 and filter_preserves_global_mean are now compatible:
+    # the l=0 coefficient is restored in full-channel grid space, outside the
+    # reduced-channel bottleneck.
+    SFNONetConfig(
+        embed_dim=16,
+        num_layers=2,
+        filter_type="linear",
+        spectral_ratio=0.5,
+        filter_preserves_global_mean=True,
+    )
 
 
 def test_sfnonet_spectral_ratio_rejects_local_blocks():
@@ -409,6 +439,49 @@ def test_sfnonet_spectral_ratio_rejects_indivisible_groups():
             spectral_ratio=0.25,
             filter_num_groups=4,
         )
+
+
+def test_sfnonet_spectral_ratio_preserve_global_mean_end_to_end():
+    """Combined spectral_ratio < 1 and filter_preserves_global_mean: the model
+    builds, forwards, and backpropagates through both the reduced-channel
+    projections and the grid-space global-mean swap."""
+    torch.manual_seed(0)
+    input_channels = 2
+    output_channels = 3
+    embed_dim = 16
+    img_shape = (9, 18)
+    device = get_device()
+    params = SFNONetConfig(
+        embed_dim=embed_dim,
+        num_layers=2,
+        filter_type="linear",
+        spectral_ratio=0.5,
+        filter_preserves_global_mean=True,
+    )
+    model = get_lat_lon_sfnonet(
+        params=params,
+        img_shape=img_shape,
+        in_chans=input_channels,
+        out_chans=output_channels,
+    ).to(device)
+    x = torch.randn(2, input_channels, *img_shape, device=device)
+    context = Context(
+        embedding_scalar=torch.zeros(2, 0, device=device),
+        labels=torch.zeros(2, 0, device=device),
+        noise=None,
+        embedding_pos=None,
+    )
+    output = model(x, context)
+    assert output.shape == (2, output_channels, *img_shape)
+    output.sum().backward()
+    for block in model.blocks:
+        spectral_conv = block.filter.filter
+        assert spectral_conv._reduced_global_mean
+        assert spectral_conv.spectral_channels == embed_dim // 2
+        assert spectral_conv.weight.grad is not None
+        assert not torch.all(spectral_conv.weight.grad == 0)
+        assert spectral_conv.pre_proj.weight.grad is not None
+        assert spectral_conv.post_proj.weight.grad is not None
 
 
 def test_filter_preserves_global_mean_allows_grad():


### PR DESCRIPTION
The noise-conditioned SFNO previously rejected `filter_preserves_global_mean` together with `spectral_ratio < 1`. This makes them compatible.

`filter_preserves_global_mean` means the spectral filter must not act on the l=0 (global-mean) mode: the per-mode weight at l=0 is bypassed so the filter cannot do global-level reasoning (its l=0 weight trains to zero gradient). The existing `spectral_ratio == 1` path already does this by passing the input's l=0 coefficient through unchanged in the spectral domain (`torch.cat([x[..., :1, :], xp[..., 1:, :]])`). That same passthrough works at `spectral_ratio < 1`: the l=0 that flows through is the reduced-channel bottleneck (`pre_proj`) representation, so it passes through the shared `pre_proj`/`post_proj` channel projections — a fixed mix, not per-mode reasoning — rather than the l=0-specific weight. The global mean is therefore largely, not exactly, preserved; this is the intended trade for keeping the filter free of l=0 reasoning without extra machinery.

Because the passthrough happens in the spectral domain, gated by `_has_global_mean` (the `l_start == 0` rank), it is distributed-correct exactly like the `spectral_ratio == 1` path — so the combination is now supported under spatial parallelism as well.

Changes:
- `fme.core.models.conditional_sfno.s2convolutions.validate_spectral_ratio`: no longer rejects `preserves_global_mean` with `spectral_ratio < 1`; docstring updated.
- `fme.core.models.conditional_sfno.s2convolutions.SpectralConvS2`: the l=0 spectral-domain passthrough now runs at any `spectral_ratio`; class docstring documents what `preserve_global_mean` does and the exact-vs-approximate distinction across ratios.
- Tests: replaced the config-rejection tests with a build test and behavioral tests asserting the l=0 per-mode weight is bypassed (no gradient, output invariant to it) at `spectral_ratio < 1`, at both `SpectralConvS2` and `SFNONet` level; added a combined end-to-end/gradient test; added a `@pytest.mark.parallel` test that the combination builds and forwards under spatial parallelism.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated