### PR TITLE
Expose drop_rate/drop_path_rate in the NoiseConditionedSFNO builder

### DIFF
--- a/fme/ace/registry/stochastic_sfno.py
+++ b/fme/ace/registry/stochastic_sfno.py
@@ -261,6 +261,8 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
             within the observed envelope (no-op when it already does).
             Bounds the global-mean of the latent the transformer blocks see
             at inference to the range observed in training.
+        drop_rate: Dropout rate.
+        drop_path_rate: Stochastic depth (drop path) rate.
     """
 
     spectral_transform: Literal["sht"] = "sht"
@@ -302,6 +304,8 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
     filter_preserves_global_mean: bool = False
     spectral_ratio: float = 1.0
     clip_latent_global_means: bool = False
+    drop_rate: float = 0.0
+    drop_path_rate: float = 0.0
 
     def __post_init__(self):
         if self.context_pos_embed_dim > 0 and self.pos_embed:
@@ -363,6 +367,8 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
             filter_preserves_global_mean=self.filter_preserves_global_mean,
             spectral_ratio=self.spectral_ratio,
             clip_latent_global_means=self.clip_latent_global_means,
+            drop_rate=self.drop_rate,
+            drop_path_rate=self.drop_path_rate,
         )
         sfno_net = get_lat_lon_sfnonet(
             params=sfno_config,

--- a/fme/ace/registry/test_stochastic_sfno.py
+++ b/fme/ace/registry/test_stochastic_sfno.py
@@ -4,7 +4,12 @@ import pytest
 import torch
 from torch_harmonics import InverseRealSHT
 
-from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNO, isotropic_noise
+from fme.ace.registry.stochastic_sfno import (
+    NoiseConditionedSFNO,
+    NoiseConditionedSFNOBuilder,
+    isotropic_noise,
+)
+from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
 from fme.core.models.conditional_sfno.layers import Context
 
@@ -88,3 +93,40 @@ def test_noise_conditioned_sfno_onehot_labels():
     args, _ = mock_sfno.call_args
     context = args[1]
     assert context.labels.shape == (batch_size, n_labels)
+
+
+def _build_small_noise_sfno(
+    drop_rate: float = 0.0, drop_path_rate: float = 0.0
+) -> NoiseConditionedSFNO:
+    builder = NoiseConditionedSFNOBuilder(
+        embed_dim=4,
+        noise_embed_dim=4,
+        num_layers=2,
+        drop_rate=drop_rate,
+        drop_path_rate=drop_path_rate,
+    )
+    return builder.build(
+        n_in_channels=3,
+        n_out_channels=3,
+        dataset_info=DatasetInfo(img_shape=(8, 16)),
+    )
+
+
+def test_noise_conditioned_sfno_builder_forwards_drop_rate():
+    """A non-zero drop_rate reaches the built network's dropout layer."""
+    model = _build_small_noise_sfno(drop_rate=0.5, drop_path_rate=0.3)
+    sfno_net = model.conditional_model
+    assert isinstance(sfno_net.pos_drop, torch.nn.Dropout)
+    assert sfno_net.pos_drop.p == 0.5
+    # drop_path_rate is spread over layers via linspace(0, rate, num_layers);
+    # the last block receives the full rate.
+    assert sfno_net.blocks[-1].drop_path.drop_prob == pytest.approx(0.3)
+
+
+def test_noise_conditioned_sfno_builder_drop_rate_default_off():
+    """The 0.0 default leaves dropout and drop-path as no-op Identity layers."""
+    model = _build_small_noise_sfno()
+    sfno_net = model.conditional_model
+    assert isinstance(sfno_net.pos_drop, torch.nn.Identity)
+    for block in sfno_net.blocks:
+        assert isinstance(block.drop_path, torch.nn.Identity)


### PR DESCRIPTION
`NoiseConditionedSFNOBuilder.build()` constructed `SFNONetConfig(...)` without passing `drop_rate` or `drop_path_rate`, so dropout and stochastic-depth regularization were silently pinned to the `SFNONetConfig` 0.0 defaults and unreachable from YAML. This exposes them so we can run dropout-regularized variants of stochastic-SFNO training.

Changes:
- `fme.ace.registry.stochastic_sfno.NoiseConditionedSFNOBuilder`: add `drop_rate: float = 0.0` and `drop_path_rate: float = 0.0` fields and forward both into the `SFNONetConfig(...)` construction in `build()`. Defaults of 0.0 preserve current behavior.
- `fme/ace/registry/test_stochastic_sfno.py`: build a small model via the builder and assert a non-zero `drop_rate=0.5` reaches `sfno_net.pos_drop` (an `nn.Dropout` with `p==0.5`) and `drop_path_rate=0.3` reaches the last block's `DropPath`; assert the 0.0 default leaves both as `nn.Identity`.

Out of scope: the deterministic SFNO builders in `fme/ace/registry/sfno.py` (`SphericalFourierNeuralOperatorBuilder`, `SFNO_V0_1_0`) target different underlying networks (modulus / makani) rather than `SFNONetConfig`, so exposing dropout there is not a trivial parallel one-line forward and would need separate verification against those nets.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated