### PR TITLE
fme/translate skeleton: component pool, freezing, checkpoint init (translate 1/6)

### DIFF
--- a/fme/translate/__init__.py
+++ b/fme/translate/__init__.py
@@ -3,8 +3,9 @@
 This package sits at the coupled/downscaling tier: it may import ``fme.core``,
 ``fme.ace``, and ``fme.downscaling``; nothing imports it. It provides the
 shared abstraction of a named pool of components (trainable transforms /
-encoders / decoders wrapped around a backbone stepper) used by the transfer
-learning and multi-resolution latent-stepping programs.
+encoders / decoders wrapped around a backbone stepper) mapping between named
+domains, used by the transfer learning and multi-resolution latent-stepping
+programs.
 """
 
 from .components import (
@@ -13,10 +14,23 @@ from .components import (
     ComponentPoolConfig,
     TransformConfig,
 )
+from .domains import DomainConfig, LatentChannels
+from .modules import (
+    InterpolateTransformConfig,
+    SameGridTransformConfig,
+    TransformModuleConfig,
+    TransformSelector,
+)
 
 __all__ = [
     "BackboneConfig",
     "ComponentPool",
     "ComponentPoolConfig",
+    "DomainConfig",
+    "InterpolateTransformConfig",
+    "LatentChannels",
+    "SameGridTransformConfig",
     "TransformConfig",
+    "TransformModuleConfig",
+    "TransformSelector",
 ]

--- a/fme/translate/__init__.py
+++ b/fme/translate/__init__.py
@@ -1,0 +1,22 @@
+"""Infrastructure for domain-translation and multi-resolution training.
+
+This package sits at the coupled/downscaling tier: it imports ``fme.core``,
+``fme.ace``, and ``fme.downscaling``; nothing imports it. It provides the
+shared abstraction of a named pool of components (trainable transforms /
+encoders / decoders wrapped around a backbone stepper) used by the transfer
+learning and multi-resolution latent-stepping programs.
+"""
+
+from .components import (
+    BackboneConfig,
+    ComponentPool,
+    ComponentPoolConfig,
+    TransformConfig,
+)
+
+__all__ = [
+    "BackboneConfig",
+    "ComponentPool",
+    "ComponentPoolConfig",
+    "TransformConfig",
+]

--- a/fme/translate/__init__.py
+++ b/fme/translate/__init__.py
@@ -1,6 +1,6 @@
 """Infrastructure for domain-translation and multi-resolution training.
 
-This package sits at the coupled/downscaling tier: it imports ``fme.core``,
+This package sits at the coupled/downscaling tier: it may import ``fme.core``,
 ``fme.ace``, and ``fme.downscaling``; nothing imports it. It provides the
 shared abstraction of a named pool of components (trainable transforms /
 encoders / decoders wrapped around a backbone stepper) used by the transfer

