### PR TITLE
Add whole-run zarr outputs across inference segments

### DIFF
--- a/fme/ace/inference/data_writer/file_writer.py
+++ b/fme/ace/inference/data_writer/file_writer.py
@@ -17,7 +17,9 @@ from fme.core.typing_ import Slice
 
 from .dataset_metadata import DatasetMetadata
 from .monthly import MonthlyDataWriter
+from .monthly_zarr import MONTHLY_SNAPSHOT_DIR, MonthlyZarrWriter
 from .raw import NetCDFWriterConfig, RawDataWriter
+from .segment import SegmentContext
 from .time_coarsen import (
     MonthlyCoarsenConfig,
     PairedTimeCoarsen,
@@ -272,9 +274,13 @@ class FileWriterConfig:
                 raise NotImplementedError(
                     "Time selection is not currently supported when writing to zarr."
                 )
-            if isinstance(self.time_coarsen, MonthlyCoarsenConfig):
+            if (
+                isinstance(self.time_coarsen, MonthlyCoarsenConfig)
+                and self.separate_ensemble_members
+            ):
                 raise NotImplementedError(
-                    "Monthly coarsening is not currently supported for the zarr format."
+                    "Writing separate ensemble members is not currently supported "
+                    "for monthly coarsening."
                 )
 
         if isinstance(self.time_coarsen, MonthlyCoarsenConfig):
@@ -322,6 +328,7 @@ class FileWriterConfig:
         dataset_metadata: DatasetMetadata,
         prediction_suffix: str = "predictions",
         reference_suffix: str = "target",
+        segment_context: SegmentContext | None = None,
     ) -> Union["PairedFileWriter", PairedTimeCoarsen]:
         if self.save_reference:
             reference_label = f"{self.label}_{reference_suffix}"
@@ -334,6 +341,7 @@ class FileWriterConfig:
                 variable_metadata=variable_metadata,
                 coords=coords,
                 dataset_metadata=dataset_metadata,
+                segment_context=segment_context,
             )
         else:
             prediction_label = self.label
@@ -346,6 +354,7 @@ class FileWriterConfig:
             variable_metadata=variable_metadata,
             coords=coords,
             dataset_metadata=dataset_metadata,
+            segment_context=segment_context,
         )
         paired_writer = PairedFileWriter(prediction_writer, reference_writer)
         # Time coarsening is built around writer in the single build method
@@ -360,6 +369,7 @@ class FileWriterConfig:
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
         dataset_metadata: DatasetMetadata,
+        segment_context: SegmentContext | None = None,
     ) -> Union["FileWriter", TimeCoarsen]:
         """
         Build a FileWriter object for saving data within the specified region.
@@ -368,12 +378,19 @@ class FileWriterConfig:
             experiment_dir: The directory where experiment outputs are saved.
             initial_condition_times: 1D array of initial condition times
                 (start time for each inference run).
-            n_timesteps: Total number of inference forward steps.
+            n_timesteps: Total number of inference forward steps. When
+                ``segment_context`` is given, this is the number of forward
+                steps per segment.
             timestep: The time delta between each timestep.
             variable_metadata: Metadata for each variable.
             coords: Coordinate arrays for the dataset. These should be the coordinates
                 of the entire global domain, not the subset region coordinates.
             dataset_metadata: Metadata for the entire dataset.
+            segment_context: When running segmented inference, the current
+                segment. Zarr outputs then accumulate into a single whole-run
+                store shared by all segments, with each segment writing its own
+                region of the time axis; netCDF outputs are unaffected and stay
+                per-segment.
         """
         if "face" in coords:
             spatial_dims = DIM_INFO_HEALPIX
@@ -415,36 +432,82 @@ class FileWriterConfig:
             | ZarrWriterAdapter
             | SeparateICZarrWriterAdapter
             | MonthlyDataWriter
+            | MonthlyZarrWriter
         )
         if isinstance(self.format, ZarrWriterConfig):
-            if isinstance(self.time_coarsen, TimeCoarsenConfig):
-                n_timesteps_write = n_timesteps // self.time_coarsen.coarsen_factor
-                timestep_write = self.time_coarsen.coarsen_factor * timestep
+            if segment_context is not None:
+                n_timesteps_run = n_timesteps * segment_context.total_segments
+                start_timestep = n_timesteps * segment_context.segment_index
+                store_dir = self.format.path or segment_context.run_dir
             else:
-                n_timesteps_write = n_timesteps
-                timestep_write = timestep
+                n_timesteps_run = n_timesteps
+                start_timestep = 0
+                store_dir = self.format.path or experiment_dir
+            store_path = os.path.join(store_dir, f"{self.label}.zarr")
 
-            zarr_writer_cls: type[SeparateICZarrWriterAdapter | ZarrWriterAdapter]
-
-            if self.separate_ensemble_members:
-                dims = ("time", *(d.name for d in spatial_dims))
-                zarr_writer_cls = SeparateICZarrWriterAdapter
+            if isinstance(self.time_coarsen, MonthlyCoarsenConfig):
+                if segment_context is not None:
+                    snapshot_path = os.path.join(
+                        segment_context.segment_dir,
+                        MONTHLY_SNAPSHOT_DIR,
+                        f"{self.label}.nc",
+                    )
+                    if segment_context.previous_segment_dir is not None:
+                        restore_path = os.path.join(
+                            segment_context.previous_segment_dir,
+                            MONTHLY_SNAPSHOT_DIR,
+                            f"{self.label}.nc",
+                        )
+                    else:
+                        restore_path = None
+                else:
+                    snapshot_path = None
+                    restore_path = None
+                raw_writer = MonthlyZarrWriter(
+                    path=store_path,
+                    initial_condition_times=initial_condition_times,
+                    n_timesteps=n_timesteps_run,
+                    timestep=timestep,
+                    save_names=self.names,
+                    variable_metadata=variable_metadata,
+                    coords=subselect_coords_,
+                    dataset_metadata=dataset_metadata,
+                    snapshot_path=snapshot_path,
+                    restore_path=restore_path,
+                )
             else:
-                dims = ("sample", "time", *(d.name for d in spatial_dims))
-                zarr_writer_cls = ZarrWriterAdapter
-            raw_writer = zarr_writer_cls(
-                path=os.path.join(experiment_dir, f"{self.label}.zarr"),
-                dims=dims,
-                data_coords=ensure_numpy_coords(subselect_coords_),
-                timestep=timestep_write,
-                n_timesteps=n_timesteps_write,
-                initial_condition_times=initial_condition_times,
-                data_vars=self.names,
-                variable_metadata=variable_metadata,
-                dataset_metadata=dataset_metadata,
-                chunks=self.format.chunks,
-                overwrite_check=self.format.overwrite_check,
-            )
+                if isinstance(self.time_coarsen, TimeCoarsenConfig):
+                    coarsen_factor = self.time_coarsen.coarsen_factor
+                    n_timesteps_write = n_timesteps_run // coarsen_factor
+                    start_timestep_write = start_timestep // coarsen_factor
+                    timestep_write = coarsen_factor * timestep
+                else:
+                    n_timesteps_write = n_timesteps_run
+                    start_timestep_write = start_timestep
+                    timestep_write = timestep
+
+                zarr_writer_cls: type[SeparateICZarrWriterAdapter | ZarrWriterAdapter]
+
+                if self.separate_ensemble_members:
+                    dims = ("time", *(d.name for d in spatial_dims))
+                    zarr_writer_cls = SeparateICZarrWriterAdapter
+                else:
+                    dims = ("sample", "time", *(d.name for d in spatial_dims))
+                    zarr_writer_cls = ZarrWriterAdapter
+                raw_writer = zarr_writer_cls(
+                    path=store_path,
+                    dims=dims,
+                    data_coords=ensure_numpy_coords(subselect_coords_),
+                    timestep=timestep_write,
+                    n_timesteps=n_timesteps_write,
+                    initial_condition_times=initial_condition_times,
+                    data_vars=self.names,
+                    variable_metadata=variable_metadata,
+                    dataset_metadata=dataset_metadata,
+                    chunks=self.format.chunks,
+                    overwrite_check=self.format.overwrite_check,
+                    start_timestep=start_timestep_write,
+                )
         else:
             if self.separate_ensemble_members:
                 raise NotImplementedError(
@@ -488,6 +551,7 @@ class FileWriter:
         params: FileWriterParams,
         writer: RawDataWriter
         | MonthlyDataWriter
+        | MonthlyZarrWriter
         | ZarrWriterAdapter
         | SeparateICZarrWriterAdapter,
         full_coords: Mapping[str, np.ndarray],

--- a/fme/ace/inference/data_writer/main.py
+++ b/fme/ace/inference/data_writer/main.py
@@ -23,6 +23,7 @@ from .dataset_metadata import DatasetMetadata
 from .file_writer import FileWriter, FileWriterConfig, PairedFileWriter
 from .monthly import MonthlyDataWriter, PairedMonthlyDataWriter
 from .raw import PairedRawDataWriter, RawDataWriter
+from .segment import SegmentContext
 from .step_diagnostics import STEP_DIAGNOSTICS_DIR, StepDiagnosticsWriter
 from .time_coarsen import PairedTimeCoarsen, TimeCoarsen, TimeCoarsenConfig
 
@@ -108,6 +109,7 @@ class DataWriterConfig:
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
         dataset_metadata: DatasetMetadata,
+        segment_context: SegmentContext | None = None,
     ) -> "PairedDataWriter":
         writers: list[PairedSubwriter] = []
         if self.save_prediction_files:
@@ -145,6 +147,7 @@ class DataWriterConfig:
                     variable_metadata=variable_metadata,
                     coords=coords,
                     dataset_metadata=dataset_metadata,
+                    segment_context=segment_context,
                 )
             )
         return PairedDataWriter(
@@ -200,6 +203,7 @@ class DataWriterConfig:
         variable_metadata: Mapping[str, VariableMetadata],
         coords: Mapping[str, np.ndarray],
         dataset_metadata: DatasetMetadata,
+        segment_context: SegmentContext | None = None,
     ) -> "DataWriter":
         writers: list[Subwriter] = []
         # TODO: handle writing HEALPix data
@@ -240,6 +244,7 @@ class DataWriterConfig:
                         variable_metadata=variable_metadata,
                         coords=coords,
                         dataset_metadata=dataset_metadata,
