### PR TITLE
Thread StepperState through CoupledStepper

### DIFF
--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -46,6 +46,7 @@ from fme.core.ocean import OceanConfig
 from fme.core.ocean_data import OCEAN_FIELD_NAME_PREFIXES, OceanData
 from fme.core.optimization import NullOptimization
 from fme.core.step.output import StepOutput
+from fme.core.stepper_state import StepperState
 from fme.core.tensors import add_ensemble_dim, unfold_ensemble_dim
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingHistory, TrainingJob
@@ -772,10 +773,12 @@ class ComponentStepPrediction:
         realm: Literal["ocean", "atmosphere"],
         data: TensorDict,
         step: int,
+        stepper_state: StepperState | None = None,
     ):
         self._realm: Literal["ocean", "atmosphere"] = realm
         self._data = data
         self._step = step
+        self._stepper_state = stepper_state
 
     @property
     def realm(self) -> Literal["ocean", "atmosphere"]:
@@ -788,6 +791,10 @@ class ComponentStepPrediction:
     @property
     def step(self) -> int:
         return self._step
+
+    @property
+    def stepper_state(self) -> StepperState | None:
+        return self._stepper_state
 
 
 class CoupledStepper:
@@ -917,6 +924,7 @@ class CoupledStepper:
                 data=atmos_ic_data,
                 time=forcing_ic_batch.time,
                 labels=forcing_ic_batch.labels,
+                stepper_state=atmos_ic_state.as_batch_data().stepper_state,
             )
         )
 
@@ -1112,15 +1120,19 @@ class CoupledStepper:
                 optimizer,
             )
             atmos_steps = []
+            atmos_stepper_state: StepperState | None = None
 
             # predict and yield atmosphere steps
             for i_inner in range(self.n_inner_steps):
                 atmos_step_num = i_outer * self.n_inner_steps + i_inner
-                atmos_step = next(atmos_generator).output
+                atmos_result = next(atmos_generator)
+                atmos_step = atmos_result.output
+                atmos_stepper_state = atmos_result.stepper_state
                 yield ComponentStepPrediction(
                     realm="atmosphere",
                     data=atmos_step,
                     step=atmos_step_num,
+                    stepper_state=atmos_stepper_state,
                 )
                 atmos_step = optimizer.detach_if_using_gradient_accumulation(atmos_step)
                 atmos_steps.append(atmos_step)
@@ -1147,7 +1159,7 @@ class CoupledStepper:
                 labels=ocean_window.labels,
             )
             # predict and yield a single ocean step
-            ocean_step = next(
+            ocean_result = next(
                 iter(
                     self.ocean.get_prediction_generator(
                         ocean_ic_state,
@@ -1156,11 +1168,13 @@ class CoupledStepper:
                         optimizer=optimizer,
                     )
                 )
-            ).output
+            )
+            ocean_step = ocean_result.output
             yield ComponentStepPrediction(
                 realm="ocean",
                 data=ocean_step,
                 step=i_outer,
+                stepper_state=ocean_result.stepper_state,
             )
 
             # prepare ic states for next coupled step
@@ -1175,6 +1189,7 @@ class CoupledStepper:
                         time=slice(-self.atmosphere.n_ic_timesteps, None)
                     ),
                     labels=atmos_window.labels,
+                    stepper_state=atmos_stepper_state,
                 )
             )
             ocean_ic_data = {
@@ -1185,6 +1200,7 @@ class CoupledStepper:
                     data=optimizer.detach_if_using_gradient_accumulation(ocean_ic_data),
                     time=ocean_window.time.isel(time=slice(-self.n_ic_timesteps, None)),
                     labels=ocean_window.labels,
+                    stepper_state=ocean_result.stepper_state,
                 )
             )
 
@@ -1195,7 +1211,7 @@ class CoupledStepper:
     ) -> CoupledBatchData:
         atmos_data = process_prediction_generator_list(
             [
-                StepOutput(output=x.data, stepper_state=None)
+                StepOutput(output=x.data, stepper_state=x.stepper_state)
                 for x in output_list
                 if x.realm == "atmosphere"
             ],
@@ -1206,7 +1222,7 @@ class CoupledStepper:
         )
         ocean_data = process_prediction_generator_list(
             [
-                StepOutput(output=x.data, stepper_state=None)
+                StepOutput(output=x.data, stepper_state=x.stepper_state)
                 for x in output_list
                 if x.realm == "ocean"
             ],

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -773,7 +773,7 @@ class ComponentStepPrediction:
         realm: Literal["ocean", "atmosphere"],
         data: TensorDict,
         step: int,
-        stepper_state: StepperState | None = None,
+        stepper_state: StepperState | None,
     ):
         self._realm: Literal["ocean", "atmosphere"] = realm
         self._data = data

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -24,6 +24,7 @@ from fme.core.dataset_info import DatasetInfo
 from fme.core.loss import StepLossConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
 from fme.core.optimization import NullOptimization
+from fme.core.random_state import RandomState
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
 from fme.core.spatial_mask_provider import SpatialMaskProvider