--- a/fme/translate/components.py
+++ b/fme/translate/components.py
@@ -1,0 +1,392 @@
+"""Named pool of translate components and its built composite container.
+
+The translate abstraction is a *pool of named components* wrapped around a
+backbone stepper. Two kinds of component live in the pool:
+
+- **Transforms** (encoders / decoders / translation maps): trainable
+  ``nn.Module``s built via :class:`ModuleSelector`, each declaring its input
+  and output variable (or latent-channel) name sets. The number of input and
+  output channels is ``len(in_names)`` and ``len(out_names)``.
+- **Backbones**: full ace :class:`Stepper`s (normalization, ocean, corrector,
+  derived variables intact), either built fresh from a :class:`StepperConfig`
+  or sourced from a checkpoint via :class:`CheckpointStepperConfig`.
+
+The built composite (:class:`ComponentPool`) holds the components, exposes a
+flattened ``.modules`` (mirroring
+:class:`fme.coupled.stepper.CoupledStepper`), fans out train/eval/epoch
+control, and implements ``get_state``/``from_state``/``load_state``.
+
+Per-component freezing (:class:`FrozenParameterConfig`) and name-matched
+partial checkpoint initialization (:class:`ParameterInitializationConfig` ->
+``overwrite_weights``) are supported. Freezing *must* happen before DDP
+wrapping, because ``DistributedDataParallel`` registers gradient hooks at wrap
+time based on ``requires_grad``. This ordering is enforced by threading a
+:class:`ParameterInitializer` into ``StepperConfig.get_stepper`` for backbones
+(freeze happens inside step construction, pre-wrap) and by freezing the raw
+module before ``wrap_module`` for transforms.
+"""
+
+import dataclasses
+from typing import Any
+
+import dacite
+import torch
+from torch import nn
+
+from fme.ace.stepper.parameter_init import (
+    ParameterInitializationConfig,
+    StepperWeightsAndHistory,
+    WeightsAndHistoryLoader,
+    null_weights_and_history,
+)
+from fme.ace.stepper.single_module import (
+    CheckpointStepperConfig,
+    Stepper,
+    StepperConfig,
+    load_stepper,
+    load_weights_and_history,
+)
+from fme.core.dataset_info import DatasetInfo
+from fme.core.distributed import Distributed
+from fme.core.registry.module import Module, ModuleSelector
+from fme.core.training_history import TrainingHistory
+
+
+def load_module_weights(path: str | None) -> StepperWeightsAndHistory:
+    """Load a single module's ``state_dict`` for name-matched initialization.
+
+    The file at ``path`` must be a ``torch.save``-d module ``state_dict``
+    (a mapping of parameter name to tensor). Its keys must be a subset of the
+    destination module's ``state_dict`` keys; ``overwrite_weights`` matches by
+    name and, where a destination axis is larger, overwrites its initial slice.
+
+    Returns ``(None, TrainingHistory())`` when ``path`` is None so an unset
+    ``weights_path`` is a no-op.
+    """
+    if path is None:
+        return null_weights_and_history()
+    state_dict = torch.load(path, map_location="cpu", weights_only=False)
+    return [state_dict], TrainingHistory()
+
+
+def _stepper_weights_loader(stepper: Stepper) -> WeightsAndHistoryLoader:
+    """A weights loader that pulls each module's ``state_dict`` from a stepper.
+
+    Mirrors ``fme.coupled.stepper``'s checkpoint-sourced loader: it lets a
+    donor stepper's weights flow through the parameter-init path so that
+    freezing can be threaded through ``get_stepper`` (pre-wrap), rather than
+    freezing after ``load_stepper`` has already DDP-wrapped an unfrozen model.
+    """
+
+    def load(*_: Any) -> StepperWeightsAndHistory:
+        return [module.state_dict() for module in stepper.modules], (
+            stepper.training_history
+        )
+
+    return load
+
+
+@dataclasses.dataclass
+class TransformConfig:
+    """Configuration for a trainable transform / encoder / decoder component.
+
+    Parameters:
+        module: The module builder. Built with ``n_in_channels=len(in_names)``
+            and ``n_out_channels=len(out_names)``.
+        in_names: Input variable (or latent-channel) names.
+        out_names: Output variable (or latent-channel) names.
+        parameter_init: Freezing and name-matched weight initialization for this
+            transform. ``weights_path`` (if set) points to a module
+            ``state_dict`` file loaded by :func:`load_module_weights`; the
+            ``parameters[0].frozen`` config selects which parameters to freeze.
+    """
+
+    module: ModuleSelector
+    in_names: list[str]
+    out_names: list[str]
+    parameter_init: ParameterInitializationConfig = dataclasses.field(
+        default_factory=ParameterInitializationConfig
+    )
+
+    def _build_raw(self, dataset_info: DatasetInfo) -> Module:
+        return self.module.build(
+            n_in_channels=len(self.in_names),
+            n_out_channels=len(self.out_names),
+            dataset_info=dataset_info,
+        )
+
+    def build(self, dataset_info: DatasetInfo) -> Module:
+        """Build the transform, applying weight init and freezing before wrap.
+
+        Order: build the raw module, overwrite a subset of its weights from the
+        configured checkpoint (name-matched), freeze the configured parameters,
+        then DDP-wrap. Freezing precedes wrapping so a fully-frozen module is
+        wrapped as a ``DummyWrapper`` with no live-gradient expectations.
+        """
+        module = self._build_raw(dataset_info)
+        initializer = self.parameter_init.build(load_module_weights)
+        # Both operate on the raw (pre-wrap) module, so state-dict keys carry
+        # no "module." prefix and match an unwrapped donor's names directly.
+        initializer.apply_weights([module.torch_module])
+        initializer.freeze_weights([module.torch_module])
+        return module.wrap_module(Distributed.get_instance().wrap_module)
+
+    def build_for_load(self, dataset_info: DatasetInfo) -> Module:
+        """Build a wrapped transform without weight init or freezing.
+
+        Used when reconstructing from a saved state: the weights are restored by
+        a subsequent ``load_state``, so external initialization is skipped and,
+        as with ``Stepper.from_state``, the reloaded module is left unfrozen.
+        """
+        module = self._build_raw(dataset_info)
+        return module.wrap_module(Distributed.get_instance().wrap_module)
+
+
+@dataclasses.dataclass
+class BackboneConfig:
+    """Configuration for a backbone stepper component.
+
+    The stepper *configuration* is either built fresh (``stepper``) or read from
+    a checkpoint (``checkpoint``); exactly one must be provided. Freezing and
+    name-matched weight initialization are threaded through ``get_stepper`` via
+    ``parameter_init`` so that freezing happens before DDP wrapping.
+
+    When ``checkpoint`` is set and ``init_from_checkpoint`` is True (the default,
+    and the transfer-learning arm's central case of a frozen SHiELD+ donor), the
+    donor's weights are sourced through the parameter-init path: the config comes
+    from ``CheckpointStepperConfig.to_stepper_config()`` and the weights from the
+    loaded stepper's modules. This lets a frozen donor be built pre-wrap, so a
+    fully-frozen backbone is wrapped as a ``DummyWrapper`` rather than a
+    ``DistributedDataParallel`` expecting gradients.
+
+    Set ``init_from_checkpoint`` False to build fresh (random) weights over a
+    checkpoint-sourced config. For a non-frozen inference/fine-tune backbone,
+    ``load_stepper`` (used directly elsewhere) remains the convenience path.
+
+    Parameters:
+        stepper: A fresh stepper configuration. Mutually exclusive with
+            ``checkpoint``.
+        checkpoint: A checkpoint to source the stepper configuration from.
+            Mutually exclusive with ``stepper``.
+        parameter_init: Freezing and (for the fresh-config case) weight
+            initialization. When ``checkpoint`` is set and
+            ``init_from_checkpoint`` is True, ``weights_path`` must be None
+            because the weights come from the checkpoint.
+        init_from_checkpoint: Whether to source weights from ``checkpoint`` via
+            the parameter-init path. Only meaningful when ``checkpoint`` is set.
+    """
+
+    stepper: StepperConfig | None = None
+    checkpoint: CheckpointStepperConfig | None = None
+    parameter_init: ParameterInitializationConfig = dataclasses.field(
+        default_factory=ParameterInitializationConfig
+    )
+    init_from_checkpoint: bool = True
+
+    def __post_init__(self):
+        if (self.stepper is None) == (self.checkpoint is None):
+            raise ValueError(
+                "Exactly one of 'stepper' or 'checkpoint' must be provided "
+                "for a BackboneConfig."
+            )
+        if self.checkpoint is not None and self.init_from_checkpoint:
+            if self.parameter_init.weights_path is not None:
+                raise ValueError(
+                    "When sourcing backbone weights from 'checkpoint', "
+                    "parameter_init.weights_path must be None (the weights come "
+                    "from the checkpoint)."
+                )
+
+    def _config_and_loader(self) -> tuple[StepperConfig, WeightsAndHistoryLoader]:
+        if self.stepper is not None:
+            return self.stepper, load_weights_and_history
+        assert self.checkpoint is not None  # guaranteed by __post_init__
+        config = self.checkpoint.to_stepper_config()
+        if self.init_from_checkpoint:
+            donor = load_stepper(self.checkpoint.checkpoint_path)
+            return config, _stepper_weights_loader(donor)
+        return config, load_weights_and_history
+
+    def build(self, dataset_info: DatasetInfo) -> Stepper:
+        """Build the backbone stepper with freezing applied before DDP wrapping.
+
+        Freezing and weight initialization are carried by the
+        :class:`ParameterInitializer` threaded into ``get_stepper``; the stepper
+        applies the freeze inside step construction (pre-wrap).
+        """
+        config, loader = self._config_and_loader()
+        initializer = self.parameter_init.build(loader)
+        return config.get_stepper(
+            dataset_info=dataset_info,
+            parameter_initializer=initializer,
+        )
+
+
+@dataclasses.dataclass
+class ComponentPoolConfig:
+    """Configuration for a named pool of translate components.
+
+    Parameters:
+        transforms: Named trainable transform / encoder / decoder components.
+        backbones: Named backbone steppers.
+    """
+
+    transforms: dict[str, TransformConfig] = dataclasses.field(default_factory=dict)
+    backbones: dict[str, BackboneConfig] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        overlap = set(self.transforms).intersection(self.backbones)
+        if overlap:
+            raise ValueError(
+                f"Component names must be unique across transforms and "
+                f"backbones; found duplicates: {sorted(overlap)}."
+            )
+
+    def build(self, dataset_info: DatasetInfo) -> "ComponentPool":
+        """Build every component against ``dataset_info``.
+
+        Note: a single ``dataset_info`` (grid) is shared by all components in
+        this version; per-component grids for resolution-changing operators are
+        a later extension.
+        """
+        transforms = {
+            name: config.build(dataset_info) for name, config in self.transforms.items()
+        }
+        backbones = {
+            name: config.build(dataset_info) for name, config in self.backbones.items()
+        }
+        return ComponentPool(
+            config=self,
+            transforms=transforms,
+            backbones=backbones,
+            dataset_info=dataset_info,
+        )
+
+    def get_state(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_state(cls, state: dict[str, Any]) -> "ComponentPoolConfig":
+        return dacite.from_dict(
+            data_class=cls,
+            data=state,
+            config=dacite.Config(
+                strict=True,
+                type_hooks={
+                    StepperConfig: StepperConfig.from_state,
+                },
+            ),
+        )
+
+
+class ComponentPool:
+    """The built composite of a translate component pool.
+
+    Holds the built transforms and backbones, exposes them for training via a
+    flattened ``.modules`` list, fans out train/eval/epoch control, and
+    round-trips its full state (config + weights) via
+    ``get_state``/``from_state``/``load_state``.
+
+    This container is deliberately minimal: it builds, holds, exposes modules,
+    and saves/loads state. It has no forward/predict/objective logic and is not
+    yet ``Stepper``-compatible.
+    """
+
+    def __init__(
+        self,
+        config: ComponentPoolConfig,
+        transforms: dict[str, Module],
+        backbones: dict[str, Stepper],
+        dataset_info: DatasetInfo,
+    ):
+        self._config = config
+        self._transforms = transforms
+        self._backbones = backbones
+        self._dataset_info = dataset_info
+
+    @property
+    def transforms(self) -> dict[str, Module]:
+        return self._transforms
+
+    @property
+    def backbones(self) -> dict[str, Stepper]:
+        return self._backbones
+
+    @property
+    def modules(self) -> nn.ModuleList:
+        """All trainable modules in the pool, as a flattened ``nn.ModuleList``.
+
+        Transforms contribute their wrapped torch module; backbones contribute
+        every module in their own ``.modules``. Ordering is transforms first
+        (in insertion order), then backbones.
+        """
+        result: list[nn.Module] = [
+            transform.torch_module for transform in self._transforms.values()
+        ]
+        for backbone in self._backbones.values():
+            result.extend(backbone.modules)
+        return nn.ModuleList(result)
+
+    def set_train(self) -> None:
+        for transform in self._transforms.values():
+            transform.torch_module.train()
+        for backbone in self._backbones.values():
+            backbone.set_train()
+
+    def set_eval(self) -> None:
+        for transform in self._transforms.values():
+            transform.torch_module.eval()
+        for backbone in self._backbones.values():
+            backbone.set_eval()
+
+    def set_epoch(self, epoch: int) -> None:
+        # Transforms have no epoch-dependent state; only backbones react.
+        for backbone in self._backbones.values():
+            backbone.set_epoch(epoch)
+
+    def get_state(self) -> dict[str, Any]:
+        return {
+            "config": self._config.get_state(),
+            "dataset_info": self._dataset_info.get_state(),
+            "transforms": {
+                name: transform.get_state()
+                for name, transform in self._transforms.items()
+            },
+            "backbones": {
+                name: backbone.get_state() for name, backbone in self._backbones.items()
+            },
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        for name, transform in self._transforms.items():
+            transform.load_state(state["transforms"][name])
+        for name, backbone in self._backbones.items():
+            backbone.load_state(state["backbones"][name])
+
+    @classmethod
+    def from_state(cls, state: dict[str, Any]) -> "ComponentPool":
+        """Rebuild a pool from saved state.
+
+        Transforms are rebuilt from the pool config against the saved
+        ``dataset_info`` (without external init or freezing) and their weights
+        restored; backbones are rebuilt via the self-contained
+        ``Stepper.from_state`` (its checkpoint path need not still exist).
+        """
+        config = ComponentPoolConfig.from_state(state["config"])
+        dataset_info = DatasetInfo.from_state(state["dataset_info"])
+        transforms = {
+            name: transform_config.build_for_load(dataset_info)
+            for name, transform_config in config.transforms.items()
+        }
+        for name, transform in transforms.items():
+            transform.load_state(state["transforms"][name])
+        backbones = {
+            name: Stepper.from_state(backbone_state)
+            for name, backbone_state in state["backbones"].items()
+        }
+        return cls(
+            config=config,
+            transforms=transforms,
+            backbones=backbones,
+            dataset_info=dataset_info,
+        )

--- a/fme/translate/components.py
+++ b/fme/translate/components.py
@@ -1,15 +1,28 @@
 """Named pool of translate components and its built composite container.
 
-The translate abstraction is a *pool of named components* wrapped around a
-backbone stepper. Two kinds of component live in the pool:
+The translate abstraction is a *pool of named components* mapping between
+*named domains* (see :mod:`fme.translate.domains`), wrapped around a backbone
+stepper. Two kinds of component live in the pool:
 
 - **Transforms** (encoders / decoders / translation maps): trainable
-  ``nn.Module``s built via :class:`ModuleSelector`, each declaring its input
-  and output variable (or latent-channel) name sets. The number of input and
-  output channels is ``len(in_names)`` and ``len(out_names)``.
+  ``nn.Module``s built via the :class:`TransformSelector` registry, each
+  declaring the domain it maps from and the domain it maps to. Channel counts
+  come from the domains' expanded channel lists, and the builder receives both
+  domains' grids, so resolution-changing operators (a 1° -> 2° encoder) are
+  first-class.
 - **Backbones**: full ace :class:`Stepper`s (normalization, ocean, corrector,
   derived variables intact), either built fresh from a :class:`StepperConfig`
-  or sourced from a checkpoint via :class:`CheckpointStepperConfig`.
+  or sourced from a checkpoint via :class:`CheckpointStepperConfig`, stepping
+  within one declared domain.
+
+Domains are how components pair with data: :meth:`ComponentPoolConfig.build`
+takes a mapping of domain name to ``DatasetInfo``, one entry per data-backed
+domain (the data-loading layer provides these, pairing each data stream with
+the domain it serves); a latent domain declares ``grid_like`` and inherits the
+referenced domain's grid. A multi-resolution chain — e.g. 1°/2°/4° domains,
+1°->2° and 2°->4° transforms (and their inverses), and a backbone stepping in
+the 4° domain — is a pool with three domains, four transforms, and one
+backbone.
 
 The built composite (:class:`ComponentPool`) holds the components, exposes a
 flattened ``.modules`` (mirroring
@@ -27,6 +40,7 @@ module before ``wrap_module`` for transforms.
 """
 
 import dataclasses
+from collections.abc import Mapping
 from typing import Any
 
 import dacite
@@ -48,8 +62,11 @@ from fme.ace.stepper.single_module import (
 )
 from fme.core.dataset_info import DatasetInfo
 from fme.core.distributed import Distributed
-from fme.core.registry.module import Module, ModuleSelector
+from fme.core.registry.module import Module
 from fme.core.training_history import TrainingHistory
+
+from .domains import DomainConfig
+from .modules import TransformSelector
 
 
 def load_module_weights(path: str | None) -> StepperWeightsAndHistory:
@@ -91,31 +108,45 @@ class TransformConfig:
     """Configuration for a trainable transform / encoder / decoder component.
 
     Parameters:
-        module: The module builder. Built with ``n_in_channels=len(in_names)``
-            and ``n_out_channels=len(out_names)``.
-        in_names: Input variable (or latent-channel) names.
-        out_names: Output variable (or latent-channel) names.
+        module: The module builder, a :class:`TransformSelector` registry
+            entry. Built with the input and output domains' channel counts and
+            ``DatasetInfo``s (so resolution-changing builders see both grids).
+        in_domain: Name of the domain this transform maps from.
+        out_domain: Name of the domain this transform maps to.
         parameter_init: Freezing and name-matched weight initialization for this
             transform. ``weights_path`` (if set) points to a module
             ``state_dict`` file loaded by :func:`load_module_weights`; the
             ``parameters[0].frozen`` config selects which parameters to freeze.
     """
 
-    module: ModuleSelector
-    in_names: list[str]
-    out_names: list[str]
+    module: TransformSelector
+    in_domain: str
+    out_domain: str
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=ParameterInitializationConfig
     )
 
-    def _build_raw(self, dataset_info: DatasetInfo) -> Module:
+    def _build_raw(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
         return self.module.build(
-            n_in_channels=len(self.in_names),
-            n_out_channels=len(self.out_names),
-            dataset_info=dataset_info,
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            in_dataset_info=in_dataset_info,
+            out_dataset_info=out_dataset_info,
         )
 
-    def build(self, dataset_info: DatasetInfo) -> Module:
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
         """Build the transform, applying weight init and freezing before wrap.
 
         Order: build the raw module, overwrite a subset of its weights from the
@@ -123,7 +154,9 @@ class TransformConfig:
         then DDP-wrap. Freezing precedes wrapping so a fully-frozen module is
         wrapped as a ``DummyWrapper`` with no live-gradient expectations.
         """
-        module = self._build_raw(dataset_info)
+        module = self._build_raw(
+            n_in_channels, n_out_channels, in_dataset_info, out_dataset_info
+        )
         initializer = self.parameter_init.build(load_module_weights)
         # Both operate on the raw (pre-wrap) module, so state-dict keys carry
         # no "module." prefix and match an unwrapped donor's names directly.
@@ -131,14 +164,22 @@ class TransformConfig:
         initializer.freeze_weights([module.torch_module])
         return module.wrap_module(Distributed.get_instance().wrap_module)
 
-    def build_for_load(self, dataset_info: DatasetInfo) -> Module:
+    def build_for_load(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
         """Build a wrapped transform without weight init or freezing.
 
         Used when reconstructing from a saved state: the weights are restored by
         a subsequent ``load_state``, so external initialization is skipped and,
         as with ``Stepper.from_state``, the reloaded module is left unfrozen.
         """
-        module = self._build_raw(dataset_info)
+        module = self._build_raw(
+            n_in_channels, n_out_channels, in_dataset_info, out_dataset_info
+        )
         return module.wrap_module(Distributed.get_instance().wrap_module)
 
 
@@ -146,8 +187,10 @@ class TransformConfig:
 class BackboneConfig:
     """Configuration for a backbone stepper component.
 
-    The stepper *configuration* is either built fresh (``stepper``) or read from
-    a checkpoint (``checkpoint``); exactly one must be provided. Freezing and
+    The backbone steps within one domain: every variable the stepper reads or
+    writes must be a channel of that domain (checked at build). The stepper
+    *configuration* is either built fresh (``stepper``) or read from a
+    checkpoint (``checkpoint``); exactly one must be provided. Freezing and
     name-matched weight initialization are threaded through ``get_stepper`` via
     ``parameter_init`` so that freezing happens before DDP wrapping.
 
@@ -164,6 +207,7 @@ class BackboneConfig:
     ``load_stepper`` (used directly elsewhere) remains the convenience path.
 
     Parameters:
+        domain: Name of the domain the backbone steps in.
         stepper: A fresh stepper configuration. Mutually exclusive with
             ``checkpoint``.
         checkpoint: A checkpoint to source the stepper configuration from.
@@ -176,6 +220,7 @@ class BackboneConfig:
             the parameter-init path. Only meaningful when ``checkpoint`` is set.
     """
 
+    domain: str
     stepper: StepperConfig | None = None
     checkpoint: CheckpointStepperConfig | None = None
     parameter_init: ParameterInitializationConfig = dataclasses.field(
@@ -207,14 +252,23 @@ class BackboneConfig:
             return config, _stepper_weights_loader(donor)
         return config, load_weights_and_history
 
-    def build(self, dataset_info: DatasetInfo) -> Stepper:
+    def build(self, dataset_info: DatasetInfo, domain: DomainConfig) -> Stepper:
         """Build the backbone stepper with freezing applied before DDP wrapping.
 
-        Freezing and weight initialization are carried by the
-        :class:`ParameterInitializer` threaded into ``get_stepper``; the stepper
-        applies the freeze inside step construction (pre-wrap).
+        ``dataset_info`` and ``domain`` are the backbone's declared domain (its
+        resolved grid and its channel declaration); the stepper's variables
+        must all be channels of the domain. Freezing and weight initialization
+        are carried by the :class:`ParameterInitializer` threaded into
+        ``get_stepper``; the stepper applies the freeze inside step
+        construction (pre-wrap).
         """
         config, loader = self._config_and_loader()
+        missing = set(config.all_names) - set(domain.names)
+        if missing:
+            raise ValueError(
+                f"Backbone stepper in domain {self.domain!r} uses variables "
+                f"that are not channels of that domain: {sorted(missing)}."
+            )
         initializer = self.parameter_init.build(loader)
         return config.get_stepper(
             dataset_info=dataset_info,
@@ -224,13 +278,17 @@ class BackboneConfig:
 
 @dataclasses.dataclass
 class ComponentPoolConfig:
-    """Configuration for a named pool of translate components.
+    """Configuration for a named pool of domains and translate components.
 
     Parameters:
-        transforms: Named trainable transform / encoder / decoder components.
-        backbones: Named backbone steppers.
+        domains: Named domains the components map between.
+        transforms: Named trainable transform / encoder / decoder components;
+            their ``in_domain``/``out_domain`` must name entries of ``domains``.
+        backbones: Named backbone steppers; their ``domain`` must name an entry
+            of ``domains``.
     """
 
+    domains: dict[str, DomainConfig] = dataclasses.field(default_factory=dict)
     transforms: dict[str, TransformConfig] = dataclasses.field(default_factory=dict)
     backbones: dict[str, BackboneConfig] = dataclasses.field(default_factory=dict)
 
@@ -241,25 +299,108 @@ class ComponentPoolConfig:
                 f"Component names must be unique across transforms and "
                 f"backbones; found duplicates: {sorted(overlap)}."
             )
+        for domain_name, domain in self.domains.items():
+            if domain.grid_like is not None:
+                if domain.grid_like not in self.domains:
+                    raise ValueError(
+                        f"Domain {domain_name!r} declares grid_like="
+                        f"{domain.grid_like!r}, which is not a domain."
+                    )
+                if self.domains[domain.grid_like].grid_like is not None:
+                    raise ValueError(
+                        f"Domain {domain_name!r} declares grid_like="
+                        f"{domain.grid_like!r}, which itself has grid_like; "
+                        "grid_like must reference a data-backed domain."
+                    )
+        for name, transform in self.transforms.items():
+            for label, domain_name in [
+                ("in_domain", transform.in_domain),
+                ("out_domain", transform.out_domain),
+            ]:
+                if domain_name not in self.domains:
+                    raise ValueError(
+                        f"Transform {name!r} declares {label}={domain_name!r}, "
+                        "which is not a domain."
+                    )
+        for name, backbone in self.backbones.items():
+            if backbone.domain not in self.domains:
+                raise ValueError(
+                    f"Backbone {name!r} declares domain={backbone.domain!r}, "
+                    "which is not a domain."
+                )
 
-    def build(self, dataset_info: DatasetInfo) -> "ComponentPool":
-        """Build every component against ``dataset_info``.
+    def _resolve_dataset_info(
+        self, dataset_info: Mapping[str, DatasetInfo]
+    ) -> dict[str, DatasetInfo]:
+        """Bind every domain to a ``DatasetInfo``.
 
-        Note: a single ``dataset_info`` (grid) is shared by all components in
-        this version; per-component grids for resolution-changing operators are
-        a later extension.
+        ``dataset_info`` must have exactly one entry per data-backed domain
+        (one without ``grid_like``); domains with ``grid_like`` inherit the
+        referenced domain's entry.
         """
+        data_backed = {
+            name for name, domain in self.domains.items() if domain.grid_like is None
+        }
+        missing = data_backed - set(dataset_info)
+        if missing:
+            raise ValueError(
+                f"Missing dataset_info for data-backed domains: {sorted(missing)}."
+            )
+        extra = set(dataset_info) - data_backed
+        if extra:
+            raise ValueError(
+                "Got dataset_info for names that are not data-backed domains: "
+                f"{sorted(extra)} (a grid_like domain inherits its grid; do "
+                "not pass one explicitly)."
+            )
+        return {
+            name: (
+                dataset_info[name]
+                if domain.grid_like is None
+                else dataset_info[domain.grid_like]
+            )
+            for name, domain in self.domains.items()
+        }
+
+    def _build_transform(
+        self,
+        transform: TransformConfig,
+        dataset_info: Mapping[str, DatasetInfo],
+        for_load: bool,
+    ) -> Module:
+        in_domain = self.domains[transform.in_domain]
+        out_domain = self.domains[transform.out_domain]
+        build = transform.build_for_load if for_load else transform.build
+        return build(
+            n_in_channels=in_domain.n_channels,
+            n_out_channels=out_domain.n_channels,
+            in_dataset_info=dataset_info[transform.in_domain],
+            out_dataset_info=dataset_info[transform.out_domain],
+        )
+
+    def build(self, dataset_info: Mapping[str, DatasetInfo]) -> "ComponentPool":
+        """Build every component against its domain's ``DatasetInfo``.
+
+        Args:
+            dataset_info: One entry per data-backed domain, keyed by domain
+                name — this is where components pair with data (the
+                data-loading layer derives each entry from the data stream
+                serving that domain).
+        """
+        resolved = self._resolve_dataset_info(dataset_info)
         transforms = {
-            name: config.build(dataset_info) for name, config in self.transforms.items()
+            name: self._build_transform(config, resolved, for_load=False)
+            for name, config in self.transforms.items()
         }
         backbones = {
-            name: config.build(dataset_info) for name, config in self.backbones.items()
+            name: config.build(resolved[config.domain], self.domains[config.domain])
+            for name, config in self.backbones.items()
         }
         return ComponentPool(
             config=self,
             transforms=transforms,
             backbones=backbones,
-            dataset_info=dataset_info,
+            dataset_info=resolved,
         )
 
     def get_state(self) -> dict[str, Any]:
@@ -297,12 +438,12 @@ class ComponentPool:
         config: ComponentPoolConfig,
         transforms: dict[str, Module],
         backbones: dict[str, Stepper],
-        dataset_info: DatasetInfo,
+        dataset_info: Mapping[str, DatasetInfo],
     ):
         self._config = config
         self._transforms = transforms
         self._backbones = backbones
-        self._dataset_info = dataset_info
+        self._dataset_info = dict(dataset_info)
 
     @property
     def transforms(self) -> dict[str, Module]:
@@ -311,6 +452,11 @@ class ComponentPool:
     @property
     def backbones(self) -> dict[str, Stepper]:
         return self._backbones
+
+    @property
+    def dataset_info(self) -> Mapping[str, DatasetInfo]:
+        """The resolved per-domain ``DatasetInfo``, keyed by domain name."""
+        return self._dataset_info
 
     @property
     def modules(self) -> nn.ModuleList:
@@ -347,7 +493,9 @@ class ComponentPool:
     def get_state(self) -> dict[str, Any]:
         return {
             "config": self._config.get_state(),
-            "dataset_info": self._dataset_info.get_state(),
+            "dataset_info": {
+                name: info.get_state() for name, info in self._dataset_info.items()
+            },
             "transforms": {
                 name: transform.get_state()
                 for name, transform in self._transforms.items()
@@ -368,14 +516,17 @@ class ComponentPool:
         """Rebuild a pool from saved state.
 
         Transforms are rebuilt from the pool config against the saved
-        ``dataset_info`` (without external init or freezing) and their weights
-        restored; backbones are rebuilt via the self-contained
+        per-domain ``dataset_info`` (without external init or freezing) and
+        their weights restored; backbones are rebuilt via the self-contained
         ``Stepper.from_state`` (its checkpoint path need not still exist).
         """
         config = ComponentPoolConfig.from_state(state["config"])
-        dataset_info = DatasetInfo.from_state(state["dataset_info"])
+        dataset_info = {
+            name: DatasetInfo.from_state(info_state)
+            for name, info_state in state["dataset_info"].items()
+        }
         transforms = {
-            name: transform_config.build_for_load(dataset_info)
+            name: config._build_transform(transform_config, dataset_info, for_load=True)
             for name, transform_config in config.transforms.items()
         }
         for name, transform in transforms.items():

--- a/fme/translate/components.py
+++ b/fme/translate/components.py
@@ -519,6 +519,11 @@ class ComponentPool:
         per-domain ``dataset_info`` (without external init or freezing) and
         their weights restored; backbones are rebuilt via the self-contained
         ``Stepper.from_state`` (its checkpoint path need not still exist).
+
+        As with ``Stepper.from_state``, the reloaded pool is left unfrozen:
+        both transforms (via ``build_for_load``) and backbones drop their
+        configured freeze. To resume training with freezing intact, build from
+        the config and ``load_state`` the weights instead.
         """
         config = ComponentPoolConfig.from_state(state["config"])
         dataset_info = {

--- a/fme/translate/domains.py
+++ b/fme/translate/domains.py
@@ -59,9 +59,14 @@ class DomainConfig:
             latent-channel blocks. Order defines channel order for every
             component built against this domain.
         grid_like: For a domain with no dataset behind it (a latent space),
-            the name of the domain whose grid it shares. Domains without
-            ``grid_like`` must be bound to a ``DatasetInfo`` (i.e. paired
-            with data) at pool build time.
+            the name of the domain whose ``DatasetInfo`` it inherits at build
+            time. Note this shares the referenced domain's *entire*
+            ``DatasetInfo`` — not only its grid, but its vertical coordinate,
+            timestep, and metadata — since no separate dataset describes the
+            latent space; a backbone stepping in a latent domain therefore
+            borrows those from the referenced data-backed domain. Domains
+            without ``grid_like`` must be bound to a ``DatasetInfo`` (i.e.
+            paired with data) at pool build time.
     """
 
     channels: list[str | LatentChannels]

--- a/fme/translate/domains.py
+++ b/fme/translate/domains.py
@@ -1,0 +1,94 @@
+"""Domains: the named spaces that translate components map between.
+
+A *domain* is a named space where data (or latent state) lives: an ordered set
+of channels on one grid. Domains are the pairing key between components and
+data: transforms declare an input and an output domain, backbones declare the
+domain they step in, and data streams (added with the data-loading PR) declare
+the domain they provide. Building a pool binds each domain to a
+:class:`DatasetInfo` by name.
+
+Channels are declared as a union of plain variable names and *latent-channel
+blocks*: a block names a group of free channels once and says how many there
+are (e.g. ``LatentChannels(name="z", channels=512)``) rather than enumerating
+them. Blocks expand to indexed names (``z_0`` ... ``z_511``) so that
+everything downstream (checkpoint name-matching, diagnostics) sees an ordinary
+ordered list of channel names.
+
+A domain with no dataset behind it (a latent space) declares ``grid_like``,
+naming the domain whose grid it shares — per the multi-resolution design, the
+latent lives on the backbone's (coarsest) grid.
+"""
+
+import dataclasses
+
+__all__ = ["DomainConfig", "LatentChannels"]
+
+
+@dataclasses.dataclass
+class LatentChannels:
+    """A named block of latent channels.
+
+    Parameters:
+        name: The block name; expanded channel names are ``{name}_{i}``.
+        channels: The number of channels in the block.
+    """
+
+    name: str
+    channels: int
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("LatentChannels requires a non-empty name.")
+        if self.channels < 1:
+            raise ValueError(
+                f"LatentChannels {self.name!r} requires channels >= 1, "
+                f"got {self.channels}."
+            )
+
+    @property
+    def names(self) -> list[str]:
+        return [f"{self.name}_{i}" for i in range(self.channels)]
+
+
+@dataclasses.dataclass
+class DomainConfig:
+    """A named space where data or latent state lives.
+
+    Parameters:
+        channels: Ordered channel declaration: a union of variable names and
+            latent-channel blocks. Order defines channel order for every
+            component built against this domain.
+        grid_like: For a domain with no dataset behind it (a latent space),
+            the name of the domain whose grid it shares. Domains without
+            ``grid_like`` must be bound to a ``DatasetInfo`` (i.e. paired
+            with data) at pool build time.
+    """
+
+    channels: list[str | LatentChannels]
+    grid_like: str | None = None
+
+    def __post_init__(self):
+        if not self.channels:
+            raise ValueError("A domain must declare at least one channel.")
+        names = self.names
+        duplicates = {name for name in names if names.count(name) > 1}
+        if duplicates:
+            raise ValueError(
+                f"Domain channel names must be unique after latent-block "
+                f"expansion; found duplicates: {sorted(duplicates)}."
+            )
+
+    @property
+    def names(self) -> list[str]:
+        """The ordered channel names, with latent blocks expanded."""
+        result: list[str] = []
+        for entry in self.channels:
+            if isinstance(entry, LatentChannels):
+                result.extend(entry.names)
+            else:
+                result.append(entry)
+        return result
+
+    @property
+    def n_channels(self) -> int:
+        return len(self.names)

--- a/fme/translate/examples/README.md
+++ b/fme/translate/examples/README.md
@@ -1,0 +1,30 @@
+# Example training configurations (intended config surface)
+
+Full example training configurations for the two target programs of the
+`fme/translate` PR series, written against the *intended* config surface
+through the whole series. Only the `component_pool:` block is implemented
+in PR 1 (the skeleton); everything else is the shape the follow-on PRs
+must parse. They exist to be critiqued now, before more code exists, and
+to let the critique drive the design — they are not runnable.
+
+| Config block | PR |
+|---|---|
+| `component_pool:` (domains / transforms / backbones, freeze, checkpoint init) | 1 — modulo latent-block-name expansion in backbone `in_names`/`out_names` and identity normalization |
+| `train_data:` / `validation_data:` streams, `sampling:` | 2 |
+| `objectives:` (`translation`, `forward_prediction`), `optimization:`, weighted-sum trainer | 3 |
+| `inference:` composites (Stepper-compatible export) | 4 |
+| `latent_consistency` objective type, noise-conditioned encoder registry entries | 6 |
+
+PR 5 (SFNO cut-point decomposition) doesn't appear in either config: it
+would show up as `parameter_init.weights_path` warm-starts on
+encoder/backbone/decoder, and as a bare-processor backbone in the
+latent-splice transfer variant.
+
+- [multi-resolution-latent.yaml](multi-resolution-latent.yaml) —
+  1°/2°/4° per-resolution encoders/decoders into a shared 4° latent, a
+  forward stepper in that latent, forward prediction at all three
+  resolutions against one shared backbone, and stochastic
+  latent-consistency constraints between adjacent resolutions.
+- [transfer-learning.yaml](transfer-learning.yaml) — learned ERA5↔SHiELD
+  translators around a fully-frozen C96-SHiELD donor stepper, end-to-end
+  rollout scored on ERA5, cycle consistency in both directions.

--- a/fme/translate/examples/README.md
+++ b/fme/translate/examples/README.md
@@ -9,11 +9,11 @@ to let the critique drive the design — they are not runnable.
 
 | Config block | PR |
 |---|---|
-| `component_pool:` (domains / transforms / backbones, freeze, checkpoint init) | 1 — modulo latent-block-name expansion in backbone `in_names`/`out_names` and identity normalization |
-| `train_data:` / `validation_data:` streams, `sampling:` | 2 |
-| `objectives:` (`translation`, `forward_prediction`), `optimization:`, weighted-sum trainer | 3 |
-| `inference:` composites (Stepper-compatible export) | 4 |
-| `latent_consistency` objective type, noise-conditioned encoder registry entries | 6 |
+| `component_pool:` (domains / transforms / backbones, freeze, checkpoint init) | 1 — modulo channels-on-transforms (domain load lists derived), int-declared latent blocks expanded in backbone `in_names`/`out_names`, and identity normalization |
+| `train_data:` / `validation_data:` stream lists (time-pairing derived from objective co-occurrence, not configured) | 2 |
+| `objectives:` (`translation`, `forward_prediction` over one-backbone component chains), `optimization:`, weighted-sum trainer | 3 |
+| `inference:` composites (one-backbone component chains, Stepper-compatible export) | 4 |
+| `latent_consistency` objective type, noise-conditioned encoder and latent-resampler registry entries | 6 |
 
 PR 5 (SFNO cut-point decomposition) doesn't appear in either config: it
 would show up as `parameter_init.weights_path` warm-starts on
@@ -21,10 +21,12 @@ encoder/backbone/decoder, and as a bare-processor backbone in the
 latent-splice transfer variant.
 
 - [multi-resolution-latent.yaml](multi-resolution-latent.yaml) —
-  1°/2°/4° per-resolution encoders/decoders into a shared 4° latent, a
-  forward stepper in that latent, forward prediction at all three
-  resolutions against one shared backbone, and stochastic
-  latent-consistency constraints between adjacent resolutions.
+  1°/2°/4° encoders/decoders into per-resolution latent domains, learned
+  resamplers between latent resolutions (so the 1° and 2° paths into the
+  4° latent share modules), a forward stepper in the 4° latent, forward
+  prediction at all three resolutions through chained components against
+  one shared backbone, and stochastic latent-consistency constraints
+  between adjacent latent resolutions.
 - [transfer-learning.yaml](transfer-learning.yaml) — learned ERA5↔SHiELD
   translators around a fully-frozen C96-SHiELD donor stepper, end-to-end
   rollout scored on ERA5, cycle consistency in both directions.

--- a/fme/translate/examples/multi-resolution-latent.yaml
+++ b/fme/translate/examples/multi-resolution-latent.yaml
@@ -1,0 +1,249 @@
+# Example A — multi-resolution latent stepping (1°/2°/4°, 4° latent backbone).
+# Intended config surface for the fme/translate PR series; only the
+# component_pool: block is implemented in PR 1. See README.md in this
+# directory for which PR lands each block. Not runnable.
+experiment_dir: train_output
+save_checkpoint: true
+validate_using_ema: true
+max_epochs: 40
+logging: {log_to_screen: true, log_to_wandb: true, log_to_file: true, project: ace}
+
+train_data:
+  batch_size: 16
+  num_data_workers: 4
+  sampling: paired_by_time    # every stream in a batch is sampled at the same
+                              # valid times (pre-coarsened datasets, shared calendar)
+  streams:
+    era5_1deg: {domain: atmos_1deg, dataset: {data_path: gs://.../era5-1deg-8layer/train}}
+    era5_2deg: {domain: atmos_2deg, dataset: {data_path: gs://.../era5-2deg-8layer/train}}
+    era5_4deg: {domain: atmos_4deg, dataset: {data_path: gs://.../era5-4deg-8layer/train}}
+
+validation_data:
+  batch_size: 16
+  sampling: paired_by_time
+  streams:
+    era5_1deg: {domain: atmos_1deg, dataset: {data_path: gs://.../era5-1deg-8layer/valid, subset: {step: 5}}}
+    era5_2deg: {domain: atmos_2deg, dataset: {data_path: gs://.../era5-2deg-8layer/valid, subset: {step: 5}}}
+    era5_4deg: {domain: atmos_4deg, dataset: {data_path: gs://.../era5-4deg-8layer/valid, subset: {step: 5}}}
+
+component_pool:
+  domains:
+    # identical channel sets at each resolution (only the grid differs, and the
+    # grid comes from the dataset bound to the domain); YAML anchors avoid
+    # writing the list three times. 8-level enumerations elided with "...".
+    atmos_1deg: &atmos
+      channels:
+        - air_temperature_0        # ... _1 through _7
+        - specific_total_water_0   # ...
+        - eastward_wind_0          # ...
+        - northward_wind_0         # ...
+        - PRESsfc
+        - surface_temperature
+        - DSWRFtoa                 # forcings
+        - ocean_fraction
+        - land_fraction
+        - sea_ice_fraction
+        - global_mean_co2
+    atmos_2deg: *atmos
+    atmos_4deg: *atmos
+    latent:
+      grid_like: atmos_4deg        # latent state lives on the backbone's (4°) grid
+      channels:
+        - {name: z, channels: 512} # named block -> z_0 ... z_511
+        # forcings are *channels of the latent domain*, overwritten from the 4°
+        # stream each step (mirrors ace's existing prescribed/forcing overwrite
+        # semantics) rather than produced by a separate forcing encoder:
+        - DSWRFtoa
+        - ocean_fraction
+        - land_fraction
+        - sea_ice_fraction
+        - global_mean_co2
+
+  transforms:
+    # resolution-changing, noise-conditioned encoders into the shared latent.
+    # ("noise_conditioned_sht_resize" / "sht_resize" are later registry
+    # entries; only same_grid and interpolate exist in PR 1.)
+    encoder_1deg:
+      in_domain: atmos_1deg
+      out_domain: latent
+      module:
+        type: noise_conditioned_sht_resize
+        config: {embed_dim: 256, num_layers: 4, n_noise_channels: 8}
+    encoder_2deg:
+      in_domain: atmos_2deg
+      out_domain: latent
+      module:
+        type: noise_conditioned_sht_resize
+        config: {embed_dim: 256, num_layers: 4, n_noise_channels: 8}
+    encoder_4deg:
+      in_domain: atmos_4deg
+      out_domain: latent
+      module:
+        type: noise_conditioned_sht_resize
+        config: {embed_dim: 256, num_layers: 4, n_noise_channels: 8}
+    decoder_1deg:
+      in_domain: latent
+      out_domain: atmos_1deg
+      module:
+        type: sht_resize
+        config: {embed_dim: 256, num_layers: 4}
+    decoder_2deg:
+      in_domain: latent
+      out_domain: atmos_2deg
+      module:
+        type: sht_resize
+        config: {embed_dim: 256, num_layers: 4}
+    decoder_4deg:
+      in_domain: latent
+      out_domain: atmos_4deg
+      module:
+        type: sht_resize
+        config: {embed_dim: 256, num_layers: 4}
+
+  backbones:
+    stepper_latent:
+      domain: latent
+      stepper:
+        step:
+          type: single_module
+          config:
+            builder:
+              type: SphericalFourierNeuralOperatorNet
+              config: {embed_dim: 384, num_layers: 8, operator_type: dhconv, scale_factor: 1}
+            # "z" is a latent-block reference, expanded against the domain
+            # declaration (z -> z_0 ... z_511) by BackboneConfig before the
+            # StepperConfig is constructed — the stepper never enumerates
+            # latent channels by hand.
+            in_names: [z, DSWRFtoa, ocean_fraction, land_fraction, sea_ice_fraction, global_mean_co2]
+            out_names: [z]
+            normalization:
+              network: {identity: true}  # NEW: latent channels have no dataset
+                                         # stats; the encoder sets their scale
+            ocean: null                  # no physical shell in the latent
+            corrector: null
+
+objectives:
+  # ---- k=0 explicit reconstruction at each resolution ----
+  - name: recon_1deg
+    type: translation
+    config:
+      components: [encoder_1deg, decoder_1deg]
+      input_stream: era5_1deg
+      target_stream: era5_1deg
+      n_ensemble: 2       # encoder is stochastic -> ensemble loss
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 1.0
+  - name: recon_2deg
+    type: translation
+    config:
+      components: [encoder_2deg, decoder_2deg]
+      input_stream: era5_2deg
+      target_stream: era5_2deg
+      n_ensemble: 2
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 1.0
+  - name: recon_4deg
+    type: translation
+    config:
+      components: [encoder_4deg, decoder_4deg]
+      input_stream: era5_4deg
+      target_stream: era5_4deg
+      n_ensemble: 2
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 1.0
+
+  # ---- forward prediction at every resolution, one shared backbone ----
+  - name: forward_4deg
+    type: forward_prediction
+    config:
+      encoder: encoder_4deg
+      backbone: stepper_latent
+      decoder: decoder_4deg
+      input_stream: era5_4deg
+      target_stream: era5_4deg
+      forcing_stream: era5_4deg   # forcings enter on the latent (4°) grid;
+                                  # paired_by_time sampling time-aligns them
+      n_forward_steps:
+        start_value: 1
+        milestones:
+          - epoch: 8
+            value: {outcomes: [{steps: 1, probability: 0.6}, {steps: 4, probability: 0.4}]}
+      n_ensemble: 2
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 1.0
+  - name: forward_2deg
+    type: forward_prediction
+    config:
+      encoder: encoder_2deg
+      backbone: stepper_latent
+      decoder: decoder_2deg
+      input_stream: era5_2deg
+      target_stream: era5_2deg
+      forcing_stream: era5_4deg   # note: cross-resolution — see issue 4 in the
+                                  # PR discussion
+      n_forward_steps:
+        start_value: 1
+        milestones:
+          - epoch: 8
+            value: {outcomes: [{steps: 1, probability: 0.6}, {steps: 4, probability: 0.4}]}
+      n_ensemble: 2
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 0.5
+  - name: forward_1deg
+    type: forward_prediction
+    config:
+      encoder: encoder_1deg
+      backbone: stepper_latent
+      decoder: decoder_1deg
+      input_stream: era5_1deg
+      target_stream: era5_1deg
+      forcing_stream: era5_4deg
+      n_forward_steps:
+        start_value: 1
+        milestones:
+          - epoch: 8
+            value: {outcomes: [{steps: 1, probability: 0.6}, {steps: 4, probability: 0.4}]}
+      n_ensemble: 2
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 0.5
+
+  # ---- stochastic latent consistency between adjacent resolutions:
+  # noise-injected coarse encoding pulled toward the stop-gradient fine
+  # encoding (stop-gradient is semantics of the objective type, not config) ----
+  - name: consistency_1v2
+    type: latent_consistency
+    config:
+      fine_encoder: encoder_1deg
+      coarse_encoder: encoder_2deg
+      fine_stream: era5_1deg
+      coarse_stream: era5_2deg
+      n_ensemble: 4
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 0.5
+  - name: consistency_2v4
+    type: latent_consistency
+    config:
+      fine_encoder: encoder_2deg
+      coarse_encoder: encoder_4deg
+      fine_stream: era5_2deg
+      coarse_stream: era5_4deg
+      n_ensemble: 4
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 0.5
+
+optimization:
+  optimizer_type: AdamW
+  lr: 1.0e-4
+  enable_automatic_mixed_precision: false
+
+# in-training inference callbacks over exported composites: any encode/decode
+# pairing around the shared backbone, evaluated with the standard aggregators
+inference:
+  - composite: {encoder: encoder_4deg, backbone: stepper_latent, decoder: decoder_4deg}
+    n_forward_steps: 1460
+    forward_steps_in_memory: 50
+    loader: {dataset: {data_path: gs://.../era5-4deg-8layer/valid}, start_indices: {first: 0, n_initial_conditions: 4, interval: 365}}
+  - composite: {encoder: encoder_1deg, backbone: stepper_latent, decoder: decoder_1deg}
+    n_forward_steps: 1460
+    forward_steps_in_memory: 50
+    loader: {dataset: {data_path: gs://.../era5-1deg-8layer/valid}, start_indices: {first: 0, n_initial_conditions: 4, interval: 365}}

--- a/fme/translate/examples/multi-resolution-latent.yaml
+++ b/fme/translate/examples/multi-resolution-latent.yaml
@@ -1,4 +1,8 @@
-# Example A — multi-resolution latent stepping (1°/2°/4°, 4° latent backbone).
+# Example A — multi-resolution latent stepping (1°/2°/4°). Each resolution
+# encodes into its own latent domain (latent_1deg/2deg/4deg); learned
+# resamplers move between latent resolutions, so the 1° and 2° paths into the
+# 4° latent share the same downsampling modules. The forward stepper lives in
+# the 4° latent.
 # Intended config surface for the fme/translate PR series; only the
 # component_pool: block is implemented in PR 1. See README.md in this
 # directory for which PR lands each block. Not runnable.
@@ -8,51 +12,54 @@ validate_using_ema: true
 max_epochs: 40
 logging: {log_to_screen: true, log_to_wandb: true, log_to_file: true, project: ace}
 
+# streams are a list; `name` is the handle objectives reference, defaulting to
+# `domain` (given explicitly here because the source, not the domain, is the
+# natural handle — several streams may share one domain). There is no sampling
+# knob: streams that appear together in some objective are sampled at the same
+# valid times, and streams that never co-occur are sampled independently.
 train_data:
   batch_size: 16
   num_data_workers: 4
-  sampling: paired_by_time    # every stream in a batch is sampled at the same
-                              # valid times (pre-coarsened datasets, shared calendar)
   streams:
-    era5_1deg: {domain: atmos_1deg, dataset: {data_path: gs://.../era5-1deg-8layer/train}}
-    era5_2deg: {domain: atmos_2deg, dataset: {data_path: gs://.../era5-2deg-8layer/train}}
-    era5_4deg: {domain: atmos_4deg, dataset: {data_path: gs://.../era5-4deg-8layer/train}}
+    - {name: era5_1deg, domain: atmos_1deg, dataset: {data_path: gs://.../era5-1deg-8layer/train}}
+    - {name: era5_2deg, domain: atmos_2deg, dataset: {data_path: gs://.../era5-2deg-8layer/train}}
+    - {name: era5_4deg, domain: atmos_4deg, dataset: {data_path: gs://.../era5-4deg-8layer/train}}
 
 validation_data:
   batch_size: 16
-  sampling: paired_by_time
   streams:
-    era5_1deg: {domain: atmos_1deg, dataset: {data_path: gs://.../era5-1deg-8layer/valid, subset: {step: 5}}}
-    era5_2deg: {domain: atmos_2deg, dataset: {data_path: gs://.../era5-2deg-8layer/valid, subset: {step: 5}}}
-    era5_4deg: {domain: atmos_4deg, dataset: {data_path: gs://.../era5-4deg-8layer/valid, subset: {step: 5}}}
+    - {name: era5_1deg, domain: atmos_1deg, dataset: {data_path: gs://.../era5-1deg-8layer/valid, subset: {step: 5}}}
+    - {name: era5_2deg, domain: atmos_2deg, dataset: {data_path: gs://.../era5-2deg-8layer/valid, subset: {step: 5}}}
+    - {name: era5_4deg, domain: atmos_4deg, dataset: {data_path: gs://.../era5-4deg-8layer/valid, subset: {step: 5}}}
 
 component_pool:
   domains:
-    # identical channel sets at each resolution (only the grid differs, and the
-    # grid comes from the dataset bound to the domain); YAML anchors avoid
-    # writing the list three times. 8-level enumerations elided with "...".
-    atmos_1deg: &atmos
+    # Data domains are primarily a data-loading concept: the grid comes from
+    # the dataset a stream binds to the domain, and the channel list is
+    # derived automatically from the channels the transforms below reference
+    # in the domain (channel lists live on transforms, so a resolution's
+    # encoder inputs and decoder outputs need not match).
+    atmos_1deg: {}
+    atmos_2deg: {}
+    atmos_4deg: {}
+    # Latent domains, one per resolution. No dataset binds to them, so they
+    # declare their channels directly: `channels` is int | list[str] (or a
+    # list mixing the two); an int declares an anonymous latent block named
+    # after the domain, referenced as a block name in backbone
+    # in_names/out_names and expanded before StepperConfig construction.
+    latent_1deg:
+      grid_like: atmos_1deg
+      channels: 512
+    latent_2deg:
+      grid_like: atmos_2deg
+      channels: 512
+    latent_4deg:
+      grid_like: atmos_4deg
       channels:
-        - air_temperature_0        # ... _1 through _7
-        - specific_total_water_0   # ...
-        - eastward_wind_0          # ...
-        - northward_wind_0         # ...
-        - PRESsfc
-        - surface_temperature
-        - DSWRFtoa                 # forcings
-        - ocean_fraction
-        - land_fraction
-        - sea_ice_fraction
-        - global_mean_co2
-    atmos_2deg: *atmos
-    atmos_4deg: *atmos
-    latent:
-      grid_like: atmos_4deg        # latent state lives on the backbone's (4°) grid
-      channels:
-        - {name: z, channels: 512} # named block -> z_0 ... z_511
-        # forcings are *channels of the latent domain*, overwritten from the 4°
-        # stream each step (mirrors ace's existing prescribed/forcing overwrite
-        # semantics) rather than produced by a separate forcing encoder:
+        - 512
+        # forcing channels of the backbone's domain, overwritten from the 4°
+        # stream each step (mirrors ace's existing prescribed/forcing
+        # overwrite semantics) rather than produced by any transform:
         - DSWRFtoa
         - ocean_fraction
         - land_fraction
@@ -60,49 +67,108 @@ component_pool:
         - global_mean_co2
 
   transforms:
-    # resolution-changing, noise-conditioned encoders into the shared latent.
-    # ("noise_conditioned_sht_resize" / "sht_resize" are later registry
-    # entries; only same_grid and interpolate exist in PR 1.)
+    # Per-resolution encoders into that resolution's latent (same grid; the
+    # resolution change happens in the latent resamplers below). The encoder
+    # ingests prognostics + forcings; channel lists are declared here on the
+    # transform. ("noise_conditioned_same_grid" and the "sht_resize" latent
+    # resamplers are later registry entries; only same_grid and interpolate
+    # exist in PR 1.)
     encoder_1deg:
       in_domain: atmos_1deg
-      out_domain: latent
+      in_channels: &encoder_in
+        - air_temperature_0        # ... _1 through _7
+        - specific_total_water_0   # ...
+        - eastward_wind_0          # ...
+        - northward_wind_0         # ...
+        - PRESsfc
+        - surface_temperature
+        - DSWRFtoa                 # forcings: encoder input only
+        - ocean_fraction
+        - land_fraction
+        - sea_ice_fraction
+        - global_mean_co2
+      out_domain: latent_1deg      # out_channels: the domain's latent block
       module:
-        type: noise_conditioned_sht_resize
+        type: noise_conditioned_same_grid
         config: {embed_dim: 256, num_layers: 4, n_noise_channels: 8}
     encoder_2deg:
       in_domain: atmos_2deg
-      out_domain: latent
+      in_channels: *encoder_in
+      out_domain: latent_2deg
       module:
-        type: noise_conditioned_sht_resize
+        type: noise_conditioned_same_grid
         config: {embed_dim: 256, num_layers: 4, n_noise_channels: 8}
     encoder_4deg:
       in_domain: atmos_4deg
-      out_domain: latent
+      in_channels: *encoder_in
+      out_domain: latent_4deg
       module:
-        type: noise_conditioned_sht_resize
+        type: noise_conditioned_same_grid
         config: {embed_dim: 256, num_layers: 4, n_noise_channels: 8}
+
+    # Per-resolution decoders out of that resolution's latent. Prognostics
+    # only — the decoder's out_channels differ from the encoder's in_channels
+    # (forcings are not reconstructed).
     decoder_1deg:
-      in_domain: latent
+      in_domain: latent_1deg
       out_domain: atmos_1deg
+      out_channels: &decoder_out
+        - air_temperature_0        # ... _1 through _7
+        - specific_total_water_0   # ...
+        - eastward_wind_0          # ...
+        - northward_wind_0         # ...
+        - PRESsfc
+        - surface_temperature
       module:
-        type: sht_resize
+        type: same_grid
         config: {embed_dim: 256, num_layers: 4}
     decoder_2deg:
-      in_domain: latent
+      in_domain: latent_2deg
       out_domain: atmos_2deg
+      out_channels: *decoder_out
       module:
-        type: sht_resize
+        type: same_grid
         config: {embed_dim: 256, num_layers: 4}
     decoder_4deg:
-      in_domain: latent
+      in_domain: latent_4deg
       out_domain: atmos_4deg
+      out_channels: *decoder_out
+      module:
+        type: same_grid
+        config: {embed_dim: 256, num_layers: 4}
+
+    # Learned resamplers between latent resolutions ("down" = toward coarser).
+    # The 1° and 2° encode paths into the 4° latent share latent_2to4. They
+    # map the latent block only; latent_4deg's forcing channels are filled by
+    # the forcing overwrite, not by a transform.
+    latent_1to2:
+      in_domain: latent_1deg
+      out_domain: latent_2deg
       module:
         type: sht_resize
-        config: {embed_dim: 256, num_layers: 4}
+        config: {embed_dim: 256, num_layers: 2}
+    latent_2to4:
+      in_domain: latent_2deg
+      out_domain: latent_4deg
+      module:
+        type: sht_resize
+        config: {embed_dim: 256, num_layers: 2}
+    latent_4to2:
+      in_domain: latent_4deg
+      out_domain: latent_2deg
+      module:
+        type: sht_resize
+        config: {embed_dim: 256, num_layers: 2}
+    latent_2to1:
+      in_domain: latent_2deg
+      out_domain: latent_1deg
+      module:
+        type: sht_resize
+        config: {embed_dim: 256, num_layers: 2}
 
   backbones:
     stepper_latent:
-      domain: latent
+      domain: latent_4deg
       stepper:
         step:
           type: single_module
@@ -110,12 +176,12 @@ component_pool:
             builder:
               type: SphericalFourierNeuralOperatorNet
               config: {embed_dim: 384, num_layers: 8, operator_type: dhconv, scale_factor: 1}
-            # "z" is a latent-block reference, expanded against the domain
-            # declaration (z -> z_0 ... z_511) by BackboneConfig before the
+            # "latent_4deg" is the domain's int-declared latent block,
+            # expanded (-> 512 channel names) by BackboneConfig before the
             # StepperConfig is constructed — the stepper never enumerates
             # latent channels by hand.
-            in_names: [z, DSWRFtoa, ocean_fraction, land_fraction, sea_ice_fraction, global_mean_co2]
-            out_names: [z]
+            in_names: [latent_4deg, DSWRFtoa, ocean_fraction, land_fraction, sea_ice_fraction, global_mean_co2]
+            out_names: [latent_4deg]
             normalization:
               network: {identity: true}  # NEW: latent channels have no dataset
                                          # stats; the encoder sets their scale
@@ -123,7 +189,10 @@ component_pool:
             corrector: null
 
 objectives:
-  # ---- k=0 explicit reconstruction at each resolution ----
+  # ---- k=0 explicit reconstruction at each resolution. The loss compares
+  # the chain's output channels (the decoder's out_channels) against the
+  # target stream — encoder-only inputs (forcings) are not reconstructed, so
+  # differing encoder/decoder channel sets are fine. ----
   - name: recon_1deg
     type: translation
     config:
@@ -152,17 +221,19 @@ objectives:
       loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
       weight: 1.0
 
-  # ---- forward prediction at every resolution, one shared backbone ----
+  # ---- forward prediction at every resolution, one shared backbone.
+  # `components` is a flat chain containing exactly one backbone, which
+  # splits it: everything before encodes once at the initial time, the
+  # backbone rolls out in its own domain, and everything after decodes every
+  # output step. forcing_stream overwrites the backbone domain's forcing
+  # channels each step. ----
   - name: forward_4deg
     type: forward_prediction
     config:
-      encoder: encoder_4deg
-      backbone: stepper_latent
-      decoder: decoder_4deg
+      components: [encoder_4deg, stepper_latent, decoder_4deg]
       input_stream: era5_4deg
       target_stream: era5_4deg
-      forcing_stream: era5_4deg   # forcings enter on the latent (4°) grid;
-                                  # paired_by_time sampling time-aligns them
+      forcing_stream: era5_4deg   # forcings enter on the latent (4°) grid
       n_forward_steps:
         start_value: 1
         milestones:
@@ -174,9 +245,7 @@ objectives:
   - name: forward_2deg
     type: forward_prediction
     config:
-      encoder: encoder_2deg
-      backbone: stepper_latent
-      decoder: decoder_2deg
+      components: [encoder_2deg, latent_2to4, stepper_latent, latent_4to2, decoder_2deg]
       input_stream: era5_2deg
       target_stream: era5_2deg
       forcing_stream: era5_4deg   # note: cross-resolution — see issue 4 in the
@@ -192,9 +261,7 @@ objectives:
   - name: forward_1deg
     type: forward_prediction
     config:
-      encoder: encoder_1deg
-      backbone: stepper_latent
-      decoder: decoder_1deg
+      components: [encoder_1deg, latent_1to2, latent_2to4, stepper_latent, latent_4to2, latent_2to1, decoder_1deg]
       input_stream: era5_1deg
       target_stream: era5_1deg
       forcing_stream: era5_4deg
@@ -207,14 +274,17 @@ objectives:
       loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
       weight: 0.5
 
-  # ---- stochastic latent consistency between adjacent resolutions:
-  # noise-injected coarse encoding pulled toward the stop-gradient fine
-  # encoding (stop-gradient is semantics of the objective type, not config) ----
+  # ---- stochastic latent consistency between adjacent resolutions: both
+  # chains must land in the same latent domain; the noise-injected coarse
+  # encoding is pulled toward the stop-gradient fine encoding (stop-gradient
+  # is semantics of the objective type, not config). The downsampler on the
+  # fine side sits behind the stop-gradient here, so latent_1to2/latent_2to4
+  # train through the forward objectives, not through consistency. ----
   - name: consistency_1v2
     type: latent_consistency
     config:
-      fine_encoder: encoder_1deg
-      coarse_encoder: encoder_2deg
+      fine_components: [encoder_1deg, latent_1to2]
+      coarse_components: [encoder_2deg]
       fine_stream: era5_1deg
       coarse_stream: era5_2deg
       n_ensemble: 4
@@ -223,8 +293,8 @@ objectives:
   - name: consistency_2v4
     type: latent_consistency
     config:
-      fine_encoder: encoder_2deg
-      coarse_encoder: encoder_4deg
+      fine_components: [encoder_2deg, latent_2to4]
+      coarse_components: [encoder_4deg]
       fine_stream: era5_2deg
       coarse_stream: era5_4deg
       n_ensemble: 4
@@ -236,14 +306,15 @@ optimization:
   lr: 1.0e-4
   enable_automatic_mixed_precision: false
 
-# in-training inference callbacks over exported composites: any encode/decode
-# pairing around the shared backbone, evaluated with the standard aggregators
+# in-training inference callbacks over exported composites: a composite is
+# the same one-backbone component chain, evaluated with the standard
+# aggregators
 inference:
-  - composite: {encoder: encoder_4deg, backbone: stepper_latent, decoder: decoder_4deg}
+  - composite: [encoder_4deg, stepper_latent, decoder_4deg]
     n_forward_steps: 1460
     forward_steps_in_memory: 50
     loader: {dataset: {data_path: gs://.../era5-4deg-8layer/valid}, start_indices: {first: 0, n_initial_conditions: 4, interval: 365}}
-  - composite: {encoder: encoder_1deg, backbone: stepper_latent, decoder: decoder_1deg}
+  - composite: [encoder_1deg, latent_1to2, latent_2to4, stepper_latent, latent_4to2, latent_2to1, decoder_1deg]
     n_forward_steps: 1460
     forward_steps_in_memory: 50
     loader: {dataset: {data_path: gs://.../era5-1deg-8layer/valid}, start_indices: {first: 0, n_initial_conditions: 4, interval: 365}}

--- a/fme/translate/examples/multi-resolution-latent.yaml
+++ b/fme/translate/examples/multi-resolution-latent.yaml
@@ -43,10 +43,12 @@ component_pool:
     atmos_2deg: {}
     atmos_4deg: {}
     # Latent domains, one per resolution. No dataset binds to them, so they
-    # declare their channels directly: `channels` is int | list[str] (or a
-    # list mixing the two); an int declares an anonymous latent block named
-    # after the domain, referenced as a block name in backbone
-    # in_names/out_names and expanded before StepperConfig construction.
+    # declare their channels directly: `channels` is int | list[str]; an int
+    # declares an anonymous latent block named after the domain, referenced
+    # as a block name in backbone in_names/out_names and expanded before
+    # StepperConfig construction. Forcings are not latent channels: they
+    # enter through the encoders (see in_channels below) and are translated
+    # between latent resolutions like the rest of the state.
     latent_1deg:
       grid_like: atmos_1deg
       channels: 512
@@ -55,16 +57,7 @@ component_pool:
       channels: 512
     latent_4deg:
       grid_like: atmos_4deg
-      channels:
-        - 512
-        # forcing channels of the backbone's domain, overwritten from the 4°
-        # stream each step (mirrors ace's existing prescribed/forcing
-        # overwrite semantics) rather than produced by any transform:
-        - DSWRFtoa
-        - ocean_fraction
-        - land_fraction
-        - sea_ice_fraction
-        - global_mean_co2
+      channels: 512
 
   transforms:
     # Per-resolution encoders into that resolution's latent (same grid; the
@@ -138,9 +131,7 @@ component_pool:
         config: {embed_dim: 256, num_layers: 4}
 
     # Learned resamplers between latent resolutions ("down" = toward coarser).
-    # The 1° and 2° encode paths into the 4° latent share latent_2to4. They
-    # map the latent block only; latent_4deg's forcing channels are filled by
-    # the forcing overwrite, not by a transform.
+    # The 1° and 2° encode paths into the 4° latent share latent_2to4.
     latent_1to2:
       in_domain: latent_1deg
       out_domain: latent_2deg
@@ -179,8 +170,10 @@ component_pool:
             # "latent_4deg" is the domain's int-declared latent block,
             # expanded (-> 512 channel names) by BackboneConfig before the
             # StepperConfig is constructed — the stepper never enumerates
-            # latent channels by hand.
-            in_names: [latent_4deg, DSWRFtoa, ocean_fraction, land_fraction, sea_ice_fraction, global_mean_co2]
+            # latent channels by hand. Forcings reach the backbone inside
+            # the latent state (encoded and translated per step from the
+            # forcing stream), not as named input channels.
+            in_names: [latent_4deg]
             out_names: [latent_4deg]
             normalization:
               network: {identity: true}  # NEW: latent channels have no dataset
@@ -225,15 +218,17 @@ objectives:
   # `components` is a flat chain containing exactly one backbone, which
   # splits it: everything before encodes once at the initial time, the
   # backbone rolls out in its own domain, and everything after decodes every
-  # output step. forcing_stream overwrites the backbone domain's forcing
-  # channels each step. ----
+  # output step. Each step's forcings are taken from forcing_stream at that
+  # objective's own resolution and carried into the backbone's latent domain
+  # through the encode chain (a forcing-only application of it — data
+  # prognostics at future steps must not leak in). ----
   - name: forward_4deg
     type: forward_prediction
     config:
       components: [encoder_4deg, stepper_latent, decoder_4deg]
       input_stream: era5_4deg
       target_stream: era5_4deg
-      forcing_stream: era5_4deg   # forcings enter on the latent (4°) grid
+      forcing_stream: era5_4deg
       n_forward_steps:
         start_value: 1
         milestones:
@@ -248,8 +243,7 @@ objectives:
       components: [encoder_2deg, latent_2to4, stepper_latent, latent_4to2, decoder_2deg]
       input_stream: era5_2deg
       target_stream: era5_2deg
-      forcing_stream: era5_4deg   # note: cross-resolution — see issue 4 in the
-                                  # PR discussion
+      forcing_stream: era5_2deg
       n_forward_steps:
         start_value: 1
         milestones:
@@ -264,7 +258,7 @@ objectives:
       components: [encoder_1deg, latent_1to2, latent_2to4, stepper_latent, latent_4to2, latent_2to1, decoder_1deg]
       input_stream: era5_1deg
       target_stream: era5_1deg
-      forcing_stream: era5_4deg
+      forcing_stream: era5_1deg
       n_forward_steps:
         start_value: 1
         milestones:

--- a/fme/translate/examples/transfer-learning.yaml
+++ b/fme/translate/examples/transfer-learning.yaml
@@ -1,0 +1,146 @@
+# Example B — transfer learning (frozen C96-SHiELD donor, ERA5↔SHiELD
+# translators). Translators operate directly on real fields (no latent
+# domain), wrapped around a fully-frozen SHiELD+ donor stepper loaded from
+# checkpoint. Cycle consistency in both directions. Both datasets at 4°, so
+# the translators are same-grid (a resolution-changing registry entry drops
+# in if the ERA5 side were 1°).
+# Intended config surface for the fme/translate PR series; only the
+# component_pool: block is implemented in PR 1. See README.md in this
+# directory for which PR lands each block. Not runnable.
+experiment_dir: train_output
+save_checkpoint: true
+validate_using_ema: true
+max_epochs: 20
+logging: {log_to_screen: true, log_to_wandb: true, log_to_file: true, project: ace}
+
+train_data:
+  batch_size: 16
+  num_data_workers: 4
+  sampling: independent   # ERA5 and SHiELD are different realities; no
+                          # objective consumes both streams in one term
+  streams:
+    era5:   {domain: era5,       dataset: {data_path: gs://.../era5-4deg-daily/train}}
+    shield: {domain: shield_c96, dataset: {data_path: gs://.../shield-c96-4deg-daily/train}}
+
+validation_data:
+  batch_size: 16
+  sampling: independent
+  streams:
+    era5:   {domain: era5,       dataset: {data_path: gs://.../era5-4deg-daily/valid}}
+    shield: {domain: shield_c96, dataset: {data_path: gs://.../shield-c96-4deg-daily/valid}}
+
+component_pool:
+  domains:
+    era5:
+      channels:              # full list elided; the two variable sets differ
+        - air_temperature_0  # ... _7
+        - specific_total_water_0   # ...
+        - eastward_wind_0    # ...
+        - northward_wind_0   # ...
+        - PRESsfc
+        - surface_temperature
+        - DSWRFtoa
+        - ocean_fraction
+        - land_fraction
+        - sea_ice_fraction
+        - global_mean_co2
+    shield_c96:
+      channels:              # the donor's full in/out union, incl. channels
+        - air_temperature_0  # ERA5 lacks — the translators map between the
+        - specific_total_water_0   # two sets; they need not match
+        - eastward_wind_0    # ...
+        - northward_wind_0   # ...
+        - PRESsfc
+        - surface_temperature
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - DSWRFtoa
+        - ocean_fraction
+        - land_fraction
+        - sea_ice_fraction
+        - global_mean_co2
+
+  transforms:
+    to_shield:
+      in_domain: era5
+      out_domain: shield_c96
+      module:
+        type: same_grid      # both domains on the same 4° grid
+        config:
+          module:
+            type: SphericalFourierNeuralOperatorNet
+            config: {embed_dim: 256, num_layers: 4, scale_factor: 1}
+    to_era5:
+      in_domain: shield_c96
+      out_domain: era5
+      module:
+        type: same_grid
+        config:
+          module:
+            type: SphericalFourierNeuralOperatorNet
+            config: {embed_dim: 256, num_layers: 4, scale_factor: 1}
+
+  backbones:
+    donor:
+      domain: shield_c96
+      checkpoint:
+        checkpoint_path: gs://.../t1-modern-pretrain/best_inference_ckpt.tar
+      init_from_checkpoint: true   # weights sourced from the checkpoint...
+      parameter_init:
+        parameters:
+          - frozen: {exclude: []}  # ...and every parameter frozen (empty
+                                   # exclude list = freeze all), applied
+                                   # before DDP wrapping
+
+objectives:
+  # end-to-end rollout scored on ERA5: translate in -> step frozen donor ->
+  # translate out. Forcings (incl. SST for the donor's ocean config, CO2) are
+  # translated per step through to_shield so they arrive in-donor-domain —
+  # the same path the +4K / future-scenario perturbation harnesses exercise.
+  - name: forward_era5
+    type: forward_prediction
+    config:
+      encoder: to_shield
+      backbone: donor
+      decoder: to_era5
+      input_stream: era5
+      target_stream: era5
+      forcing_stream: era5
+      n_forward_steps:
+        start_value: 1
+        milestones:
+          - epoch: 4
+            value: {outcomes: [{steps: 1, probability: 0.5}, {steps: 4, probability: 0.5}]}
+      n_ensemble: 2   # donor is the v2 noise-conditioned SFNO
+      loss: {type: EnsembleLoss, kwargs: {crps_weight: 1.0, energy_score_weight: 1.0}}
+      weight: 1.0
+
+  # cycle consistency: translating to the other domain and back is identity
+  - name: cycle_era5
+    type: translation
+    config:
+      components: [to_shield, to_era5]
+      input_stream: era5
+      target_stream: era5
+      loss: {type: MSE}
+      weight: 0.2
+  - name: cycle_shield
+    type: translation
+    config:
+      components: [to_era5, to_shield]
+      input_stream: shield
+      target_stream: shield
+      loss: {type: MSE}
+      weight: 0.2
+
+optimization:
+  optimizer_type: AdamW
+  lr: 1.0e-4
+  enable_automatic_mixed_precision: false
+
+inference:
+  - composite: {encoder: to_shield, backbone: donor, decoder: to_era5}
+    n_forward_steps: 1460
+    forward_steps_in_memory: 50
+    loader: {dataset: {data_path: gs://.../era5-4deg-daily/valid}, start_indices: {first: 0, n_initial_conditions: 4, interval: 365}}

--- a/fme/translate/examples/transfer-learning.yaml
+++ b/fme/translate/examples/transfer-learning.yaml
@@ -13,30 +13,38 @@ validate_using_ema: true
 max_epochs: 20
 logging: {log_to_screen: true, log_to_wandb: true, log_to_file: true, project: ace}
 
+# stream `name` defaults to `domain` (omitted here). No objective consumes
+# both streams in one term, so they are sampled independently — pairing is
+# derived from objective co-occurrence, not configured.
 train_data:
   batch_size: 16
   num_data_workers: 4
-  sampling: independent   # ERA5 and SHiELD are different realities; no
-                          # objective consumes both streams in one term
   streams:
-    era5:   {domain: era5,       dataset: {data_path: gs://.../era5-4deg-daily/train}}
-    shield: {domain: shield_c96, dataset: {data_path: gs://.../shield-c96-4deg-daily/train}}
+    - {domain: era5,       dataset: {data_path: gs://.../era5-4deg-daily/train}}
+    - {domain: shield_c96, dataset: {data_path: gs://.../shield-c96-4deg-daily/train}}
 
 validation_data:
   batch_size: 16
-  sampling: independent
   streams:
-    era5:   {domain: era5,       dataset: {data_path: gs://.../era5-4deg-daily/valid}}
-    shield: {domain: shield_c96, dataset: {data_path: gs://.../shield-c96-4deg-daily/valid}}
+    - {domain: era5,       dataset: {data_path: gs://.../era5-4deg-daily/valid}}
+    - {domain: shield_c96, dataset: {data_path: gs://.../shield-c96-4deg-daily/valid}}
 
 component_pool:
   domains:
-    era5:
-      channels:              # full list elided; the two variable sets differ
-        - air_temperature_0  # ... _7
-        - specific_total_water_0   # ...
-        - eastward_wind_0    # ...
-        - northward_wind_0   # ...
+    # channel lists live on the transforms below; each domain's load list is
+    # derived from the channels the transforms reference in it. Grids come
+    # from the bound datasets (both 4°).
+    era5: {}
+    shield_c96: {}
+
+  transforms:
+    to_shield:
+      in_domain: era5
+      in_channels: &era5_channels  # full list elided; the two variable sets
+        - air_temperature_0        # differ, and the translators map between
+        - specific_total_water_0   # them — they need not match
+        - eastward_wind_0          # ...
+        - northward_wind_0         # ...
         - PRESsfc
         - surface_temperature
         - DSWRFtoa
@@ -44,12 +52,12 @@ component_pool:
         - land_fraction
         - sea_ice_fraction
         - global_mean_co2
-    shield_c96:
-      channels:              # the donor's full in/out union, incl. channels
-        - air_temperature_0  # ERA5 lacks — the translators map between the
-        - specific_total_water_0   # two sets; they need not match
-        - eastward_wind_0    # ...
-        - northward_wind_0   # ...
+      out_domain: shield_c96
+      out_channels: &shield_channels  # the donor's full in/out union, incl.
+        - air_temperature_0           # channels ERA5 lacks
+        - specific_total_water_0      # ...
+        - eastward_wind_0             # ...
+        - northward_wind_0            # ...
         - PRESsfc
         - surface_temperature
         - LHTFLsfc
@@ -60,11 +68,6 @@ component_pool:
         - land_fraction
         - sea_ice_fraction
         - global_mean_co2
-
-  transforms:
-    to_shield:
-      in_domain: era5
-      out_domain: shield_c96
       module:
         type: same_grid      # both domains on the same 4° grid
         config:
@@ -73,7 +76,9 @@ component_pool:
             config: {embed_dim: 256, num_layers: 4, scale_factor: 1}
     to_era5:
       in_domain: shield_c96
+      in_channels: *shield_channels
       out_domain: era5
+      out_channels: *era5_channels
       module:
         type: same_grid
         config:
@@ -94,16 +99,16 @@ component_pool:
                                    # before DDP wrapping
 
 objectives:
-  # end-to-end rollout scored on ERA5: translate in -> step frozen donor ->
-  # translate out. Forcings (incl. SST for the donor's ocean config, CO2) are
-  # translated per step through to_shield so they arrive in-donor-domain —
-  # the same path the +4K / future-scenario perturbation harnesses exercise.
+  # end-to-end rollout scored on ERA5: a component chain with exactly one
+  # backbone — to_shield encodes once, the frozen donor rolls out, to_era5
+  # decodes every output step. Forcings (incl. SST for the donor's ocean
+  # config, CO2) are translated per step through to_shield so they arrive
+  # in-donor-domain — the same path the +4K / future-scenario perturbation
+  # harnesses exercise.
   - name: forward_era5
     type: forward_prediction
     config:
-      encoder: to_shield
-      backbone: donor
-      decoder: to_era5
+      components: [to_shield, donor, to_era5]
       input_stream: era5
       target_stream: era5
       forcing_stream: era5
@@ -129,8 +134,8 @@ objectives:
     type: translation
     config:
       components: [to_era5, to_shield]
-      input_stream: shield
-      target_stream: shield
+      input_stream: shield_c96
+      target_stream: shield_c96
       loss: {type: MSE}
       weight: 0.2
 
@@ -140,7 +145,7 @@ optimization:
   enable_automatic_mixed_precision: false
 
 inference:
-  - composite: {encoder: to_shield, backbone: donor, decoder: to_era5}
+  - composite: [to_shield, donor, to_era5]
     n_forward_steps: 1460
     forward_steps_in_memory: 50
     loader: {dataset: {data_path: gs://.../era5-4deg-daily/valid}, start_indices: {first: 0, n_initial_conditions: 4, interval: 365}}

--- a/fme/translate/modules.py
+++ b/fme/translate/modules.py
@@ -1,0 +1,197 @@
+"""Registry of transform module builders spanning an input and an output grid.
+
+The generic :class:`fme.core.registry.module.ModuleConfig` contract builds a
+module against a single ``DatasetInfo``, which cannot express a
+resolution-changing operator (a 1°→2° encoder needs both grids). Transform
+builders registered here receive the input *and* output domains'
+``DatasetInfo``s. Two builders ship with the skeleton:
+
+- ``same_grid`` wraps any existing :class:`ModuleSelector` entry (SFNO,
+  prebuilt, ...) for transforms whose input and output grids match.
+- ``interpolate`` is the trivial resolution-change operator: a 1x1 convolution
+  for the channel mapping followed by interpolation to the output grid. It
+  exists as the simplest registry member exercising the two-grid contract (and
+  a baseline); learned operators (SHT truncation, transformer resizers) are
+  later registry entries.
+"""
+
+import abc
+import dataclasses
+from collections.abc import Callable, Mapping
+
+# we use Type to distinguish from type attr of TransformSelector
+from typing import Any, ClassVar, Type  # noqa: UP035
+
+import dacite
+import torch
+from torch import nn
+
+from fme.core.dataset_info import DatasetInfo
+from fme.core.registry.module import Module, ModuleSelector
+from fme.core.registry.registry import Registry
+
+__all__ = [
+    "InterpolateTransformConfig",
+    "SameGridTransformConfig",
+    "TransformModuleConfig",
+    "TransformSelector",
+]
+
+
+@dataclasses.dataclass
+class TransformModuleConfig(abc.ABC):
+    """Builds a transform module given both domains' channel counts and grids."""
+
+    @abc.abstractmethod
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        """Build a module mapping the input domain to the output domain.
+
+        Args:
+            n_in_channels: number of input channels
+            n_out_channels: number of output channels
+            in_dataset_info: information about the input domain's dataset,
+                including its img_shape.
+            out_dataset_info: information about the output domain's dataset;
+                the built module must map to this domain's img_shape.
+
+        Returns:
+            a Module object
+        """
+        ...
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, Any]) -> "TransformModuleConfig":
+        return dacite.from_dict(
+            data_class=cls, data=state, config=dacite.Config(strict=True)
+        )
+
+
+@dataclasses.dataclass
+class TransformSelector:
+    """Selects and configures a registered :class:`TransformModuleConfig`.
+
+    Parameters:
+        type: the type of the TransformModuleConfig
+        config: data for a TransformModuleConfig instance of the indicated type
+    """
+
+    type: str
+    config: Mapping[str, Any]
+    registry: ClassVar[Registry[TransformModuleConfig]] = Registry[
+        TransformModuleConfig
+    ]()
+
+    def __post_init__(self):
+        if not isinstance(self.registry, Registry):
+            raise ValueError("TransformSelector.registry should not be set manually")
+        self._instance = self.registry.get(self.type, self.config)
+
+    @classmethod
+    def register(
+        cls, type_name: str
+    ) -> Callable[[Type[TransformModuleConfig]], Type[TransformModuleConfig]]:  # noqa: UP006
+        return cls.registry.register(type_name)
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        return self._instance.build(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            in_dataset_info=in_dataset_info,
+            out_dataset_info=out_dataset_info,
+        )
+
+
+@TransformSelector.register("same_grid")
+@dataclasses.dataclass
+class SameGridTransformConfig(TransformModuleConfig):
+    """Adapts a generic :class:`ModuleSelector` entry as a same-grid transform.
+
+    Parameters:
+        module: The module builder; built against the (shared) input grid.
+    """
+
+    module: ModuleSelector
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        if in_dataset_info.img_shape != out_dataset_info.img_shape:
+            raise ValueError(
+                "A same_grid transform requires matching input and output "
+                f"grids, got img_shapes {in_dataset_info.img_shape} and "
+                f"{out_dataset_info.img_shape}. Use a resolution-changing "
+                "transform type instead."
+            )
+        return self.module.build(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            dataset_info=in_dataset_info,
+        )
+
+
+class _ConvInterpolate(nn.Module):
+    def __init__(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        out_shape: tuple[int, int],
+        mode: str,
+    ):
+        super().__init__()
+        self.conv = nn.Conv2d(n_in_channels, n_out_channels, kernel_size=1)
+        self.out_shape = out_shape
+        self.mode = mode
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        return nn.functional.interpolate(x, size=self.out_shape, mode=self.mode)
+
+
+@TransformSelector.register("interpolate")
+@dataclasses.dataclass
+class InterpolateTransformConfig(TransformModuleConfig):
+    """The trivial resolution-change operator: 1x1 conv + interpolation.
+
+    Maps channels with a pointwise convolution, then interpolates to the
+    output domain's grid. Interpolation is planar (it ignores spherical
+    geometry); this is the baseline / test operator, not a recommended
+    resolution-change operator for experiments.
+
+    Parameters:
+        mode: Interpolation mode passed to ``torch.nn.functional.interpolate``.
+    """
+
+    mode: str = "bilinear"
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        return Module(
+            _ConvInterpolate(
+                n_in_channels=n_in_channels,
+                n_out_channels=n_out_channels,
+                out_shape=out_dataset_info.img_shape,
+                mode=self.mode,
+            ),
+            label_encoding=None,
+        )

--- a/fme/translate/test_components.py
+++ b/fme/translate/test_components.py
@@ -1,4 +1,5 @@
 import dataclasses
+from collections.abc import Mapping
 
 import pytest
 import torch
@@ -24,15 +25,30 @@ from fme.translate.components import (
     ComponentPoolConfig,
     TransformConfig,
 )
+from fme.translate.domains import DomainConfig, LatentChannels
+from fme.translate.modules import TransformSelector
 
 IMG_SHAPE = (5, 5)
 
 
-def _sfno_selector(embed_dim: int = 2) -> ModuleSelector:
-    return ModuleSelector(
-        type="SphericalFourierNeuralOperatorNet",
-        config={"scale_factor": 1, "embed_dim": embed_dim, "num_layers": 1},
+def _sfno_selector(embed_dim: int = 2) -> TransformSelector:
+    return TransformSelector(
+        type="same_grid",
+        config={
+            "module": {
+                "type": "SphericalFourierNeuralOperatorNet",
+                "config": {
+                    "scale_factor": 1,
+                    "embed_dim": embed_dim,
+                    "num_layers": 1,
+                },
+            }
+        },
     )
+
+
+def _interpolate_selector() -> TransformSelector:
+    return TransformSelector(type="interpolate", config={})
 
 
 def _stepper_config(in_names: list[str], out_names: list[str]) -> StepperConfig:
@@ -41,7 +57,14 @@ def _stepper_config(in_names: list[str], out_names: list[str]) -> StepperConfig:
             type="single_module",
             config=dataclasses.asdict(
                 SingleModuleStepConfig(
-                    builder=_sfno_selector(),
+                    builder=ModuleSelector(
+                        type="SphericalFourierNeuralOperatorNet",
+                        config={
+                            "scale_factor": 1,
+                            "embed_dim": 2,
+                            "num_layers": 1,
+                        },
+                    ),
                     in_names=in_names,
                     out_names=out_names,
                     normalization=trivial_network_and_loss_normalization(
@@ -65,24 +88,50 @@ def _save_stepper_checkpoint(stepper: Stepper, path) -> None:
     torch.save({"stepper": stepper.get_state()}, path)
 
 
+def _encoder_decoder_config(
+    parameter_init: ParameterInitializationConfig | None = None,
+    with_backbone: bool = True,
+) -> ComponentPoolConfig:
+    """A pool with a physical domain, a same-grid latent domain (grid_like),
+    an encoder/decoder pair between them, and optionally a latent backbone.
+    """
+    kwargs = {} if parameter_init is None else {"parameter_init": parameter_init}
+    backbones = {}
+    if with_backbone:
+        backbones["backbone"] = BackboneConfig(
+            domain="latent",
+            stepper=_stepper_config(["z_0", "z_1"], ["z_0", "z_1"]),
+        )
+    return ComponentPoolConfig(
+        domains={
+            "physical": DomainConfig(channels=["a", "b"]),
+            "latent": DomainConfig(
+                channels=[LatentChannels(name="z", channels=2)],
+                grid_like="physical",
+            ),
+        },
+        transforms={
+            "encoder": TransformConfig(
+                _sfno_selector(), "physical", "latent", **kwargs
+            ),
+            "decoder": TransformConfig(_sfno_selector(), "latent", "physical"),
+        },
+        backbones=backbones,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Build + modules exposure
 # ---------------------------------------------------------------------------
 
 
 def test_pool_builds_and_exposes_flattened_modules():
-    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    config = ComponentPoolConfig(
-        transforms={
-            "encoder": TransformConfig(_sfno_selector(), ["a", "b"], ["z"]),
-            "decoder": TransformConfig(_sfno_selector(), ["z"], ["a", "b"]),
-        },
-        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
-    )
-    pool = config.build(dataset_info)
+    config = _encoder_decoder_config()
+    pool = config.build({"physical": get_dataset_info(img_shape=IMG_SHAPE)})
 
     assert set(pool.transforms) == {"encoder", "decoder"}
     assert set(pool.backbones) == {"backbone"}
+    assert set(pool.dataset_info) == {"physical", "latent"}
 
     modules = pool.modules
     assert isinstance(modules, torch.nn.ModuleList)
@@ -102,14 +151,133 @@ def test_pool_builds_and_exposes_flattened_modules():
     assert pool_param_count > 0
 
 
-def test_transform_channel_counts_from_names():
-    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    transform = TransformConfig(_sfno_selector(), ["a", "b", "c"], ["x"]).build(
-        dataset_info
+def test_transform_channel_counts_come_from_domains():
+    config = ComponentPoolConfig(
+        domains={
+            "physical": DomainConfig(channels=["a", "b", "c"]),
+            "latent": DomainConfig(
+                channels=[LatentChannels(name="z", channels=7)],
+                grid_like="physical",
+            ),
+        },
+        transforms={"encoder": TransformConfig(_sfno_selector(), "physical", "latent")},
     )
-    grid = torch.zeros(1, 3, *IMG_SHAPE)
-    out = transform(grid)
-    assert out.shape == (1, 1, *IMG_SHAPE)
+    pool = config.build({"physical": get_dataset_info(img_shape=IMG_SHAPE)})
+    out = pool.transforms["encoder"](torch.zeros(1, 3, *IMG_SHAPE))
+    assert out.shape == (1, 7, *IMG_SHAPE)
+
+
+def test_multi_resolution_chain_builds_and_runs():
+    """Jeremy's multi-resolution scenario at toy scale: three physical domains
+    at descending resolution, resolution-changing transforms between adjacent
+    resolutions, and a backbone stepping in the coarsest domain.
+    """
+    shapes = {
+        "one_deg": (8, 16),
+        "two_deg": (4, 8),
+        "four_deg": (2, 4),
+    }
+    config = ComponentPoolConfig(
+        domains={name: DomainConfig(channels=["a", "b"]) for name in shapes},
+        transforms={
+            "enc_1to2": TransformConfig(_interpolate_selector(), "one_deg", "two_deg"),
+            "enc_2to4": TransformConfig(_interpolate_selector(), "two_deg", "four_deg"),
+            "dec_4to2": TransformConfig(_interpolate_selector(), "four_deg", "two_deg"),
+            "dec_2to1": TransformConfig(_interpolate_selector(), "two_deg", "one_deg"),
+        },
+        backbones={
+            "backbone": BackboneConfig(
+                domain="four_deg", stepper=_stepper_config(["a", "b"], ["a", "b"])
+            )
+        },
+    )
+    pool = config.build(
+        {name: get_dataset_info(img_shape=shape) for name, shape in shapes.items()}
+    )
+
+    x = torch.randn(1, 2, *shapes["one_deg"])
+    coarse = pool.transforms["enc_2to4"](pool.transforms["enc_1to2"](x))
+    assert coarse.shape == (1, 2, *shapes["four_deg"])
+    fine = pool.transforms["dec_2to1"](pool.transforms["dec_4to2"](coarse))
+    assert fine.shape == x.shape
+
+
+# ---------------------------------------------------------------------------
+# Domain wiring validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_transform_domain_rejected():
+    with pytest.raises(ValueError, match="out_domain='nowhere'"):
+        ComponentPoolConfig(
+            domains={"physical": DomainConfig(channels=["a"])},
+            transforms={
+                "encoder": TransformConfig(_sfno_selector(), "physical", "nowhere")
+            },
+        )
+
+
+def test_unknown_backbone_domain_rejected():
+    with pytest.raises(ValueError, match="domain='nowhere'"):
+        ComponentPoolConfig(
+            domains={"physical": DomainConfig(channels=["a"])},
+            backbones={
+                "backbone": BackboneConfig(
+                    domain="nowhere", stepper=_stepper_config(["a"], ["a"])
+                )
+            },
+        )
+
+
+def test_unknown_grid_like_rejected():
+    with pytest.raises(ValueError, match="grid_like='nowhere'"):
+        ComponentPoolConfig(
+            domains={
+                "latent": DomainConfig(
+                    channels=[LatentChannels(name="z", channels=2)],
+                    grid_like="nowhere",
+                )
+            },
+        )
+
+
+def test_chained_grid_like_rejected():
+    with pytest.raises(ValueError, match="itself has grid_like"):
+        ComponentPoolConfig(
+            domains={
+                "physical": DomainConfig(channels=["a"]),
+                "latent": DomainConfig(
+                    channels=[LatentChannels(name="z", channels=2)],
+                    grid_like="physical",
+                ),
+                "latent2": DomainConfig(
+                    channels=[LatentChannels(name="w", channels=2)],
+                    grid_like="latent",
+                ),
+            },
+        )
+
+
+def test_missing_and_extra_dataset_info_rejected():
+    config = _encoder_decoder_config()
+    with pytest.raises(ValueError, match="Missing dataset_info.*physical"):
+        config.build({})
+    info = get_dataset_info(img_shape=IMG_SHAPE)
+    with pytest.raises(ValueError, match="not data-backed domains.*latent"):
+        config.build({"physical": info, "latent": info})
+
+
+def test_backbone_variables_must_be_domain_channels():
+    config = ComponentPoolConfig(
+        domains={"physical": DomainConfig(channels=["a"])},
+        backbones={
+            "backbone": BackboneConfig(
+                domain="physical", stepper=_stepper_config(["a", "b"], ["a"])
+            )
+        },
+    )
+    with pytest.raises(ValueError, match="not channels of that domain.*'b'"):
+        config.build({"physical": get_dataset_info(img_shape=IMG_SHAPE)})
 
 
 # ---------------------------------------------------------------------------
@@ -137,10 +305,11 @@ def test_frozen_backbone_from_checkpoint_is_frozen_and_not_ddp(tmp_path):
     _save_stepper_checkpoint(donor, ckpt)
 
     backbone = BackboneConfig(
+        domain="physical",
         checkpoint=CheckpointStepperConfig(checkpoint_path=str(ckpt)),
         init_from_checkpoint=True,
         parameter_init=_all_frozen_init(),
-    ).build(dataset_info)
+    ).build(dataset_info, DomainConfig(channels=["a"]))
 
     _assert_fully_frozen_dummy_wrapped(backbone.modules)
 
@@ -152,33 +321,36 @@ def test_frozen_backbone_from_checkpoint_is_frozen_and_not_ddp(tmp_path):
         torch.testing.assert_close(loaded_state[name], value)
 
 
-def test_fresh_backbone_freeze_before_wrap(tmp_path):
+def test_fresh_backbone_freeze_before_wrap():
     dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
     backbone = BackboneConfig(
+        domain="physical",
         stepper=_stepper_config(["a"], ["a"]),
         parameter_init=_all_frozen_init(),
-    ).build(dataset_info)
+    ).build(dataset_info, DomainConfig(channels=["a"]))
     _assert_fully_frozen_dummy_wrapped(backbone.modules)
 
 
 def test_unfrozen_fresh_backbone_is_trainable():
     dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    backbone = BackboneConfig(stepper=_stepper_config(["a"], ["a"])).build(dataset_info)
+    backbone = BackboneConfig(
+        domain="physical", stepper=_stepper_config(["a"], ["a"])
+    ).build(dataset_info, DomainConfig(channels=["a"]))
     assert any(p.requires_grad for p in backbone.modules.parameters())
 
 
 def test_transform_freeze_before_wrap():
-    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    transform = TransformConfig(
-        _sfno_selector(),
-        ["a"],
-        ["a"],
-        parameter_init=_all_frozen_init(),
-    ).build(dataset_info)
-    assert isinstance(transform.torch_module, DummyWrapper)
-    params = list(transform.torch_module.parameters())
+    config = _encoder_decoder_config(parameter_init=_all_frozen_init())
+    pool = config.build({"physical": get_dataset_info(img_shape=IMG_SHAPE)})
+    encoder = pool.transforms["encoder"]
+    assert isinstance(encoder.torch_module, DummyWrapper)
+    params = list(encoder.torch_module.parameters())
     assert len(params) > 0
     assert all(not p.requires_grad for p in params)
+    # the decoder was not configured frozen
+    assert any(
+        p.requires_grad for p in pool.transforms["decoder"].torch_module.parameters()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -186,29 +358,30 @@ def test_transform_freeze_before_wrap():
 # ---------------------------------------------------------------------------
 
 
+def _transform_state(pool: ComponentPool, name: str) -> Mapping[str, torch.Tensor]:
+    return strip_leading_module(pool.transforms[name].torch_module.state_dict())
+
+
 def test_transform_name_matched_init(tmp_path):
     dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    selector = _sfno_selector()
 
-    # A "donor" transform whose raw (pre-wrap) state_dict we save.
+    # A "donor" pool whose encoder's raw (pre-wrap) state_dict we save.
     torch.manual_seed(0)
-    donor_raw = selector.build(
-        n_in_channels=1, n_out_channels=1, dataset_info=dataset_info
+    donor_pool = _encoder_decoder_config(with_backbone=False).build(
+        {"physical": dataset_info}
     )
-    donor_state = donor_raw.torch_module.state_dict()
+    donor_state = _transform_state(donor_pool, "encoder")
     ckpt = tmp_path / "transform.pt"
     torch.save(donor_state, ckpt)
 
-    # A fresh transform of matching shape, initialized from the donor by name.
+    # A fresh encoder of matching shape, initialized from the donor by name.
     torch.manual_seed(1)
-    transform = TransformConfig(
-        selector,
-        ["a"],
-        ["a"],
+    pool = _encoder_decoder_config(
         parameter_init=ParameterInitializationConfig(weights_path=str(ckpt)),
-    ).build(dataset_info)
+        with_backbone=False,
+    ).build({"physical": dataset_info})
 
-    loaded_state = strip_leading_module(transform.torch_module.state_dict())
+    loaded_state = _transform_state(pool, "encoder")
     assert set(loaded_state) == set(donor_state)
     for name, value in donor_state.items():
         torch.testing.assert_close(loaded_state[name], value)
@@ -216,22 +389,20 @@ def test_transform_name_matched_init(tmp_path):
 
 def test_transform_partial_init_excludes_named_params(tmp_path):
     dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    selector = _sfno_selector()
     torch.manual_seed(0)
-    donor_raw = selector.build(
-        n_in_channels=1, n_out_channels=1, dataset_info=dataset_info
+    donor_pool = _encoder_decoder_config(with_backbone=False).build(
+        {"physical": dataset_info}
     )
-    donor_state = donor_raw.torch_module.state_dict()
+    donor_state = _transform_state(donor_pool, "encoder")
     ckpt = tmp_path / "transform.pt"
     torch.save(donor_state, ckpt)
 
     # exclude a parameter that differs between the donor and a fresh init, so
     # the assertions distinguish "kept fresh" from "overwritten from donor".
     torch.manual_seed(1)
-    fresh_reference = strip_leading_module(
-        TransformConfig(selector, ["a"], ["a"])
-        .build(dataset_info)
-        .torch_module.state_dict()
+    fresh_reference = _transform_state(
+        _encoder_decoder_config(with_backbone=False).build({"physical": dataset_info}),
+        "encoder",
     )
     excluded = next(
         name
@@ -246,17 +417,15 @@ def test_transform_partial_init_excludes_named_params(tmp_path):
     )
 
     torch.manual_seed(1)
-    transform = TransformConfig(
-        selector,
-        ["a"],
-        ["a"],
+    pool = _encoder_decoder_config(
         parameter_init=ParameterInitializationConfig(
             weights_path=str(ckpt),
             parameters=[ParameterClassification(exclude=[excluded])],
         ),
-    ).build(dataset_info)
+        with_backbone=False,
+    ).build({"physical": dataset_info})
 
-    loaded_state = strip_leading_module(transform.torch_module.state_dict())
+    loaded_state = _transform_state(pool, "encoder")
     # the excluded parameter kept its fresh initialization
     torch.testing.assert_close(loaded_state[excluded], fresh_reference[excluded])
     # a non-excluded parameter was overwritten from the donor
@@ -269,17 +438,15 @@ def test_transform_partial_init_excludes_named_params(tmp_path):
 
 
 def test_component_pool_state_round_trip():
-    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    config = ComponentPoolConfig(
-        transforms={"encoder": TransformConfig(_sfno_selector(), ["a"], ["z"])},
-        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+    pool = _encoder_decoder_config().build(
+        {"physical": get_dataset_info(img_shape=IMG_SHAPE)}
     )
-    pool = config.build(dataset_info)
     state = pool.get_state()
 
     reloaded = ComponentPool.from_state(state)
     assert set(reloaded.transforms) == set(pool.transforms)
     assert set(reloaded.backbones) == set(pool.backbones)
+    assert set(reloaded.dataset_info) == set(pool.dataset_info)
 
     orig = strip_leading_module(pool.transforms["encoder"].torch_module.state_dict())
     new = strip_leading_module(reloaded.transforms["encoder"].torch_module.state_dict())
@@ -294,10 +461,8 @@ def test_component_pool_state_round_trip():
 
 
 def test_component_pool_load_state_into_built_pool():
-    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    config = ComponentPoolConfig(
-        transforms={"encoder": TransformConfig(_sfno_selector(), ["a"], ["z"])},
-    )
+    config = _encoder_decoder_config(with_backbone=False)
+    dataset_info = {"physical": get_dataset_info(img_shape=IMG_SHAPE)}
     pool = config.build(dataset_info)
     state = pool.get_state()
 
@@ -322,18 +487,21 @@ def test_component_pool_load_state_into_built_pool():
 
 
 def test_config_dacite_round_trip():
-    config = ComponentPoolConfig(
-        transforms={"encoder": TransformConfig(_sfno_selector(), ["a", "b"], ["z"])},
-        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
-    )
+    config = _encoder_decoder_config()
     reloaded = ComponentPoolConfig.from_state(config.get_state())
-    assert set(reloaded.transforms) == {"encoder"}
-    assert reloaded.transforms["encoder"].in_names == ["a", "b"]
-    assert reloaded.transforms["encoder"].out_names == ["z"]
+    assert set(reloaded.domains) == {"physical", "latent"}
+    assert reloaded.domains["physical"].names == ["a", "b"]
+    # the latent block deserializes back to a LatentChannels entry
+    assert reloaded.domains["latent"].channels == [LatentChannels(name="z", channels=2)]
+    assert reloaded.domains["latent"].grid_like == "physical"
+    assert set(reloaded.transforms) == {"encoder", "decoder"}
+    assert reloaded.transforms["encoder"].in_domain == "physical"
+    assert reloaded.transforms["encoder"].out_domain == "latent"
     assert set(reloaded.backbones) == {"backbone"}
+    assert reloaded.backbones["backbone"].domain == "latent"
     assert reloaded.backbones["backbone"].stepper is not None
     # the rebuilt config still builds
-    reloaded.build(get_dataset_info(img_shape=IMG_SHAPE))
+    reloaded.build({"physical": get_dataset_info(img_shape=IMG_SHAPE)})
 
 
 # ---------------------------------------------------------------------------
@@ -342,12 +510,9 @@ def test_config_dacite_round_trip():
 
 
 def test_set_train_eval_fans_out():
-    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
-    config = ComponentPoolConfig(
-        transforms={"encoder": TransformConfig(_sfno_selector(), ["a"], ["z"])},
-        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+    pool = _encoder_decoder_config().build(
+        {"physical": get_dataset_info(img_shape=IMG_SHAPE)}
     )
-    pool = config.build(dataset_info)
 
     pool.set_eval()
     assert not pool.transforms["encoder"].torch_module.training
@@ -368,9 +533,10 @@ def test_set_train_eval_fans_out():
 
 def test_backbone_requires_exactly_one_source():
     with pytest.raises(ValueError, match="Exactly one"):
-        BackboneConfig()
+        BackboneConfig(domain="physical")
     with pytest.raises(ValueError, match="Exactly one"):
         BackboneConfig(
+            domain="physical",
             stepper=_stepper_config(["a"], ["a"]),
             checkpoint=CheckpointStepperConfig(checkpoint_path="x"),
         )
@@ -379,6 +545,7 @@ def test_backbone_requires_exactly_one_source():
 def test_backbone_checkpoint_weights_path_conflict():
     with pytest.raises(ValueError, match="weights_path must be None"):
         BackboneConfig(
+            domain="physical",
             checkpoint=CheckpointStepperConfig(checkpoint_path="x"),
             init_from_checkpoint=True,
             parameter_init=ParameterInitializationConfig(weights_path="y"),
@@ -388,6 +555,13 @@ def test_backbone_checkpoint_weights_path_conflict():
 def test_duplicate_component_names_rejected():
     with pytest.raises(ValueError, match="unique"):
         ComponentPoolConfig(
-            transforms={"shared": TransformConfig(_sfno_selector(), ["a"], ["z"])},
-            backbones={"shared": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+            domains={"physical": DomainConfig(channels=["a"])},
+            transforms={
+                "shared": TransformConfig(_sfno_selector(), "physical", "physical")
+            },
+            backbones={
+                "shared": BackboneConfig(
+                    domain="physical", stepper=_stepper_config(["a"], ["a"])
+                )
+            },
         )

--- a/fme/translate/test_components.py
+++ b/fme/translate/test_components.py
@@ -504,6 +504,30 @@ def test_config_dacite_round_trip():
     reloaded.build({"physical": get_dataset_info(img_shape=IMG_SHAPE)})
 
 
+def test_checkpoint_backbone_config_dacite_round_trip():
+    """The frozen-donor arm's config (a checkpoint-sourced backbone) round-trips
+    through get_state/from_state, preserving the checkpoint source and freeze.
+    """
+    config = ComponentPoolConfig(
+        domains={"physical": DomainConfig(channels=["a"])},
+        backbones={
+            "backbone": BackboneConfig(
+                domain="physical",
+                checkpoint=CheckpointStepperConfig(checkpoint_path="donor.pt"),
+                init_from_checkpoint=True,
+                parameter_init=_all_frozen_init(),
+            )
+        },
+    )
+    reloaded = ComponentPoolConfig.from_state(config.get_state())
+    backbone = reloaded.backbones["backbone"]
+    assert backbone.stepper is None
+    assert backbone.checkpoint is not None
+    assert backbone.checkpoint.checkpoint_path == "donor.pt"
+    assert backbone.init_from_checkpoint is True
+    assert backbone.parameter_init.parameters[0].frozen.include == ["*"]
+
+
 # ---------------------------------------------------------------------------
 # train / eval / epoch fan-out
 # ---------------------------------------------------------------------------

--- a/fme/translate/test_components.py
+++ b/fme/translate/test_components.py
@@ -1,0 +1,393 @@
+import dataclasses
+
+import pytest
+import torch
+
+from fme.ace.stepper.parameter_init import (
+    FrozenParameterConfig,
+    ParameterClassification,
+    ParameterInitializationConfig,
+)
+from fme.ace.stepper.single_module import (
+    CheckpointStepperConfig,
+    Stepper,
+    StepperConfig,
+)
+from fme.core.distributed.non_distributed import DummyWrapper
+from fme.core.registry.module import ModuleSelector
+from fme.core.step import SingleModuleStepConfig, StepSelector
+from fme.core.testing import get_dataset_info, trivial_network_and_loss_normalization
+from fme.core.weight_ops import strip_leading_module
+from fme.translate.components import (
+    BackboneConfig,
+    ComponentPool,
+    ComponentPoolConfig,
+    TransformConfig,
+)
+
+IMG_SHAPE = (5, 5)
+
+
+def _sfno_selector(embed_dim: int = 2) -> ModuleSelector:
+    return ModuleSelector(
+        type="SphericalFourierNeuralOperatorNet",
+        config={"scale_factor": 1, "embed_dim": embed_dim, "num_layers": 1},
+    )
+
+
+def _stepper_config(in_names: list[str], out_names: list[str]) -> StepperConfig:
+    return StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=_sfno_selector(),
+                    in_names=in_names,
+                    out_names=out_names,
+                    normalization=trivial_network_and_loss_normalization(
+                        list(set(in_names) | set(out_names))
+                    ),
+                )
+            ),
+        ),
+    )
+
+
+def _all_frozen_init() -> ParameterInitializationConfig:
+    return ParameterInitializationConfig(
+        parameters=[
+            ParameterClassification(frozen=FrozenParameterConfig(include=["*"]))
+        ]
+    )
+
+
+def _save_stepper_checkpoint(stepper: Stepper, path) -> None:
+    torch.save({"stepper": stepper.get_state()}, path)
+
+
+# ---------------------------------------------------------------------------
+# Build + modules exposure
+# ---------------------------------------------------------------------------
+
+
+def test_pool_builds_and_exposes_flattened_modules():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    config = ComponentPoolConfig(
+        transforms={
+            "encoder": TransformConfig(_sfno_selector(), ["a", "b"], ["z"]),
+            "decoder": TransformConfig(_sfno_selector(), ["z"], ["a", "b"]),
+        },
+        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+    )
+    pool = config.build(dataset_info)
+
+    assert set(pool.transforms) == {"encoder", "decoder"}
+    assert set(pool.backbones) == {"backbone"}
+
+    modules = pool.modules
+    assert isinstance(modules, torch.nn.ModuleList)
+    # two transforms + one backbone module
+    assert len(modules) == 3
+    # every parameter of every component is reachable through .modules
+    pool_param_count = sum(p.numel() for p in modules.parameters())
+    component_param_count = sum(
+        p.numel() for t in pool.transforms.values() for p in t.torch_module.parameters()
+    ) + sum(
+        p.numel()
+        for b in pool.backbones.values()
+        for m in b.modules
+        for p in m.parameters()
+    )
+    assert pool_param_count == component_param_count
+    assert pool_param_count > 0
+
+
+def test_transform_channel_counts_from_names():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    transform = TransformConfig(_sfno_selector(), ["a", "b", "c"], ["x"]).build(
+        dataset_info
+    )
+    grid = torch.zeros(1, 3, *IMG_SHAPE)
+    out = transform(grid)
+    assert out.shape == (1, 1, *IMG_SHAPE)
+
+
+# ---------------------------------------------------------------------------
+# Freeze-before-wrap correctness
+# ---------------------------------------------------------------------------
+
+
+def _assert_fully_frozen_dummy_wrapped(modules):
+    assert len(modules) > 0
+    for module in modules:
+        assert isinstance(module, DummyWrapper)
+        params = list(module.parameters())
+        assert len(params) > 0
+        assert all(not p.requires_grad for p in params)
+
+
+def test_frozen_backbone_from_checkpoint_is_frozen_and_not_ddp(tmp_path):
+    """A configured-frozen donor backbone sourced from a checkpoint has all
+    parameters frozen and is wrapped as a DummyWrapper (no live-gradient DDP
+    expectations), because freezing precedes wrapping.
+    """
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    donor = _stepper_config(["a"], ["a"]).get_stepper(dataset_info)
+    ckpt = tmp_path / "donor.pt"
+    _save_stepper_checkpoint(donor, ckpt)
+
+    backbone = BackboneConfig(
+        checkpoint=CheckpointStepperConfig(checkpoint_path=str(ckpt)),
+        init_from_checkpoint=True,
+        parameter_init=_all_frozen_init(),
+    ).build(dataset_info)
+
+    _assert_fully_frozen_dummy_wrapped(backbone.modules)
+
+    # weights were actually sourced from the donor (name-matched)
+    donor_state = strip_leading_module(donor.modules[0].state_dict())
+    loaded_state = strip_leading_module(backbone.modules[0].state_dict())
+    assert set(donor_state) == set(loaded_state)
+    for name, value in donor_state.items():
+        torch.testing.assert_close(loaded_state[name], value)
+
+
+def test_fresh_backbone_freeze_before_wrap(tmp_path):
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    backbone = BackboneConfig(
+        stepper=_stepper_config(["a"], ["a"]),
+        parameter_init=_all_frozen_init(),
+    ).build(dataset_info)
+    _assert_fully_frozen_dummy_wrapped(backbone.modules)
+
+
+def test_unfrozen_fresh_backbone_is_trainable():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    backbone = BackboneConfig(stepper=_stepper_config(["a"], ["a"])).build(dataset_info)
+    assert any(p.requires_grad for p in backbone.modules.parameters())
+
+
+def test_transform_freeze_before_wrap():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    transform = TransformConfig(
+        _sfno_selector(),
+        ["a"],
+        ["a"],
+        parameter_init=_all_frozen_init(),
+    ).build(dataset_info)
+    assert isinstance(transform.torch_module, DummyWrapper)
+    params = list(transform.torch_module.parameters())
+    assert len(params) > 0
+    assert all(not p.requires_grad for p in params)
+
+
+# ---------------------------------------------------------------------------
+# Name-matched partial checkpoint init
+# ---------------------------------------------------------------------------
+
+
+def test_transform_name_matched_init(tmp_path):
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    selector = _sfno_selector()
+
+    # A "donor" transform whose raw (pre-wrap) state_dict we save.
+    torch.manual_seed(0)
+    donor_raw = selector.build(
+        n_in_channels=1, n_out_channels=1, dataset_info=dataset_info
+    )
+    donor_state = donor_raw.torch_module.state_dict()
+    ckpt = tmp_path / "transform.pt"
+    torch.save(donor_state, ckpt)
+
+    # A fresh transform of matching shape, initialized from the donor by name.
+    torch.manual_seed(1)
+    transform = TransformConfig(
+        selector,
+        ["a"],
+        ["a"],
+        parameter_init=ParameterInitializationConfig(weights_path=str(ckpt)),
+    ).build(dataset_info)
+
+    loaded_state = strip_leading_module(transform.torch_module.state_dict())
+    assert set(loaded_state) == set(donor_state)
+    for name, value in donor_state.items():
+        torch.testing.assert_close(loaded_state[name], value)
+
+
+def test_transform_partial_init_excludes_named_params(tmp_path):
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    selector = _sfno_selector()
+    torch.manual_seed(0)
+    donor_raw = selector.build(
+        n_in_channels=1, n_out_channels=1, dataset_info=dataset_info
+    )
+    donor_state = donor_raw.torch_module.state_dict()
+    ckpt = tmp_path / "transform.pt"
+    torch.save(donor_state, ckpt)
+
+    # exclude a parameter that differs between the donor and a fresh init, so
+    # the assertions distinguish "kept fresh" from "overwritten from donor".
+    torch.manual_seed(1)
+    fresh_reference = strip_leading_module(
+        TransformConfig(selector, ["a"], ["a"])
+        .build(dataset_info)
+        .torch_module.state_dict()
+    )
+    excluded = next(
+        name
+        for name in sorted(donor_state)
+        if not torch.allclose(fresh_reference[name], donor_state[name])
+    )
+    other = next(
+        name
+        for name in sorted(donor_state)
+        if name != excluded
+        and not torch.allclose(fresh_reference[name], donor_state[name])
+    )
+
+    torch.manual_seed(1)
+    transform = TransformConfig(
+        selector,
+        ["a"],
+        ["a"],
+        parameter_init=ParameterInitializationConfig(
+            weights_path=str(ckpt),
+            parameters=[ParameterClassification(exclude=[excluded])],
+        ),
+    ).build(dataset_info)
+
+    loaded_state = strip_leading_module(transform.torch_module.state_dict())
+    # the excluded parameter kept its fresh initialization
+    torch.testing.assert_close(loaded_state[excluded], fresh_reference[excluded])
+    # a non-excluded parameter was overwritten from the donor
+    torch.testing.assert_close(loaded_state[other], donor_state[other])
+
+
+# ---------------------------------------------------------------------------
+# State round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_component_pool_state_round_trip():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    config = ComponentPoolConfig(
+        transforms={"encoder": TransformConfig(_sfno_selector(), ["a"], ["z"])},
+        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+    )
+    pool = config.build(dataset_info)
+    state = pool.get_state()
+
+    reloaded = ComponentPool.from_state(state)
+    assert set(reloaded.transforms) == set(pool.transforms)
+    assert set(reloaded.backbones) == set(pool.backbones)
+
+    orig = strip_leading_module(pool.transforms["encoder"].torch_module.state_dict())
+    new = strip_leading_module(reloaded.transforms["encoder"].torch_module.state_dict())
+    assert set(orig) == set(new)
+    for name, value in orig.items():
+        torch.testing.assert_close(new[name], value)
+
+    orig_b = strip_leading_module(pool.backbones["backbone"].modules[0].state_dict())
+    new_b = strip_leading_module(reloaded.backbones["backbone"].modules[0].state_dict())
+    for name, value in orig_b.items():
+        torch.testing.assert_close(new_b[name], value)
+
+
+def test_component_pool_load_state_into_built_pool():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    config = ComponentPoolConfig(
+        transforms={"encoder": TransformConfig(_sfno_selector(), ["a"], ["z"])},
+    )
+    pool = config.build(dataset_info)
+    state = pool.get_state()
+
+    other = config.build(dataset_info)
+    # perturb every parameter so the load is observable
+    with torch.no_grad():
+        for param in other.modules.parameters():
+            param.add_(1.0)
+    before = {
+        name: value.clone()
+        for name, value in strip_leading_module(
+            other.transforms["encoder"].torch_module.state_dict()
+        ).items()
+    }
+    other.load_state(state)
+    after = strip_leading_module(other.transforms["encoder"].torch_module.state_dict())
+    saved = strip_leading_module(pool.transforms["encoder"].torch_module.state_dict())
+    for name, value in saved.items():
+        torch.testing.assert_close(after[name], value)
+    # sanity: at least one parameter actually changed on load
+    assert any(not torch.allclose(before[name], after[name]) for name in before)
+
+
+def test_config_dacite_round_trip():
+    config = ComponentPoolConfig(
+        transforms={"encoder": TransformConfig(_sfno_selector(), ["a", "b"], ["z"])},
+        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+    )
+    reloaded = ComponentPoolConfig.from_state(config.get_state())
+    assert set(reloaded.transforms) == {"encoder"}
+    assert reloaded.transforms["encoder"].in_names == ["a", "b"]
+    assert reloaded.transforms["encoder"].out_names == ["z"]
+    assert set(reloaded.backbones) == {"backbone"}
+    assert reloaded.backbones["backbone"].stepper is not None
+    # the rebuilt config still builds
+    reloaded.build(get_dataset_info(img_shape=IMG_SHAPE))
+
+
+# ---------------------------------------------------------------------------
+# train / eval / epoch fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_set_train_eval_fans_out():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE)
+    config = ComponentPoolConfig(
+        transforms={"encoder": TransformConfig(_sfno_selector(), ["a"], ["z"])},
+        backbones={"backbone": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+    )
+    pool = config.build(dataset_info)
+
+    pool.set_eval()
+    assert not pool.transforms["encoder"].torch_module.training
+    assert all(not m.training for m in pool.backbones["backbone"].modules)
+
+    pool.set_train()
+    assert pool.transforms["encoder"].torch_module.training
+    assert all(m.training for m in pool.backbones["backbone"].modules)
+
+    # set_epoch must not raise even with only transforms/backbones present
+    pool.set_epoch(3)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_backbone_requires_exactly_one_source():
+    with pytest.raises(ValueError, match="Exactly one"):
+        BackboneConfig()
+    with pytest.raises(ValueError, match="Exactly one"):
+        BackboneConfig(
+            stepper=_stepper_config(["a"], ["a"]),
+            checkpoint=CheckpointStepperConfig(checkpoint_path="x"),
+        )
+
+
+def test_backbone_checkpoint_weights_path_conflict():
+    with pytest.raises(ValueError, match="weights_path must be None"):
+        BackboneConfig(
+            checkpoint=CheckpointStepperConfig(checkpoint_path="x"),
+            init_from_checkpoint=True,
+            parameter_init=ParameterInitializationConfig(weights_path="y"),
+        )
+
+
+def test_duplicate_component_names_rejected():
+    with pytest.raises(ValueError, match="unique"):
+        ComponentPoolConfig(
+            transforms={"shared": TransformConfig(_sfno_selector(), ["a"], ["z"])},
+            backbones={"shared": BackboneConfig(stepper=_stepper_config(["z"], ["z"]))},
+        )

--- a/fme/translate/test_domains.py
+++ b/fme/translate/test_domains.py
@@ -1,0 +1,40 @@
+import pytest
+
+from fme.translate.domains import DomainConfig, LatentChannels
+
+
+def test_latent_channels_expand_to_indexed_names():
+    block = LatentChannels(name="z", channels=3)
+    assert block.names == ["z_0", "z_1", "z_2"]
+
+
+def test_latent_channels_validation():
+    with pytest.raises(ValueError, match="channels >= 1"):
+        LatentChannels(name="z", channels=0)
+    with pytest.raises(ValueError, match="non-empty name"):
+        LatentChannels(name="", channels=2)
+
+
+def test_domain_mixes_variables_and_latent_blocks_in_order():
+    domain = DomainConfig(
+        channels=["air_temperature_0", LatentChannels(name="z", channels=2), "co2"]
+    )
+    assert domain.names == ["air_temperature_0", "z_0", "z_1", "co2"]
+    assert domain.n_channels == 4
+
+
+def test_domain_rejects_empty_channels():
+    with pytest.raises(ValueError, match="at least one channel"):
+        DomainConfig(channels=[])
+
+
+def test_domain_rejects_duplicate_names_after_expansion():
+    with pytest.raises(ValueError, match="duplicates.*z_0"):
+        DomainConfig(channels=["z_0", LatentChannels(name="z", channels=1)])
+    with pytest.raises(ValueError, match="duplicates"):
+        DomainConfig(
+            channels=[
+                LatentChannels(name="z", channels=2),
+                LatentChannels(name="z", channels=2),
+            ]
+        )

--- a/fme/translate/test_modules.py
+++ b/fme/translate/test_modules.py
@@ -1,0 +1,58 @@
+import pytest
+import torch
+
+from fme.core.testing import get_dataset_info
+from fme.translate.modules import TransformSelector
+
+
+def _sfno_same_grid_selector() -> TransformSelector:
+    return TransformSelector(
+        type="same_grid",
+        config={
+            "module": {
+                "type": "SphericalFourierNeuralOperatorNet",
+                "config": {"scale_factor": 1, "embed_dim": 2, "num_layers": 1},
+            }
+        },
+    )
+
+
+def test_same_grid_builds_on_matching_grids():
+    info = get_dataset_info(img_shape=(5, 5))
+    module = _sfno_same_grid_selector().build(
+        n_in_channels=2, n_out_channels=3, in_dataset_info=info, out_dataset_info=info
+    )
+    out = module(torch.zeros(1, 2, 5, 5))
+    assert out.shape == (1, 3, 5, 5)
+
+
+def test_same_grid_rejects_mismatched_grids():
+    with pytest.raises(ValueError, match="matching input and output"):
+        _sfno_same_grid_selector().build(
+            n_in_channels=1,
+            n_out_channels=1,
+            in_dataset_info=get_dataset_info(img_shape=(8, 16)),
+            out_dataset_info=get_dataset_info(img_shape=(4, 8)),
+        )
+
+
+@pytest.mark.parametrize(
+    "in_shape, out_shape",
+    [((8, 16), (4, 8)), ((4, 8), (8, 16))],
+    ids=["downsample", "upsample"],
+)
+def test_interpolate_maps_channels_and_resizes(in_shape, out_shape):
+    selector = TransformSelector(type="interpolate", config={})
+    module = selector.build(
+        n_in_channels=3,
+        n_out_channels=2,
+        in_dataset_info=get_dataset_info(img_shape=in_shape),
+        out_dataset_info=get_dataset_info(img_shape=out_shape),
+    )
+    out = module(torch.randn(2, 3, *in_shape))
+    assert out.shape == (2, 2, *out_shape)
+
+
+def test_unregistered_type_raises():
+    with pytest.raises(KeyError):
+        TransformSelector(type="not_a_transform", config={})


### PR DESCRIPTION
First PR of a six-PR series introducing `fme/translate`, a new package that provides one shared abstraction for two upcoming experiment programs: transfer learning (learned ERA5↔SHiELD transforms around a frozen SHiELD+ forward model) and multi-resolution latent stepping (per-resolution encoders/decoders around a shared coarse-latent backbone). Both reduce to *learned transforms wrapped around a backbone stepper*, differing in what is frozen and which loss terms are active. This PR lays the skeleton the rest of the series builds on; it adds no training, data-loading, objective, or inference logic.

The package sits at the coupled/downscaling tier (it may import `fme.core`, `fme.ace`, and `fme.downscaling`; nothing imports it) and follows the `fme.coupled.stepper` embed-a-stepper template.

The organizing concept is the **domain**: a named space where data or latent state lives — an ordered channel set on one grid. Components declare the domains they map between, and domains are the key that pairs components with data: `ComponentPoolConfig.build` takes one `DatasetInfo` per data-backed domain, keyed by domain name (the data-loading PR derives each entry from the data stream serving that domain). A 1°/2°/4° multi-resolution model is three domains, resolution-changing transforms between adjacent resolutions, and a backbone stepping in the 4° domain; `test_components.py` builds and runs exactly this chain at toy scale.

Changes:
- `fme.translate.DomainConfig` — a domain's channel declaration: an ordered union of plain variable names and `LatentChannels` blocks. A block names a group of free channels once and gives a count (`{name: z, channels: 512}` expands to `z_0`…`z_511`), so latent spaces are never enumerated by hand. A domain with no dataset behind it (a latent space) declares `grid_like: <domain>` and inherits that domain's grid at build.
- `fme.translate.TransformSelector` — a registry of transform module builders whose contract takes both the input and output domains' `DatasetInfo`s (the generic `ModuleConfig` takes one grid and cannot express a resolution-changing operator). Ships with `same_grid` (adapts any existing `ModuleSelector` entry; validates the grids match) and `interpolate` (1x1 conv + interpolation to the output grid — the trivial resize operator and test vehicle; SHT truncation and learned operators are later registry entries).
- `fme.translate.TransformConfig` — a trainable transform/encoder/decoder declaring `in_domain`/`out_domain`; channel counts come from the domains' expanded channel lists. Per-component freezing and name-matched partial checkpoint init are applied to the raw module before `wrap_module`.
- `fme.translate.BackboneConfig` — a backbone ace `Stepper` stepping within one declared `domain` (every stepper variable must be a channel of that domain, checked at build), its config either built fresh (`StepperConfig`) or sourced from a checkpoint (`CheckpointStepperConfig`). Freezing/init are threaded through `StepperConfig.get_stepper(..., parameter_initializer=...)` so they happen inside step construction, before DDP wrapping. When sourcing from a checkpoint, weights flow through the parameter-init path (mirroring `fme.coupled.stepper.CoupledParameterInitConfig`) so a frozen donor is never DDP-wrapped-then-frozen.
- `fme.translate.ComponentPoolConfig` — declares the named domains, transforms, and backbones; validates the wiring (domain references resolve, `grid_like` targets are data-backed, component names unique); dacite-round-trippable via `get_state`/`from_state`.
- `fme.translate.ComponentPool` — the built composite: holds the components and the resolved per-domain `DatasetInfo`s, exposes a flattened `.modules` `nn.ModuleList` (mirroring `CoupledStepper.modules`), fans out `set_train`/`set_eval`/`set_epoch`, and implements `get_state`/`from_state`/`load_state`. It has no forward/predict/objective logic and is not yet `Stepper`-compatible.
- `fme.translate.load_module_weights` — a `WeightsAndHistoryLoader` for the transform init path (loads a saved module `state_dict`).
- `fme/translate/examples/` — full example training configs for the two target programs, written against the intended config surface of the whole series (only `component_pool:` parses in this PR); committed for line-commenting, not runnable.

Freeze-before-wrap is the central correctness requirement: DDP registers gradient hooks at wrap time based on `requires_grad`, so freezing must precede wrapping (the established ordering in `fme/core/step/single_module.py`). A fully-frozen module wrapped fresh becomes a `DummyWrapper` with no live-gradient expectations. Tests cover this on tiny synthetic grids, including a test that a configured-frozen checkpoint-sourced backbone has all parameters frozen, is `DummyWrapper`-wrapped, and carries the donor's weights; plus the multi-resolution chain above, latent-block expansion, domain wiring validation, name-matched (full and partial/excluded) init, state round-trip, train/eval fan-out, and config validation.

Out of scope (later PRs): TranslateBatchData/data loaders binding streams to domains (2); objectives, weighted-sum train stepper, train entrypoint (3); Stepper-compatible export and evaluator (4); cut-point SFNO decomposition (5); latent-consistency objective and noise channels (6).

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