+                        segment_context=segment_context,
                     )
                 )
         return DataWriter(

--- a/fme/ace/inference/data_writer/monthly_zarr.py
+++ b/fme/ace/inference/data_writer/monthly_zarr.py
@@ -1,0 +1,368 @@
+import copy
+import datetime
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+
+import cftime
+import numpy as np
+import numpy.typing as npt
+import torch
+import xarray as xr
+import zarr
+
+from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
+from fme.ace.inference.data_writer.monthly import (
+    COUNTS,
+    INIT_TIME,
+    LEAD_TIME_DIM,
+    LEAD_TIME_UNITS,
+    TIME_UNITS,
+    VALID_TIME,
+    add_data,
+    get_days_since_reference,
+)
+from fme.ace.inference.data_writer.raw import infer_calendar
+from fme.ace.inference.data_writer.utils import (
+    DIM_INFO_HEALPIX,
+    DIM_INFO_LATLON,
+    get_all_names,
+)
+from fme.core.cloud import (
+    exists,
+    open_dataset_via_inter_filesystem_copy,
+    to_netcdf_via_inter_filesystem_copy,
+)
+from fme.core.dataset.data_typing import VariableMetadata
+from fme.core.writer import DATETIME_ENCODING_UNITS
+
+logger = logging.getLogger(__name__)
+
+ENSEMBLE_DIM = "sample"
+INIT_YEARS_ATTR = "fme_init_years"
+INIT_MONTHS_ATTR = "fme_init_months"
+MONTHLY_SNAPSHOT_DIR = "monthly_snapshots"
+
+
+def _n_months_in_run(
+    init_years: np.ndarray,
+    init_months: np.ndarray,
+    initial_condition_times: npt.NDArray[cftime.datetime],
+    timestep: datetime.timedelta,
+    n_timesteps: int,
+) -> int:
+    """Number of calendar months touched by the run, across all samples."""
+    n_months = 0
+    for i, init_time in enumerate(initial_condition_times):
+        last_time = init_time + n_timesteps * timestep
+        months = 12 * (last_time.year - init_years[i]) + (
+            last_time.month - 1 - init_months[i]
+        )
+        n_months = max(n_months, int(months) + 1)
+    return n_months
+
+
+class MonthlyZarrWriter:
+    """
+    Write monthly mean data and sample counts to a zarr store.
+
+    Unlike ``MonthlyDataWriter``, the month axis is pre-allocated from the
+    whole run's length, so the store can be shared across the segments of a
+    segmented run: each ``append_batch`` reads the affected months back, folds
+    the new data into the stored means using the stored counts, and writes them
+    back. Because that accumulation is not idempotent, ``finalize`` writes a
+    netCDF snapshot of the store to ``snapshot_path``; a writer constructed
+    with ``restore_path`` (the previous segment's snapshot) starts from that
+    state, so re-running a partially completed segment reproduces the same
+    result as running it once.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        initial_condition_times: npt.NDArray[cftime.datetime],
+        n_timesteps: int,
+        timestep: datetime.timedelta,
+        save_names: Sequence[str] | None,
+        variable_metadata: Mapping[str, VariableMetadata],
+        coords: Mapping[str, np.ndarray],
+        dataset_metadata: DatasetMetadata,
+        snapshot_path: str | None = None,
+        restore_path: str | None = None,
+    ):
+        """
+        Args:
+            path: Path of the zarr store, on any fsspec-compatible filesystem.
+            initial_condition_times: 1D array of initial condition times. When
+                ``restore_path`` is not given these must be the run's initial
+                condition times, from which the store's month axis is computed.
+            n_timesteps: Number of timesteps in the whole run (all segments).
+            timestep: The time delta between each timestep.
+            save_names: Names of variables to save, or None to save all.
+            variable_metadata: Metadata for each variable.
+            coords: Coordinate data for the spatial dimensions.
+            dataset_metadata: Metadata for the dataset.
+            snapshot_path: If given, ``finalize`` writes a netCDF snapshot of
+                the store here.
+            restore_path: If given, the store is rebuilt from this snapshot
+                (written by the previous segment) instead of starting empty.
+        """
+        self.path = path
+        self._save_names = save_names
+        self.variable_metadata = variable_metadata
+        self.coords = coords
+        self._snapshot_path = snapshot_path
+        self._label = path.rsplit("/", 1)[-1].removesuffix(".zarr")
+
+        dataset_metadata = copy.copy(dataset_metadata)
+        dataset_metadata.title = f"ACE {self._label.replace('_', ' ')} data file"
+        self._dataset_metadata = dataset_metadata.as_flat_str_dict()
+
+        self._calendar = infer_calendar(initial_condition_times)
+        n_initial_conditions = len(initial_condition_times)
+        self._initial_condition_times = initial_condition_times
+
+        if restore_path is not None:
+            if not exists(restore_path):
+                raise RuntimeError(
+                    f"Cannot restore monthly writer state from {restore_path}: "
+                    "the snapshot does not exist. It is written by the previous "
+                    "segment's finalize."
+                )
+            snapshot = open_dataset_via_inter_filesystem_copy(
+                restore_path, decode_times=False, decode_timedelta=False
+            )
+            # the month origin of the whole run rides the snapshot; the initial
+            # condition times of a resumed segment sit at its restart time and
+            # must not redefine it
+            # netCDF attributes collapse single-element lists to scalars
+            self._init_years = np.atleast_1d(
+                np.asarray(snapshot.attrs[INIT_YEARS_ATTR], dtype=int)
+            )
+            self._init_months = np.atleast_1d(
+                np.asarray(snapshot.attrs[INIT_MONTHS_ATTR], dtype=int)
+            )
+            self._n_months = int(snapshot.sizes[LEAD_TIME_DIM])
+            # write the normalized origin attributes so the restored store's
+            # attributes match those of a store that was never snapshotted
+            snapshot.attrs[INIT_YEARS_ATTR] = self._init_years.tolist()
+            snapshot.attrs[INIT_MONTHS_ATTR] = self._init_months.tolist()
+            snapshot.to_zarr(self.path, mode="w")
+            self._store_initialized = True
+        else:
+            # months are indexed relative to each sample's first forward
+            # (post-initial-condition) time
+            first_forward_times = initial_condition_times + timestep
+            self._init_years = np.array(
+                [t.year for t in first_forward_times], dtype=int
+            )
+            self._init_months = np.array(
+                [t.month - 1 for t in first_forward_times], dtype=int
+            )
+            self._n_months = _n_months_in_run(
+                self._init_years,
+                self._init_months,
+                initial_condition_times,
+                timestep,
+                n_timesteps,
+            )
+            # the store's spatial dims are only known once data is seen
+            self._store_initialized = False
+
+        if n_initial_conditions != len(self._init_years):
+            raise ValueError(
+                f"Got {n_initial_conditions} initial conditions but the "
+                f"restored snapshot has {len(self._init_years)} samples."
+            )
+
+    def _initialize_store(self, data: dict[str, torch.Tensor]):
+        """Create the empty store, with the month axis pre-allocated."""
+        dim_info = DIM_INFO_HEALPIX if "face" in self.coords else DIM_INFO_LATLON
+        example = next(iter(data.values()))
+        n_samples = example.shape[0]
+        root = zarr.open_group(self.path, mode="w")
+        root.update_attributes(
+            {
+                **self._dataset_metadata,
+                INIT_YEARS_ATTR: self._init_years.tolist(),
+                INIT_MONTHS_ATTR: self._init_months.tolist(),
+            }
+        )
+
+        lead_time = root.create_array(
+            name=LEAD_TIME_DIM,
+            shape=(self._n_months,),
+            dtype="int64",
+            dimension_names=[LEAD_TIME_DIM],
+        )
+        lead_time.attrs["units"] = LEAD_TIME_UNITS
+        lead_time[:] = np.arange(self._n_months)
+
+        init_time = root.create_array(
+            name=INIT_TIME,
+            shape=(n_samples,),
+            dtype="int64",
+            dimension_names=[ENSEMBLE_DIM],
+        )
+        init_time.attrs["units"] = DATETIME_ENCODING_UNITS
+        init_time.attrs["calendar"] = self._calendar
+        init_time[:] = cftime.date2num(
+            self._initial_condition_times,
+            units=DATETIME_ENCODING_UNITS,
+            calendar=self._calendar,
+        )
+
+        valid_time = root.create_array(
+            name=VALID_TIME,
+            shape=(n_samples, self._n_months),
+            dtype="int64",
+            dimension_names=[ENSEMBLE_DIM, LEAD_TIME_DIM],
+        )
+        valid_time.attrs["units"] = TIME_UNITS
+        valid_time.attrs["calendar"] = self._calendar
+        reference_date = cftime.datetime(1970, 1, 1, calendar=self._calendar)
+        days_since_reference = get_days_since_reference(
+            years=self._init_years,
+            months=self._init_months,
+            n_months=self._n_months,
+            reference_date=reference_date,
+            calendar=self._calendar,
+        )
+        # use the 15th of each month, which is 14 days into the month
+        valid_time[:] = days_since_reference + 14
+
+        counts = root.create_array(
+            name=COUNTS,
+            shape=(n_samples, self._n_months),
+            dtype="int64",
+            dimension_names=[ENSEMBLE_DIM, LEAD_TIME_DIM],
+        )
+        counts[:] = 0
+
+        spatial_names = []
+        spatial_sizes = []
+        for dim in dim_info:
+            dim_size = example.shape[dim.index]
+            spatial_names.append(dim.name)
+            spatial_sizes.append(dim_size)
+            if dim.name in self.coords:
+                coord = root.create_array(
+                    name=dim.name,
+                    shape=(dim_size,),
+                    dtype="f4",
+                    dimension_names=[dim.name],
+                )
+                coord[:] = np.asarray(self.coords[dim.name])
+
+        dims = (ENSEMBLE_DIM, LEAD_TIME_DIM, *spatial_names)
+        for name in self._get_variable_names_to_save(data.keys()):
+            var = root.create_array(
+                name=name,
+                shape=(n_samples, self._n_months, *spatial_sizes),
+                chunks=(1, 1, *spatial_sizes),
+                dtype="f4",
+                dimension_names=dims,
+            )
+            attrs: dict[str, str] = {}
+            if name in self.variable_metadata:
+                attrs.update(self.variable_metadata[name].as_attrs())
+            attrs["coordinates"] = " ".join([INIT_TIME, VALID_TIME, COUNTS])
+            var.attrs.update(attrs)
+            var[:] = 0.0
+        zarr.consolidate_metadata(root.store)
+        self._store_initialized = True
+
+    def _get_variable_names_to_save(
+        self, *data_varnames: Iterable[str]
+    ) -> Iterable[str]:
+        return get_all_names(*data_varnames, allowlist=self._save_names)
+
+    def _get_month_indices(self, batch_time: xr.DataArray) -> np.ndarray:
+        years = batch_time.dt.year.values
+        # datetime months are 1-indexed, we want 0-indexed
+        months = batch_time.dt.month.values - 1
+        return 12 * (years - self._init_years[:, None]) + (
+            months - self._init_months[:, None]
+        )
+
+    def append_batch(
+        self,
+        data: dict[str, torch.Tensor],
+        batch_time: xr.DataArray,
+    ):
+        """
+        Fold a batch of data into the stored monthly means.
+
+        Args:
+            data: Values to store.
+            batch_time: Time coordinate for each sample in the batch.
+        """
+        n_samples_data = list(data.values())[0].shape[0]
+        n_samples_time = batch_time.sizes["sample"]
+        if n_samples_data != n_samples_time:
+            raise ValueError(
+                f"Batch size mismatch, data has {n_samples_data} samples "
+                f"and batch_time has {n_samples_time} samples."
+            )
+        n_times_data = list(data.values())[0].shape[1]
+        n_times_time = batch_time.sizes["time"]
+        if n_times_data != n_times_time:
+            raise ValueError(
+                f"Batch time dimension mismatch, data has {n_times_data} times "
+                f"and batch_time has {n_times_time} times."
+            )
+
+        if not self._store_initialized:
+            self._initialize_store(data)
+
+        months = self._get_month_indices(batch_time)
+        if np.min(months) < 0 or np.max(months) >= self._n_months:
+            raise ValueError(
+                f"Batch times span month indices {np.min(months)} to "
+                f"{np.max(months)}, outside the store's pre-allocated range of "
+                f"{self._n_months} months."
+            )
+        month_min = int(np.min(months))
+        month_slice = slice(month_min, int(np.max(months)) + 1)
+
+        root = zarr.open_group(self.path, mode="r+")
+        count_data = root[COUNTS][:, month_slice]
+        for variable_name in self._get_variable_names_to_save(data.keys()):
+            array = data[variable_name].detach().cpu().numpy()
+            month_data = root[variable_name][:, month_slice]
+            add_data(
+                target=month_data,
+                target_start_counts=count_data,
+                source=array,
+                months_elapsed=months - month_min,
+            )
+            root[variable_name][:, month_slice] = month_data
+        # counts must be added after data, as we use the base counts when
+        # updating means
+        counts = root[COUNTS]
+        for i_sample in range(n_samples_data):
+            counts[i_sample] = counts[i_sample] + np.bincount(
+                months[i_sample], minlength=self._n_months
+            )
+
+    def flush(self):
+        pass
+
+    def finalize(self):
+        """Write a snapshot of the store, if configured to do so.
+
+        In a segmented run this runs before the segment's restart files are
+        written, so a segment with restart files always has a snapshot.
+        """
+        if self._snapshot_path is None:
+            return
+        if not self._store_initialized:
+            logger.warning(
+                f"No data was written to {self.path}; skipping its snapshot."
+            )
+            return
+        snapshot = xr.open_zarr(
+            self.path, decode_times=False, decode_timedelta=False
+        ).load()
+        snapshot.attrs[INIT_YEARS_ATTR] = self._init_years.tolist()
+        snapshot.attrs[INIT_MONTHS_ATTR] = self._init_months.tolist()
+        to_netcdf_via_inter_filesystem_copy(snapshot, self._snapshot_path)

--- a/fme/ace/inference/data_writer/segment.py
+++ b/fme/ace/inference/data_writer/segment.py
@@ -1,0 +1,37 @@
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class SegmentContext:
+    """
+    Runtime description of the current segment of a segmented inference run,
+    used by data writers that accumulate a single whole-run output across
+    segments (e.g. zarr stores written via region writes).
+
+    Parameters:
+        segment_index: Zero-based index of the current segment.
+        total_segments: Total number of segments in the run.
+        run_dir: The root experiment directory shared by all segments.
+        segment_dir: The current segment's output directory.
+        previous_segment_dir: The previous segment's output directory, or None
+            for the first segment. Stateful writers restore their accumulator
+            snapshots from here so that re-running a partially completed
+            segment does not double-count.
+    """
+
+    segment_index: int
+    total_segments: int
+    run_dir: str
+    segment_dir: str
+    previous_segment_dir: str | None
+
+    def __post_init__(self):
+        if self.segment_index < 0 or self.segment_index >= self.total_segments:
+            raise ValueError(
+                f"segment_index {self.segment_index} out of range for "
+                f"{self.total_segments} segments"
+            )
+        if self.segment_index > 0 and self.previous_segment_dir is None:
+            raise ValueError(
+                "previous_segment_dir is required for segments after the first"
+            )

--- a/fme/ace/inference/data_writer/test_monthly_zarr.py
+++ b/fme/ace/inference/data_writer/test_monthly_zarr.py
@@ -1,0 +1,140 @@
+import datetime
+
+import cftime
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
+from fme.ace.inference.data_writer.monthly_zarr import MonthlyZarrWriter
+
+TIMESTEP = datetime.timedelta(days=5)
+
+
+def _writer(
+    tmp_path,
+    initial_condition_times: np.ndarray,
+    n_timesteps: int,
+    snapshot_path: str | None = None,
+    restore_path: str | None = None,
+) -> MonthlyZarrWriter:
+    return MonthlyZarrWriter(
+        path=str(tmp_path / "monthly.zarr"),
+        initial_condition_times=initial_condition_times,
+        n_timesteps=n_timesteps,
+        timestep=TIMESTEP,
+        save_names=None,
+        variable_metadata={},
+        coords={"lat": np.array([0.0, 1.0]), "lon": np.array([0.0, 1.0])},
+        dataset_metadata=DatasetMetadata(),
+        snapshot_path=snapshot_path,
+        restore_path=restore_path,
+    )
+
+
+def _batch(values: list[float], times: list[cftime.datetime]):
+    data = {
+        "foo": torch.tensor(values, dtype=torch.float32).reshape(1, len(values), 1, 1)
+        * torch.ones(1, len(values), 2, 2)
+    }
+    batch_time = xr.DataArray([times], dims=("sample", "time"))
+    return data, batch_time
+
+
+def test_monthly_zarr_accumulates_means_and_counts(tmp_path):
+    """5-day steps starting late January span two months; the stored means and
+    counts must aggregate by calendar month across multiple appends."""
+    initial_condition_times = np.array([cftime.datetime(2020, 1, 17)])
+    # forward times: Jan 22, Jan 27, Feb 1, Feb 6
+    writer = _writer(tmp_path, initial_condition_times, n_timesteps=4)
+    data, batch_time = _batch(
+        [1.0, 2.0],
+        [cftime.datetime(2020, 1, 22), cftime.datetime(2020, 1, 27)],
+    )
+    writer.append_batch(data, batch_time)
+    data, batch_time = _batch(
+        [3.0, 5.0],
+        [cftime.datetime(2020, 2, 1), cftime.datetime(2020, 2, 6)],
+    )
+    writer.append_batch(data, batch_time)
+
+    ds = xr.open_zarr(str(tmp_path / "monthly.zarr"), decode_timedelta=False)
+    assert ds.sizes["time"] == 2
+    np.testing.assert_array_equal(ds["counts"].values, [[2, 2]])
+    np.testing.assert_allclose(
+        ds["foo"].isel(sample=0).mean(["lat", "lon"]).values, [1.5, 4.0]
+    )
+
+
+def test_monthly_zarr_snapshot_restore_is_idempotent(tmp_path):
+    """Re-running a segment after restoring the previous segment's snapshot
+    yields the same result as running each segment once, and matches an
+    unsegmented run."""
+    initial_condition_times = np.array([cftime.datetime(2020, 1, 17)])
+    segment_times = [
+        [cftime.datetime(2020, 1, 22), cftime.datetime(2020, 1, 27)],
+        [cftime.datetime(2020, 2, 1), cftime.datetime(2020, 2, 6)],
+    ]
+    segment_values = [[1.0, 2.0], [3.0, 5.0]]
+    snapshot_path = str(tmp_path / "segment_0000" / "monthly.nc")
+
+    single_dir = tmp_path / "single"
+    single_dir.mkdir()
+    single = _writer(single_dir, initial_condition_times, n_timesteps=4)
+    for values, times in zip(segment_values, segment_times):
+        single.append_batch(*_batch(values, times))
+    ds_single = xr.open_zarr(
+        str(single_dir / "monthly.zarr"), decode_timedelta=False
+    ).load()
+
+    # the writer is always constructed with the whole run's length, so the
+    # month axis covers all segments
+    segment_0 = _writer(
+        tmp_path,
+        initial_condition_times,
+        n_timesteps=4,
+        snapshot_path=snapshot_path,
+    )
+    segment_0.append_batch(*_batch(segment_values[0], segment_times[0]))
+    segment_0.finalize()
+
+    # segment 1 is constructed with its restart time as the initial condition
+    # time, which must not redefine the run's month origin
+    restart_times = np.array([cftime.datetime(2020, 1, 27)])
+
+    def run_segment_1():
+        writer = _writer(
+            tmp_path,
+            restart_times,
+            n_timesteps=4,
+            restore_path=snapshot_path,
+        )
+        writer.append_batch(*_batch(segment_values[1], segment_times[1]))
+
+    run_segment_1()
+    # simulate a preempted segment 1 being re-run from the snapshot
+    run_segment_1()
+
+    ds_segmented = xr.open_zarr(
+        str(tmp_path / "monthly.zarr"), decode_timedelta=False
+    ).load()
+    xr.testing.assert_allclose(ds_segmented.drop_attrs(), ds_single.drop_attrs())
+    np.testing.assert_array_equal(ds_segmented["counts"].values, [[2, 2]])
+
+
+def test_monthly_zarr_restore_requires_snapshot(tmp_path):
+    with pytest.raises(RuntimeError, match="does not exist"):
+        _writer(
+            tmp_path,
+            np.array([cftime.datetime(2020, 1, 17)]),
+            n_timesteps=2,
+            restore_path=str(tmp_path / "missing.nc"),
+        )
+
+
+def test_monthly_zarr_rejects_times_outside_run(tmp_path):
+    writer = _writer(tmp_path, np.array([cftime.datetime(2020, 1, 17)]), n_timesteps=2)
+    data, batch_time = _batch([1.0], [cftime.datetime(2020, 6, 1)])
+    with pytest.raises(ValueError, match="pre-allocated"):
+        writer.append_batch(data, batch_time)

--- a/fme/ace/inference/data_writer/test_zarr.py
+++ b/fme/ace/inference/data_writer/test_zarr.py
@@ -218,3 +218,67 @@ def test_zarr_adapter_single_timestep_data(
 
     ds = xr.open_zarr(str(tmpdir / "test.zarr"))
     assert ds.time.size == 1
+
+
+def _segment_adapter_args(tmpdir, n_timesteps: int, start_timestep: int) -> dict:
+    return dict(
+        path=str(tmpdir / "test.zarr"),
+        dims=("sample", "time", "lat", "lon"),
+        data_coords=ensure_numpy_coords(
+            {
+                "lat": xr.DataArray([0, 1], dims=["lat"]),
+                "lon": xr.DataArray([0, 1], dims=["lon"]),
+            }
+        ),
+        timestep=datetime.timedelta(days=1),
+        n_timesteps=n_timesteps,
+        initial_condition_times=np.array([cftime.datetime(2019, 12, 31)]),
+        start_timestep=start_timestep,
+    )
+
+
+def _daily_batch_time(start_day: int, n_times: int) -> xr.DataArray:
+    return xr.DataArray(
+        [[cftime.datetime(2020, 1, start_day + i) for i in range(n_times)]],
+        dims=("sample", "time"),
+    )
+
+
+def test_zarr_adapter_segmented_resume(tmpdir):
+    """Two adapters writing consecutive segments of a run produce the same
+    store as one adapter writing the whole run."""
+    data = {
+        "foo": torch.arange(4, dtype=torch.float32).reshape(1, 4, 1, 1)
+        * torch.ones(1, 4, 2, 2)
+    }
+    first_half = {k: v[:, :2] for k, v in data.items()}
+    second_half = {k: v[:, 2:] for k, v in data.items()}
+
+    segment_0 = ZarrWriterAdapter(
+        **_segment_adapter_args(tmpdir, n_timesteps=4, start_timestep=0)
+    )
+    segment_0.append_batch(first_half, _daily_batch_time(1, 2))
+    segment_1 = ZarrWriterAdapter(
+        **_segment_adapter_args(tmpdir, n_timesteps=4, start_timestep=2)
+    )
+    segment_1.append_batch(second_half, _daily_batch_time(3, 2))
+    ds_segmented = xr.open_zarr(str(tmpdir / "test.zarr")).load()
+
+    single_dir = tmpdir.mkdir("single")
+    single = ZarrWriterAdapter(
+        **_segment_adapter_args(single_dir, n_timesteps=4, start_timestep=0)
+    )
+    single.append_batch(first_half, _daily_batch_time(1, 2))
+    single.append_batch(second_half, _daily_batch_time(3, 2))
+    ds_single = xr.open_zarr(str(single_dir / "test.zarr")).load()
+
+    xr.testing.assert_identical(ds_segmented, ds_single)
+
+
+def test_zarr_adapter_resume_requires_existing_store(tmpdir):
+    data = {"foo": torch.zeros(1, 2, 2, 2)}
+    adapter = ZarrWriterAdapter(
+        **_segment_adapter_args(tmpdir, n_timesteps=4, start_timestep=2)
+    )
+    with pytest.raises(RuntimeError, match="does not exist"):
+        adapter.append_batch(data, _daily_batch_time(3, 2))

--- a/fme/ace/inference/data_writer/zarr.py
+++ b/fme/ace/inference/data_writer/zarr.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 import cftime
+import fsspec
 import numpy as np
 import numpy.typing as npt
 import torch
@@ -86,12 +87,32 @@ def _get_ace_time_coords(
 
 @dataclass
 class ZarrWriterConfig:
+    """
+    Configuration for zarr output stores.
+
+    Parameters:
+        chunks: Chunk sizes by dimension name.
+        overwrite_check: If true, check when recording each batch that the
+            slice of the existing store does not already contain data.
+        path: Directory in which to create the store, on any fsspec-compatible
+            filesystem (e.g. a remote bucket URL). If not given, stores are
+            created in the experiment directory, or in the root experiment
+            directory when running segmented inference so that all segments
+            write to the same store.
+    """
+
     name: Literal["zarr"] = "zarr"  # defined for yaml+dacite ease of use
     chunks: dict[str, int] | None = field(
         default_factory=lambda: {"time": 1, "sample": 1}
     )
     overwrite_check: bool = False
     suffix: str = "zarr"
+    path: str | None = None
+
+
+def _store_exists(path: str) -> bool:
+    fs, _ = fsspec.url_to_fs(path)
+    return fs.exists(path)
 
 
 def ensure_numpy_coords(
@@ -123,7 +144,33 @@ class ZarrWriterAdapter:
         data_vars: list[str] | None = None,
         chunks: dict[str, int] | None = None,
         overwrite_check: bool = False,
+        start_timestep: int = 0,
     ):
+        """
+        Args:
+            path: Path of the zarr store.
+            dims: Order of data dimensions.
+            data_coords: Coordinate arrays for the spatial dimensions.
+            timestep: The time delta between each written timestep.
+            n_timesteps: Number of timesteps the store holds. When writing a
+                segment of a longer run, this is the whole run's length, not
+                the segment's.
+            initial_condition_times: 1D array of initial condition times. When
+                ``start_timestep`` is 0 these must be the run's initial
+                condition times, from which the store's time coordinates are
+                computed.
+            variable_metadata: Metadata for each variable.
+            dataset_metadata: Metadata for the dataset.
+            data_vars: Variables to write, or None to write all.
+            chunks: Chunk sizes by dimension name.
+            overwrite_check: If true, check when recording each batch that the
+                slice of the existing store does not already contain data.
+            start_timestep: Time index at which the first appended batch is
+                written. When positive, the store must already exist (it is
+                created by the run's first segment, whose initial condition
+                times determine the whole store's time coordinates) and is
+                opened for writing rather than overwritten.
+        """
         self.path = path
         self.dims = dims
 
@@ -131,7 +178,8 @@ class ZarrWriterAdapter:
         self.n_timesteps = n_timesteps
         self.initial_condition_times = initial_condition_times
         self.n_initial_conditions = len(self.initial_condition_times)
-        self._current_timestep = 0
+        self._start_timestep = start_timestep
+        self._current_timestep = start_timestep
         self.variable_metadata = _variable_metadata_to_dict(variable_metadata)
 
         dataset_metadata = copy.copy(dataset_metadata)
@@ -173,6 +221,13 @@ class ZarrWriterAdapter:
         return self._writer
 
     def _initialize_writer(self, batch_time: xr.DataArray):
+        if self._start_timestep > 0 and not _store_exists(self.path):
+            raise RuntimeError(
+                f"Cannot resume writing to {self.path} at timestep "
+                f"{self._start_timestep}: the store does not exist. It is "
+                "created by the run's first segment, whose initial condition "
+                "times determine the whole store's time coordinates."
+            )
         # batch.time is dataarray with dims (sample, time) w/o coords
         lead_times_coord, init_times_coord, valid_times_coord = _get_ace_time_coords(
             self.initial_condition_times, batch_time, self.timestep, self.n_timesteps
@@ -200,7 +255,9 @@ class ZarrWriterAdapter:
             time_units=TIMEDELTA_ENCODING_UNITS,
             time_calendar=None,
             nondim_coords=self._nondim_coords,
-            mode="w",  # ACE data writers are expected to overwrite existing data
+            # ACE data writers are expected to overwrite existing data, but a
+            # resumed segment writes its region into the existing store
+            mode="a" if self._start_timestep > 0 else "w",
             overwrite_check=self.overwrite_check,
         )
 
@@ -259,6 +316,7 @@ class SeparateICZarrWriterAdapter:
         data_vars: list[str] | None = None,
         chunks: dict[str, int] | None = None,
         overwrite_check: bool = False,
+        start_timestep: int = 0,
     ):
         self.path = path
         self.dims = dims
@@ -268,7 +326,8 @@ class SeparateICZarrWriterAdapter:
         self.n_timesteps = n_timesteps
         self.initial_condition_times = initial_condition_times
         self.n_initial_conditions = len(self.initial_condition_times)
-        self._current_timestep = 0
+        self._start_timestep = start_timestep
+        self._current_timestep = start_timestep
         self.data_vars = data_vars
         self.chunks = chunks
         self.overwrite_check = overwrite_check
@@ -309,6 +368,15 @@ class SeparateICZarrWriterAdapter:
             self.n_timesteps,
         )
         for s in range(self.n_initial_conditions):
+            member_path = self.path.replace(".zarr", f"_ic{s:04d}.zarr")
+            if self._start_timestep > 0 and not _store_exists(member_path):
+                raise RuntimeError(
+                    f"Cannot resume writing to {member_path} at timestep "
+                    f"{self._start_timestep}: the store does not exist. It is "
+                    "created by the run's first segment, whose initial "
+                    "condition times determine the whole store's time "
+                    "coordinates."
+                )
             _coords = copy.copy(self.coords)
             init_time_numeric = cftime.date2num(
                 self.initial_condition_times[s],
@@ -318,7 +386,7 @@ class SeparateICZarrWriterAdapter:
             _coords["time"] = init_time_numeric + lead_time_microseconds
             self._writers.append(
                 ZarrWriter(
-                    path=self.path.replace(".zarr", f"_ic{s:04d}.zarr"),
+                    path=member_path,
                     dims=self.dims,
                     coords=_coords,
                     data_vars=self.data_vars,
@@ -328,7 +396,7 @@ class SeparateICZarrWriterAdapter:
                     group_attributes=self.dataset_metadata,
                     nondim_coords=self._nondim_coords,
                     time_calendar=first_batch_time.dt.calendar,
-                    mode="w",
+                    mode="a" if self._start_timestep > 0 else "w",
                     overwrite_check=self.overwrite_check,
                 )
             )

--- a/fme/coupled/data_loading/inference.py
+++ b/fme/coupled/data_loading/inference.py
@@ -1,3 +1,4 @@
+import copy
 import dataclasses
 import logging
 from math import ceil
@@ -216,18 +217,22 @@ class CoupledForcingDataLoaderConfig:
         self,
         start_indices: ExplicitIndices,
     ):
+        # the built loader takes ownership of its dataset configs and updates
+        # the atmosphere subset in place to align it with the ocean start, so
+        # hand out copies to leave this user-provided config untouched (e.g.
+        # for reuse by the following segments of a segmented run)
         if self.ocean is None:
             return InferenceDataLoaderConfig(
                 dataset=CoupledDatasetWithOptionalOceanConfig(
-                    atmosphere=self.atmosphere.dataset,
+                    atmosphere=copy.deepcopy(self.atmosphere.dataset),
                 ),
                 start_indices=start_indices,
                 num_data_workers=self.num_data_workers,
             )
         return InferenceDataLoaderConfig(
             dataset=CoupledDatasetWithOptionalOceanConfig(
-                atmosphere=self.atmosphere.dataset,
-                ocean=self.ocean.dataset,
+                atmosphere=copy.deepcopy(self.atmosphere.dataset),
+                ocean=copy.deepcopy(self.ocean.dataset),
             ),
             start_indices=start_indices,
             num_data_workers=self.num_data_workers,

--- a/fme/coupled/inference/__main__.py
+++ b/fme/coupled/inference/__main__.py
@@ -5,6 +5,18 @@ from .inference import main
 
 if __name__ == "__main__":
     parser = get_parser()
+    parser.add_argument(
+        "--segments",
+        type=int,
+        default=None,
+        help=(
+            "If provided, number of times to repeat the inference in time, "
+            "saving each segment in a separate folder labeled as "
+            "'segment_0000', 'segment_0001' etc. "
+            "WARNING: this feature is experimental and its API is subject "
+            "to change.",
+        ),
+    )
     args = parser.parse_args()
     with Distributed.context():
-        main(args.yaml_config, override_dotlist=args.override)
+        main(args.yaml_config, segments=args.segments, override_dotlist=args.override)

--- a/fme/coupled/inference/data_writer.py
+++ b/fme/coupled/inference/data_writer.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 
 from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
 from fme.ace.inference.data_writer.main import DataWriterConfig, PairedDataWriter
+from fme.ace.inference.data_writer.segment import SegmentContext
 from fme.core.cloud import makedirs
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.generics.writer import WriterABC
@@ -19,6 +20,24 @@ from fme.coupled.data_loading.data_typing import CoupledCoords
 
 OCEAN_OUTPUT_DIR_NAME = "ocean"
 ATMOSPHERE_OUTPUT_DIR_NAME = "atmosphere"
+
+
+def _component_segment_context(
+    segment_context: SegmentContext | None, component_dir_name: str
+) -> SegmentContext | None:
+    """Point a run-level segment context at one component's subdirectories."""
+    if segment_context is None:
+        return None
+    return dataclasses.replace(
+        segment_context,
+        run_dir=os.path.join(segment_context.run_dir, component_dir_name),
+        segment_dir=os.path.join(segment_context.segment_dir, component_dir_name),
+        previous_segment_dir=(
+            os.path.join(segment_context.previous_segment_dir, component_dir_name)
+            if segment_context.previous_segment_dir is not None
+            else None
+        ),
+    )
 
 
 @dataclasses.dataclass
@@ -49,6 +68,7 @@ class CoupledDataWriterConfig:
         variable_metadata: Mapping[str, VariableMetadata],
         coords: CoupledCoords,
         dataset_metadata: dict[str, DatasetMetadata],
+        segment_context: SegmentContext | None = None,
     ) -> "CoupledPairedDataWriter":
         ocean_dir = os.path.join(experiment_dir, OCEAN_OUTPUT_DIR_NAME)
         makedirs(ocean_dir, exist_ok=True)
@@ -63,6 +83,9 @@ class CoupledDataWriterConfig:
                 variable_metadata=variable_metadata,
                 coords=coords.ocean,
                 dataset_metadata=dataset_metadata["ocean"],
+                segment_context=_component_segment_context(
+                    segment_context, OCEAN_OUTPUT_DIR_NAME
+                ),
             ),
             atmosphere_writer=self.atmosphere.build_paired(
                 experiment_dir=atmos_dir,
@@ -72,6 +95,9 @@ class CoupledDataWriterConfig:
                 variable_metadata=variable_metadata,
                 coords=coords.atmosphere,
                 dataset_metadata=dataset_metadata["atmosphere"],
+                segment_context=_component_segment_context(
+                    segment_context, ATMOSPHERE_OUTPUT_DIR_NAME
+                ),
             ),
         )
 

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -15,6 +15,7 @@ from fme.ace.data_loading.inference import (
     InferenceInitialConditionIndices,
     TimestampList,
 )
