### PR TITLE
Add two-track (global/local latent) SFNO step

### DIFF
--- a/fme/ace/registry/__init__.py
+++ b/fme/ace/registry/__init__.py
@@ -8,6 +8,8 @@ from . import prebuilt as _prebuilt
 from . import sfno as _sfno
 from . import stochastic_sfno as _sfno_crps
 from . import swin_transformer as _swin
+from . import two_track_sfno as _two_track_sfno
 from .registry import ModuleSelector
 
 del _prebuilt, _sfno, _m2lines, _landnet, _localnet, _sfno_crps, _mlp, _swin
+del _two_track_sfno

--- a/fme/ace/registry/two_track_sfno.py
+++ b/fme/ace/registry/two_track_sfno.py
@@ -1,0 +1,167 @@
+import dataclasses
+from typing import Literal
+
+import torch
+
+from fme.ace.registry.registry import ModuleConfig, ModuleSelector
+from fme.ace.registry.stochastic_sfno import NoiseConditionedModel
+from fme.core.dataset_info import DatasetInfo
+from fme.core.models.conditional_sfno.layers import ContextConfig
+from fme.core.models.conditional_sfno.two_track_sfnonet import (
+    TwoTrackSFNONetConfig,
+    get_lat_lon_two_track_sfnonet,
+)
+
+
+@ModuleSelector.register("TwoTrackSFNO")
+@dataclasses.dataclass
+class TwoTrackSFNOBuilder(ModuleConfig):
+    """Builder for a two-track (global / local latent) noise-conditioned SFNO.
+
+    The network splits its latent into a global track (which passes through the
+    spherical harmonic transform) and a local, pointwise-only track. Unlike the
+    single-track builders, the per-track *channel* counts are not known until
+    the owning two-track step assigns variables to tracks, so this builder is
+    driven by ``build_two_track`` (called directly by the step) rather than the
+    standard ``build``. It is still registered in the module registry so the
+    config loads from YAML like any other builder.
+
+    Attributes:
+        embed_dim: Total latent width (global + local).
+        local_embed_dim: Width of the local latent track. 0 recovers the
+            single-track network exactly.
+        noise_embed_dim: Dimension of the noise conditioning channels. 0
+            disables noise conditioning.
+        noise_type: "gaussian" or "isotropic" noise.
+        context_pos_embed_dim: Dimension of the context positional embedding.
+        label_embed_dim: Dimension of a learned label embedding (0 = one-hot).
+        data_grid: Grid type for the spherical harmonic transforms.
+        feed_global_to_local: OPTION 1 (default off).
+        parallel_conv1x1: OPTION 2 (default off).
+        per_track_layer_norm: OPTION 3 (default off).
+
+    The remaining attributes mirror the single-track SFNO config.
+    """
+
+    embed_dim: int = 256
+    local_embed_dim: int = 0
+    filter_type: Literal["linear"] = "linear"
+    noise_embed_dim: int = 256
+    noise_type: Literal["isotropic", "gaussian"] = "gaussian"
+    context_pos_embed_dim: int = 0
+    label_embed_dim: int = 0
+    global_layer_norm: bool = False
+    num_layers: int = 12
+    use_mlp: bool = True
+    mlp_ratio: float = 2.0
+    activation_function: str = "gelu"
+    encoder_layers: int = 1
+    pos_embed: bool = True
+    big_skip: bool = True
+    checkpointing: int = 0
+    data_grid: Literal["legendre-gauss", "equiangular"] = "legendre-gauss"
+    hard_thresholding_fraction: float = 1.0
+    filter_residual: bool = False
+    filter_output: bool = False
+    normalize_big_skip: bool = False
+    affine_norms: bool = False
+    filter_num_groups: int = 1
+    drop_rate: float = 0.0
+    drop_path_rate: float = 0.0
+    feed_global_to_local: bool = False
+    parallel_conv1x1: bool = False
+    per_track_layer_norm: bool = False
+
+    def __post_init__(self):
+        if self.context_pos_embed_dim > 0 and self.pos_embed:
+            raise ValueError(
+                "context_pos_embed_dim and pos_embed should not both be set"
+            )
+        # Validate the network config (embed_dim / local_embed_dim / groups).
+        self._net_config()
+
+    def _net_config(self) -> TwoTrackSFNONetConfig:
+        return TwoTrackSFNONetConfig(
+            embed_dim=self.embed_dim,
+            local_embed_dim=self.local_embed_dim,
+            filter_type=self.filter_type,
+            global_layer_norm=self.global_layer_norm,
+            num_layers=self.num_layers,
+            use_mlp=self.use_mlp,
+            mlp_ratio=self.mlp_ratio,
+            activation_function=self.activation_function,
+            encoder_layers=self.encoder_layers,
+            pos_embed=self.pos_embed,
+            drop_rate=self.drop_rate,
+            drop_path_rate=self.drop_path_rate,
+            hard_thresholding_fraction=self.hard_thresholding_fraction,
+            big_skip=self.big_skip,
+            checkpointing=self.checkpointing,
+            filter_num_groups=self.filter_num_groups,
+            filter_residual=self.filter_residual,
+            filter_output=self.filter_output,
+            normalize_big_skip=self.normalize_big_skip,
+            affine_norms=self.affine_norms,
+            feed_global_to_local=self.feed_global_to_local,
+            parallel_conv1x1=self.parallel_conv1x1,
+            per_track_layer_norm=self.per_track_layer_norm,
+        )
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        dataset_info: DatasetInfo,
+    ) -> torch.nn.Module:
+        raise NotImplementedError(
+            "TwoTrackSFNOBuilder cannot be built through the single-tensor "
+            "build interface because it needs the per-track channel counts. "
+            "It is built by the two-track step via build_two_track."
+        )
+
+    def build_two_track(
+        self,
+        global_in_channels: int,
+        local_in_channels: int,
+        global_out_channels: int,
+        local_out_channels: int,
+        dataset_info: DatasetInfo,
+    ) -> torch.nn.Module:
+        n_labels = len(dataset_info.all_labels)
+        effective_label_dim = (
+            self.label_embed_dim if self.label_embed_dim > 0 else n_labels
+        )
+        net = get_lat_lon_two_track_sfnonet(
+            params=self._net_config(),
+            global_in_channels=global_in_channels,
+            local_in_channels=local_in_channels,
+            global_out_channels=global_out_channels,
+            local_out_channels=local_out_channels,
+            img_shape=dataset_info.img_shape,
+            data_grid=self.data_grid,
+            context_config=ContextConfig(
+                embed_dim_scalar=0,
+                embed_dim_pos=self.context_pos_embed_dim,
+                embed_dim_noise=self.noise_embed_dim,
+                embed_dim_labels=effective_label_dim,
+            ),
+        )
+        if self.noise_type == "isotropic":
+            inverse_sht = net.itrans_up
+            lmax = inverse_sht.lmax
+            mmax = inverse_sht.mmax
+        else:
+            inverse_sht = None
+            lmax = 0
+            mmax = 0
+        return NoiseConditionedModel(
+            net,
+            embed_dim_noise=self.noise_embed_dim,
+            embed_dim_pos=self.context_pos_embed_dim,
+            n_labels=n_labels,
+            label_embed_dim=self.label_embed_dim,
+            img_shape=dataset_info.img_shape,
+            inverse_sht=inverse_sht,
+            lmax=lmax,
+            mmax=mmax,
+        )

--- a/fme/ace/registry/two_track_sfno.py
+++ b/fme/ace/registry/two_track_sfno.py
@@ -29,7 +29,11 @@ class TwoTrackSFNOBuilder(ModuleConfig):
     Attributes:
         embed_dim: Total latent width (global + local).
         local_embed_dim: Width of the local latent track. 0 recovers the
-            single-track network exactly.
+            single-track network exactly, but only on the ``legendre-gauss``
+            grid (``local_embed_dim=0`` with ``data_grid='equiangular'`` is
+            rejected in ``__post_init__``; see the note there). Must be 0 if
+            and only if the local track carries no input or output channels
+            (validated in ``build_two_track``).
         noise_embed_dim: Dimension of the noise conditioning channels. 0
             disables noise conditioning.
         noise_type: "gaussian" or "isotropic" noise.