@@ -1725,6 +1726,76 @@ def test_predict_paired():
     torch.testing.assert_close(
         paired_data.ocean_data.prediction["o_diag"].select(dim=1, index=1),
         o_diag1,
+    )
+
+
+def test_predict_paired_threads_stepper_state():
+    """Stepper state attached to the initial condition must survive the coupled
+    rollout into the final prognostic state, so restarts can carry it.
+
+    Each component's state has to pass through the SST prescription and the
+    per-coupled-step initial-condition rebuild, so a two-coupled-step rollout
+    exercises every hand-off point.
+    """
+    ocean_in_names = ["o_prog", "o_sfc_temp", "o_mask", "a_diag"]
+    ocean_out_names = ["o_prog", "o_sfc_temp", "o_diag"]
+    atmos_in_names = ["a_prog", "a_sfc_temp", "ocean_frac", "o_prog"]
+    atmos_out_names = ["a_prog", "a_sfc_temp", "a_diag"]
+
+    class Ocean(torch.nn.Module):
+        def forward(self, x):
+            return torch.concat([x[:, :1], x[:, :1], x[:, :1]], dim=1)
+
+    class Atmos(torch.nn.Module):
+        def forward(self, x):
+            return torch.concat([x[:, :1], x[:, 1:2], x[:, :1]], dim=1)
+
+    coupler, coupled_data, _, _ = get_stepper_and_batch(
+        ocean_in_names=ocean_in_names,
+        ocean_out_names=ocean_out_names,
+        atmosphere_in_names=atmos_in_names,
+        atmosphere_out_names=atmos_out_names,
+        n_forward_times_ocean=2,
+        n_forward_times_atmosphere=4,
+        n_samples=3,
+        sst_name_in_ocean_data="o_sfc_temp",
+        sfc_temp_name_in_atmosphere_data="a_sfc_temp",
+        ocean_fraction_name="ocean_frac",
+        ocean_builder=ModuleSelector(type="prebuilt", config={"module": Ocean()}),
+        atmosphere_builder=ModuleSelector(type="prebuilt", config={"module": Atmos()}),
+    )
+    data = coupled_data.data
+
+    atmos_prognostic = data.atmosphere_data.get_start(
+        coupler.atmosphere.prognostic_names, n_ic_timesteps=1
+    ).with_random_state(RandomState.from_seed(0))
+    ocean_prognostic = data.ocean_data.get_start(
+        coupler.ocean.prognostic_names, n_ic_timesteps=1
+    ).with_random_state(RandomState.from_seed(1))
+    ic = CoupledPrognosticState(
+        atmosphere_data=atmos_prognostic, ocean_data=ocean_prognostic
+    )
+
+    _, prognostic_state = coupler.predict_paired(
+        initial_condition=ic,
+        forcing=data,
+    )
+
+    atmos_state = prognostic_state.atmosphere_data.as_batch_data().stepper_state
+    ocean_state = prognostic_state.ocean_data.as_batch_data().stepper_state
+    assert atmos_state is not None
+    assert atmos_state.random_state is not None
+    assert ocean_state is not None
+    assert ocean_state.random_state is not None
+    # the deterministic test modules never draw from the generators, so the
+    # states must be exactly the seeded initial states, not reseeded ones
+    torch.testing.assert_close(
+        atmos_state.random_state.generator.get_state(),
+        RandomState.from_seed(0).generator.get_state(),
+    )
+    torch.testing.assert_close(
+        ocean_state.random_state.generator.get_state(),
+        RandomState.from_seed(1).generator.get_state(),
     )
 
 


### PR DESCRIPTION
`CoupledStepper` drops each component's `StepperState` (noise-generator random state and corrector state) at every coupled-step boundary: per-step initial conditions are rebuilt without it, the SST prescription discards it from the atmosphere state, and the terminal `StepOutput`s are built with `stepper_state=None`. As a result, stochastic modules reseed at each coupled step, correctors re-capture their reference values, and coupled restart files carry no embedded state, so a run resumed from a restart is not bitwise-identical to an uninterrupted run. This PR threads the per-component stepper states through the coupled rollout and into the restart serialization added in #1341.

Coupled runs do not currently carry a seeded random state, so existing stochastic runs are unaffected. But a random state attached to the initial condition (e.g. restored from a restart) now persists through the rollout instead of being silently dropped. 

One behavioral change for existing runs is for checkpoints with dry-air conservation enabled: the corrector's reference dry-air mass was previously re-captured at every coupled-step boundary. Since each step's output is corrected to exactly match the reference, this caused no physical drift, but it made coupled runs inconsistent with uncoupled ACE and would have prevented segmented runs from being bitwise-identical to unsegmented ones. The reference is now captured once from the run's initial condition and held, matching the uncoupled behavior.

Changes:
- `fme.coupled.stepper.ComponentStepPrediction` carries a `stepper_state`
- `fme.coupled.stepper.CoupledStepper.get_prediction_generator` threads each component's terminal stepper state into the next coupled step's initial conditions; `_prescribe_ic_sst` preserves the incoming atmosphere stepper state; `_process_prediction_generator_list` attaches the terminal states to the component `StepOutput`'s, so `BatchData` serialization embeds them in `ocean/restart.nc` and `atmosphere/restart.nc`

- [x] Tests added