+from fme.ace.inference.data_writer.segment import SegmentContext
 from fme.ace.inference.inference import InitialConditionConfig, get_initial_condition
 from fme.ace.requirements import InitialConditionRequirements
 from fme.core.cli import prepare_config, prepare_directory
@@ -193,6 +194,7 @@ class InferenceConfig:
     def get_data_writer(
         self,
         data: InferenceGriddedData,
+        segment_context: SegmentContext | None = None,
     ) -> CoupledPairedDataWriter:
         if self.data_writer.ocean.time_coarsen is not None:
             try:
@@ -231,6 +233,7 @@ class InferenceConfig:
             variable_metadata=variable_metadata,
             coords=data.coords,
             dataset_metadata=coupled_dataset_metadata,
+            segment_context=segment_context,
         )
 
 
@@ -289,6 +292,7 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
     )
     config_copy = copy.deepcopy(config)
     original_wandb_name = os.environ.get("WANDB_NAME")
+    previous_segment_dir: str | None = None
     for segment in range(segments):
         segment_label = f"segment_{segment:04d}"
         segment_dir = os.path.join(config.experiment_dir, segment_label)
@@ -305,8 +309,16 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
             config_copy.experiment_dir = segment_dir
             if original_wandb_name is not None:
                 os.environ["WANDB_NAME"] = f"{original_wandb_name}-{segment_label}"
+            segment_context = SegmentContext(
+                segment_index=segment,
+                total_segments=segments,
+                run_dir=config.experiment_dir,
+                segment_dir=segment_dir,
+                previous_segment_dir=previous_segment_dir,
+            )
             with GlobalTimer():
-                run_inference_from_config(config_copy)
+                run_inference_from_config(config_copy, segment_context=segment_context)
+        previous_segment_dir = segment_dir
         config_copy.initial_condition = CoupledInitialConditionConfig(
             ocean=ComponentInitialConditionConfig(
                 path=ocean_restart_path, engine="netcdf4"
@@ -317,7 +329,10 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
         )
 
 
-def run_inference_from_config(config: InferenceConfig):
+def run_inference_from_config(
+    config: InferenceConfig,
+    segment_context: SegmentContext | None = None,
+):
     timer = GlobalTimer.get_instance()
     timer.start_outer("inference")
     timer.start("initialization")
@@ -364,7 +379,7 @@ def run_inference_from_config(config: InferenceConfig):
         output_dir=config.experiment_dir,
     )
 
-    writer = config.get_data_writer(data=data)
+    writer = config.get_data_writer(data=data, segment_context=segment_context)
     timer.stop("initialization")
     logging.info("Starting inference")
     logger = get_record_to_wandb(label="inference")

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -1,5 +1,7 @@
+import copy
 import dataclasses
 import logging
