### PR TITLE
extend per channel loss to validation

### DIFF
--- a/fme/ace/aggregator/one_step/main.py
+++ b/fme/ace/aggregator/one_step/main.py
@@ -5,7 +5,10 @@ from collections.abc import Sequence
 
 import torch
 
-from fme.ace.aggregator.loss_metrics import PerStepLossAggregator
+from fme.ace.aggregator.loss_metrics import (
+    PerChannelLossAggregator,
+    PerStepLossAggregator,
+)
 from fme.ace.aggregator.one_step.deterministic import (
     DeterministicTrainOutput,
     OneStepDeterministicAggregator,
@@ -53,6 +56,7 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         self,
         deterministic_aggregator: OneStepDeterministicAggregator,
         ensemble_aggregators: dict[str, EnsembleAggregator] | None = None,
+        per_channel_loss: bool = True,
     ):
         self._deterministic_aggregator = deterministic_aggregator
         self._ensemble_aggregators: dict[str, EnsembleAggregator] = (
@@ -60,6 +64,9 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         )
         self._ensemble_recorded = False
         self._per_step_losses = PerStepLossAggregator()
+        self._per_channel_losses: PerChannelLossAggregator | None = (
+            PerChannelLossAggregator() if per_channel_loss else None
+        )
 
     @torch.no_grad()
     def record_batch(
@@ -72,6 +79,11 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
             if k.startswith("loss_step_") or k.startswith("loss/")
         }
         self._per_step_losses.record(step_metrics)
+        if (
+            self._per_channel_losses is not None
+            and batch.per_channel_losses is not None
+        ):
+            self._per_channel_losses.record(batch.per_channel_losses)
         folded_gen_data, n_ensemble = fold_ensemble_dim(batch.gen_data)
         folded_target_data = fold_sized_ensemble_dim(batch.target_data, n_ensemble)
         self._deterministic_aggregator.record_batch(
@@ -100,6 +112,8 @@ class OneStepAggregator(AggregatorABC[TrainOutput]):
         det_summary = self._deterministic_aggregator.get_summary(label)
         logs = dict(det_summary.logs)
         logs.update(self._per_step_losses.get_logs(label))
+        if self._per_channel_losses is not None:
+            logs.update(self._per_channel_losses.get_logs(label))
         if self._ensemble_recorded and self._ensemble_aggregators:
             stochastic_logs: dict = {}
             for agg_name, ensemble_aggregator in self._ensemble_aggregators.items():
@@ -146,6 +160,7 @@ def build_one_step_aggregator(
     channel_mean_names: Sequence[str] | None = None,
     raise_on_unsupported: bool = True,
     include_default_ensemble: bool = True,
+    per_channel_loss: bool = True,
 ) -> OneStepAggregator:
     _validate_no_duplicate_names(metrics)
     ctx = OneStepBuildContext(
@@ -192,6 +207,7 @@ def build_one_step_aggregator(
     return OneStepAggregator(
         deterministic_aggregator=deterministic,
         ensemble_aggregators=ensemble_aggregators,
+        per_channel_loss=per_channel_loss,
     )
 
 
@@ -215,6 +231,9 @@ class OneStepAggregatorConfig:
         mean_map: Mean map image metrics.
         ensemble_denorm: Ensemble spread metrics on denormalized data.
         ensemble_norm: Ensemble spread metrics on normalized data.
+        per_channel_loss: Whether to accumulate and report per-variable (per-channel)
+            loss in get_logs (e.g. val/mean/loss/<var_name>), mirroring the
+            train aggregator.
     """
 
     mean_denorm: OneStepMeanMetricConfig = dataclasses.field(
@@ -244,6 +263,7 @@ class OneStepAggregatorConfig:
             target="norm", enabled=False
         )
     )
+    per_channel_loss: bool = True
 
     def __post_init__(self):
         if not self.mean_denorm.enabled:
@@ -299,6 +319,7 @@ class OneStepAggregatorConfig:
             channel_mean_names=channel_mean_names,
             raise_on_unsupported=False,
             include_default_ensemble=False,
+            per_channel_loss=self.per_channel_loss,
         )
 
 

--- a/fme/ace/aggregator/one_step/test_main.py
+++ b/fme/ace/aggregator/one_step/test_main.py
@@ -20,6 +20,7 @@ from fme.ace.stepper import TrainOutput
 from fme.core.coordinates import LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
+from fme.core.loss import ChannelLossInfo
 from fme.core.typing_ import EnsembleTensorDict
 
 
@@ -77,6 +78,83 @@ def test_labels_exist():
     ]
     assert set(summary.logs.keys()) == set(expected_keys)
     assert summary.loss == summary.logs["test/mean/loss"]
+
+
+def test_aggregator_logs_per_channel_loss():
+    """Per-channel loss from batch.per_channel_losses is reported during validation.
+
+    Mirrors the training aggregator so validation logs are directly comparable
+    to train/mean/loss/<var>.
+    """
+    batch_size = 4
+    n_ensemble = 1
+    n_time = 2
+    nx, ny = 2, 2
+    device = get_device()
+    ds_info = get_ds_info(nx, ny)
+    agg = OneStepAggregatorConfig().build(ds_info, save_diagnostics=False)
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, 1, n_time, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(batch_size, n_ensemble, n_time, nx, ny, device=device)},
+    )
+    time = xr.DataArray(np.zeros((batch_size, n_time)), dims=["sample", "time"])
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=time,
+            normalize=lambda x: x,
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(0.5, device=device), count=4)
+            },
+        ),
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(2.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=time,
+            normalize=lambda x: x,
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(1.0, device=device), count=4)
+            },
+        ),
+    )
+    logs = agg.get_logs(label="val")
+    assert logs["val/mean/loss/a"] == 0.75
+
+
+def test_aggregator_omits_per_channel_loss_when_disabled():
+    nx, ny = 2, 2
+    device = get_device()
+    ds_info = get_ds_info(nx, ny)
+    agg = OneStepAggregatorConfig(per_channel_loss=False).build(
+        ds_info, save_diagnostics=False
+    )
+    target_data = EnsembleTensorDict(
+        {"a": torch.randn(4, 1, 2, nx, ny, device=device)},
+    )
+    gen_data = EnsembleTensorDict(
+        {"a": torch.randn(4, 1, 2, nx, ny, device=device)},
+    )
+    agg.record_batch(
+        batch=TrainOutput(
+            metrics={"loss": torch.tensor(1.0, device=device)},
+            target_data=target_data,
+            gen_data=gen_data,
+            time=xr.DataArray(np.zeros((4, 2)), dims=["sample", "time"]),
+            normalize=lambda x: x,
+            per_channel_losses={
+                "a": ChannelLossInfo(loss=torch.tensor(0.5, device=device), count=4)
+            },
+        ),
+    )
+    logs = agg.get_logs(label="val")
+    assert "val/mean/loss/a" not in logs
 
 
 def test_aggregator_raises_on_no_data():


### PR DESCRIPTION
Validation currently only reports scalar loss and per-variable RMSE, so there's no direct per-variable counterpart to training's `train/mean/loss/<var>` for spotting which channels drive the loss. This seems to have been an oversight in the previous per-channel PR as the stepper already populates `TrainOutput.per_channel_losses `during validation (loss-schedule steps run with optimize=True regardless of the null optimizer), this PR simply has the validation aggregator consume that field, reusing the same `PerChannelLossAggregator` as training so validation emits directly comparable `val/mean/loss/<var>` metrics.

Changes:
- `fme.ace.aggregator.one_step.OneStepAggregator` now records batch.per_channel_losses and logs `<label>/mean/loss/<var>` in get_summary, mirroring TrainAggregator.
- `fme.ace.aggregator.one_step.OneStepAggregatorConfig` and` build_one_step_aggregator `gain a `per_channel_loss: bool = True` flag (matching `TrainAggregatorConfig.per_channel_loss`) to toggle the behavior.

- [x] Tests added
