### PR TITLE
Refactor HEALPix UNet configs/models to the Builder pattern (Rule 2)

### DIFF
--- a/fme/ace/models/healpix/healpix_blocks.py
+++ b/fme/ace/models/healpix/healpix_blocks.py
@@ -17,6 +17,7 @@
 
 import dataclasses
 import math
+from collections.abc import Callable
 from typing import Literal, Optional, Sequence, Tuple, Union
 
 import torch
@@ -185,7 +186,7 @@ class TransposedConvUpsampleBlockConfig:
             in_channels=in_channels,
             out_channels=out_channels,
             upsampling=self.stride,
-            activation=self.activation,
+            activation_factory=self.activation.build if self.activation else None,
             hpx_padding_mode=layer_ctx.hpx_padding_mode,
             nside=layer_ctx.nside,
         )
@@ -217,7 +218,7 @@ class SmoothedInterpolateConvBlockConfig:
             dilation=self.dilation,
             scale_factor=self.stride,
             mode=self.upsample_mode,
-            activation=self.activation.build() if self.activation else None,
+            activation_factory=self.activation.build if self.activation else None,
             hpx_padding_mode=layer_ctx.hpx_padding_mode,
             nside=layer_ctx.nside,
             nside_after=layer_ctx.nside_after,
@@ -288,7 +289,7 @@ class BasicConvBlockConfig:
             dilation=dilation,
             n_layers=n_layers_resolved,
             latent_channels=latent_channels,
-            activation=self.activation,
+            activation_factory=self.activation.build if self.activation else None,
             hpx_padding_mode=layer_ctx.hpx_padding_mode,
             nside=layer_ctx.nside,
         )
@@ -324,7 +325,7 @@ class ConvNeXtBlockConfig:
             kernel_size=self.kernel_size,
             dilation=dilation,
             upscale_factor=self.upscale_factor,
-            activation=self.activation,
+            activation_factory=self.activation.build if self.activation else None,
             hpx_padding_mode=layer_ctx.hpx_padding_mode,
             nside=layer_ctx.nside,
         )
@@ -360,7 +361,7 @@ class SymmetricConvNeXtBlockConfig:
             kernel_size=self.kernel_size,
             dilation=dilation,
             upscale_factor=self.upscale_factor,
-            activation=self.activation,
+            activation_factory=self.activation.build if self.activation else None,
             hpx_padding_mode=layer_ctx.hpx_padding_mode,
             nside=layer_ctx.nside,
         )
@@ -398,7 +399,7 @@ class MultiSymmetricConvNeXtBlockConfig:
             dilation=dilation,
             upscale_factor=self.upscale_factor,
             n_layers=n_layers_resolved,
-            activation=self.activation,
+            activation_factory=self.activation.build if self.activation else None,
             hpx_padding_mode=layer_ctx.hpx_padding_mode,
             nside=layer_ctx.nside,
         )
@@ -644,7 +645,7 @@ class TransposedConvUpsample(nn.Module):
         in_channels: int = 3,
         out_channels: int = 1,
         upsampling: int = 2,
-        activation: Optional[CappedGELUConfig] = None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -655,7 +656,8 @@ class TransposedConvUpsample(nn.Module):
             in_channels: The number of input channels.
             out_channels: The number of output channels.
             upsampling: Stride size that will be used for upsampling.
-            activation: ModuleConfig for the activation function used in upsampling.
+            activation_factory: Zero-arg callable returning a fresh activation
+                module, or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -678,8 +680,8 @@ class TransposedConvUpsample(nn.Module):
                 ),
             )
         )
-        if activation is not None:
-            upsampler.append(activation.build())
+        if activation_factory is not None:
+            upsampler.append(activation_factory())
         self.upsampler = nn.Sequential(*upsampler)
 
     def forward(self, x):
@@ -768,7 +770,7 @@ class SmoothedInterpolateConv(nn.Module):
         dilation: int = 1,
         scale_factor: int = 2,
         mode: str = "nearest",
-        activation: Optional[nn.Module] = None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -783,7 +785,8 @@ class SmoothedInterpolateConv(nn.Module):
             dilation: Convolution dilation (must be 1 for HEALPix resize).
             scale_factor: Interpolation scale factor.
             mode: Interpolation mode for the smoothed upsample step.
-            activation: Optional activation module appended after the conv.
+            activation_factory: Zero-arg callable returning a fresh activation
+                module appended after the conv, or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to ``HEALPixLayer``.
             nside: Face height/width before upsampling (isolatitude gather indices).
             nside_after: Face height/width after upsampling for the conv step; required
@@ -844,8 +847,8 @@ class SmoothedInterpolateConv(nn.Module):
             ),
         ]
 
-        if activation is not None:
-            block.append(activation)
+        if activation_factory is not None:
+            block.append(activation_factory())
         self.block = nn.Sequential(*block)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -873,7 +876,7 @@ class BasicConvBlock(nn.Module):
         dilation=1,
         n_layers=1,
         latent_channels=None,
-        activation=None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode="earth2grid",
         nside=None,
     ):
@@ -885,7 +888,8 @@ class BasicConvBlock(nn.Module):
             dilation: Spacing between kernel points, passed to nn.Conv2d.
             n_layers: Number of convolutional layers.
             latent_channels: Number of latent channels.
-            activation: ModuleConfig for activation function to use.
+            activation_factory: Zero-arg callable returning a fresh activation
+                module (one per conv layer), or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -909,8 +913,8 @@ class BasicConvBlock(nn.Module):
                     ),
                 )
             )
-            if activation is not None:
-                convblock.append(activation.build())
+            if activation_factory is not None:
+                convblock.append(activation_factory())
         self.convblock = nn.Sequential(*convblock)
 
     def forward(self, x):
@@ -945,7 +949,7 @@ class ConvNeXtBlock(nn.Module):
         kernel_size: int = 3,
         dilation: int = 1,
         upscale_factor: int = 4,
-        activation: Optional[CappedGELUConfig] = None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -961,7 +965,8 @@ class ConvNeXtBlock(nn.Module):
             kernel_size: Size of the convolutional kernels.
             dilation: Dilation rate for convolutions.
             upscale_factor: Factor by which to upscale the number of latent channels.
-            activation: Configuration for the activation function used between layers.
+            activation_factory: Zero-arg callable returning a fresh activation
+                module (one per activation site), or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -997,8 +1002,8 @@ class ConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock.append(activation.build())
+        if activation_factory is not None:
+            convblock.append(activation_factory())
         # 3x3 convolution maintaining increased channels
         convblock.append(
             HEALPixLayer(
@@ -1010,8 +1015,8 @@ class ConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock.append(activation.build())
+        if activation_factory is not None:
+            convblock.append(activation_factory())
         # Linear postprocessing
         convblock.append(
             HEALPixLayer(
@@ -1054,7 +1059,7 @@ class DoubleConvNeXtBlock(nn.Module):
         dilation: int = 1,
         upscale_factor: int = 4,
         latent_channels: int = 1,
-        activation: Optional[CappedGELUConfig] = None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -1070,7 +1075,7 @@ class DoubleConvNeXtBlock(nn.Module):
             dilation: Dilation rate for convolutions (default is 1).
             upscale_factor: Factor by which to upscale the number of latent channels (default is 4).
             latent_channels: Number of latent channels used in the block (default is 1).
-            activation: Configuration for the activation function used between layers (default is None).
+            activation_factory: Zero-arg callable returning a fresh activation module (one per activation site), or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1120,8 +1125,8 @@ class DoubleConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock1.append(activation.build())
+        if activation_factory is not None:
+            convblock1.append(activation_factory())
         # 1x1 convolution establishing increased channels
         convblock1.append(
             HEALPixLayer(
@@ -1133,8 +1138,8 @@ class DoubleConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock1.append(activation.build())
+        if activation_factory is not None:
+            convblock1.append(activation_factory())
         # 1x1 convolution returning to latent channels
         convblock1.append(
             HEALPixLayer(
@@ -1146,8 +1151,8 @@ class DoubleConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock1.append(activation.build())
+        if activation_factory is not None:
+            convblock1.append(activation_factory())
         self.convblock1 = nn.Sequential(*convblock1)
 
         # 2nd ConNeXt block, takes the output of the first convnext block
@@ -1163,8 +1168,8 @@ class DoubleConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock2.append(activation.build())
+        if activation_factory is not None:
+            convblock2.append(activation_factory())
         # 1x1 convolution establishing increased channels
         convblock2.append(
             HEALPixLayer(
@@ -1176,8 +1181,8 @@ class DoubleConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock2.append(activation.build())
+        if activation_factory is not None:
+            convblock2.append(activation_factory())
         # 1x1 convolution reducing to output channels
         convblock2.append(
             HEALPixLayer(
@@ -1189,8 +1194,8 @@ class DoubleConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock2.append(activation.build())
+        if activation_factory is not None:
+            convblock2.append(activation_factory())
         self.convblock2 = nn.Sequential(*convblock2)
 
     def forward(self, x):
@@ -1224,7 +1229,7 @@ class SymmetricConvNeXtBlock(nn.Module):
         kernel_size: int = 3,
         dilation: int = 1,
         upscale_factor: int = 4,
-        activation: Optional[CappedGELUConfig] = None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -1240,7 +1245,7 @@ class SymmetricConvNeXtBlock(nn.Module):
             dilation: Dilation rate for convolutions (default is 1).
             upscale_factor: Upscale factor.
             latent_channels: Number of latent channels used in the block (default is 1).
-            activation: Configuration for the activation function used between layers (default is None).
+            activation_factory: Zero-arg callable returning a fresh activation module (one per activation site), or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to wrapper.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1275,8 +1280,8 @@ class SymmetricConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock.append(activation.build())
+        if activation_factory is not None:
+            convblock.append(activation_factory())
         # 1x1 convolution establishing increased channels
         convblock.append(
             HEALPixLayer(
@@ -1288,8 +1293,8 @@ class SymmetricConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock.append(activation.build())
+        if activation_factory is not None:
+            convblock.append(activation_factory())
         # 1x1 convolution returning to latent channels
         convblock.append(
             HEALPixLayer(
@@ -1301,8 +1306,8 @@ class SymmetricConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock.append(activation.build())
+        if activation_factory is not None:
+            convblock.append(activation_factory())
         # 3x3 convolution from latent channels to latent channels
         convblock.append(
             HEALPixLayer(
@@ -1314,8 +1319,8 @@ class SymmetricConvNeXtBlock(nn.Module):
                 **healpix_kwargs,
             )
         )
-        if activation is not None:
-            convblock.append(activation.build())
+        if activation_factory is not None:
+            convblock.append(activation_factory())
         self.convblock = nn.Sequential(*convblock)
 
     def forward(self, x):
@@ -1341,7 +1346,7 @@ class Multi_SymmetricConvNeXtBlock(nn.Module):
         dilation: int = 1,
         upscale_factor: int = 4,
         n_layers: int = 1,
-        activation: Optional[CappedGELUConfig] = None,
+        activation_factory: Callable[[], nn.Module] | None = None,
         hpx_padding_mode: Literal[
             "earth2grid", "karlbauer", "isolatitude"
         ] = "earth2grid",
@@ -1356,7 +1361,8 @@ class Multi_SymmetricConvNeXtBlock(nn.Module):
             dilation: Convolution dilation.
             upscale_factor: Channel upscale factor inside each block.
             n_layers: Number of stacked ``SymmetricConvNeXtBlock`` modules.
-            activation: Optional ``CappedGELUConfig`` between layers.
+            activation_factory: Zero-arg callable returning a fresh activation
+                module per activation site, or ``None`` for no activation.
             hpx_padding_mode: HEALPix padding backend passed to child blocks.
             nside: Native face height/width for HEALPix padding.
         """
@@ -1372,7 +1378,7 @@ class Multi_SymmetricConvNeXtBlock(nn.Module):
                     kernel_size=kernel_size,
                     dilation=dilation,
                     upscale_factor=upscale_factor,
-                    activation=activation,
+                    activation_factory=activation_factory,
                     hpx_padding_mode=hpx_padding_mode,
                     nside=nside,
                 )

--- a/fme/ace/models/healpix/healpix_decoder.py
+++ b/fme/ace/models/healpix/healpix_decoder.py
@@ -91,7 +91,7 @@ class UNetDecoderConfig:
         n_channels = self.n_channels
         n_levels = len(n_channels)
 
-        decoder: List[nn.Module] = []
+        decoder: list[DecoderLevel] = []
         for n, curr_channel in enumerate(n_channels):
             up_sample_module = None
             level_nside = (
@@ -139,7 +139,7 @@ class UNetDecoderConfig:
         )
 
         return UNetDecoder(
-            decoder=nn.ModuleList(decoder),
+            decoder=decoder,
             output_layer=output_layer,
         )
 
@@ -185,17 +185,18 @@ class UNetDecoder(nn.Module):
 
     def __init__(
         self,
-        decoder: nn.ModuleList,
+        decoder: list[DecoderLevel],
         output_layer: nn.Module,
     ):
         """
         Args:
             decoder: Ordered per-level :class:`DecoderLevel` modules built by
-                :meth:`UNetDecoderConfig._build`.
+                :meth:`UNetDecoderConfig._build`; wrapped in an
+                ``nn.ModuleList`` here for submodule registration.
             output_layer: Final output-projection module.
         """
         super().__init__()
-        self.decoder = decoder
+        self.decoder = nn.ModuleList(decoder)
         self.output_layer = output_layer
 
     def forward(self, inputs: Sequence[torch.Tensor]) -> torch.Tensor:

--- a/fme/ace/models/healpix/healpix_decoder.py
+++ b/fme/ace/models/healpix/healpix_decoder.py
@@ -78,9 +78,9 @@ class UNetDecoderConfig:
     ) -> "UNetDecoder":
         """Construct the ordered per-level decoder modules plus output layer.
 
-        Builds a per-level ``{upsamp, conv}`` module dict (threading channel
-        counts and validating the nside upsample ratios) and the output layer,
-        then passes the built modules to :class:`UNetDecoder`.
+        Builds one :class:`DecoderLevel` per level (threading channel counts and
+        validating the nside upsample ratios) and the output layer, then passes
+        the built modules to :class:`UNetDecoder`.
         """
         dilations = self.dilations
         if dilations is None:
@@ -129,14 +129,7 @@ class UNetDecoderConfig:
                 ctx=ctx.layer(n_levels - 1 - n),
             )
 
-            decoder.append(
-                nn.ModuleDict(
-                    {
-                        "upsamp": up_sample_module,
-                        "conv": conv_module,
-                    }
-                )
-            )
+            decoder.append(DecoderLevel(upsamp=up_sample_module, conv=conv_module))
 
         output_layer = self.output_layer.build(
             in_channels=curr_channel,
@@ -151,8 +144,44 @@ class UNetDecoderConfig:
         )
 
 
+class DecoderLevel(nn.Module):
+    """One decoder level: optional upsample + skip-concat, then a conv block.
+
+    The deepest level (built first, ``upsamp is None``) receives the encoder
+    bottleneck and applies only its conv block. Each shallower level upsamples
+    the running activation, concatenates the matching encoder skip connection
+    along the channel dimension, then applies its conv block. Bundling the
+    upsample and conv into one module keeps this per-level branching structure
+    with the module that runs it, so :class:`UNetDecoder.forward` never reaches
+    into the level's internals.
+    """
+
+    def __init__(self, upsamp: Optional[nn.Module], conv: nn.Module):
+        super().__init__()
+        self.upsamp = upsamp
+        self.conv = conv
+        self.channel_dim = 1
+
+    def forward(self, x: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Running activation from the deeper level.
+            skip: Matching encoder skip connection (unused when ``upsamp`` is
+                ``None``, i.e. the deepest level).
+        """
+        if self.upsamp is not None:
+            x = torch.cat([self.upsamp(x), skip], dim=self.channel_dim)
+        return self.conv(x)
+
+
 class UNetDecoder(nn.Module):
-    """Generic UNetDecoder that can be applied to arbitrary meshes."""
+    """Applies the decoder levels deepest-to-shallowest, then the output layer.
+
+    Receives the ordered per-level :class:`DecoderLevel` modules and the output
+    layer already built by :meth:`UNetDecoderConfig._build`; it constructs
+    nothing itself, so it is directly constructible from its signature and its
+    ``forward`` needs no knowledge of how the levels were assembled.
+    """
 
     def __init__(
         self,
@@ -160,15 +189,12 @@ class UNetDecoder(nn.Module):
         output_layer: nn.Module,
     ):
         """
-        Initialize the UNetDecoder.
-
         Args:
-            decoder: Ordered per-level ``{upsamp, conv}`` module dicts built by
+            decoder: Ordered per-level :class:`DecoderLevel` modules built by
                 :meth:`UNetDecoderConfig._build`.
             output_layer: Final output-projection module.
         """
         super().__init__()
-        self.channel_dim = 1
         self.decoder = decoder
         self.output_layer = output_layer
 
@@ -177,15 +203,13 @@ class UNetDecoder(nn.Module):
         Forward pass of the UNetDecoder.
 
         Args:
-            inputs: Sequence of tensors, one for each decoder level.
+            inputs: Sequence of tensors, one per decoder level (encoder outputs,
+                shallow-to-deep).
 
         Returns:
             The decoded values.
         """
         x = inputs[-1]
-        for n, layer in enumerate(self.decoder):
-            if layer["upsamp"] is not None:
-                up = layer["upsamp"](x)
-                x = torch.cat([up, inputs[-1 - n]], dim=self.channel_dim)
-            x = layer["conv"](x)
+        for n, level in enumerate(self.decoder):
+            x = level(x, inputs[-1 - n])
         return self.output_layer(x)

--- a/fme/ace/models/healpix/healpix_decoder.py
+++ b/fme/ace/models/healpix/healpix_decoder.py
@@ -62,65 +62,36 @@ class UNetDecoderConfig:
         Returns:
             UNet Decoder model.
         """
-        return UNetDecoder(
-            conv_block=self.conv_block,
-            up_sampling_block=self.up_sampling_block,
-            output_layer=self.output_layer,
-            n_channels=self.n_channels,
-            n_layers=self.n_layers,
-            output_channels=output_channels,
-            dilations=self.dilations,
-            ctx=ctx,
-        )
-
-
-class UNetDecoder(nn.Module):
-    """Generic UNetDecoder that can be applied to arbitrary meshes."""
-
-    def __init__(
-        self,
-        conv_block: ConvBlockConfig,
-        up_sampling_block: UpsamplingBlockConfig,
-        output_layer: ConvBlockConfig,
-        n_channels: Sequence = (64, 32, 16),
-        n_layers: Sequence = (1, 2, 2),
-        output_channels: int = 1,
-        dilations: Optional[list] = None,
-        ctx: HEALPixBuildContext | None = None,
-    ):
-        """
-        Initialize the UNetDecoder.
-
-        Args:
-            conv_block: Configuration for the convolutional block.
-            up_sampling_block: Configuration for the upsampling block.
-            output_layer: Configuration for the output layer.
-            n_channels: Sequence specifying the number of channels in each decoder layer.
-            n_layers: Sequence specifying the number of layers in each block.
-            output_channels: Number of output channels.
-            dilations: List of dilations to use for the convolutional blocks.
-            ctx: Shared HEALPix runtime settings for all child modules.
-        """
-        super().__init__()
-        build_ctx = ctx or HEALPixBuildContext()
-        self.channel_dim = 1
-
-        if dilations is None:
-            dilations = [1 for _ in range(len(n_channels))]
-
-        nside_levels = build_ctx.nside_levels
-        if nside_levels is not None and len(nside_levels) != len(n_channels):
+        nside_levels = ctx.nside_levels
+        if nside_levels is not None and len(nside_levels) != len(self.n_channels):
             raise ValueError(
                 f"nside length must match decoder levels; got {len(nside_levels)} "
-                f"vs {len(n_channels)}"
+                f"vs {len(self.n_channels)}"
             )
+        return self._build(output_channels, ctx=ctx)
 
-        conv_tpl = conv_block
-        up_tpl = up_sampling_block
-        up_factor = up_tpl.stride
+    def _build(
+        self,
+        output_channels: int,
+        *,
+        ctx: HEALPixBuildContext,
+    ) -> "UNetDecoder":
+        """Construct the ordered per-level decoder modules plus output layer.
+
+        Builds a per-level ``{upsamp, conv}`` module dict (threading channel
+        counts and validating the nside upsample ratios) and the output layer,
+        then passes the built modules to :class:`UNetDecoder`.
+        """
+        dilations = self.dilations
+        if dilations is None:
+            dilations = [1 for _ in range(len(self.n_channels))]
+
+        nside_levels = ctx.nside_levels
+        up_factor = self.up_sampling_block.stride
+        n_channels = self.n_channels
         n_levels = len(n_channels)
 
-        self.decoder = []
+        decoder: List[nn.Module] = []
         for n, curr_channel in enumerate(n_channels):
             up_sample_module = None
             level_nside = (
@@ -136,10 +107,10 @@ class UNetDecoder(nn.Module):
                             f"must equal nside[{n_levels - n}] * upsample factor "
                             f"({up_factor}), but nside[{n_levels - n}]={before}"
                         )
-                up_sample_module = up_tpl.build(
+                up_sample_module = self.up_sampling_block.build(
                     in_channels=curr_channel,
                     out_channels=curr_channel,
-                    ctx=build_ctx.layer(
+                    ctx=ctx.layer(
                         n_levels - n,
                         nside_after=level_nside,
                     ),
@@ -149,16 +120,16 @@ class UNetDecoder(nn.Module):
                 n_channels[n + 1] if n < len(n_channels) - 1 else n_channels[-1]
             )
 
-            conv_module = conv_tpl.build(
+            conv_module = self.conv_block.build(
                 in_channels=curr_channel * 2 if n > 0 else curr_channel,
                 out_channels=next_channel,
                 latent_channels=curr_channel,
                 dilation=dilations[n],
-                n_layers=n_layers[n],
-                ctx=build_ctx.layer(n_levels - 1 - n),
+                n_layers=self.n_layers[n],
+                ctx=ctx.layer(n_levels - 1 - n),
             )
 
-            self.decoder.append(
+            decoder.append(
                 nn.ModuleDict(
                     {
                         "upsamp": up_sample_module,
@@ -167,14 +138,39 @@ class UNetDecoder(nn.Module):
                 )
             )
 
-        self.decoder = nn.ModuleList(self.decoder)
-
-        self.output_layer = output_layer.build(
+        output_layer = self.output_layer.build(
             in_channels=curr_channel,
             out_channels=output_channels,
             dilation=dilations[-1],
-            ctx=build_ctx.layer(0),
+            ctx=ctx.layer(0),
         )
+
+        return UNetDecoder(
+            decoder=nn.ModuleList(decoder),
+            output_layer=output_layer,
+        )
+
+
+class UNetDecoder(nn.Module):
+    """Generic UNetDecoder that can be applied to arbitrary meshes."""
+
+    def __init__(
+        self,
+        decoder: nn.ModuleList,
+        output_layer: nn.Module,
+    ):
+        """
+        Initialize the UNetDecoder.
+
+        Args:
+            decoder: Ordered per-level ``{upsamp, conv}`` module dicts built by
+                :meth:`UNetDecoderConfig._build`.
+            output_layer: Final output-projection module.
+        """
+        super().__init__()
+        self.channel_dim = 1
+        self.decoder = decoder
+        self.output_layer = output_layer
 
     def forward(self, inputs: Sequence[torch.Tensor]) -> torch.Tensor:
         """

--- a/fme/ace/models/healpix/healpix_encoder.py
+++ b/fme/ace/models/healpix/healpix_encoder.py
@@ -91,7 +91,7 @@ class UNetEncoderConfig:
         down_factor = self.down_sampling_block.downsample_spatial_factor()
 
         old_channels = input_channels
-        encoder: List[nn.Module] = []
+        encoder: list[nn.Sequential] = []
         for n, curr_channel in enumerate(self.n_channels):
             modules: List[nn.Module] = []
             if n > 0:
@@ -124,7 +124,7 @@ class UNetEncoderConfig:
 
             encoder.append(nn.Sequential(*modules))
 
-        return UNetEncoder(encoder=nn.ModuleList(encoder))
+        return UNetEncoder(encoder=encoder)
 
 
 class UNetEncoder(nn.Module):
@@ -139,14 +139,15 @@ class UNetEncoder(nn.Module):
     padding backend, and the channel schedule, which live in the config.
     """
 
-    def __init__(self, encoder: nn.ModuleList):
+    def __init__(self, encoder: list[nn.Sequential]):
         """
         Args:
             encoder: Ordered per-level encoder modules built by
-                :meth:`UNetEncoderConfig._build`.
+                :meth:`UNetEncoderConfig._build`; wrapped in an
+                ``nn.ModuleList`` here for submodule registration.
         """
         super().__init__()
-        self.encoder = encoder
+        self.encoder = nn.ModuleList(encoder)
 
     def forward(self, inputs: torch.Tensor) -> Sequence[torch.Tensor]:
         """

--- a/fme/ace/models/healpix/healpix_encoder.py
+++ b/fme/ace/models/healpix/healpix_encoder.py
@@ -128,7 +128,16 @@ class UNetEncoderConfig:
 
 
 class UNetEncoder(nn.Module):
-    """Generic UNetEncoder that can be applied to arbitrary meshes."""
+    """Runs the encoder levels in sequence, returning each level's activation.
+
+    Receives the ordered per-level modules already built by
+    :meth:`UNetEncoderConfig._build` (each a downsample-then-conv
+    ``nn.Sequential``, or just a conv at the shallowest level) and applies them
+    in order, feeding each level's output into the next. It builds nothing
+    itself and holds no config. The returned per-level activations are the skip
+    connections the decoder consumes; the module is agnostic to the mesh, the
+    padding backend, and the channel schedule, which live in the config.
+    """
 
     def __init__(self, encoder: nn.ModuleList):
         """

--- a/fme/ace/models/healpix/healpix_encoder.py
+++ b/fme/ace/models/healpix/healpix_encoder.py
@@ -63,62 +63,36 @@ class UNetEncoderConfig:
         Returns:
             UNet Encoder model.
         """
-        return UNetEncoder(
-            conv_block=self.conv_block,
-            down_sampling_block=self.down_sampling_block,
-            input_channels=input_channels,
-            n_channels=self.n_channels,
-            n_layers=self.n_layers,
-            dilations=self.dilations,
-            ctx=ctx,
-        )
-
-
-class UNetEncoder(nn.Module):
-    """Generic UNetEncoder that can be applied to arbitrary meshes."""
-
-    def __init__(
-        self,
-        conv_block: ConvBlockConfig,
-        down_sampling_block: DownsamplingBlockConfig,
-        input_channels: int = 3,
-        n_channels: Sequence = (16, 32, 64),
-        n_layers: Sequence = (2, 2, 1),
-        dilations: Optional[list] = None,
-        ctx: HEALPixBuildContext | None = None,
-    ):
-        """
-        Args:
-            conv_block: config for the convolutional block
-            down_sampling_block: DownsamplingBlockConfig for the downsample block
-            input_channels: # of input channels
-            n_channels: # of channels in each encoder layer
-            n_layers:, # of layers to use for the convolutional blocks
-            dilations: list of dilations to use for the the convolutional blocks
-            ctx: Shared HEALPix runtime settings for all child modules.
-        """
-        super().__init__()
-        build_ctx = ctx or HEALPixBuildContext()
-        self.n_channels = n_channels
-        self.hpx_padding_mode = build_ctx.hpx_padding_mode
-
-        if dilations is None:
-            dilations = [1 for _ in range(len(n_channels))]
-
-        nside_levels = build_ctx.nside_levels
-        if nside_levels is not None and len(nside_levels) != len(n_channels):
+        nside_levels = ctx.nside_levels
+        if nside_levels is not None and len(nside_levels) != len(self.n_channels):
             raise ValueError(
                 f"nside length must match encoder levels; got {len(nside_levels)} "
-                f"vs {len(n_channels)}"
+                f"vs {len(self.n_channels)}"
             )
+        return self._build(input_channels, ctx=ctx)
 
-        conv_tpl = conv_block
-        down_tpl = down_sampling_block
-        down_factor = down_tpl.downsample_spatial_factor()
+    def _build(
+        self,
+        input_channels: int,
+        *,
+        ctx: HEALPixBuildContext,
+    ) -> "UNetEncoder":
+        """Construct the ordered per-level encoder modules and the impl.
+
+        Builds one ``nn.Sequential(down?, conv)`` per level, threading channel
+        counts and validating the nside downsample ratios, then passes the built
+        module list to :class:`UNetEncoder`.
+        """
+        dilations = self.dilations
+        if dilations is None:
+            dilations = [1 for _ in range(len(self.n_channels))]
+
+        nside_levels = ctx.nside_levels
+        down_factor = self.down_sampling_block.downsample_spatial_factor()
 
         old_channels = input_channels
-        self.encoder = []
-        for n, curr_channel in enumerate(n_channels):
+        encoder: List[nn.Module] = []
+        for n, curr_channel in enumerate(self.n_channels):
             modules: List[nn.Module] = []
             if n > 0:
                 if nside_levels is not None:
@@ -130,27 +104,40 @@ class UNetEncoder(nn.Module):
                             f"but nside[{n}]={fine}"
                         )
                 modules.append(
-                    down_tpl.build(
+                    self.down_sampling_block.build(
                         in_channels=old_channels,
-                        ctx=build_ctx.layer(n - 1),
+                        ctx=ctx.layer(n - 1),
                     )
                 )
 
             modules.append(
-                conv_tpl.build(
+                self.conv_block.build(
                     in_channels=old_channels,
                     out_channels=curr_channel,
                     latent_channels=curr_channel,
                     dilation=dilations[n],
-                    n_layers=n_layers[n],
-                    ctx=build_ctx.layer(n),
+                    n_layers=self.n_layers[n],
+                    ctx=ctx.layer(n),
                 )
             )
             old_channels = curr_channel
 
-            self.encoder.append(nn.Sequential(*modules))
+            encoder.append(nn.Sequential(*modules))
 
-        self.encoder = nn.ModuleList(self.encoder)
+        return UNetEncoder(encoder=nn.ModuleList(encoder))
+
+
+class UNetEncoder(nn.Module):
+    """Generic UNetEncoder that can be applied to arbitrary meshes."""
+
+    def __init__(self, encoder: nn.ModuleList):
+        """
+        Args:
+            encoder: Ordered per-level encoder modules built by
+                :meth:`UNetEncoderConfig._build`.
+        """
+        super().__init__()
+        self.encoder = encoder
 
     def forward(self, inputs: torch.Tensor) -> Sequence[torch.Tensor]:
         """

--- a/fme/ace/models/healpix/healpix_unet.py
+++ b/fme/ace/models/healpix/healpix_unet.py
@@ -4,15 +4,9 @@ HEALPix UNet: single forward-pass encoder–decoder stack.
 Adapted from the modulus-uw ``physicsnemo.models.dlwp_healpix.HEALPixUNet``.
 """
 
-from collections.abc import Sequence
-from typing import Literal
-
 import torch
 import torch.nn as nn
 
-from .healpix_blocks import HEALPixBuildContext
-from .healpix_decoder import UNetDecoderConfig
-from .healpix_encoder import UNetEncoderConfig
 from .healpix_layers import HEALPixFoldFaces, HEALPixUnfoldFaces
 
 
@@ -24,79 +18,48 @@ class HEALPixUNet(nn.Module):
     folded into the batch dimension before the encoder/decoder and unfolded
     after the decoder, so the encoder/decoder operate on plain 4D tensors of
     shape ``[B*F, C, H, W]``.
+
+    The encoder and decoder modules are built and validated by
+    :class:`~fme.ace.registry.hpx.HEALPixUNetBuilder`; this module receives the
+    built collaborators and the runtime scalars it needs and does no building
+    itself.
     """
 
     CHANNEL_DIM = 2  # [B, F, C, H, W]
 
     def __init__(
         self,
-        encoder: UNetEncoderConfig,
-        decoder: UNetDecoderConfig,
+        encoder: nn.Module,
+        decoder: nn.Module,
         input_channels: int,
         output_channels: int,
-        hpx_padding_mode: Literal[
-            "earth2grid", "karlbauer", "isolatitude"
-        ] = "earth2grid",
-        nside: Sequence[int] | None = None,
+        nside: tuple[int, ...] | None = None,
     ):
         """
         Initialize the HEALPixUNet model.
 
         Args:
-            encoder: Configuration for the U-net encoder.
-            decoder: Configuration for the U-net decoder.
+            encoder: Built U-net encoder module.
+            decoder: Built U-net decoder module.
             input_channels: Number of channels in the input tensor (i.e. the
                 size of the channel dimension of the tensor passed to
                 ``forward``).
             output_channels: Number of channels in the output tensor.
-            hpx_padding_mode: HEALPix padding backend. One of ``"earth2grid"``,
-                ``"karlbauer"``, or ``"isolatitude"``. Default ``"earth2grid"``.
-            nside: Face height/width per UNet level, shallowest to deepest.
-                Length must equal ``len(encoder.n_channels)``. Required when
-                ``hpx_padding_mode`` is ``"isolatitude"``. Child modules validate
-                face size at runtime (e.g. ``HEALPixPaddingIsolatitude``).
+            nside: Resolved face height/width per UNet level, shallowest to
+                deepest, or ``None``. ``forward`` checks the input face size
+                against ``nside[0]`` when set.
         """
         super().__init__()
 
         self.input_channels = input_channels
         self.output_channels = output_channels
-        self.hpx_padding_mode = hpx_padding_mode
-
-        levels = len(encoder.n_channels)
-        if len(decoder.n_channels) != levels:
-            raise ValueError(
-                "encoder and decoder must have same number of levels; got "
-                f"{levels} vs {len(decoder.n_channels)}"
-            )
-        if hpx_padding_mode == "isolatitude" and nside is None:
-            raise ValueError(
-                'hpx_padding_mode="isolatitude" requires nside (one int per UNet level)'
-            )
-        nside_resolved: tuple[int, ...] | None
-        if nside is not None:
-            nside_levels = tuple(int(v) for v in nside)
-            if len(nside_levels) != levels:
-                raise ValueError(
-                    f"nside length must match UNet levels; got {len(nside_levels)} "
-                    f"vs {levels}"
-                )
-            if any(v < 1 for v in nside_levels):
-                raise ValueError(f"nside values must be positive; got {nside_levels}")
-            nside_resolved = nside_levels
-        else:
-            nside_resolved = None
-        self.nside = nside_resolved
-
-        build_ctx = HEALPixBuildContext(
-            hpx_padding_mode=hpx_padding_mode,
-            nside_levels=nside_resolved,
-        )
+        self.nside = nside
 
         self.fold = HEALPixFoldFaces()
         self.unfold = HEALPixUnfoldFaces(num_faces=12)
 
-        self.encoder = encoder.build(input_channels=input_channels, ctx=build_ctx)
-        self.decoder = decoder.build(output_channels=output_channels, ctx=build_ctx)
+        self.encoder = encoder
+        self.decoder = decoder
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         """Forward pass.

--- a/fme/ace/registry/hpx.py
+++ b/fme/ace/registry/hpx.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 import torch.nn as nn
 
+from fme.ace.models.healpix.healpix_blocks import HEALPixBuildContext
 from fme.ace.models.healpix.healpix_decoder import UNetDecoderConfig
 from fme.ace.models.healpix.healpix_encoder import UNetEncoderConfig
 from fme.ace.models.healpix.healpix_unet import HEALPixUNet
@@ -54,11 +55,57 @@ class HEALPixUNetBuilder(ModuleConfig):
         """
         if len(dataset_info.all_labels) > 0:
             raise ValueError("HEALPixUNet does not support labels")
-        return HEALPixUNet(
-            encoder=self.encoder,
-            decoder=self.decoder,
+        return self._build(
             input_channels=n_in_channels,
             output_channels=n_out_channels,
+        )
+
+    def _build(
+        self,
+        input_channels: int,
+        output_channels: int,
+    ) -> HEALPixUNet:
+        """Build the encoder/decoder modules and assemble the HEALPixUNet.
+
+        Constructs the shared ``HEALPixBuildContext``, validates the
+        encoder/decoder level counts and the ``nside`` sequence, builds the
+        encoder and decoder ``nn.Module``s, and passes the built collaborators
+        plus the runtime scalars into :class:`HEALPixUNet`.
+        """
+        levels = len(self.encoder.n_channels)
+        if len(self.decoder.n_channels) != levels:
+            raise ValueError(
+                "encoder and decoder must have same number of levels; got "
+                f"{levels} vs {len(self.decoder.n_channels)}"
+            )
+        if self.hpx_padding_mode == "isolatitude" and self.nside is None:
+            raise ValueError(
+                'hpx_padding_mode="isolatitude" requires nside (one int per UNet level)'
+            )
+        nside_resolved: tuple[int, ...] | None
+        if self.nside is not None:
+            nside_levels = tuple(int(v) for v in self.nside)
+            if len(nside_levels) != levels:
+                raise ValueError(
+                    f"nside length must match UNet levels; got {len(nside_levels)} "
+                    f"vs {levels}"
+                )
+            if any(v < 1 for v in nside_levels):
+                raise ValueError(f"nside values must be positive; got {nside_levels}")
+            nside_resolved = nside_levels
+        else:
+            nside_resolved = None
+
+        build_ctx = HEALPixBuildContext(
             hpx_padding_mode=self.hpx_padding_mode,
-            nside=self.nside,
+            nside_levels=nside_resolved,
+        )
+        encoder = self.encoder.build(input_channels=input_channels, ctx=build_ctx)
+        decoder = self.decoder.build(output_channels=output_channels, ctx=build_ctx)
+        return HEALPixUNet(
+            encoder=encoder,
+            decoder=decoder,
+            input_channels=input_channels,
+            output_channels=output_channels,
+            nside=nside_resolved,
         )

--- a/fme/ace/registry/test_hpx.py
+++ b/fme/ace/registry/test_hpx.py
@@ -18,6 +18,7 @@ from fme.ace.models.healpix.healpix_blocks import (
     DealiasedDownsample,
     DealiasedDownsampleBlockConfig,
     DownsamplingBlockConfig,
+    HEALPixBuildContext,
     HEALPixLayerBuildContext,
     MaxPoolDownsamplingBlockConfig,
     MultiSymmetricConvNeXtBlockConfig,
@@ -40,7 +41,11 @@ from fme.ace.models.healpix.healpix_paddings import (
     make_hpx_padding_layer,
 )
 from fme.ace.models.healpix.healpix_unet import HEALPixUNet
-from fme.ace.registry.hpx import UNetDecoderConfig, UNetEncoderConfig
+from fme.ace.registry.hpx import (
+    HEALPixUNetBuilder,
+    UNetDecoderConfig,
+    UNetEncoderConfig,
+)
 from fme.ace.stepper import StepperConfig
 from fme.core.coordinates import HEALPixCoordinates, HybridSigmaPressureCoordinate
 from fme.core.dataset_info import DatasetInfo
@@ -173,6 +178,23 @@ def _hpx_unet_configs(
     return enc, dec
 
 
+def _build_hpx_unet(
+    encoder,
+    decoder,
+    input_channels,
+    output_channels,
+    hpx_padding_mode="karlbauer",
+    nside=None,
+):
+    """Build a HEALPixUNet through its builder (the real config-build path)."""
+    return HEALPixUNetBuilder(
+        encoder=encoder,
+        decoder=decoder,
+        hpx_padding_mode=hpx_padding_mode,
+        nside=nside,
+    )._build(input_channels=input_channels, output_channels=output_channels)
+
+
 def _test_data():
     # create dummy data
     def generate_test_data(batch_size=8, time_dim=1, channels=7, img_size=16):
@@ -267,22 +289,28 @@ def test_UNetEncoder_initialize():
     conv_block_config = ConvNeXtBlockConfig()
     down_sampling_block_config = MaxPoolDownsamplingBlockConfig(pooling=2)
 
-    encoder = UNetEncoder(
-        conv_block=conv_block_config,
-        down_sampling_block=down_sampling_block_config,
-        n_channels=n_channels,
-        input_channels=channels,
-    ).to(device)
+    encoder = (
+        UNetEncoderConfig(
+            conv_block=conv_block_config,
+            down_sampling_block=down_sampling_block_config,
+            n_channels=list(n_channels),
+        )
+        .build(input_channels=channels, ctx=HEALPixBuildContext())
+        .to(device)
+    )
     assert isinstance(encoder, UNetEncoder)
 
     # with dilations
-    encoder = UNetEncoder(
-        conv_block=conv_block_config,
-        down_sampling_block=down_sampling_block_config,
-        n_channels=n_channels,
-        input_channels=channels,
-        dilations=[1, 1, 1],
-    ).to(device)
+    encoder = (
+        UNetEncoderConfig(
+            conv_block=conv_block_config,
+            down_sampling_block=down_sampling_block_config,
+            n_channels=list(n_channels),
+            dilations=[1, 1, 1],
+        )
+        .build(input_channels=channels, ctx=HEALPixBuildContext())
+        .to(device)
+    )
     assert isinstance(encoder, UNetEncoder)
 
 
@@ -297,12 +325,15 @@ def test_UNetEncoder_forward():
     # block configs used by encoder
     conv_block_config = ConvNeXtBlockConfig()
     down_sampling_block_config = MaxPoolDownsamplingBlockConfig(pooling=2)
-    encoder = UNetEncoder(
-        conv_block=conv_block_config,
-        down_sampling_block=down_sampling_block_config,
-        n_channels=n_channels,
-        input_channels=channels,
-    ).to(device)
+    encoder = (
+        UNetEncoderConfig(
+            conv_block=conv_block_config,
+            down_sampling_block=down_sampling_block_config,
+            n_channels=list(n_channels),
+        )
+        .build(input_channels=channels, ctx=HEALPixBuildContext())
+        .to(device)
+    )
 
     tensor_size = [b_size, channels, hw_size, hw_size]
     invar = torch.rand(tensor_size).to(device)
@@ -329,22 +360,30 @@ def test_UNetDecoder_initilization():
         kernel_size=1,
     )
 
-    decoder = UNetDecoder(
-        conv_block=conv_block_config,
-        up_sampling_block=up_sampling_block_config,
-        output_layer=output_layer_config,
-        n_channels=n_channels,
-    ).to(device)
+    decoder = (
+        UNetDecoderConfig(
+            conv_block=conv_block_config,
+            up_sampling_block=up_sampling_block_config,
+            output_layer=output_layer_config,
+            n_channels=list(n_channels),
+        )
+        .build(output_channels=1, ctx=HEALPixBuildContext())
+        .to(device)
+    )
 
     assert isinstance(decoder, UNetDecoder)
 
-    decoder = UNetDecoder(
-        conv_block=conv_block_config,
-        up_sampling_block=up_sampling_block_config,
-        output_layer=output_layer_config,
-        n_channels=n_channels,
-        dilations=[1, 1, 1],
-    ).to(device)
+    decoder = (
+        UNetDecoderConfig(
+            conv_block=conv_block_config,
+            up_sampling_block=up_sampling_block_config,
+            output_layer=output_layer_config,
+            n_channels=list(n_channels),
+            dilations=[1, 1, 1],
+        )
+        .build(output_channels=1, ctx=HEALPixBuildContext())
+        .to(device)
+    )
     assert isinstance(decoder, UNetDecoder)
 
 
@@ -363,12 +402,16 @@ def test_UNetDecoder_forward():
         kernel_size=1,
         n_layers=1,
     )
-    decoder = UNetDecoder(
-        conv_block=conv_block_config,
-        up_sampling_block=up_sampling_block_config,
-        output_layer=output_layer_config,
-        n_channels=n_channels,
-    ).to(device)
+    decoder = (
+        UNetDecoderConfig(
+            conv_block=conv_block_config,
+            up_sampling_block=up_sampling_block_config,
+            output_layer=output_layer_config,
+            n_channels=list(n_channels),
+        )
+        .build(output_channels=out_channels, ctx=HEALPixBuildContext())
+        .to(device)
+    )
 
     output_2_size = torch.Size([b_size, out_channels, hw_size, hw_size])
 
@@ -386,13 +429,17 @@ def test_UNetDecoder_forward():
     outvar_repeat = decoder(invars)
     assert compare_output(outvar, outvar_repeat)
 
-    decoder = UNetDecoder(
-        conv_block=conv_block_config,
-        up_sampling_block=up_sampling_block_config,
-        output_layer=output_layer_config,
-        n_channels=n_channels,
-        dilations=[1, 1, 1],
-    ).to(device)
+    decoder = (
+        UNetDecoderConfig(
+            conv_block=conv_block_config,
+            up_sampling_block=up_sampling_block_config,
+            output_layer=output_layer_config,
+            n_channels=list(n_channels),
+            dilations=[1, 1, 1],
+        )
+        .build(output_channels=out_channels, ctx=HEALPixBuildContext())
+        .to(device)
+    )
 
     outvar = decoder(invars)
     assert outvar.shape == output_2_size
@@ -957,7 +1004,7 @@ def test_healpix_unet_dealias_smoothed():
     # Channel count matches prior stacked layout:
     # 2*(3+1) prognostic+decoder + 1 constant
     in_ch = 9
-    m = HEALPixUNet(
+    m = _build_hpx_unet(
         encoder=enc,
         decoder=dec,
         input_channels=in_ch,
@@ -1056,7 +1103,7 @@ def test_healpix_unet_isolatitude_nside_sequence():
         n_layers=[1, 1, 1],
         dilations=[1, 1, 1],
     )
-    model = HEALPixUNet(
+    model = _build_hpx_unet(
         encoder=encoder,
         decoder=decoder,
         input_channels=5,
@@ -1102,7 +1149,7 @@ def test_HEALPixUNet_initialize():
     enc, dec = _hpx_unet_configs(img=img, output_channels=out_channels)
     device = get_device()
 
-    model = HEALPixUNet(
+    model = _build_hpx_unet(
         encoder=enc,
         decoder=dec,
         input_channels=in_channels,
@@ -1123,7 +1170,7 @@ def test_HEALPixUNet_forward_shape():
     enc, dec = _hpx_unet_configs(img=img, output_channels=out_channels)
     device = get_device()
 
-    model = HEALPixUNet(
+    model = _build_hpx_unet(
         encoder=enc,
         decoder=dec,
         input_channels=in_channels,
@@ -1145,7 +1192,7 @@ def test_HEALPixUNet_input_channel_validation():
     enc, dec = _hpx_unet_configs(img=img, output_channels=out_channels)
     device = get_device()
 
-    model = HEALPixUNet(
+    model = _build_hpx_unet(
         encoder=enc,
         decoder=dec,
         input_channels=in_channels,
@@ -1176,7 +1223,7 @@ def test_HEALPixUNet_forward_padding_mode(mode):
     )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = HEALPixUNet(
+    model = _build_hpx_unet(
         encoder=enc,
         decoder=dec,
         input_channels=in_channels,

--- a/fme/ace/registry/test_hpx.py
+++ b/fme/ace/registry/test_hpx.py
@@ -27,7 +27,7 @@ from fme.ace.models.healpix.healpix_blocks import (
     TransposedConvUpsampleBlockConfig,
     UpsamplingBlockConfig,
 )
-from fme.ace.models.healpix.healpix_decoder import UNetDecoder
+from fme.ace.models.healpix.healpix_decoder import DecoderLevel, UNetDecoder
 from fme.ace.models.healpix.healpix_encoder import UNetEncoder
 from fme.ace.models.healpix.healpix_layers import (
     HEALPixLayer,
@@ -1158,8 +1158,12 @@ def test_HEALPixUNet_initialize():
         nside=_nside_levels(img, len(enc.n_channels)),
     ).to(device)
     assert isinstance(model, HEALPixUNet)
-    for layer in model.decoder.decoder:
-        assert set(layer.keys()) == {"upsamp", "conv"}
+    levels = list(model.decoder.decoder)
+    for i, level in enumerate(levels):
+        assert isinstance(level, DecoderLevel)
+        assert isinstance(level.conv, nn.Module)
+        # the deepest level (built first) has no upsample; the rest do
+        assert (level.upsamp is None) == (i == 0)
 
 
 def test_HEALPixUNet_forward_shape():


### PR DESCRIPTION
<!-- This description becomes the squash-and-merge commit message: keep it self-contained and describe the final state from main. Put PR-process notes (stacking/rebase, review responses, commit-by-commit narratives) in a PR comment, not here. -->
Refactors the HEALPix UNet stack to the Builder pattern (Rule 2): each builder `Config` constructs its sub-objects from sub-config fields and passes the built objects to the implementation, so no implementation class receives a sub-config to build.

This is the pure Rule 2 follow-up to #1326 (HEALPix UNet code cleanup), which already introduced `HEALPixBuildContext`, made channel counts flow as explicit `.build()` args, and removed the in-place config mutation (`encoder.input_channels = …`, `.nside`) and the `dataclasses.replace(...).build()` pattern. Those violations are already gone on `main`; the residual addressed here is that implementation classes still called `.build()` on their sub-configs.

The three layers:

- **UNet.** `HEALPixUNet.__init__` no longer builds anything. `HEALPixUNetBuilder.build` (via a private `_build`) constructs the `HEALPixBuildContext`, validates the encoder/decoder level counts and the `nside` sequence, builds the encoder and decoder `nn.Module`s, and passes the built modules plus the runtime scalars the impl needs (`input_channels`, `output_channels`, and the resolved `nside` tuple used by `forward`'s face-size check) into `HEALPixUNet`. The impl holds no configs.
- **Encoder / decoder.** The per-level construction loop (channel threading and nside-ratio validation) moves from `UNetEncoder`/`UNetDecoder.__init__` into `UNetEncoderConfig._build` / `UNetDecoderConfig._build`. The config builds the ordered per-level modules (encoder: an `nn.Sequential(down?, conv)` per level; decoder: a per-level `DecoderLevel` module — a small `nn.Module` bundling the optional upsample + skip-concat + conv and running that branching in its own `forward` — plus the `output_layer`) and passes the built `nn.ModuleList`/modules to the impl, which just stores them. `UNetDecoder.forward` iterates the typed levels rather than reaching into string-keyed module dicts, so the impl is directly constructible from its signature and its `forward` needs no knowledge of how the levels were assembled.
- **Activations.** The ~7 conv/upsample block impls no longer take a `CappedGELUConfig` and call `activation.build()`. Each block config now passes an **activation factory** — the bound `activation.build` callable (or `None`) — as `activation_factory: Callable[[], nn.Module] | None`, and each impl calls `activation_factory()` exactly where it used to call `activation.build()`. This is deliberate: `CappedGELU` registers a `cap` buffer (so it appears in `state_dict`), and a block needs N *independent* activation instances (N depends on `n_layers`), so a single shared built instance would be wrong. The factory keeps the module instantiation count and order — and thus `state_dict` — identical. `SmoothedInterpolateConv`, which previously received a single built activation module, is folded into the same factory form for family consistency.

**Behavior-preserving and checkpoint-compatible.** The set and ordering of constructed submodules — and therefore `state_dict` keys — is unchanged, so a HEALPix checkpoint trained on `main` still loads. Verified by building representative models (BasicConv / ConvNeXt / MultiSymmetricConvNeXt convs; transposed-conv and smoothed-interpolate upsampling; karlbauer, isolatitude, and earth2grid padding; dealiased downsample) on both `main` and this branch under a fixed seed and confirming the full `state_dict` dumps (keys, order, shapes, dtypes) and parameter values are byte-identical across all 36 combinations.

Changes:
- `fme.ace.registry.hpx`: `HEALPixUNetBuilder.build` delegates to `_build`, which builds the context, validates, builds encoder/decoder, and assembles `HEALPixUNet`.
- `fme.ace.models.healpix.healpix_unet`: `HEALPixUNet.__init__` takes built encoder/decoder modules plus runtime scalars; no building, no configs.
- `fme.ace.models.healpix.healpix_encoder`, `.healpix_decoder`: construction loop hoisted into `UNetEncoderConfig._build` / `UNetDecoderConfig._build`; impls store built modules. The decoder's per-level unit is a typed `DecoderLevel` (submodules named `upsamp`/`conv`, so `state_dict` keys and order are unchanged from the previous `ModuleDict`); the encoder keeps its `nn.Sequential`-per-level structure.
- `fme.ace.models.healpix.healpix_blocks`: block impls take `activation_factory`; block configs pass `activation.build`; impls no longer reference `CappedGELUConfig`.
- `fme.ace.registry.test_hpx`: construct encoder/decoder/UNet through the config build path to match the new signatures (behavior identical).

- [x] Tests added (existing hpx tests updated to build via the config path; behavior-preserving, no new behavior to cover)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