+import os
 from collections.abc import Sequence
 from typing import Literal
 
@@ -16,7 +18,7 @@ from fme.ace.data_loading.inference import (
 from fme.ace.inference.inference import InitialConditionConfig, get_initial_condition
 from fme.ace.requirements import InitialConditionRequirements
 from fme.core.cli import prepare_config, prepare_directory
-from fme.core.cloud import makedirs
+from fme.core.cloud import exists, makedirs
 from fme.core.derived_variables import get_derived_variable_metadata
 from fme.core.generics.inference import get_record_to_wandb, run_inference
 from fme.core.logging_utils import LoggingConfig
@@ -27,6 +29,8 @@ from fme.coupled.data_loading.getters import get_forcing_data
 from fme.coupled.data_loading.gridded_data import InferenceGriddedData
 from fme.coupled.data_loading.inference import CoupledForcingDataLoaderConfig
 from fme.coupled.inference.data_writer import (
+    ATMOSPHERE_OUTPUT_DIR_NAME,
+    OCEAN_OUTPUT_DIR_NAME,
     CoupledDataWriterConfig,
     CoupledPairedDataWriter,
     DatasetMetadata,
@@ -88,9 +92,34 @@ class CoupledInitialConditionConfig:
         ocean = self.ocean.get_dataset(self.start_indices)
         # time is a required variable but not necessarily a dimension
         sample_dim_name = ocean.time.dims[0]
-        atmos = self.atmosphere.get_dataset().sel(
-            {sample_dim_name: ocean[sample_dim_name]}
-        )
+        atmos = self.atmosphere.get_dataset()
+        if sample_dim_name in ocean.indexes:
+            atmos = atmos.sel({sample_dim_name: ocean[sample_dim_name]})
+        else:
+            # Datasets without a sample coordinate (e.g. paired restart files
+            # written from a single CoupledPrognosticState) are positionally
+            # aligned, so validate the alignment instead of selecting.
+            if self.start_indices is not None:
+                raise ValueError(
+                    "start_indices cannot be used with an ocean initial "
+                    f"condition dataset that has no '{sample_dim_name}' "
+                    "coordinate to select by."
+                )
+            if atmos.sizes[sample_dim_name] != ocean.sizes[sample_dim_name]:
+                raise ValueError(
+                    "Ocean and atmosphere initial condition datasets have no "
+                    f"'{sample_dim_name}' coordinate and different numbers of "
+                    f"samples: {ocean.sizes[sample_dim_name]} and "
+                    f"{atmos.sizes[sample_dim_name]}."
+                )
+            if not (atmos["time"].values == ocean["time"].values).all():
+                raise ValueError(
+                    "Ocean and atmosphere initial condition datasets have no "
+                    f"'{sample_dim_name}' coordinate and different times; both "
+                    "must be at the same coupled step boundary. Got ocean "
+                    f"times {ocean['time'].values} and atmosphere times "
+                    f"{atmos['time'].values}."
+                )
         return CoupledPrognosticState(
             ocean_data=get_initial_condition(
                 ds=ocean,
@@ -207,6 +236,7 @@ class InferenceConfig:
 
 def main(
     yaml_config: str,
+    segments: int | None = None,
     override_dotlist: Sequence[str] | None = None,
 ):
     config_data = prepare_config(yaml_config, override=override_dotlist)
@@ -217,8 +247,74 @@ def main(
     )
     prepare_directory(config.experiment_dir, config_data)
     with torch.no_grad():
-        with GlobalTimer():
-            return run_inference_from_config(config)
+        if segments is None:
+            with GlobalTimer():
+                return run_inference_from_config(config)
+        else:
+            config.configure_logging(log_filename="inference_out.log")
+            run_segmented_inference(config, segments)
+
+
+def run_segmented_inference(config: InferenceConfig, segments: int):
+    """Run coupled inference in multiple segments.
+
+    Each segment runs ``config.n_coupled_steps`` coupled steps, writing its
+    outputs to a ``segment_{n:04d}`` subdirectory of the experiment directory.
+    A segment is complete when both its ocean and atmosphere restart files
+    exist; they are written last, after all other segment outputs. Completed
+    segments are skipped, so an interrupted run resumes at the first incomplete
+    segment when invoked again with the same configuration. Each segment after
+    the first initializes from the previous segment's restart files, which sit
+    at a coupled step boundary and therefore satisfy the ocean-anchored initial
+    condition timing.
+
+    Args:
+        config: inference configuration to be used for each individual segment.
+            The provided initial condition configuration will only be used for
+            the first segment.
+        segments: total number of segments desired. Only missing segments will
+            be run.
+    """
+    if config.n_ensemble_per_ic > 1:
+        raise ValueError(
+            "Ensemble inference (n_ensemble_per_ic > 1) is not supported with "
+            "segmented inference. A segment's restart already carries the "
+            "broadcasted ensemble as its sample dimension, so later segments "
+            "cannot re-broadcast it consistently. Run with n_ensemble_per_ic=1, "
+            "or run a single non-segmented inference for ensemble runs."
+        )
+    logging.info(
+        f"Starting segmented coupled inference with {segments} segments. "
+        f"Saving to {config.experiment_dir}."
+    )
+    config_copy = copy.deepcopy(config)
+    original_wandb_name = os.environ.get("WANDB_NAME")
+    for segment in range(segments):
+        segment_label = f"segment_{segment:04d}"
+        segment_dir = os.path.join(config.experiment_dir, segment_label)
+        ocean_restart_path = os.path.join(
+            segment_dir, OCEAN_OUTPUT_DIR_NAME, "restart.nc"
+        )
+        atmosphere_restart_path = os.path.join(
+            segment_dir, ATMOSPHERE_OUTPUT_DIR_NAME, "restart.nc"
+        )
+        if exists(ocean_restart_path) and exists(atmosphere_restart_path):
+            logging.info(f"Skipping segment {segment} because it has already been run.")
+        else:
+            logging.info(f"Running segment {segment}.")
+            config_copy.experiment_dir = segment_dir
+            if original_wandb_name is not None:
+                os.environ["WANDB_NAME"] = f"{original_wandb_name}-{segment_label}"
+            with GlobalTimer():
+                run_inference_from_config(config_copy)
+        config_copy.initial_condition = CoupledInitialConditionConfig(
+            ocean=ComponentInitialConditionConfig(
+                path=ocean_restart_path, engine="netcdf4"
+            ),
+            atmosphere=ComponentInitialConditionConfig(
+                path=atmosphere_restart_path, engine="netcdf4"
+            ),
+        )
 
 
 def run_inference_from_config(config: InferenceConfig):

--- a/fme/coupled/inference/test_segmented.py
+++ b/fme/coupled/inference/test_segmented.py
@@ -15,6 +15,9 @@ import yaml
 from fme.ace.data_loading.batch_data import BatchData, PrognosticState
 from fme.ace.inference.data_writer import PairedDataWriter
 from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
+from fme.ace.inference.data_writer.file_writer import FileWriterConfig
+from fme.ace.inference.data_writer.time_coarsen import MonthlyCoarsenConfig
+from fme.ace.inference.data_writer.zarr import ZarrWriterConfig
 from fme.ace.inference.inference import ForcingDataLoaderConfig
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.logging_utils import LoggingConfig
@@ -64,7 +67,7 @@ def _restart_paths(segment_dir: str) -> tuple[str, str]:
     )
 
 
-def _run_inference_from_config_mock(config: InferenceConfig):
+def _run_inference_from_config_mock(config: InferenceConfig, segment_context=None):
     for restart_path in _restart_paths(config.experiment_dir):
         os.makedirs(os.path.dirname(restart_path), exist_ok=True)
         with open(restart_path, "w") as f:
@@ -351,3 +354,99 @@ def test_inference_segmented_entrypoint():
             xr.testing.assert_equal(
                 ds_segment_1, ds_single.isel(time=slice(n_component_steps, None))
             )
+
+
+@pytest.mark.medium_duration
+def test_inference_segmented_entrypoint_zarr_outputs():
+    """Zarr outputs configured via `files` accumulate into single whole-run
+    stores shared by all segments, identical to those of an unsegmented run.
+    Monthly zarr outputs accumulate across the segment boundary via the
+    per-segment snapshots."""
+    from fme.ace.inference.data_writer.main import DataWriterConfig
+    from fme.coupled.inference.data_writer import CoupledDataWriterConfig
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = pathlib.Path(tmp_dir)
+        n_coupled_steps = 2
+        ocean_in_names = ["o_prog", "sst", "mask_0", "a_diag"]
+        ocean_out_names = ["o_prog", "sst", "o_diag"]
+        atmos_in_names = [
+            "a_prog",
+            "surface_temperature",
+            "forcing_var",
+            "ocean_fraction",
+        ]
+        atmos_out_names = ["a_prog", "surface_temperature", "a_diag"]
+
+        config, _, _ = _setup(
+            ocean_in_names=ocean_in_names,
+            ocean_out_names=ocean_out_names,
+            atmos_in_names=atmos_in_names,
+            atmos_out_names=atmos_out_names,
+            tmp_path=tmp_path,
+            n_coupled_steps=2 * n_coupled_steps,
+            coupled_steps_in_memory=1,
+            n_initial_conditions=1,
+        )
+        component_writer_config = DataWriterConfig(
+            save_prediction_files=False,
+            save_monthly_files=False,
+            files=[
+                FileWriterConfig(label="output", format=ZarrWriterConfig()),
+                FileWriterConfig(
+                    label="monthly",
+                    format=ZarrWriterConfig(),
+                    time_coarsen=MonthlyCoarsenConfig(),
+                ),
+            ],
+        )
+        config.data_writer = CoupledDataWriterConfig(
+            ocean=component_writer_config,
+            atmosphere=component_writer_config,
+        )
+        config.logging = LoggingConfig(
+            log_to_screen=True, log_to_file=False, log_to_wandb=False
+        )
+
+        segmented_dir = tmp_path / "segmented_run"
+        config.n_coupled_steps = n_coupled_steps
+        config.experiment_dir = str(segmented_dir)
+        config_filename = tmp_path / "config.yaml"
+        with open(config_filename, "w") as f:
+            yaml.dump(dataclasses.asdict(config), f)
+        main(yaml_config=str(config_filename), segments=2)
+
+        single_dir = tmp_path / "single_run"
+        config.n_coupled_steps = 2 * n_coupled_steps
+        config.experiment_dir = str(single_dir)
+        with open(config_filename, "w") as f:
+            yaml.dump(dataclasses.asdict(config), f)
+        main(yaml_config=str(config_filename))
+
+        for component_dir in [OCEAN_OUTPUT_DIR_NAME, ATMOSPHERE_OUTPUT_DIR_NAME]:
+            for store in [
+                "output_predictions.zarr",
+                "output_target.zarr",
+                "monthly_predictions.zarr",
+                "monthly_target.zarr",
+            ]:
+                ds_segmented = xr.open_zarr(
+                    str(segmented_dir / component_dir / store),
+                    decode_timedelta=False,
+                ).load()
+                ds_single = xr.open_zarr(
+                    str(single_dir / component_dir / store),
+                    decode_timedelta=False,
+                ).load()
+                # the creation timestamps differ by construction
+                ds_segmented.attrs.pop("history.created", None)
+                ds_single.attrs.pop("history.created", None)
+                xr.testing.assert_identical(ds_segmented, ds_single)
+        # the monthly snapshots ride the segment directories
+        assert (
+            segmented_dir
+            / "segment_0000"
+            / OCEAN_OUTPUT_DIR_NAME
+            / "monthly_snapshots"
+            / "monthly_predictions.nc"
+        ).exists()

--- a/fme/coupled/inference/test_segmented.py
+++ b/fme/coupled/inference/test_segmented.py
@@ -1,0 +1,353 @@
+"""Tests for the segmented coupled inference entrypoint."""
+
+import dataclasses
+import os
+import pathlib
+import tempfile
+import unittest.mock
+
+import cftime
+import pytest
+import torch
+import xarray as xr
+import yaml
+
+from fme.ace.data_loading.batch_data import BatchData, PrognosticState
+from fme.ace.inference.data_writer import PairedDataWriter
+from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
+from fme.ace.inference.inference import ForcingDataLoaderConfig
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.core.logging_utils import LoggingConfig
+from fme.core.random_state import RandomState
+from fme.core.stepper_state import StepperState
+from fme.coupled.data_loading.batch_data import CoupledPrognosticState
+from fme.coupled.data_loading.inference import CoupledForcingDataLoaderConfig
+from fme.coupled.inference.data_writer import (
+    ATMOSPHERE_OUTPUT_DIR_NAME,
+    OCEAN_OUTPUT_DIR_NAME,
+    CoupledPairedDataWriter,
+)
+from fme.coupled.inference.inference import (
+    ComponentInitialConditionConfig,
+    CoupledInitialConditionConfig,
+    InferenceConfig,
+    main,
+    run_segmented_inference,
+)
+from fme.coupled.inference.test_inference import _setup
+
+
+def _get_mock_config(experiment_dir: str) -> InferenceConfig:
+    return InferenceConfig(
+        experiment_dir=experiment_dir,
+        n_coupled_steps=3,
+        checkpoint_path="mock_checkpoint",
+        logging=LoggingConfig(
+            log_to_screen=True, log_to_file=False, log_to_wandb=False
+        ),
+        initial_condition=CoupledInitialConditionConfig(
+            ocean=ComponentInitialConditionConfig(path="mock_ocean_ic"),
+            atmosphere=ComponentInitialConditionConfig(path="mock_atmosphere_ic"),
+        ),
+        forcing_loader=CoupledForcingDataLoaderConfig(
+            atmosphere=ForcingDataLoaderConfig(
+                dataset=XarrayDataConfig(data_path="mock_forcing")
+            ),
+        ),
+    )
+
+
+def _restart_paths(segment_dir: str) -> tuple[str, str]:
+    return (
+        os.path.join(segment_dir, OCEAN_OUTPUT_DIR_NAME, "restart.nc"),
+        os.path.join(segment_dir, ATMOSPHERE_OUTPUT_DIR_NAME, "restart.nc"),
+    )
+
+
+def _run_inference_from_config_mock(config: InferenceConfig):
+    for restart_path in _restart_paths(config.experiment_dir):
+        os.makedirs(os.path.dirname(restart_path), exist_ok=True)
+        with open(restart_path, "w") as f:
+            f.write("mock restart file")
+    with open(os.path.join(config.experiment_dir, "wandb_name_env_var"), "w") as f:
+        f.write(os.environ.get("WANDB_NAME", ""))
+    with open(os.path.join(config.experiment_dir, "ic_paths"), "w") as f:
+        f.write(
+            f"{config.initial_condition.ocean.path}\n"
+            f"{config.initial_condition.atmosphere.path}"
+        )
+
+
+def test_run_segmented_inference(tmp_path, monkeypatch):
+    mock = unittest.mock.MagicMock(side_effect=_run_inference_from_config_mock)
+    config = _get_mock_config(str(tmp_path))
+
+    with unittest.mock.patch(
+        "fme.coupled.inference.inference.run_inference_from_config", new=mock
+    ):
+        # run a single segment
+        monkeypatch.setenv("WANDB_NAME", "run_name")
+        run_segmented_inference(config, 1)
+        segment_dir = os.path.join(config.experiment_dir, "segment_0000")
+        for restart_path in _restart_paths(segment_dir):
+            assert os.path.exists(restart_path)
+        assert mock.call_count == 1
+        with open(os.path.join(segment_dir, "wandb_name_env_var")) as f:
+            assert f.read() == "run_name-segment_0000"
+
+        # rerun the same segment and ensure run_inference_from_config isn't
+        # called again
+        run_segmented_inference(config, 1)
+        assert mock.call_count == 1
+
+        # extend to three segments; exactly two more segments are run, and each
+        # segment after the first initializes from the previous segment's
+        # restart files
+        monkeypatch.setenv("WANDB_NAME", "run_name")
+        run_segmented_inference(config, 3)
+        assert mock.call_count == 3
+        for i in range(3):
+            segment_dir = os.path.join(config.experiment_dir, f"segment_{i:04d}")
+            for restart_path in _restart_paths(segment_dir):
+                assert os.path.exists(restart_path)
+        for i in range(1, 3):
+            segment_dir = os.path.join(config.experiment_dir, f"segment_{i:04d}")
+            with open(os.path.join(segment_dir, "wandb_name_env_var")) as f:
+                assert f.read() == f"run_name-segment_{i:04d}"
+            previous_segment_dir = os.path.join(
+                config.experiment_dir, f"segment_{i - 1:04d}"
+            )
+            with open(os.path.join(segment_dir, "ic_paths")) as f:
+                assert f.read().splitlines() == list(
+                    _restart_paths(previous_segment_dir)
+                )
+
+
+def test_run_segmented_inference_reruns_partial_segment(tmp_path):
+    """A segment with only one of its two restart files is incomplete and must
+    be re-run."""
+    mock = unittest.mock.MagicMock(side_effect=_run_inference_from_config_mock)
+    config = _get_mock_config(str(tmp_path))
+    segment_dir = os.path.join(config.experiment_dir, "segment_0000")
+    ocean_restart_path, _ = _restart_paths(segment_dir)
+    os.makedirs(os.path.dirname(ocean_restart_path))
+    with open(ocean_restart_path, "w") as f:
+        f.write("mock restart file")
+
+    with unittest.mock.patch(
+        "fme.coupled.inference.inference.run_inference_from_config", new=mock
+    ):
+        run_segmented_inference(config, 1)
+    assert mock.call_count == 1
+
+
+def test_segmented_inference_rejects_ensemble(tmp_path):
+    config = _get_mock_config(str(tmp_path))
+    config.n_ensemble_per_ic = 3
+    with pytest.raises(ValueError, match="n_ensemble_per_ic"):
+        run_segmented_inference(config, 3)
+
+
+def _paired_writer(path: pathlib.Path) -> PairedDataWriter:
+    os.makedirs(path, exist_ok=True)
+    return PairedDataWriter(
+        writers=[],
+        path=str(path),
+        variable_metadata={},
+        coords={},
+        dataset_metadata=DatasetMetadata(),
+    )
+
+
+def _coupled_prognostic_state(
+    n_samples: int = 2,
+    atmosphere_time_offset: int = 0,
+) -> CoupledPrognosticState:
+    def _component(name: str, hour: int) -> PrognosticState:
+        time = xr.DataArray(
+            [[cftime.DatetimeProlepticGregorian(2000, 1, 2, hour)]] * n_samples,
+            dims=["sample", "time"],
+        )
+        return PrognosticState(
+            BatchData.new_on_cpu(
+                data={name: torch.rand(n_samples, 1, 4, 8)},
+                time=time,
+                stepper_state=StepperState(random_state=RandomState.from_seed(0)),
+            )
+        )
+
+    return CoupledPrognosticState(
+        ocean_data=_component("o_prog", 0),
+        atmosphere_data=_component("a_prog", atmosphere_time_offset),
+    )
+
+
+def _write_coupled_restart(
+    tmp_path: pathlib.Path, state: CoupledPrognosticState
+) -> tuple[str, str]:
+    writer = CoupledPairedDataWriter(
+        ocean_writer=_paired_writer(tmp_path / OCEAN_OUTPUT_DIR_NAME),
+        atmosphere_writer=_paired_writer(tmp_path / ATMOSPHERE_OUTPUT_DIR_NAME),
+    )
+    writer.write(state, "restart.nc")
+    return _restart_paths(str(tmp_path))
+
+
+def test_restart_files_as_initial_condition(tmp_path):
+    """Paired restart files have no sample coordinate; the coupled initial
+    condition config must read them positionally and restore the embedded
+    stepper state."""
+    state = _coupled_prognostic_state()
+    ocean_restart_path, atmosphere_restart_path = _write_coupled_restart(
+        tmp_path, state
+    )
+
+    config = CoupledInitialConditionConfig(
+        ocean=ComponentInitialConditionConfig(path=ocean_restart_path),
+        atmosphere=ComponentInitialConditionConfig(path=atmosphere_restart_path),
+    )
+    restored = config.get_initial_condition(
+        ocean_prognostic_names=["o_prog"],
+        atmosphere_prognostic_names=["a_prog"],
+        n_ensemble_per_ic=1,
+    )
+
+    for restored_component, written_component, name in [
+        (restored.ocean_data, state.ocean_data, "o_prog"),
+        (restored.atmosphere_data, state.atmosphere_data, "a_prog"),
+    ]:
+        restored_batch = restored_component.as_batch_data()
+        written_batch = written_component.as_batch_data()
+        torch.testing.assert_close(
+            restored_batch.data[name], written_batch.data[name], rtol=0, atol=0
+        )
+        assert (restored_batch.time.values == written_batch.time.values).all()
+        assert restored_batch.stepper_state is not None
+        assert restored_batch.stepper_state.random_state is not None
+
+
+def test_restart_files_as_initial_condition_rejects_start_indices(tmp_path):
+    from fme.ace.data_loading.inference import ExplicitIndices
+
+    ocean_restart_path, atmosphere_restart_path = _write_coupled_restart(
+        tmp_path, _coupled_prognostic_state()
+    )
+    config = CoupledInitialConditionConfig(
+        ocean=ComponentInitialConditionConfig(path=ocean_restart_path),
+        atmosphere=ComponentInitialConditionConfig(path=atmosphere_restart_path),
+        start_indices=ExplicitIndices([0]),
+    )
+    with pytest.raises(ValueError, match="start_indices"):
+        config.get_initial_condition(
+            ocean_prognostic_names=["o_prog"],
+            atmosphere_prognostic_names=["a_prog"],
+            n_ensemble_per_ic=1,
+        )
+
+
+def test_restart_files_as_initial_condition_rejects_mismatched_times(tmp_path):
+    ocean_restart_path, atmosphere_restart_path = _write_coupled_restart(
+        tmp_path, _coupled_prognostic_state(atmosphere_time_offset=6)
+    )
+    config = CoupledInitialConditionConfig(
+        ocean=ComponentInitialConditionConfig(path=ocean_restart_path),
+        atmosphere=ComponentInitialConditionConfig(path=atmosphere_restart_path),
+    )
+    with pytest.raises(ValueError, match="different times"):
+        config.get_initial_condition(
+            ocean_prognostic_names=["o_prog"],
+            atmosphere_prognostic_names=["a_prog"],
+            n_ensemble_per_ic=1,
+        )
+
+
+@pytest.mark.medium_duration
+def test_inference_segmented_entrypoint():
+    """Two segments of N coupled steps reproduce a single 2N-step run exactly,
+    and completed segments are skipped on re-invocation."""
+    # tempfile instead of the tmp_path fixture, since the latter causes issues
+    # with checking the last modified time of files produced by the test
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = pathlib.Path(tmp_dir)
+        n_coupled_steps = 2
+        ocean_in_names = ["o_prog", "sst", "mask_0", "a_diag"]
+        ocean_out_names = ["o_prog", "sst", "o_diag"]
+        atmos_in_names = [
+            "a_prog",
+            "surface_temperature",
+            "forcing_var",
+            "ocean_fraction",
+        ]
+        atmos_out_names = ["a_prog", "surface_temperature", "a_diag"]
+
+        # provide enough forcing data for both segments
+        config, mock_data, atmos_steps_per_ocean_step = _setup(
+            ocean_in_names=ocean_in_names,
+            ocean_out_names=ocean_out_names,
+            atmos_in_names=atmos_in_names,
+            atmos_out_names=atmos_out_names,
+            tmp_path=tmp_path,
+            n_coupled_steps=2 * n_coupled_steps,
+            coupled_steps_in_memory=1,
+            n_initial_conditions=1,
+        )
+        segmented_dir = tmp_path / "segmented_run"
+        config.n_coupled_steps = n_coupled_steps
+        config.experiment_dir = str(segmented_dir)
+        config.logging = LoggingConfig(
+            log_to_screen=True, log_to_file=False, log_to_wandb=False
+        )
+        config_filename = tmp_path / "config.yaml"
+        with open(config_filename, "w") as f:
+            yaml.dump(dataclasses.asdict(config), f)
+
+        # both segments run in a single invocation
+        main(yaml_config=str(config_filename), segments=2)
+
+        # re-invoke and ensure completed segments are not re-run
+        prediction_filenames = [
+            os.path.join(
+                segmented_dir,
+                f"segment_{segment:04d}",
+                OCEAN_OUTPUT_DIR_NAME,
+                "autoregressive_predictions.nc",
+            )
+            for segment in range(2)
+        ]
+        mtimes = [os.path.getmtime(filename) for filename in prediction_filenames]
+        main(yaml_config=str(config_filename), segments=2)
+        for filename, mtime in zip(prediction_filenames, mtimes):
+            assert os.path.getmtime(filename) == pytest.approx(mtime)
+
+        # a non-segmented run over the same total duration
+        single_dir = tmp_path / "single_run"
+        config.n_coupled_steps = 2 * n_coupled_steps
+        config.experiment_dir = str(single_dir)
+        with open(config_filename, "w") as f:
+            yaml.dump(dataclasses.asdict(config), f)
+        main(yaml_config=str(config_filename))
+
+        # the second segment must match the second half of the single run
+        for component_dir, n_component_steps in [
+            (OCEAN_OUTPUT_DIR_NAME, n_coupled_steps),
+            (ATMOSPHERE_OUTPUT_DIR_NAME, n_coupled_steps * atmos_steps_per_ocean_step),
+        ]:
+            ds_segment_1 = xr.open_dataset(
+                segmented_dir
+                / "segment_0001"
+                / component_dir
+                / "autoregressive_predictions.nc",
+                decode_timedelta=False,
+            )
+            ds_single = xr.open_dataset(
+                single_dir / component_dir / "autoregressive_predictions.nc",
+                decode_timedelta=False,
+            )
+            assert ds_single.sizes["time"] == 2 * n_component_steps
+            # drop time coordinates, which differ by construction
+            # (per-segment initial time)
+            ds_segment_1 = ds_segment_1.drop_vars(["init_time", "time"])
+            ds_single = ds_single.drop_vars(["init_time", "time"])
+            xr.testing.assert_equal(
+                ds_segment_1, ds_single.isel(time=slice(n_component_steps, None))
+            )

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -46,6 +46,7 @@ from fme.core.ocean import OceanConfig
 from fme.core.ocean_data import OCEAN_FIELD_NAME_PREFIXES, OceanData
 from fme.core.optimization import NullOptimization
 from fme.core.step.output import StepOutput
+from fme.core.stepper_state import StepperState
 from fme.core.tensors import add_ensemble_dim, unfold_ensemble_dim
 from fme.core.timing import GlobalTimer
 from fme.core.training_history import TrainingHistory, TrainingJob
@@ -772,10 +773,12 @@ class ComponentStepPrediction:
         realm: Literal["ocean", "atmosphere"],
         data: TensorDict,
         step: int,
+        stepper_state: StepperState | None = None,
     ):
         self._realm: Literal["ocean", "atmosphere"] = realm
         self._data = data
         self._step = step
+        self._stepper_state = stepper_state
 
     @property
     def realm(self) -> Literal["ocean", "atmosphere"]:
@@ -788,6 +791,10 @@ class ComponentStepPrediction:
     @property
     def step(self) -> int:
         return self._step
+
+    @property
+    def stepper_state(self) -> StepperState | None:
+        return self._stepper_state
 
 
 class CoupledStepper:
@@ -917,6 +924,7 @@ class CoupledStepper:
                 data=atmos_ic_data,
                 time=forcing_ic_batch.time,
                 labels=forcing_ic_batch.labels,
+                stepper_state=atmos_ic_state.as_batch_data().stepper_state,
             )
         )
 
@@ -1112,15 +1120,19 @@ class CoupledStepper:
                 optimizer,
             )
             atmos_steps = []
+            atmos_stepper_state: StepperState | None = None
 
             # predict and yield atmosphere steps
             for i_inner in range(self.n_inner_steps):
                 atmos_step_num = i_outer * self.n_inner_steps + i_inner
-                atmos_step = next(atmos_generator).output
+                atmos_result = next(atmos_generator)
+                atmos_step = atmos_result.output
+                atmos_stepper_state = atmos_result.stepper_state
                 yield ComponentStepPrediction(
                     realm="atmosphere",
                     data=atmos_step,
                     step=atmos_step_num,
+                    stepper_state=atmos_stepper_state,
                 )
                 atmos_step = optimizer.detach_if_using_gradient_accumulation(atmos_step)
                 atmos_steps.append(atmos_step)
@@ -1147,7 +1159,7 @@ class CoupledStepper:
                 labels=ocean_window.labels,
             )
             # predict and yield a single ocean step
-            ocean_step = next(
+            ocean_result = next(
                 iter(
                     self.ocean.get_prediction_generator(
                         ocean_ic_state,
@@ -1156,11 +1168,13 @@ class CoupledStepper:
                         optimizer=optimizer,
                     )
                 )
-            ).output
+            )
+            ocean_step = ocean_result.output
             yield ComponentStepPrediction(
                 realm="ocean",
                 data=ocean_step,
                 step=i_outer,
+                stepper_state=ocean_result.stepper_state,
             )
 
             # prepare ic states for next coupled step