@@ -44,9 +48,9 @@ class TwoTrackSFNOBuilder(ModuleConfig):
     """
 
     embed_dim: int = 256
-    local_embed_dim: int = 0
+    local_embed_dim: int = 256
     filter_type: Literal["linear"] = "linear"
-    noise_embed_dim: int = 256
+    noise_embed_dim: int = 32
     noise_type: Literal["isotropic", "gaussian"] = "gaussian"
     context_pos_embed_dim: int = 0
     label_embed_dim: int = 0
@@ -76,6 +80,21 @@ class TwoTrackSFNOBuilder(ModuleConfig):
         if self.context_pos_embed_dim > 0 and self.pos_embed:
             raise ValueError(
                 "context_pos_embed_dim and pos_embed should not both be set"
+            )
+        if self.local_embed_dim == 0 and self.data_grid == "equiangular":
+            # local_embed_dim=0 is the single-track-equivalent configuration,
+            # used only to warm-start from an old single-track checkpoint. That
+            # byte-for-byte equivalence holds on legendre-gauss but NOT on
+            # equiangular: there the first/last blocks round-trip their spectral
+            # residual, so the two-track block's (full-normed-input) skip differs
+            # from the single-track block's (filter-residual) skip and the loaded
+            # checkpoint silently produces wrong output. Fail loudly instead.
+            raise ValueError(
+                "local_embed_dim=0 (single-track-equivalent) is not backwards "
+                "compatible with data_grid='equiangular': an old single-track "
+                "checkpoint loads without error but does not reproduce its output "
+                "on this grid. Warm-start from a single-track checkpoint only with "
+                "data_grid='legendre-gauss', or use a nonzero local_embed_dim."
             )
         # Validate the network config (embed_dim / local_embed_dim / groups).
         self._net_config()
@@ -127,6 +146,20 @@ class TwoTrackSFNOBuilder(ModuleConfig):
         local_out_channels: int,
         dataset_info: DatasetInfo,
     ) -> torch.nn.Module:
+        # local_embed_dim must be nonzero iff the local track carries channels.
+        has_local_channels = local_in_channels > 0 or local_out_channels > 0
+        if has_local_channels and self.local_embed_dim == 0:
+            raise ValueError(
+                "local_embed_dim must be > 0 when the local track carries any "
+                f"input or output channels (got local_in={local_in_channels}, "
+                f"local_out={local_out_channels}, local_embed_dim=0)."
+            )
+        if not has_local_channels and self.local_embed_dim > 0:
+            raise ValueError(
+                "local_embed_dim must be 0 when the local track carries no input "
+                f"or output channels (got local_embed_dim={self.local_embed_dim}); "
+                "with no local track, use the single-track step instead."
+            )
         n_labels = len(dataset_info.all_labels)
         effective_label_dim = (
             self.label_embed_dim if self.label_embed_dim > 0 else n_labels

--- a/fme/ace/registry/two_track_sfno.py
+++ b/fme/ace/registry/two_track_sfno.py
@@ -40,6 +40,11 @@ class TwoTrackSFNOBuilder(ModuleConfig):
         context_pos_embed_dim: Dimension of the context positional embedding.
         label_embed_dim: Dimension of a learned label embedding (0 = one-hot).
         data_grid: Grid type for the spherical harmonic transforms.
+        spectral_ratio: Fraction of the *global* latent width that
+            participates in the spectral filter (the filter is sized to the
+            global track, not embed_dim). Double it when the global width is
+            halved to keep the actual filter (channels-per-group x groups)
+            equal to a single-track baseline's.
         feed_global_to_local: OPTION 1 (default off).
         parallel_conv1x1: OPTION 2 (default off).
         per_track_layer_norm: OPTION 3 (default off).
@@ -70,6 +75,7 @@ class TwoTrackSFNOBuilder(ModuleConfig):
     normalize_big_skip: bool = False
     affine_norms: bool = False
     filter_num_groups: int = 1
+    spectral_ratio: float = 1.0
     drop_rate: float = 0.0
     drop_path_rate: float = 0.0
     feed_global_to_local: bool = False
@@ -121,6 +127,7 @@ class TwoTrackSFNOBuilder(ModuleConfig):
             filter_output=self.filter_output,
             normalize_big_skip=self.normalize_big_skip,
             affine_norms=self.affine_norms,
+            spectral_ratio=self.spectral_ratio,
             feed_global_to_local=self.feed_global_to_local,
             parallel_conv1x1=self.parallel_conv1x1,
             per_track_layer_norm=self.per_track_layer_norm,

--- a/fme/ace/step/__init__.py
+++ b/fme/ace/step/__init__.py
@@ -1,1 +1,2 @@
 from .fcn3 import FCN3Config, FCN3Selector, FCN3StepConfig
+from .two_track import TwoTrackStep, TwoTrackStepConfig

--- a/fme/ace/step/example_configs/two_track_baseline.yaml
+++ b/fme/ace/step/example_configs/two_track_baseline.yaml
@@ -1,0 +1,55 @@
+# Baseline two-track (global / local latent) SFNO step configuration.
+#
+# This is the entry-point recipe for the two-track validation runs: all three
+# ablation options are off (feed_global_to_local, parallel_conv1x1,
+# per_track_layer_norm all default False and omitted here), and a subset of
+# variables is assigned to the local (pointwise-only) track. In a full training
+# config this block is the value of `stepper.step.config` with
+# `stepper.step.type: two_track`.
+#
+# The global track carries the dynamical prognostics that need a global
+# (spectral) operator; the local track carries column-local inputs/outputs that
+# should not pass through the spherical harmonic transform (e.g. RH-like or
+# change-of-basis variables). The real training-scale widths and variable lists
+# are wired at launch time; the tiny dims here keep the example loadable and
+# CPU-testable.
+builder:
+  embed_dim: 32
+  local_embed_dim: 8
+  noise_embed_dim: 4
+  noise_type: gaussian
+  num_layers: 2
+  pos_embed: true
+  filter_type: linear
+global_in_names:
+  - air_temperature_0
+  - air_temperature_1
+  - eastward_wind_0
+  - DSWRFtoa
+local_in_names:
+  - relative_humidity_0
+  - relative_humidity_1
+global_out_names:
+  - air_temperature_0
+  - air_temperature_1
+  - eastward_wind_0
+local_out_names:
+  - relative_humidity_0
+  - relative_humidity_1
+residual_prediction: true
+normalization:
+  network:
+    means:
+      air_temperature_0: 0.0
+      air_temperature_1: 0.0
+      eastward_wind_0: 0.0
+      DSWRFtoa: 0.0
+      relative_humidity_0: 0.0
+      relative_humidity_1: 0.0
+    stds:
+      air_temperature_0: 1.0
+      air_temperature_1: 1.0
+      eastward_wind_0: 1.0
+      DSWRFtoa: 1.0
+      relative_humidity_0: 1.0
+      relative_humidity_1: 1.0

--- a/fme/ace/step/test_two_track.py
+++ b/fme/ace/step/test_two_track.py
@@ -165,6 +165,47 @@ def test_builder_single_tensor_build_raises():
 
 
 # ---------------------------------------------------------------------------
+# builder: local_embed_dim=0 (single-track-equivalent) is grid-restricted, and
+# local_embed_dim must be nonzero iff the local track carries channels
+# ---------------------------------------------------------------------------
+def test_builder_rejects_zero_local_embed_dim_with_equiangular():
+    # The single-track-equivalent config (local_embed_dim=0) is byte-for-byte
+    # backwards compatible only on legendre-gauss; equiangular is rejected loudly
+    # instead of silently loading a wrong-output checkpoint.
+    with pytest.raises(ValueError, match="equiangular"):
+        _builder(local_embed_dim=0, data_grid="equiangular")
+
+
+def test_builder_allows_zero_local_embed_dim_with_legendre_gauss():
+    builder = _builder(local_embed_dim=0, data_grid="legendre-gauss")
+    assert builder.local_embed_dim == 0
+
+
+def test_build_two_track_requires_nonzero_local_embed_dim_when_local_present():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE, device=fme.get_device())
+    with pytest.raises(ValueError, match="local_embed_dim must be > 0"):
+        _builder(local_embed_dim=0).build_two_track(
+            global_in_channels=2,
+            local_in_channels=1,
+            global_out_channels=2,
+            local_out_channels=0,
+            dataset_info=dataset_info,
+        )
+
+
+def test_build_two_track_requires_zero_local_embed_dim_when_no_local():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE, device=fme.get_device())
+    with pytest.raises(ValueError, match="local_embed_dim must be 0"):
+        _builder(local_embed_dim=3).build_two_track(
+            global_in_channels=2,
+            local_in_channels=0,
+            global_out_channels=2,
+            local_out_channels=0,
+            dataset_info=dataset_info,
+        )
+
+
+# ---------------------------------------------------------------------------
 # config load round trip
 # ---------------------------------------------------------------------------
 def test_config_state_round_trip():

--- a/fme/ace/step/test_two_track.py
+++ b/fme/ace/step/test_two_track.py
@@ -1,0 +1,239 @@
+import dataclasses
+import pathlib
+
+import pytest
+import torch
+import yaml
+
+import fme
+from fme.ace.registry.two_track_sfno import TwoTrackSFNOBuilder
+from fme.ace.step.two_track import TwoTrackStep, TwoTrackStepConfig
+from fme.core.normalizer import NetworkAndLossNormalizationConfig
+from fme.core.step.args import StepArgs
+from fme.core.step.step import StepSelector
+from fme.core.testing import get_dataset_info, trivial_network_and_loss_normalization
+
+IMG_SHAPE = (16, 32)
+EXAMPLE_CONFIG = (
+    pathlib.Path(__file__).parent / "example_configs" / "two_track_baseline.yaml"
+)
+
+
+def _builder(embed_dim=8, local_embed_dim=3, **kwargs) -> TwoTrackSFNOBuilder:
+    return TwoTrackSFNOBuilder(
+        embed_dim=embed_dim,
+        local_embed_dim=local_embed_dim,
+        noise_embed_dim=4,
+        num_layers=2,
+        pos_embed=True,
+        **kwargs,
+    )
+
+
+def _config(**overrides) -> TwoTrackStepConfig:
+    names = ["g_in", "l_in", "shared", "g_out", "l_out"]
+    base = TwoTrackStepConfig(
+        builder=_builder(),
+        global_in_names=["g_in", "shared"],
+        local_in_names=["l_in"],
+        global_out_names=["g_out", "shared"],
+        local_out_names=["l_out"],
+        normalization=trivial_network_and_loss_normalization(names),
+    )
+    if overrides:
+        # dataclasses.replace re-runs __post_init__ so overrides are validated.
+        base = dataclasses.replace(base, **overrides)
+    return base
+
+
+def _selector(config: TwoTrackStepConfig) -> StepSelector:
+    return StepSelector(type="two_track", config=dataclasses.asdict(config))
+
+
+def _get_step(config: TwoTrackStepConfig) -> TwoTrackStep:
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE, device=fme.get_device())
+    step = _selector(config).get_step(dataset_info, lambda _: None)
+    assert isinstance(step, TwoTrackStep)
+    return step
+
+
+def _tensor_dict(names, n_samples=3):
+    device = fme.get_device()
+    return {n: torch.rand(n_samples, *IMG_SHAPE, device=device) for n in names}
+
+
+# ---------------------------------------------------------------------------
+# post-init validation: a variable may not be on both tracks on the same side
+# ---------------------------------------------------------------------------
+def test_raises_when_input_variable_on_both_tracks():
+    with pytest.raises(ValueError, match="both global_in_names"):
+        _config(global_in_names=["x", "shared"], local_in_names=["x"])
+
+
+def test_raises_when_output_variable_on_both_tracks():
+    with pytest.raises(ValueError, match="both global_out_names"):
+        _config(global_out_names=["g_out", "y"], local_out_names=["y"])
+
+
+def test_same_variable_on_different_sides_is_allowed():
+    # A variable global on input and local on output (different sides) is fine.
+    config = _config(
+        global_in_names=["g_in", "shared"],
+        local_in_names=["l_in"],
+        global_out_names=["g_out"],
+        local_out_names=["shared"],
+    )
+    assert "shared" in config.global_in_names
+    assert "shared" in config.local_out_names
+
+
+# ---------------------------------------------------------------------------
+# pack / unpack: global inputs precede local inputs; outputs split the same way
+# ---------------------------------------------------------------------------
+def test_in_out_packer_order_is_global_then_local():
+    config = _config()
+    step = _get_step(config)
+    assert step.in_packer.names == ["g_in", "shared", "l_in"]
+    assert step.out_packer.names == ["g_out", "shared", "l_out"]
+
+
+def test_step_produces_all_outputs_with_correct_shape():
+    torch.manual_seed(0)
+    step = _get_step(_config())
+    output = step.step(
+        args=StepArgs(
+            input=_tensor_dict(step.input_names),
+            next_step_input_data=_tensor_dict(step.next_step_input_names),
+            labels=None,
+        ),
+    ).output
+    assert set(output) == {"g_out", "shared", "l_out"}
+    for name in output:
+        assert output[name].shape == (3, *IMG_SHAPE)
+
+
+def test_step_unpacks_network_output_in_declared_order(monkeypatch):
+    # The network output tensor is [global_out | local_out]; the step must
+    # unpack it into (global_out_names + local_out_names) in that channel order.
+    config = _config()
+    step = _get_step(config)
+    n = 2
+    device = fme.get_device()
+
+    # Replace the network with one returning per-channel constant tensors so we
+    # can assert each output name maps to its packed channel index.
+    n_out = len(config.global_out_names) + len(config.local_out_names)
+
+    class ConstantChannels:
+        """Mimics the Module wrapper boundary: wrap_module then (input, labels)."""
+
+        def wrap_module(self, wrapper):
+            return self
+
+        def __call__(self, input_tensor, labels=None):
+            batch = input_tensor.shape[0]
+            channels = [
+                torch.full((batch, 1, *IMG_SHAPE), float(i), device=device)
+                for i in range(n_out)
+            ]
+            return torch.cat(channels, dim=-3)
+
+    monkeypatch.setattr(step, "module", ConstantChannels())
+    output = step.step(
+        args=StepArgs(
+            input=_tensor_dict(step.input_names, n),
+            next_step_input_data=_tensor_dict(step.next_step_input_names, n),
+            labels=None,
+        ),
+    ).output
+    ordered = config.global_out_names + config.local_out_names
+    for i, name in enumerate(ordered):
+        # normalization is trivial (mean 0, std 1), residual prediction off, so
+        # the denormalized output equals the network's constant channel value.
+        assert torch.allclose(
+            output[name], torch.full_like(output[name], float(i))
+        ), name
+
+
+# ---------------------------------------------------------------------------
+# builder: single-tensor build interface is unsupported (needs per-track counts)
+# ---------------------------------------------------------------------------
+def test_builder_single_tensor_build_raises():
+    dataset_info = get_dataset_info(img_shape=IMG_SHAPE, device=fme.get_device())
+    with pytest.raises(NotImplementedError, match="build_two_track"):
+        _builder().build(n_in_channels=3, n_out_channels=2, dataset_info=dataset_info)
+
+
+# ---------------------------------------------------------------------------
+# config load round trip
+# ---------------------------------------------------------------------------
+def test_config_state_round_trip():
+    config = _config(residual_prediction=True)
+    restored = TwoTrackStepConfig.from_state(config.get_state())
+    assert restored.global_in_names == config.global_in_names
+    assert restored.local_out_names == config.local_out_names
+    assert restored.residual_prediction is True
+
+
+# ---------------------------------------------------------------------------
+# documented baseline example config: loads, builds, and runs a train iteration
+# ---------------------------------------------------------------------------
+def _load_example_config() -> TwoTrackStepConfig:
+    with open(EXAMPLE_CONFIG) as f:
+        data = yaml.safe_load(f)
+    return TwoTrackStepConfig.from_state(data)
+
+
+def test_example_baseline_config_loads_with_options_off():
+    config = _load_example_config()
+    assert config.builder.feed_global_to_local is False
+    assert config.builder.parallel_conv1x1 is False
+    assert config.builder.per_track_layer_norm is False
+    # some variables are assigned to the local track
+    assert len(config.local_in_names) > 0
+    assert len(config.local_out_names) > 0
+    assert isinstance(config.normalization, NetworkAndLossNormalizationConfig)
+
+
+def test_example_baseline_config_smoke_train_step():
+    torch.manual_seed(0)
+    config = _load_example_config()
+    step = _get_step(config)
+    step.train()
+    output = step.step(
+        args=StepArgs(
+            input=_tensor_dict(step.input_names, n_samples=2),
+            next_step_input_data=_tensor_dict(step.next_step_input_names, n_samples=2),
+            labels=None,
+        ),
+    ).output
+    loss = sum(v.sum() for v in output.values())
+    loss.backward()
+    # every trainable module received gradients
+    grads = [
+        p.grad is not None
+        for module in step.modules
+        for p in module.parameters()
+        if p.requires_grad
+    ]
+    assert grads and all(grads)
+
+
+def test_example_baseline_state_round_trip_matches_output():
+    torch.manual_seed(0)
+    config = _load_example_config()
+    step1 = _get_step(config)
+    step2 = _get_step(config)
+    step2.load_state(step1.get_state())
+    step1.eval()
+    step2.eval()
+    args = StepArgs(
+        input=_tensor_dict(step1.input_names, n_samples=1),
+        next_step_input_data=_tensor_dict(step1.next_step_input_names, n_samples=1),
+        labels=None,
+    )
+    with torch.no_grad():
+        out1 = step1.step(args=args).output
+        out2 = step2.step(args=args).output
+    for name in out1:
+        torch.testing.assert_close(out1[name], out2[name])

--- a/fme/ace/step/test_two_track.py
+++ b/fme/ace/step/test_two_track.py
@@ -205,6 +205,14 @@ def test_build_two_track_requires_zero_local_embed_dim_when_no_local():
         )
 
 
+def test_builder_threads_spectral_ratio_to_net_config():
+    # An out-of-range spectral_ratio is rejected via _net_config, proving the
+    # builder passes it through to the network config (validated against the
+    # global width).
+    with pytest.raises(ValueError, match="spectral_ratio must be in"):
+        _builder(spectral_ratio=1.5)
+
+
 # ---------------------------------------------------------------------------
 # config load round trip
 # ---------------------------------------------------------------------------

--- a/fme/ace/step/two_track.py
+++ b/fme/ace/step/two_track.py
@@ -1,0 +1,343 @@
+import dataclasses
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import dacite
+import torch
+from torch import nn
+
+from fme.ace.registry.two_track_sfno import TwoTrackSFNOBuilder
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
+from fme.core.corrector.registry import CorrectorABC
+from fme.core.dataset_info import DatasetInfo
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.labels import LabelEncoding
+from fme.core.normalizer import NetworkAndLossNormalizationConfig, StandardNormalizer
+from fme.core.ocean import Ocean, OceanConfig
+from fme.core.optimization import NullOptimization
+from fme.core.packer import Packer
+from fme.core.registry import CorrectorSelector
+from fme.core.registry.module import Module
+from fme.core.step.args import StepArgs
+from fme.core.step.output import StepOutput
+from fme.core.step.single_module import step_with_adjustments
+from fme.core.step.step import StepABC, StepConfigABC, StepSelector
+from fme.core.typing_ import TensorDict, TensorMapping
+
+
+@StepSelector.register("two_track")
+@dataclasses.dataclass
+class TwoTrackStepConfig(StepConfigABC):
+    """Configuration for a two-track (global / local latent) SFNO step.
+
+    Variables are explicitly assigned to a global track (whose latents pass
+    through the spherical harmonic transform) or a local, pointwise-only track,
+    separately on the input and output sides. Inputs are packed as
+    ``global_in_names + local_in_names`` into a single tensor; the network
+    splits at ``len(global_in_names)``. Outputs are unpacked as
+    ``global_out_names + local_out_names``. Aside from the two-track packing
+    and passing the four per-track channel counts to the builder, the step
+    mirrors ``SingleModuleStep``'s orchestration
+    (normalization / corrector / ocean / residual prediction).
+
+    Parameters:
+        builder: The two-track SFNO builder.
+        global_in_names: Input variables on the global (spectral) track.
+        local_in_names: Input variables on the local (pointwise) track.
+        global_out_names: Output variables on the global track.
+        local_out_names: Output variables on the local track.
+        normalization: The normalization configuration.
+        ocean: The ocean configuration.
+        corrector: The corrector configuration.
+        next_step_forcing_names: Forcing variables taken from the output step.
+        prescribed_prognostic_names: Prognostic names overwritten from forcing.
+        residual_prediction: Whether to use residual prediction.
+    """
+
+    builder: TwoTrackSFNOBuilder
+    global_in_names: list[str]
+    local_in_names: list[str]
+    global_out_names: list[str]
+    local_out_names: list[str]
+    normalization: NetworkAndLossNormalizationConfig
+    ocean: OceanConfig | None = None
+    corrector: AtmosphereCorrectorConfig | CorrectorSelector = dataclasses.field(
+        default_factory=lambda: AtmosphereCorrectorConfig()
+    )
+    next_step_forcing_names: list[str] = dataclasses.field(default_factory=list)
+    prescribed_prognostic_names: list[str] = dataclasses.field(default_factory=list)
+    residual_prediction: bool = False
+
+    def __post_init__(self):
+        in_overlap = set(self.global_in_names) & set(self.local_in_names)
+        if in_overlap:
+            raise ValueError(
+                "a variable may not appear in both global_in_names and "
+                f"local_in_names: {sorted(in_overlap)}"
+            )
+        out_overlap = set(self.global_out_names) & set(self.local_out_names)
+        if out_overlap:
+            raise ValueError(
+                "a variable may not appear in both global_out_names and "
+                f"local_out_names: {sorted(out_overlap)}"
+            )
+        self.in_names = self.global_in_names + self.local_in_names
+        self.out_names = self.global_out_names + self.local_out_names
+        for name in self.prescribed_prognostic_names:
+            if name not in self.out_names:
+                raise ValueError(
+                    f"prescribed_prognostic_name '{name}' must be in out_names: "
+                    f"{self.out_names}"
+                )
+        for name in self.next_step_forcing_names:
+            if name not in self.in_names:
+                raise ValueError(
+                    f"next_step_forcing_name '{name}' not in in_names: {self.in_names}"
+                )
+            if name in self.out_names:
+                raise ValueError(
+                    f"next_step_forcing_name is an output variable: '{name}'"
+                )
+
+    @property
+    def n_ic_timesteps(self) -> int:
+        return 1
+
+    def get_state(self):
+        return dataclasses.asdict(self)
+
+    def get_loss_normalizer(
+        self,
+        extra_names: list[str] | None = None,
+        extra_residual_scaled_names: list[str] | None = None,
+    ) -> StandardNormalizer:
+        if extra_names is None:
+            extra_names = []
+        if extra_residual_scaled_names is None:
+            extra_residual_scaled_names = []
+        return self.normalization.get_loss_normalizer(
+            names=self._normalize_names + extra_names,
+            residual_scaled_names=self.prognostic_names + extra_residual_scaled_names,
+        )
+
+    @classmethod
+    def from_state(cls, state) -> "TwoTrackStepConfig":
+        return dacite.from_dict(
+            data_class=cls, data=state, config=dacite.Config(strict=True)
+        )
+
+    @property
+    def _normalize_names(self) -> list[str]:
+        """Names of variables which require normalization (inputs/outputs)."""
+        return list(set(self.in_names).union(self.output_names))
+
+    @property
+    def input_names(self) -> list[str]:
+        if self.ocean is None:
+            return self.in_names
+        return list(set(self.in_names).union(self.ocean.forcing_names))
+
+    def get_next_step_forcing_names(self) -> list[str]:
+        return self.next_step_forcing_names
+
+    @property
+    def diagnostic_names(self) -> list[str]:
+        return list(set(self.output_names).difference(self.in_names))
+
+    @property
+    def output_names(self) -> list[str]:
+        return self.out_names
+
+    @property
+    def next_step_input_names(self) -> list[str]:
+        result = set(self.input_names).difference(self.output_names)
+        if self.ocean is not None:
+            result = result.union(self.ocean.forcing_names)
+        result = result.union(self.prescribed_prognostic_names)
+        return list(result)
+
+    @property
+    def loss_names(self) -> list[str]:
+        return self.output_names
+
+    @property
+    def allow_missing_variables(self) -> bool:
+        return False
+
+    def replace_ocean(self, ocean: OceanConfig | None):
+        self.ocean = ocean
+
+    def get_ocean(self) -> OceanConfig | None:
+        return self.ocean
+
+    def replace_prescribed_prognostic_names(self, names: list[str]) -> None:
+        for name in names:
+            if name not in self.out_names:
+                raise ValueError(
+                    f"prescribed_prognostic_name '{name}' must be in out_names: "
+                    f"{self.out_names}"
+                )
+        self.prescribed_prognostic_names = names
+
+    def get_step(
+        self,
+        dataset_info: DatasetInfo,
+        init_weights: Callable[[list[nn.Module]], None],
+    ) -> "TwoTrackStep":
+        logging.info("Initializing two-track stepper from provided config")
+        corrector = self.corrector.get_corrector(dataset_info)
+        normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        return TwoTrackStep(
+            config=self,
+            dataset_info=dataset_info,
+            corrector=corrector,
+            normalizer=normalizer,
+            init_weights=init_weights,
+        )
+
+    def load(self):
+        self.normalization.load()
+
+
+class TwoTrackStep(StepABC):
+    """Step for the two-track (global / local latent) SFNO network."""
+
+    CHANNEL_DIM = -3
+
+    def __init__(
+        self,
+        config: TwoTrackStepConfig,
+        dataset_info: DatasetInfo,
+        corrector: CorrectorABC,
+        normalizer: StandardNormalizer,
+        init_weights: Callable[[list[nn.Module]], None],
+    ):
+        super().__init__()
+        # Packing order matches the network's split: global inputs first, then
+        # local. The network splits the input tensor at len(global_in_names)
+        # and returns [global_out | local_out].
+        self.in_packer = Packer(config.global_in_names + config.local_in_names)
+        self.out_packer = Packer(config.global_out_names + config.local_out_names)
+        self._normalizer = normalizer
+        if config.ocean is not None:
+            self.ocean: Ocean | None = config.ocean.build(
+                config.in_names, config.out_names, dataset_info.timestep
+            )
+        else:
+            self.ocean = None
+
+        net = config.builder.build_two_track(
+            global_in_channels=len(config.global_in_names),
+            local_in_channels=len(config.local_in_names),
+            global_out_channels=len(config.global_out_names),
+            local_out_channels=len(config.local_out_names),
+            dataset_info=dataset_info,
+        )
+        # Wrap in Module so the tensor boundary stays single-tensor in / single
+        # tensor out with optional label conditioning, as for SingleModuleStep.
+        if len(dataset_info.all_labels) > 0:
+            label_encoding: LabelEncoding | None = LabelEncoding(
+                sorted(dataset_info.all_labels)
+            )
+        else:
+            label_encoding = None
+        self.module = Module(net, label_encoding).to(get_device())
+
+        init_weights(self.modules)
+        self._img_shape = dataset_info.img_shape
+        self._config = config
+        self._no_optimization = NullOptimization()
+
+        dist = Distributed.get_instance()
+        self.module = self.module.wrap_module(dist.wrap_module)
+        self._timestep = dataset_info.timestep
+        self._corrector = corrector
+        self.in_names = config.in_names
+        self.out_names = config.out_names
+
+    @property
+    def config(self) -> TwoTrackStepConfig:
+        return self._config
+
+    @property
+    def normalizer(self) -> StandardNormalizer:
+        return self._normalizer
+
+    @property
+    def surface_temperature_name(self) -> str | None:
+        if self._config.ocean is not None:
+            return self._config.ocean.surface_temperature_name
+        return None
+
+    @property
+    def ocean_fraction_name(self) -> str | None:
+        if self._config.ocean is not None:
+            return self._config.ocean.ocean_fraction_name
+        return None
+
+    def prescribe_sst(
+        self,
+        mask_data: TensorMapping,
+        gen_data: TensorMapping,
+        target_data: TensorMapping,
+    ) -> TensorDict:
+        if self.ocean is None:
+            raise RuntimeError(
+                "The Ocean interface is missing but required to prescribe "
+                "sea surface temperature."
+            )
+        return self.ocean.prescriber(mask_data, gen_data, target_data)
+
+    @property
+    def modules(self) -> nn.ModuleList:
+        return nn.ModuleList([self.module.torch_module])
+
+    def step(
+        self,
+        args: StepArgs,
+        wrapper: Callable[[nn.Module], nn.Module] = lambda x: x,
+    ) -> StepOutput:
+        def network_call(input_norm: TensorDict) -> TensorDict:
+            input_tensor = self.in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
+            output_tensor = self.module.wrap_module(wrapper)(
+                input_tensor,
+                labels=args.labels,
+            )
+            return self.out_packer.unpack(output_tensor, axis=self.CHANNEL_DIM)
+
+        return step_with_adjustments(
+            input=args.input,
+            next_step_input_data=args.next_step_input_data,
+            network_calls=network_call,
+            normalizer=self.normalizer,
+            corrector=self._corrector,
+            ocean=self.ocean,
+            residual_prediction=self._config.residual_prediction,
+            prognostic_names=self.prognostic_names,
+            prescribed_prognostic_names=self._config.prescribed_prognostic_names,
+            stepper_state=args.stepper_state,
+        )
+
+    def get_regularizer_loss(self):
+        return torch.tensor(0.0)
+
+    def train(self, mode: bool = True) -> StepABC:
+        super().train(mode)
+        self._corrector.train(mode)
+        return self
+
+    def set_epoch(self, epoch: int) -> None:
+        self._corrector.set_epoch(epoch)
+
+    def get_state(self):
+        state: dict[str, Any] = {"module": self.module.get_state()}
+        corrector_state = self._corrector.get_state()
+        if len(corrector_state) > 0:
+            state["corrector"] = corrector_state
+        return state
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self.module.load_state(state["module"])
+        self._corrector.load_state(state.get("corrector", {}))

--- a/fme/core/models/conditional_sfno/latents.py
+++ b/fme/core/models/conditional_sfno/latents.py
@@ -1,0 +1,82 @@
+"""A small wrapper over a two-track ``[global | local]`` latent tensor.
+
+The two-track SFNO carries a single concatenated latent whose leading
+``global`` channels participate in the spherical (spectral) operator and
+whose trailing ``local`` channels only ever see pointwise operations. Most
+sublayers (norms, MLP, skip connections) act on the full concatenation and
+keep taking a plain ``Tensor``; ``Latents`` exists so the two places that do
+care about the split -- the spectral filter call site and the parallel
+``conv1x1`` -- can address the global and local parts without threading a raw
+channel-count integer through the block. The split index is a construction
+detail supplied to the constructors; it is never exposed on the accessor
+surface, which returns plain tensors.
+"""
+
+import torch
+
+
+class Latents:
+    """A ``[global | local]`` latent, hiding the concat and channel counts."""
+
+    def __init__(self, global_channels: torch.Tensor, local_channels: torch.Tensor):
+        if global_channels.shape[:-3] != local_channels.shape[:-3]:
+            raise ValueError(
+                "global and local tracks must share leading (batch) dimensions, "
+                f"got {tuple(global_channels.shape)} and {tuple(local_channels.shape)}"
+            )
+        if global_channels.shape[-2:] != local_channels.shape[-2:]:
+            raise ValueError(
+                "global and local tracks must share spatial dimensions, "
+                f"got {tuple(global_channels.shape)} and {tuple(local_channels.shape)}"
+            )
+        self._global = global_channels
+        self._local = local_channels
+
+    @classmethod
+    def new_from_all(cls, tensor: torch.Tensor, global_channels: int) -> "Latents":
+        """Build from a full ``[global | local]`` tensor split at ``global_channels``.
+
+        Args:
+            tensor: concatenated latent of shape ``(..., global + local, H, W)``.
+            global_channels: number of leading channels in the global track.
+        """
+        return cls(
+            tensor[..., :global_channels, :, :],
+            tensor[..., global_channels:, :, :],
+        )
+
+    @classmethod
+    def new_from_global(
+        cls, global_tensor: torch.Tensor, local_channels: int
+    ) -> "Latents":
+        """Build from a global-only tensor, padding the local track with zeros.
+
+        Args:
+            global_tensor: the global track, shape ``(..., global, H, W)``.
+            local_channels: width of the (zero) local track to attach.
+        """
+        local_shape = (
+            *global_tensor.shape[:-3],
+            local_channels,
+            *global_tensor.shape[-2:],
+        )
+        local = global_tensor.new_zeros(local_shape)
+        return cls(global_tensor, local)
+
+    @property
+    def global_channels(self) -> torch.Tensor:
+        return self._global
+
+    @property
+    def local_channels(self) -> torch.Tensor:
+        return self._local
+
+    @property
+    def all(self) -> torch.Tensor:
+        return torch.cat([self._global, self._local], dim=-3)
+
+    def __add__(self, other: "Latents") -> "Latents":
+        return Latents(
+            self._global + other._global,
+            self._local + other._local,
+        )

--- a/fme/core/models/conditional_sfno/test_two_track_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_two_track_sfnonet.py
@@ -1,0 +1,267 @@
+import pytest
+import torch
+
+from fme.core.device import get_device
+
+from .latents import Latents
+from .layers import Context, ContextConfig
+from .sfnonet import SFNONetConfig, get_lat_lon_sfnonet
+from .two_track_sfnonet import TwoTrackSFNONetConfig, get_lat_lon_two_track_sfnonet
+
+IMG_SHAPE = (9, 18)
+NOISE_DIM = 8
+
+
+def _noise_context(n_samples: int, img_shape=IMG_SHAPE) -> Context:
+    device = get_device()
+    return Context(
+        embedding_scalar=None,
+        labels=None,
+        noise=torch.randn(n_samples, NOISE_DIM, *img_shape, device=device),
+        embedding_pos=None,
+    )
+
+
+def _context_config() -> ContextConfig:
+    return ContextConfig(
+        embed_dim_scalar=0,
+        embed_dim_labels=0,
+        embed_dim_noise=NOISE_DIM,
+        embed_dim_pos=0,
+    )
+
+
+def _build_two_track(
+    embed_dim=16,
+    local_embed_dim=6,
+    global_in=2,
+    local_in=3,
+    global_out=3,
+    local_out=1,
+    **kwargs,
+):
+    config = TwoTrackSFNONetConfig(
+        embed_dim=embed_dim,
+        local_embed_dim=local_embed_dim,
+        num_layers=2,
+        filter_type="linear",
+        **kwargs,
+    )
+    return get_lat_lon_two_track_sfnonet(
+        params=config,
+        global_in_channels=global_in,
+        local_in_channels=local_in,
+        global_out_channels=global_out,
+        local_out_channels=local_out,
+        img_shape=IMG_SHAPE,
+        data_grid="legendre-gauss",
+        context_config=_context_config(),
+    ).to(get_device())
+
+
+# ---------------------------------------------------------------------------
+# Latents
+# ---------------------------------------------------------------------------
+def test_latents_new_from_all_splits_at_global_channels():
+    t = torch.randn(2, 7, 4, 5)
+    latents = Latents.new_from_all(t, global_channels=3)
+    assert latents.global_channels.shape[-3] == 3
+    assert latents.local_channels.shape[-3] == 4
+    torch.testing.assert_close(latents.global_channels, t[:, :3])
+    torch.testing.assert_close(latents.local_channels, t[:, 3:])
+    torch.testing.assert_close(latents.all, t)
+
+
+def test_latents_new_from_global_pads_local_with_zeros():
+    g = torch.randn(2, 3, 4, 5)
+    latents = Latents.new_from_global(g, local_channels=4)
+    assert latents.local_channels.shape[-3] == 4
+    assert torch.count_nonzero(latents.local_channels) == 0
+    torch.testing.assert_close(latents.global_channels, g)
+
+
+def test_latents_new_from_global_zero_local_is_global_only():
+    g = torch.randn(2, 3, 4, 5)
+    latents = Latents.new_from_global(g, local_channels=0)
+    assert latents.local_channels.shape[-3] == 0
+    torch.testing.assert_close(latents.all, g)
+
+
+def test_latents_addition_is_per_track():
+    a = Latents.new_from_all(torch.randn(2, 5, 4, 4), global_channels=3)
+    b = Latents.new_from_all(torch.randn(2, 5, 4, 4), global_channels=3)
+    summed = a + b
+    torch.testing.assert_close(
+        summed.global_channels, a.global_channels + b.global_channels
+    )
+    torch.testing.assert_close(
+        summed.local_channels, a.local_channels + b.local_channels
+    )
+
+
+def test_latents_option2_wiring():
+    # Option 2 sums a global-only spectral output with a dense conv1x1 all->all
+    # map: global = spectral + conv1x1[global], local = conv1x1[local].
+    spectral = torch.randn(2, 3, 4, 4)
+    dense = torch.randn(2, 5, 4, 4)
+    out = Latents.new_from_global(spectral, local_channels=2) + Latents.new_from_all(
+        dense, global_channels=3
+    )
+    torch.testing.assert_close(out.global_channels, spectral + dense[:, :3])
+    torch.testing.assert_close(out.local_channels, dense[:, 3:])
+
+
+# ---------------------------------------------------------------------------
+# L=0 equivalence (regression): the two-track net with zero local channels and
+# all options off is byte-for-byte the single-track conditional SFNO.
+# ---------------------------------------------------------------------------
+def test_two_track_zero_local_matches_single_track():
+    torch.manual_seed(0)
+    in_chans, out_chans, n = 2, 3, 4
+    context_config = _context_config()
+    single = get_lat_lon_sfnonet(
+        params=SFNONetConfig(embed_dim=16, num_layers=2, filter_type="linear"),
+        in_chans=in_chans,
+        out_chans=out_chans,
+        img_shape=IMG_SHAPE,
+        data_grid="legendre-gauss",
+        context_config=context_config,
+    ).to(get_device())
+    two_track = get_lat_lon_two_track_sfnonet(
+        params=TwoTrackSFNONetConfig(
+            embed_dim=16, local_embed_dim=0, num_layers=2, filter_type="linear"
+        ),
+        global_in_channels=in_chans,
+        local_in_channels=0,
+        global_out_channels=out_chans,
+        local_out_channels=0,
+        img_shape=IMG_SHAPE,
+        data_grid="legendre-gauss",
+        context_config=context_config,
+    ).to(get_device())
+
+    # Parameter names match exactly: the old checkpoint loads with no remap.
+    missing, unexpected = two_track.load_state_dict(single.state_dict(), strict=True)
+    assert missing == []
+    assert unexpected == []
+
+    x = torch.randn(n, in_chans, *IMG_SHAPE, device=get_device())
+    context = _noise_context(n)
+    single.eval()
+    two_track.eval()
+    with torch.no_grad():
+        expected = single(x, context)
+        actual = two_track(x, context)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# L>0 network behavior and option wiring
+# ---------------------------------------------------------------------------
+def test_two_track_forward_shape_and_grad():
+    torch.manual_seed(0)
+    net = _build_two_track()
+    n = 2
+    x = torch.randn(n, 5, *IMG_SHAPE, device=get_device())  # 2 global + 3 local
+    out = net(x, _noise_context(n))
+    assert out.shape == (n, 4, *IMG_SHAPE)  # 3 global out + 1 local out
+    out.sum().backward()
+    assert net.encoder[0].weight.grad is not None
+    assert net.local_encoder[0].weight.grad is not None
+
+
+def _local_encoder_output_changes_with_global_input(net) -> bool:
+    """Whether perturbing a global input changes the local encoder's output.
+
+    Captures the local-encoder output via a forward hook so we probe exactly
+    the graph edge option 1 adds, isolated from the downstream pointwise
+    global<->local mixing that happens in every block regardless.
+    """
+    net.eval()
+    captured = []
+    handle = net.local_encoder.register_forward_hook(
+        lambda _m, _in, out: captured.append(out.detach().clone())
+    )
+    n = 2
+    x = torch.randn(n, 5, *IMG_SHAPE, device=get_device())
+    x2 = x.clone()
+    x2[:, 0] += 5.0  # perturb a global input channel
+    context = _noise_context(n)
+    with torch.no_grad():
+        net(x, context)
+        net(x2, context)
+    handle.remove()
+    return not torch.allclose(captured[0], captured[1])
+
+
+def test_option1_feeds_global_into_local_encoder():
+    net_off = _build_two_track(feed_global_to_local=False)
+    net_on = _build_two_track(feed_global_to_local=True)
+    # local encoder input width = local_in (off) vs local_in + global_in (on)
+    assert net_off.local_encoder[0].in_channels == 3
+    assert net_on.local_encoder[0].in_channels == 5
+
+
+def test_option1_off_local_encoder_ignores_global_input():
+    torch.manual_seed(0)
+    assert not _local_encoder_output_changes_with_global_input(
+        _build_two_track(feed_global_to_local=False)
+    )
+
+
+def test_option1_on_local_encoder_reads_global_input():
+    torch.manual_seed(0)
+    assert _local_encoder_output_changes_with_global_input(
+        _build_two_track(feed_global_to_local=True)
+    )
+
+
+def test_option2_off_local_filter_stage_output_is_zero():
+    torch.manual_seed(0)
+    net = _build_two_track(parallel_conv1x1=False)
+    block = net.blocks[0]
+    assert block.conv1x1 is None
+    n = 2
+    x_norm = torch.randn(n, net.embed_dim, *IMG_SHAPE, device=get_device())
+    latents = Latents.new_from_all(x_norm, block.global_channels)
+    spectral_global, _ = block.filter(latents.global_channels)
+    filter_out = Latents.new_from_global(spectral_global, block.local_channels)
+    assert torch.count_nonzero(filter_out.local_channels) == 0
+
+
+def test_option2_on_adds_dense_conv1x1():
+    net = _build_two_track(parallel_conv1x1=True)
+    block = net.blocks[0]
+    assert isinstance(block.conv1x1, torch.nn.Conv2d)
+    assert block.conv1x1.in_channels == net.embed_dim
+    assert block.conv1x1.out_channels == net.embed_dim
+
+
+def test_option3_off_uses_joint_layer_norm():
+    net = _build_two_track(per_track_layer_norm=False)
+    block = net.blocks[0]
+    assert block.norm0 is not None
+    assert block.norm0_global is None and block.norm0_local is None
+    # joint norm covers the full concatenation
+    assert block.norm0.n_channels == net.embed_dim
+
+
+def test_option3_on_uses_per_track_layer_norm():
+    net = _build_two_track(per_track_layer_norm=True)
+    block = net.blocks[0]
+    assert block.norm0 is None
+    assert block.norm0_global is not None and block.norm0_local is not None
+    assert block.norm0_global.n_channels == net.global_embed_dim
+    assert block.norm0_local.n_channels == net.local_embed_dim
+
+
+def test_config_rejects_local_wider_than_embed_dim():
+    with pytest.raises(ValueError, match="local_embed_dim must be < embed_dim"):
+        TwoTrackSFNONetConfig(embed_dim=8, local_embed_dim=8)
+
+
+def test_config_rejects_non_linear_filter():
+    with pytest.raises(NotImplementedError, match="filter_type='linear'"):
+        TwoTrackSFNONetConfig(
+            embed_dim=8, local_embed_dim=2, filter_type="makani-linear"
+        )

--- a/fme/core/models/conditional_sfno/test_two_track_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_two_track_sfnonet.py
@@ -116,6 +116,13 @@ def test_latents_option2_wiring():
 # all options off is byte-for-byte the single-track conditional SFNO.
 # ---------------------------------------------------------------------------
 def test_two_track_zero_local_matches_single_track():
+    # data_grid="legendre-gauss" makes all four transforms share a grid, so the
+    # spectral filter never round-trips its residual and the two-track block's
+    # (full-normed-input) skip equals the single-track block's (filter-residual)
+    # skip. Byte-for-byte output equivalence holds ONLY in this regime; with
+    # data_grid="equiangular" the first/last blocks round-trip and the outputs
+    # diverge (the checkpoint still loads -- module tree and names are identical
+    # -- it just does not reproduce the output). See the module docstring.
     torch.manual_seed(0)
     in_chans, out_chans, n = 2, 3, 4
     context_config = _context_config()

--- a/fme/core/models/conditional_sfno/test_two_track_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_two_track_sfnonet.py
@@ -272,3 +272,24 @@ def test_config_rejects_non_linear_filter():
         TwoTrackSFNONetConfig(
             embed_dim=8, local_embed_dim=2, filter_type="makani-linear"
         )
+
+
+# ---------------------------------------------------------------------------
+# spectral_ratio: sized against the global width (not embed_dim)
+# ---------------------------------------------------------------------------
+def test_spectral_ratio_below_one_builds_and_runs():
+    # global width = embed_dim - local_embed_dim = 16 - 6 = 10; ratio 0.5 gives a
+    # 5-channel spectral bottleneck. The net still produces the full output.
+    torch.manual_seed(0)
+    net = _build_two_track(spectral_ratio=0.5)
+    n = 2
+    x = torch.randn(n, 5, *IMG_SHAPE, device=get_device())  # 2 global + 3 local
+    out = net(x, _noise_context(n))
+    assert out.shape == (n, 4, *IMG_SHAPE)  # 3 global out + 1 local out
+
+
+def test_spectral_ratio_validated_against_global_width():
+    # spectral_ratio is checked against the global latent width, so a message
+    # naming that width (not embed_dim) is raised for an out-of-range value.
+    with pytest.raises(ValueError, match="spectral_ratio must be in"):
+        TwoTrackSFNONetConfig(embed_dim=16, local_embed_dim=6, spectral_ratio=1.5)

--- a/fme/core/models/conditional_sfno/two_track_sfnonet.py
+++ b/fme/core/models/conditional_sfno/two_track_sfnonet.py
@@ -17,10 +17,21 @@ variable-to-track assignment and the packing/unpacking.
 
 Design invariant (pins the regression test): when the local track has zero
 width and all three options are off, the module tree and every parameter name
-are identical to the single-track ``SphericalFourierNeuralOperatorNet``, and
-the forward computation reduces to it byte-for-byte (for the linear filter
-without a round-trip residual). An old single-track checkpoint therefore loads
-directly, with no remap.
+are identical to the single-track ``SphericalFourierNeuralOperatorNet``, so an
+old single-track checkpoint loads directly with no remap.
+
+The *forward output* additionally reduces to the single-track net byte-for-byte
+only when the spectral filter uses no round-trip residual. ``filter_residual``
+is one way to turn that residual on; the other is ``data_grid='equiangular'``,
+which gives the first and last blocks a forward/inverse transform on different
+grids and so forces ``SpectralConvS2._round_trip_residual`` true for those
+blocks. The single-track block then feeds its skip from the round-tripped
+residual, whereas this two-track block always takes the skip from the full
+normed input (see ``TwoTrackFourierNeuralOperatorBlock.forward``). Output
+equivalence therefore holds for the default ``data_grid='legendre-gauss'`` (all
+transforms share a grid, no round trip) but NOT for ``'equiangular'``. The
+regression test exercises the legendre-gauss case; a checkpoint trained with
+``'equiangular'`` loads without error but does not reproduce its output.
 """
 
 import dataclasses