@@ -1175,6 +1189,7 @@ class CoupledStepper:
                         time=slice(-self.atmosphere.n_ic_timesteps, None)
                     ),
                     labels=atmos_window.labels,
+                    stepper_state=atmos_stepper_state,
                 )
             )
             ocean_ic_data = {
@@ -1185,6 +1200,7 @@ class CoupledStepper:
                     data=optimizer.detach_if_using_gradient_accumulation(ocean_ic_data),
                     time=ocean_window.time.isel(time=slice(-self.n_ic_timesteps, None)),
                     labels=ocean_window.labels,
+                    stepper_state=ocean_result.stepper_state,
                 )
             )
 
@@ -1195,7 +1211,7 @@ class CoupledStepper:
     ) -> CoupledBatchData:
         atmos_data = process_prediction_generator_list(
             [
-                StepOutput(output=x.data, stepper_state=None)
+                StepOutput(output=x.data, stepper_state=x.stepper_state)
                 for x in output_list
                 if x.realm == "atmosphere"
             ],
@@ -1206,7 +1222,7 @@ class CoupledStepper:
         )
         ocean_data = process_prediction_generator_list(
             [
-                StepOutput(output=x.data, stepper_state=None)
+                StepOutput(output=x.data, stepper_state=x.stepper_state)
                 for x in output_list
                 if x.realm == "ocean"
             ],

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -24,6 +24,7 @@ from fme.core.dataset_info import DatasetInfo
 from fme.core.loss import StepLossConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
 from fme.core.optimization import NullOptimization
+from fme.core.random_state import RandomState
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
 from fme.core.spatial_mask_provider import SpatialMaskProvider
@@ -1725,6 +1726,76 @@ def test_predict_paired():
     torch.testing.assert_close(
         paired_data.ocean_data.prediction["o_diag"].select(dim=1, index=1),
         o_diag1,
+    )
+
+
+def test_predict_paired_threads_stepper_state():
+    """Stepper state attached to the initial condition must survive the coupled
+    rollout into the final prognostic state, so restarts can carry it.
+
+    Each component's state has to pass through the SST prescription and the
+    per-coupled-step initial-condition rebuild, so a two-coupled-step rollout
+    exercises every hand-off point.
+    """
+    ocean_in_names = ["o_prog", "o_sfc_temp", "o_mask", "a_diag"]
+    ocean_out_names = ["o_prog", "o_sfc_temp", "o_diag"]
+    atmos_in_names = ["a_prog", "a_sfc_temp", "ocean_frac", "o_prog"]
+    atmos_out_names = ["a_prog", "a_sfc_temp", "a_diag"]
+
+    class Ocean(torch.nn.Module):
+        def forward(self, x):
+            return torch.concat([x[:, :1], x[:, :1], x[:, :1]], dim=1)
+
+    class Atmos(torch.nn.Module):
+        def forward(self, x):
+            return torch.concat([x[:, :1], x[:, 1:2], x[:, :1]], dim=1)
+
+    coupler, coupled_data, _, _ = get_stepper_and_batch(
+        ocean_in_names=ocean_in_names,
+        ocean_out_names=ocean_out_names,
+        atmosphere_in_names=atmos_in_names,
+        atmosphere_out_names=atmos_out_names,
+        n_forward_times_ocean=2,
+        n_forward_times_atmosphere=4,
+        n_samples=3,
+        sst_name_in_ocean_data="o_sfc_temp",
+        sfc_temp_name_in_atmosphere_data="a_sfc_temp",
+        ocean_fraction_name="ocean_frac",
+        ocean_builder=ModuleSelector(type="prebuilt", config={"module": Ocean()}),
+        atmosphere_builder=ModuleSelector(type="prebuilt", config={"module": Atmos()}),
+    )
+    data = coupled_data.data
+
+    atmos_prognostic = data.atmosphere_data.get_start(
+        coupler.atmosphere.prognostic_names, n_ic_timesteps=1
+    ).with_random_state(RandomState.from_seed(0))
+    ocean_prognostic = data.ocean_data.get_start(
+        coupler.ocean.prognostic_names, n_ic_timesteps=1
+    ).with_random_state(RandomState.from_seed(1))
+    ic = CoupledPrognosticState(
+        atmosphere_data=atmos_prognostic, ocean_data=ocean_prognostic
+    )
+
+    _, prognostic_state = coupler.predict_paired(
+        initial_condition=ic,
+        forcing=data,
+    )
+
+    atmos_state = prognostic_state.atmosphere_data.as_batch_data().stepper_state
+    ocean_state = prognostic_state.ocean_data.as_batch_data().stepper_state
+    assert atmos_state is not None
+    assert atmos_state.random_state is not None
+    assert ocean_state is not None
+    assert ocean_state.random_state is not None
+    # the deterministic test modules never draw from the generators, so the
+    # states must be exactly the seeded initial states, not reseeded ones
+    torch.testing.assert_close(
+        atmos_state.random_state.generator.get_state(),
+        RandomState.from_seed(0).generator.get_state(),
+    )
+    torch.testing.assert_close(
+        ocean_state.random_state.generator.get_state(),
+        RandomState.from_seed(1).generator.get_state(),
     )
 
 


### PR DESCRIPTION
Segmented inference writes each segment's outputs to its own directory, which fragments long-run outputs (e.g. monthly means) into per-segment files. This PR makes zarr outputs configured through `DataWriterConfig.files` accumulate into a single whole-run store shared by all segments, written to any fsspec-compatible location (including directly to a remote bucket), so a preempted-and-resumed run produces the same single stores as an uninterrupted one. netCDF outputs are unaffected and `MonthlyDataWriter` / `save_monthly_files` are untouched.

Block-mean `time_coarsen` needs no special handling across segments: it is stateless per batch and its validation requires the per-segment step count to be divisible by the coarsen factor, so no coarsening block can straddle a segment boundary; whole-run store offsets are simply expressed in coarsened units.

Changes:
- `fme.ace.inference.data_writer.zarr.ZarrWriterAdapter` and `SeparateICZarrWriterAdapter` take a `start_timestep`: the store is sized for the whole run, each segment region-writes its slice of the time axis, and resumed segments open the existing store in append mode; only the run's first segment may create the store, since its initial condition times determine the store's time coordinates
- `fme.ace.inference.data_writer.monthly_zarr.MonthlyZarrWriter`, built from a `files` entry with zarr format and `monthly_mean` time coarsening (previously rejected), with the month axis pre-allocated from the whole run's length; because monthly accumulation is not idempotent, `finalize` writes a netCDF snapshot to the segment directory (before the restart files, so restarts remain the completion marker) and the next segment's writer restores from it, making segment re-runs exact
- `fme.ace.inference.data_writer.zarr.ZarrWriterConfig` gains an optional `path` for placing stores outside the experiment directory
- `fme.ace.inference.data_writer.segment.SegmentContext` threaded at runtime from the coupled segmented driver through `DataWriterConfig` / `FileWriterConfig` build paths; no user-facing config changes and non-segmented runs are unchanged

- [x] Tests added