@@ -152,10 +163,15 @@ class TwoTrackFourierNeuralOperatorBlock(nn.Module):
     output is zero (or, with option 2, the conv1x1 local map) and is carried
     forward by the inner-skip residual over the full width.
 
-    When ``local_channels == 0`` and both options are off, the submodule tree,
-    parameter names and forward computation are identical to
-    ``sfnonet.FourierNeuralOperatorBlock`` with ``inner_skip="linear"`` and
-    ``outer_skip="identity"``.
+    When ``local_channels == 0`` and both options are off, the submodule tree
+    and parameter names are identical to ``sfnonet.FourierNeuralOperatorBlock``
+    with ``inner_skip="linear"`` and ``outer_skip="identity"``. The forward
+    computation matches it too *only when the filter returns no round-trip
+    residual*: the skips here are always taken from the full normed input
+    ``x_norm``, while the single-track block takes them from the filter's
+    returned residual, which equals ``x_norm`` only when the filter does not
+    round-trip (see the module docstring for when it does -- ``filter_residual``
+    or ``data_grid='equiangular'``).
     """
 
     def __init__(

--- a/fme/core/models/conditional_sfno/two_track_sfnonet.py
+++ b/fme/core/models/conditional_sfno/two_track_sfnonet.py
@@ -1,0 +1,633 @@
+"""A two-track (global / local latent) spherical Fourier neural operator.
+
+This extends the conditional SFNO (see ``sfnonet.py``) so that only a subset
+of the latent channels -- the *global* track -- passes through the spherical
+harmonic transform and the per-mode spectral weight. The remaining *local*
+track sees only pointwise operations (conditional norm, activation, MLP, skip
+connections and, optionally, a dense ``conv1x1``), so its horizontal gradients
+are never distorted by the spatial mixing. The motivation is a more physical
+prior for out-of-sample climates and support for column-local
+variable-transformation bases (see the sibling investigation).
+
+The network is deliberately semantics-agnostic: it takes a single input tensor
+whose leading ``global_in_channels`` channels are the global-track inputs and
+whose trailing channels are the local-track inputs, and returns a single
+output tensor ordered ``[global_out | local_out]``. The step owns the
+variable-to-track assignment and the packing/unpacking.
+
+Design invariant (pins the regression test): when the local track has zero
+width and all three options are off, the module tree and every parameter name
+are identical to the single-track ``SphericalFourierNeuralOperatorNet``, and
+the forward computation reduces to it byte-for-byte (for the linear filter
+without a round-trip residual). An old single-track checkpoint therefore loads
+directly, with no remap.
+"""
+
+import dataclasses
+from collections.abc import Callable
+
+import torch
+import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
+
+from fme.core.benchmark.timer import NullTimer, Timer
+from fme.core.distributed import Distributed
+
+from .initialization import trunc_normal_
+from .latents import Latents
+from .layers import MLP, ConditionalLayerNorm, Context, ContextConfig, DropPath
+from .lora import LoRAConv2d
+from .sfnonet import NoLayerNorm, SpectralFilterLayer
+
+ACTIVATION_FUNCTIONS = {"relu": nn.ReLU, "gelu": nn.GELU, "silu": nn.SiLU}
+
+
+@dataclasses.dataclass
+class TwoTrackSFNONetConfig:
+    """Configuration for ``TwoTrackSphericalFourierNeuralOperatorNet``.
+
+    Attributes:
+        embed_dim: Total latent width, i.e. global + local. The spectral filter
+            is sized to the global width ``embed_dim - local_embed_dim``.
+        local_embed_dim: Width of the local (pointwise-only) latent track. 0
+            (default) recovers the single-track network.
+        filter_type: Spectral filter type. Only "linear" is supported.
+        scale_factor: Must be 1 (matches the single-track network).
+        global_layer_norm: Whether the conditional norm reduces over the whole
+            spatial domain rather than per-pixel over channels.
+        num_layers: Number of Fourier neural operator blocks.
+        use_mlp: Whether each block uses an MLP.
+        mlp_ratio: MLP hidden-dim ratio.
+        activation_function: One of "relu", "gelu", "silu".
+        encoder_layers: Number of encoder/decoder hidden conv layers.
+        pos_embed: Whether to add a learned positional embedding to the latent.
+        drop_rate: Dropout rate.
+        drop_path_rate: Stochastic-depth rate.
+        hard_thresholding_fraction: Fraction of spectral modes retained.
+        big_skip: Whether to use an input->decoder skip connection.
+        checkpointing: Gradient-checkpointing level (0=none, 1=encoder/decoder,
+            3=all blocks).
+        filter_num_groups: Number of groups in the grouped spectral conv.
+        filter_residual: Whether the spectral filter round-trips its residual
+            through the SHT. Off in the baseline; when on, L=0 equivalence with
+            the single-track net no longer holds byte-for-byte (the block's
+            skip residual is taken from the full normed input, not the filter's
+            round-tripped global residual).
+        filter_output: Whether to filter the global decoder output through an
+            SHT round-trip.
+        normalize_big_skip: Whether to normalize the big-skip connection.
+        affine_norms: Whether the norm layers use element-wise affine params.
+        feed_global_to_local: OPTION 1. Also feed the global inputs to the
+            local encoder. Default off.
+        parallel_conv1x1: OPTION 2. Add a dense pointwise all->all map whose
+            output is summed onto the (global-only) spectral output via Latents
+            addition, so ``global = spectral + conv1x1[global]`` and
+            ``local = conv1x1[local]``. Default off; when off the local
+            filter-stage output is zero, carried by the inner skip.
+        per_track_layer_norm: OPTION 3. Compute each conditional layer norm
+            separately per track rather than jointly over the concatenation.
+            Default off.
+    """
+
+    embed_dim: int = 256
+    local_embed_dim: int = 0
+    filter_type: str = "linear"
+    scale_factor: int = 1
+    global_layer_norm: bool = False
+    num_layers: int = 12
+    use_mlp: bool = True
+    mlp_ratio: float = 2.0
+    activation_function: str = "gelu"
+    encoder_layers: int = 1
+    pos_embed: bool = True
+    drop_rate: float = 0.0
+    drop_path_rate: float = 0.0
+    hard_thresholding_fraction: float = 1.0
+    big_skip: bool = True
+    checkpointing: int = 0
+    filter_num_groups: int = 1
+    filter_residual: bool = False
+    filter_output: bool = False
+    normalize_big_skip: bool = False
+    affine_norms: bool = False
+    feed_global_to_local: bool = False
+    parallel_conv1x1: bool = False
+    per_track_layer_norm: bool = False
+
+    def __post_init__(self):
+        if self.filter_type != "linear":
+            raise NotImplementedError(
+                "TwoTrackSFNONet only supports filter_type='linear', got "
+                f"'{self.filter_type}'."
+            )
+        if self.scale_factor != 1:
+            raise NotImplementedError("scale_factor must be 1.")
+        if self.local_embed_dim < 0:
+            raise ValueError("local_embed_dim must be >= 0.")
+        if self.local_embed_dim >= self.embed_dim:
+            raise ValueError(
+                "local_embed_dim must be < embed_dim so the global track has at "
+                f"least one channel; got local_embed_dim={self.local_embed_dim}, "
+                f"embed_dim={self.embed_dim}."
+            )
+        global_channels = self.embed_dim - self.local_embed_dim
+        if global_channels % self.filter_num_groups != 0:
+            raise ValueError(
+                f"global latent width {global_channels} (embed_dim - "
+                f"local_embed_dim) must be divisible by filter_num_groups="
+                f"{self.filter_num_groups}."
+            )
+
+    @property
+    def global_embed_dim(self) -> int:
+        return self.embed_dim - self.local_embed_dim
+
+
+class TwoTrackFourierNeuralOperatorBlock(nn.Module):
+    """A FNO block whose spectral filter acts on only the global slice.
+
+    The pointwise parts (conditional norm, activation, MLP, inner/outer skips)
+    act on the full ``[global | local]`` concatenation. The spectral filter
+    reads and writes only the global slice; the local slice's filter-stage
+    output is zero (or, with option 2, the conv1x1 local map) and is carried
+    forward by the inner-skip residual over the full width.
+
+    When ``local_channels == 0`` and both options are off, the submodule tree,
+    parameter names and forward computation are identical to
+    ``sfnonet.FourierNeuralOperatorBlock`` with ``inner_skip="linear"`` and
+    ``outer_skip="identity"``.
+    """
+
+    def __init__(
+        self,
+        forward_transform,
+        inverse_transform,
+        embed_dim: int,
+        global_channels: int,
+        img_shape: tuple[int, int],
+        context_config: ContextConfig,
+        global_layer_norm: bool = False,
+        mlp_ratio: float = 2.0,
+        drop_rate: float = 0.0,
+        drop_path: float = 0.0,
+        act_layer=nn.GELU,
+        use_mlp: bool = False,
+        checkpointing: int = 0,
+        filter_residual: bool = False,
+        affine_norms: bool = False,
+        filter_num_groups: int = 1,
+        parallel_conv1x1: bool = False,
+        per_track_layer_norm: bool = False,
+    ):
+        super().__init__()
+        self.input_shape_loc = img_shape
+        self.output_shape_loc = img_shape
+        self.global_channels = global_channels
+        self.local_channels = embed_dim - global_channels
+        self._per_track_layer_norm = per_track_layer_norm
+
+        def make_norm(n_channels: int) -> ConditionalLayerNorm:
+            return ConditionalLayerNorm(
+                n_channels,
+                img_shape=img_shape,
+                global_layer_norm=global_layer_norm,
+                context_config=context_config,
+                elementwise_affine=affine_norms,
+            )
+
+        if per_track_layer_norm:
+            self.norm0_global: ConditionalLayerNorm | None = make_norm(global_channels)
+            self.norm0_local: ConditionalLayerNorm | None = make_norm(
+                self.local_channels
+            )
+            self.norm1_global: ConditionalLayerNorm | None = make_norm(global_channels)
+            self.norm1_local: ConditionalLayerNorm | None = make_norm(
+                self.local_channels
+            )
+            self.norm0: ConditionalLayerNorm | None = None
+            self.norm1: ConditionalLayerNorm | None = None
+        else:
+            self.norm0 = make_norm(embed_dim)
+            self.norm1 = make_norm(embed_dim)
+            self.norm0_global = None
+            self.norm0_local = None
+            self.norm1_global = None
+            self.norm1_local = None
+
+        # Spectral filter is sized to the global width only.
+        self.filter = SpectralFilterLayer(
+            forward_transform,
+            inverse_transform,
+            global_channels,
+            "linear",
+            filter_residual=filter_residual,
+            num_groups=filter_num_groups,
+        )
+
+        if parallel_conv1x1:
+            self.conv1x1: nn.Conv2d | None = nn.Conv2d(
+                embed_dim, embed_dim, kernel_size=1, bias=True
+            )
+        else:
+            self.conv1x1 = None
+
+        self.inner_skip = LoRAConv2d(embed_dim, embed_dim, 1, 1)
+        self.act_layer = act_layer()
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+        if use_mlp:
+            mlp_hidden_dim = int(embed_dim * mlp_ratio)
+            self.mlp = MLP(
+                in_features=embed_dim,
+                hidden_features=mlp_hidden_dim,
+                act_layer=act_layer,
+                drop_rate=drop_rate,
+                checkpointing=checkpointing,
+            )
+
+        self.outer_skip = nn.Identity()
+
+    def _norm(
+        self,
+        joint: ConditionalLayerNorm | None,
+        norm_global: ConditionalLayerNorm | None,
+        norm_local: ConditionalLayerNorm | None,
+        x: torch.Tensor,
+        context: Context,
+    ) -> torch.Tensor:
+        """Apply a conditional norm over the local spatial extent.
+
+        Mirrors the single-track block's zero-then-fill spatial slicing so that
+        padded regions (distributed spatial parallelism) stay zero. Applies a
+        single joint norm over the concatenation, or two per-track norms.
+        """
+        h, w = self.input_shape_loc
+        x_norm = torch.zeros_like(x)
+        active = x[..., :h, :w]
+        if self._per_track_layer_norm:
+            assert norm_global is not None and norm_local is not None
+            g = norm_global(active[..., : self.global_channels, :, :], context)
+            local_slice = active[..., self.global_channels :, :, :]
+            normed = torch.cat([g, norm_local(local_slice, context)], dim=-3)
+        else:
+            assert joint is not None
+            normed = joint(active, context)
+        x_norm[..., :h, :w] = normed
+        return x_norm
+
+    def forward(
+        self, x: torch.Tensor, context: Context, timer: Timer = NullTimer()
+    ) -> torch.Tensor:
+        x_norm = self._norm(self.norm0, self.norm0_global, self.norm0_local, x, context)
+
+        # Spectral filter on the global slice only; local filter-stage output
+        # is zero unless the parallel conv1x1 (option 2) supplies it.
+        latents_norm = Latents.new_from_all(x_norm, self.global_channels)
+        spectral_global, _ = self.filter(latents_norm.global_channels, timer=timer)
+        filter_out = Latents.new_from_global(spectral_global, self.local_channels)
+        if self.conv1x1 is not None:
+            filter_out = filter_out + Latents.new_from_all(
+                self.conv1x1(x_norm), self.global_channels
+            )
+        x = filter_out.all
+
+        # Inner-skip residual comes from the full normed input, not the
+        # filter's (global-only) returned residual.
+        x = x + self.inner_skip(x_norm)
+        x = self.act_layer(x)
+
+        x_norm1 = self._norm(
+            self.norm1, self.norm1_global, self.norm1_local, x, context
+        )
+        x = x_norm1
+        if hasattr(self, "mlp"):
+            x = self.mlp(x)
+        x = self.drop_path(x)
+        x = x + self.outer_skip(x_norm)
+        return x
+
+
+class TwoTrackSphericalFourierNeuralOperatorNet(nn.Module):
+    """Two-track SFNO. See module docstring for the design invariant."""
+
+    def __init__(
+        self,
+        params: TwoTrackSFNONetConfig,
+        img_shape: tuple[int, int],
+        get_pos_embed: Callable[[], nn.Parameter],
+        trans_down: nn.Module,
+        itrans_up: nn.Module,
+        trans: nn.Module,
+        itrans: nn.Module,
+        global_in_channels: int,
+        local_in_channels: int,
+        global_out_channels: int,
+        local_out_channels: int,
+        context_config: ContextConfig,
+    ):
+        super().__init__()
+        self._params = params
+        self.img_shape = img_shape
+        self.global_in_channels = global_in_channels
+        self.local_in_channels = local_in_channels
+        self.global_out_channels = global_out_channels
+        self.local_out_channels = local_out_channels
+        self.embed_dim = params.embed_dim
+        self.global_embed_dim = params.global_embed_dim
+        self.local_embed_dim = params.local_embed_dim
+        self.num_layers = params.num_layers
+        self.big_skip = params.big_skip
+        self.checkpointing = params.checkpointing
+        self._feed_global_to_local = params.feed_global_to_local
+        self._has_local = params.local_embed_dim > 0
+
+        self._spatial_h_slice, self._spatial_w_slice = (
+            Distributed.get_instance().get_local_slices(self.img_shape)
+        )
+
+        self.trans_down = trans_down
+        self.itrans_up = itrans_up
+        self.trans = trans
+        self.itrans = itrans
+
+        if params.filter_residual:
+            self.residual_filter_down: nn.Module = self.trans_down
+            self.residual_filter_up: nn.Module = self.itrans_up
+        else:
+            self.residual_filter_down = nn.Identity()
+            self.residual_filter_up = nn.Identity()
+
+        if params.filter_output:
+            self.filter_output_down: nn.Module = self.trans_down
+            self.filter_output_up: nn.Module = self.itrans_up
+        else:
+            self.filter_output_down = nn.Identity()
+            self.filter_output_up = nn.Identity()
+
+        if params.activation_function not in ACTIVATION_FUNCTIONS:
+            raise ValueError(
+                f"Unknown activation function {params.activation_function}"
+            )
+        act_layer = ACTIVATION_FUNCTIONS[params.activation_function]
+
+        # Global encoder keeps the single-track name ``encoder``.
+        self.encoder = _build_encoder(
+            in_channels=global_in_channels,
+            out_channels=self.global_embed_dim,
+            encoder_layers=params.encoder_layers,
+            act_layer=act_layer,
+        )
+        if self._has_local:
+            local_in = local_in_channels + (
+                global_in_channels if self._feed_global_to_local else 0
+            )
+            self.local_encoder: nn.Sequential | None = _build_encoder(
+                in_channels=local_in,
+                out_channels=self.local_embed_dim,
+                encoder_layers=params.encoder_layers,
+                act_layer=act_layer,
+            )
+        else:
+            self.local_encoder = None
+
+        self.pos_drop = (
+            nn.Dropout(p=params.drop_rate) if params.drop_rate > 0.0 else nn.Identity()
+        )
+        dpr = [
+            x.item() for x in torch.linspace(0, params.drop_path_rate, self.num_layers)
+        ]
+
+        self.blocks = nn.ModuleList([])
+        for i in range(self.num_layers):
+            first_layer = i == 0
+            last_layer = i == self.num_layers - 1
+            forward_transform = self.trans_down if first_layer else self.trans
+            inverse_transform = self.itrans_up if last_layer else self.itrans
+            self.blocks.append(
+                TwoTrackFourierNeuralOperatorBlock(
+                    forward_transform,
+                    inverse_transform,
+                    self.embed_dim,
+                    self.global_embed_dim,
+                    img_shape=self.img_shape,
+                    context_config=context_config,
+                    global_layer_norm=params.global_layer_norm,
+                    mlp_ratio=params.mlp_ratio,
+                    drop_rate=params.drop_rate,
+                    drop_path=dpr[i],
+                    act_layer=act_layer,
+                    use_mlp=params.use_mlp,
+                    checkpointing=params.checkpointing,
+                    filter_residual=params.filter_residual,
+                    affine_norms=params.affine_norms,
+                    filter_num_groups=params.filter_num_groups,
+                    parallel_conv1x1=params.parallel_conv1x1,
+                    per_track_layer_norm=params.per_track_layer_norm,
+                )
+            )
+
+        # Global decoder keeps the single-track name ``decoder``.
+        self.decoder = _build_decoder(
+            in_channels=self.global_embed_dim + params.big_skip * global_in_channels,
+            hidden_channels=self.global_embed_dim,
+            out_channels=global_out_channels,
+            encoder_layers=params.encoder_layers,
+            act_layer=act_layer,
+        )
+        if self._has_local:
+            self.local_decoder: nn.Sequential | None = _build_decoder(
+                in_channels=self.local_embed_dim + params.big_skip * local_in_channels,
+                hidden_channels=self.local_embed_dim,
+                out_channels=local_out_channels,
+                encoder_layers=params.encoder_layers,
+                act_layer=act_layer,
+            )
+        else:
+            self.local_decoder = None
+
+        if params.pos_embed:
+            self.pos_embed: nn.Parameter | None = get_pos_embed()
+        else:
+            self.pos_embed = None
+
+        if params.normalize_big_skip:
+            self.norm_big_skip: nn.Module = ConditionalLayerNorm(
+                global_in_channels,
+                img_shape=self.img_shape,
+                global_layer_norm=params.global_layer_norm,
+                context_config=context_config,
+                elementwise_affine=params.affine_norms,
+            )
+            if self._has_local:
+                self.local_norm_big_skip: nn.Module | None = ConditionalLayerNorm(
+                    local_in_channels,
+                    img_shape=self.img_shape,
+                    global_layer_norm=params.global_layer_norm,
+                    context_config=context_config,
+                    elementwise_affine=params.affine_norms,
+                )
+            else:
+                self.local_norm_big_skip = None
+        else:
+            self.norm_big_skip = NoLayerNorm()
+            self.local_norm_big_skip = NoLayerNorm() if self._has_local else None
+
+    @torch.jit.ignore
+    def no_weight_decay(self):  # pragma: no cover
+        return {"pos_embed"}
+
+    def _forward_features(self, x: torch.Tensor, context: Context) -> torch.Tensor:
+        for blk in self.blocks:
+            if self.checkpointing >= 3:
+                x = checkpoint(blk, x, context)
+            else:
+                x = blk(x, context)
+        return x
+
+    def forward(self, x: torch.Tensor, context: Context) -> torch.Tensor:
+        global_in = x[..., : self.global_in_channels, :, :]
+        local_in = x[..., self.global_in_channels :, :, :]
+
+        if self.big_skip:
+            global_residual = self.residual_filter_up(
+                self.residual_filter_down(global_in)
+            )
+            global_residual = self.norm_big_skip(global_residual, context=context)
+            if self._has_local:
+                assert self.local_norm_big_skip is not None
+                local_residual = self.local_norm_big_skip(local_in, context=context)
+
+        if self.checkpointing >= 1:
+            g = checkpoint(self.encoder, global_in)
+        else:
+            g = self.encoder(global_in)
+        if self._has_local:
+            assert self.local_encoder is not None
+            local_encoder_in = (
+                torch.cat([global_in, local_in], dim=-3)
+                if self._feed_global_to_local
+                else local_in
+            )
+            latent = torch.cat([g, self.local_encoder(local_encoder_in)], dim=-3)
+        else:
+            latent = g
+
+        if self.pos_embed is not None:
+            latent = (
+                latent
+                + self.pos_embed[..., self._spatial_h_slice, self._spatial_w_slice]
+            )
+        latent = self.pos_drop(latent)
+
+        latent = self._forward_features(latent, context)
+
+        global_latent = latent[..., : self.global_embed_dim, :, :]
+        local_latent = latent[..., self.global_embed_dim :, :, :]
+
+        if self.big_skip:
+            global_dec_in = torch.cat([global_latent, global_residual], dim=-3)
+        else:
+            global_dec_in = global_latent
+        if self.checkpointing >= 1:
+            global_out = checkpoint(self.decoder, global_dec_in)
+        else:
+            global_out = self.decoder(global_dec_in)
+        global_out = self.filter_output_up(self.filter_output_down(global_out))
+
+        if not self._has_local:
+            return global_out
+
+        assert self.local_decoder is not None
+        if self.big_skip:
+            local_dec_in = torch.cat([local_latent, local_residual], dim=-3)
+        else:
+            local_dec_in = local_latent
+        local_out = self.local_decoder(local_dec_in)
+        return torch.cat([global_out, local_out], dim=-3)
+
+
+def _build_encoder(
+    in_channels: int,
+    out_channels: int,
+    encoder_layers: int,
+    act_layer,
+) -> nn.Sequential:
+    hidden_dim = out_channels
+    current_dim = in_channels
+    modules: list[nn.Module] = []
+    for _ in range(encoder_layers):
+        modules.append(LoRAConv2d(current_dim, hidden_dim, 1, bias=True))
+        modules.append(act_layer())
+        current_dim = hidden_dim
+    modules.append(LoRAConv2d(current_dim, out_channels, 1, bias=False))
+    return nn.Sequential(*modules)
+
+
+def _build_decoder(
+    in_channels: int,
+    hidden_channels: int,
+    out_channels: int,
+    encoder_layers: int,
+    act_layer,
+) -> nn.Sequential:
+    current_dim = in_channels
+    modules: list[nn.Module] = []
+    for _ in range(encoder_layers):
+        modules.append(LoRAConv2d(current_dim, hidden_channels, 1, bias=True))
+        modules.append(act_layer())
+        current_dim = hidden_channels
+    modules.append(LoRAConv2d(current_dim, out_channels, 1, bias=False))
+    return nn.Sequential(*modules)
+
+
+def get_lat_lon_two_track_sfnonet(
+    params: TwoTrackSFNONetConfig,
+    global_in_channels: int,
+    local_in_channels: int,
+    global_out_channels: int,
+    local_out_channels: int,
+    img_shape: tuple[int, int],
+    data_grid: str = "equiangular",
+    context_config: ContextConfig = ContextConfig(
+        embed_dim_scalar=0,
+        embed_dim_noise=0,
+        embed_dim_labels=0,
+        embed_dim_pos=0,
+    ),
+) -> TwoTrackSphericalFourierNeuralOperatorNet:
+    h, w = img_shape
+    modes_lat = int(h * params.hard_thresholding_fraction)
+    modes_lon = int((w // 2 + 1) * params.hard_thresholding_fraction)
+
+    dist = Distributed.get_instance()
+    trans_down = dist.get_sht(
+        *img_shape, lmax=modes_lat, mmax=modes_lon, grid=data_grid
+    )
+    itrans_up = dist.get_isht(
+        *img_shape, lmax=modes_lat, mmax=modes_lon, grid=data_grid
+    )
+    trans = dist.get_sht(
+        *img_shape, lmax=modes_lat, mmax=modes_lon, grid="legendre-gauss"
+    )
+    itrans = dist.get_isht(h, w, lmax=modes_lat, mmax=modes_lon, grid="legendre-gauss")
+
+    def get_pos_embed() -> nn.Parameter:
+        pos_embed = nn.Parameter(torch.zeros(1, params.embed_dim, h, w))
+        pos_embed.is_shared_mp = ["matmul"]  # type: ignore[attr-defined]
+        trunc_normal_(pos_embed, std=0.02)
+        return pos_embed
+
+    return TwoTrackSphericalFourierNeuralOperatorNet(
+        params,
+        img_shape=img_shape,
+        get_pos_embed=get_pos_embed,
+        trans_down=trans_down,
+        itrans_up=itrans_up,
+        trans=trans,
+        itrans=itrans,
+        global_in_channels=global_in_channels,
+        local_in_channels=local_in_channels,
+        global_out_channels=global_out_channels,
+        local_out_channels=local_out_channels,
+        context_config=context_config,
+    )

--- a/fme/core/models/conditional_sfno/two_track_sfnonet.py
+++ b/fme/core/models/conditional_sfno/two_track_sfnonet.py
@@ -48,6 +48,7 @@ from .initialization import trunc_normal_
 from .latents import Latents
 from .layers import MLP, ConditionalLayerNorm, Context, ContextConfig, DropPath
 from .lora import LoRAConv2d
+from .s2convolutions import validate_spectral_ratio
 from .sfnonet import NoLayerNorm, SpectralFilterLayer
 
 ACTIVATION_FUNCTIONS = {"relu": nn.ReLU, "gelu": nn.GELU, "silu": nn.SiLU}
@@ -117,6 +118,7 @@ class TwoTrackSFNONetConfig:
     big_skip: bool = True
     checkpointing: int = 0
     filter_num_groups: int = 1
+    spectral_ratio: float = 1.0
     filter_residual: bool = False
     filter_output: bool = False
     normalize_big_skip: bool = False
@@ -148,6 +150,18 @@ class TwoTrackSFNONetConfig:
                 f"local_embed_dim) must be divisible by filter_num_groups="
                 f"{self.filter_num_groups}."
             )
+        # The spectral filter is sized to the global width, so spectral_ratio is
+        # validated against global_channels (not embed_dim). To keep the actual
+        # filter (channels-per-group x num-groups) fixed when the global track is
+        # narrowed relative to a single-track baseline, scale spectral_ratio up
+        # by the same factor the global width was scaled down.
+        validate_spectral_ratio(
+            self.spectral_ratio,
+            global_channels,
+            self.filter_num_groups,
+            channels_name="global latent width (embed_dim - local_embed_dim)",
+            filter_type=self.filter_type,
+        )
 
     @property
     def global_embed_dim(self) -> int:
@@ -192,6 +206,7 @@ class TwoTrackFourierNeuralOperatorBlock(nn.Module):
         filter_residual: bool = False,
         affine_norms: bool = False,
         filter_num_groups: int = 1,
+        spectral_ratio: float = 1.0,
         parallel_conv1x1: bool = False,
         per_track_layer_norm: bool = False,
     ):
@@ -238,6 +253,7 @@ class TwoTrackFourierNeuralOperatorBlock(nn.Module):
             "linear",
             filter_residual=filter_residual,
             num_groups=filter_num_groups,
+            spectral_ratio=spectral_ratio,
         )
 
         if parallel_conv1x1:
@@ -437,6 +453,7 @@ class TwoTrackSphericalFourierNeuralOperatorNet(nn.Module):
                     filter_residual=params.filter_residual,
                     affine_norms=params.affine_norms,
                     filter_num_groups=params.filter_num_groups,
+                    spectral_ratio=params.spectral_ratio,
                     parallel_conv1x1=params.parallel_conv1x1,
                     per_track_layer_norm=params.per_track_layer_norm,
                 )


### PR DESCRIPTION
Adds a two-track (global / local latent) SFNO as a new step type. The
spherical harmonic (spectral) operator acts on only a *global* subset of the
latent channels; the remaining *local* channels see only pointwise operations,
so their horizontal gradients are never distorted by the network's spatial
mixing. This is intended as a more physical prior for out-of-sample climates
and lets column-local variable-transformation bases (e.g. RH-like or
convective-basis inputs) participate without the SHT distorting between-column
differences.

The global track reuses the single-track conditional SFNO's encoder, decoder,
and per-block submodule names and widths, so with zero local channels and all
options off the module tree and parameter names are byte-for-byte identical to
`SphericalFourierNeuralOperatorNet` — an existing single-track checkpoint loads
into the two-track network with no remap.

Changes:
- `fme.core.models.conditional_sfno.latents.Latents`: wraps a concatenated
  `[global | local]` latent, exposing `.global_channels` / `.local_channels` /
  `.all` tensors and per-track `__add__`, hiding the split index from callers.
- `fme.core.models.conditional_sfno.two_track_sfnonet`: `TwoTrackSFNONetConfig`,
  `TwoTrackFourierNeuralOperatorBlock`, and
  `TwoTrackSphericalFourierNeuralOperatorNet` (+ `get_lat_lon_two_track_sfnonet`).
  Per block, the pointwise parts (conditional norm, activation, MLP,
  inner/outer skips) act on the full concatenation; the spectral filter reads
  and writes only the global slice, with the local filter-stage output zero and
  carried by the inner-skip residual over the full width. Three default-off
  options: `feed_global_to_local` (option 1), `parallel_conv1x1` (option 2),
  `per_track_layer_norm` (option 3).
- `fme.ace.registry.two_track_sfno.TwoTrackSFNOBuilder` (registered
  `TwoTrackSFNO`): builds the noise-conditioned two-track network via
  `build_two_track`, which takes the four per-track channel counts; the
  single-tensor `build` raises since the split is not known there. Defaults:
  `embed_dim=256`, `local_embed_dim=256`, `noise_embed_dim=32`. `spectral_ratio`
  (default 1.0) is sized against the *global* width (the filter's width), so it
  can be scaled up to keep the actual filter (channels-per-group x groups) equal
  to a single-track baseline's when the global track is narrowed.
- `fme.ace.step.two_track.TwoTrackStep` / `TwoTrackStepConfig` (registered
  `two_track`): explicit `global_in_names` / `local_in_names` /
  `global_out_names` / `local_out_names`; post-init raises if a variable
  appears on both tracks on the same side. Inputs are packed
  `global + local` into one tensor (the network splits at
  `len(global_in_names)`); outputs unpack `global + local`. Orchestration
  (normalization / corrector / ocean / residual prediction) reuses
  `step_with_adjustments`, mirroring `SingleModuleStep`.
- `fme/ace/step/example_configs/two_track_baseline.yaml`: documented baseline
  step config (options off, some variables on the local track), exercised by a
  CPU smoke train-step test.

Out of scope for this first pass (not added): global-mean removal,
`include_channel_mask_inputs`, secondary decoder, input dropout, LoRA,
local (DISCO) blocks, and non-linear filters. Only `filter_type='linear'`
is supported.

L=0 *output* equivalence (the two-track forward reproducing the single-track
forward byte-for-byte at zero local width) holds only when the spectral filter
returns no round-trip residual, because the two-track block takes its
inner/outer skip from the full normed input rather than the filter's returned
residual. Two things force a round trip and so break output equivalence:
`filter_residual=True`, and `data_grid='equiangular'` (which gives the first
and last blocks a forward/inverse transform on different grids). The baseline
uses the default `data_grid='legendre-gauss'` (all transforms share a grid),
where equivalence holds and is covered by the regression test. Because the
module tree and parameter names are identical regardless of grid, an
`equiangular` single-track checkpoint would load without reproducing its
output — so `TwoTrackSFNOBuilder.__post_init__` rejects `local_embed_dim=0`
with `data_grid='equiangular'`, failing loudly on the backwards-incompatibility
rather than loading a wrong-output checkpoint. `local_embed_dim` must also be
nonzero if and only if the local track carries input or output channels
(validated in `build_two_track`): the practical config always has a nonzero
local track, and `local_embed_dim=0` is reserved for warm-starting from a
single-track checkpoint on `legendre-gauss`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated