### PR TITLE
Stochastic-ACE baseline bake-off configs (Phase 0)

### DIFF
--- a/configs/baselines/stochastic-ace-bakeoff/README.md
+++ b/configs/baselines/stochastic-ace-bakeoff/README.md
@@ -1,0 +1,52 @@
+# Stochastic-ACE baseline bake-off
+
+Phase 0 of the stochastic-ACE paper. Five training runs on the 1°/daily
+ERA5-only dataset that vary only the loss weighting, the total-energy
+corrector, and spectral whitening of the energy score, to pick the
+stochastic-ACE baseline recipe. Runs are launched by Jeremy via
+`run-train.sh` — this directory only defines the configs.
+
+## Arms
+
+All five arms share one base config (arm 1). Arms differ only in the
+knobs below.
+
+| config | crps_weight | energy_score_weight | total-energy corrector | energy-score whitening |
+|---|---|---|---|---|
+| `arm1-90-10-ec.yaml` (base) | 0.9 | 0.1 | `constant_temperature` | none |
+| `arm2-90-10-noec.yaml` | 0.9 | 0.1 | off | none |
+| `arm3-50-50-ec.yaml` | 0.5 | 0.5 | `constant_temperature` | none |
+| `arm4-90-10-ec-whiten-g0.5.yaml` | 0.9 | 0.1 | `constant_temperature` | `per_sample`, γ=0.5 |
+| `arm5-50-50-ec-whiten-g0.5.yaml` | 0.5 | 0.5 | `constant_temperature` | `per_sample`, γ=0.5 |
+
+`crps_weight`/`energy_score_weight` and `energy_score_whitening` live in
+`stepper_training.loss.kwargs`; the corrector toggle is
+`stepper.step.config.corrector.total_energy_budget_correction`
+(`constant_unaccounted_heating` defaults to 0.0). Every arm uses
+`seed: 0`.
+
+## Base recipe
+
+Recovered from Troy's run `nzccs8zd`
+(https://wandb.ai/ai2cm/ace/runs/nzccs8zd): NoiseConditionedSFNO
+(embed_dim 512, 8 layers, spectral_ratio 0.125, isotropic noise),
+residual prediction, EnsembleLoss (n_ensemble 2, n_forward_steps 1),
+shared global-mean removal, dry-air + moisture-budget correction, EMA
+0.999, FusedAdam lr 1e-4, batch_size 8. Trained 80 epochs on
+`/climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr` with
+an `h500: 5` per-channel loss weight. Data is 06Z daily, so every
+inference initial condition is at `T06:00:00`.
+
+In-training inference monitors 10-year stability/day-5 SSR/CRPS
+(`10year`, `10year_insample`, `weather_2024`, `weather_1994`). The
+46-year rollout is not run per arm; it and the full selection metrics
+(10-yr bias, day-5 SSR, climate-skill overview, spectral power) are a
+dedicated offline eval on the selected winner after the runs finish.
+
+## Train/validation split (stitch-aware ACE2 split)
+
+Train window is the ACE2 window (1940–1995, 2011–2019, 2021–2025), but
+split at the 11 ERA5 production-stream boundaries so that no residual
+training sample straddles a stream stitch (a stitch produces a spurious
+tendency). This yields 14 `subset` segments in `train_loader`. Validation
+is 1996–1997 (a held-out gap year pair between the two train blocks).

--- a/configs/baselines/stochastic-ace-bakeoff/README.md
+++ b/configs/baselines/stochastic-ace-bakeoff/README.md
@@ -29,10 +29,13 @@ knobs below.
 
 Recovered from Troy's run `nzccs8zd`
 (https://wandb.ai/ai2cm/ace/runs/nzccs8zd): NoiseConditionedSFNO
-(embed_dim 512, 8 layers, spectral_ratio 0.125, isotropic noise),
-residual prediction, EnsembleLoss (n_ensemble 2, n_forward_steps 1),
-shared global-mean removal, dry-air + moisture-budget correction, EMA
-0.999, FusedAdam lr 1e-4, batch_size 8. Trained 80 epochs on
+(embed_dim 512, 8 layers, spectral_ratio 0.125, isotropic noise,
+`clip_latent_global_means` off), residual prediction, EnsembleLoss
+(n_ensemble 2, n_forward_steps 1), shared global-mean removal, dry-air +
+moisture-budget correction, EMA 0.999, FusedAdam lr 1e-4, batch_size 8.
+40 inputs / 51 outputs: the four near-surface fields (TMP2m, Q2m,
+UGRD10m, VGRD10m) are output-only diagnostics, not inputs, and the model
+predicts `total_frozen_precipitation_rate`. Trained 80 epochs on
 `/climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr` with
 an `h500: 5` per-channel loss weight. Data is 06Z daily, so every
 inference initial condition is at `T06:00:00`.

--- a/configs/baselines/stochastic-ace-bakeoff/README.md
+++ b/configs/baselines/stochastic-ace-bakeoff/README.md
@@ -1,29 +1,50 @@
 # Stochastic-ACE baseline bake-off
 
-Phase 0 of the stochastic-ACE paper. Five training runs on the 1°/daily
-ERA5-only dataset that vary only the loss weighting, the total-energy
-corrector, and spectral whitening of the energy score, to pick the
-stochastic-ACE baseline recipe. Runs are launched by Jeremy via
-`run-train.sh` — this directory only defines the configs.
+Phase 0 of the stochastic-ACE paper. Eight training runs on the 1°/daily
+ERA5-only dataset that vary only the loss weighting (CRPS, energy score,
+and spectral-power CRPS), the total-energy corrector, and spectral
+whitening, to pick the stochastic-ACE baseline recipe. Runs are launched
+by Jeremy via `run-train.sh` — this directory only defines the configs.
 
 ## Arms
 
-All five arms share one base config (arm 1). Arms differ only in the
-knobs below.
+All eight arms share one base config (arm 1). Arms differ only in the
+knobs below. The weight columns are `crps` (`crps_weight`), `es`
+(`energy_score_weight`), and `sp` (`spectral_power_crps_weight`).
 
-| config | crps_weight | energy_score_weight | total-energy corrector | energy-score whitening |
-|---|---|---|---|---|
-| `arm1-90-10-ec.yaml` (base) | 0.9 | 0.1 | `constant_temperature` | none |
-| `arm2-90-10-noec.yaml` | 0.9 | 0.1 | off | none |
-| `arm3-50-50-ec.yaml` | 0.5 | 0.5 | `constant_temperature` | none |
-| `arm4-90-10-ec-whiten-g0.5.yaml` | 0.9 | 0.1 | `constant_temperature` | `per_sample`, γ=0.5 |
-| `arm5-50-50-ec-whiten-g0.5.yaml` | 0.5 | 0.5 | `constant_temperature` | `per_sample`, γ=0.5 |
+| config | crps | es | sp | total-energy corrector | whitening |
+|---|---|---|---|---|---|
+| `arm1-90-10-ec.yaml` (base) | 0.9 | 0.1 | 0 | `constant_temperature` | none |
+| `arm2-90-10-noec.yaml` | 0.9 | 0.1 | 0 | off | none |
+| `arm3-50-50-ec.yaml` | 0.5 | 0.5 | 0 | `constant_temperature` | none |
+| `arm4-90-10-ec-whiten-g0.5.yaml` | 0.9 | 0.1 | 0 | `constant_temperature` | `per_sample`, γ=0.5 |
+| `arm5-50-50-ec-whiten-g0.5.yaml` | 0.5 | 0.5 | 0 | `constant_temperature` | `per_sample`, γ=0.5 |
+| `arm6-80-10-sp10-ec.yaml` | 0.8 | 0.1 | 0.1 | `constant_temperature` | none |
+| `arm7-90-0-sp10-ec.yaml` | 0.9 | 0.0 | 0.1 | `constant_temperature` | none |
+| `arm8-80-10-sp10-ec-whiten-g0.5.yaml` | 0.8 | 0.1 | 0.1 | `constant_temperature` | `per_sample`, γ=0.5 |
 
-`crps_weight`/`energy_score_weight` and `energy_score_whitening` live in
-`stepper_training.loss.kwargs`; the corrector toggle is
+`crps_weight`/`energy_score_weight`/`spectral_power_crps_weight` and
+`energy_score_whitening` live in `stepper_training.loss.kwargs`; the
+corrector toggle is
 `stepper.step.config.corrector.total_energy_budget_correction`
 (`constant_unaccounted_heating` defaults to 0.0). Every arm uses
-`seed: 0`.
+`seed: 0`. Arm 8 shares its γ=0.5 whitening operator between the energy
+score and the spectral-power CRPS term (the same reweight applies to
+both).
+
+## Spectral-power CRPS term
+
+Arms 6–8 add a spectral-power-CRPS loss term
+(`SpectralPowerCRPSLoss`, `spectral_power_crps_weight`), an unmerged
+`fme/core/loss.py` feature this experiment branch integrates. It scores
+the (almost-)fair CRPS of the per-degree log spectral power, so it is
+phase-free (per-sample spatial phase noise does not enter) and
+scale-equitable across the red spectrum, giving a high-SNR amplitude
+gradient at degrees where per-mode energy-score gradients are
+noise-starved. It was validated at small scale in the 2026-07-06
+small-scale-calibration report (arm 2 there = `5k3fmlif`). When
+`energy_score_whitening` is enabled (arm 8), the per-degree power CRPS is
+reweighted with the same whitening operator the energy score uses.
 
 ## Base recipe
 

--- a/configs/baselines/stochastic-ace-bakeoff/README.md
+++ b/configs/baselines/stochastic-ace-bakeoff/README.md
@@ -61,16 +61,33 @@ predicts `total_frozen_precipitation_rate`. Trained 80 epochs on
 an `h500: 5` per-channel loss weight. Data is 06Z daily, so every
 inference initial condition is at `T06:00:00`.
 
-In-training inference monitors 10-year stability/day-5 SSR/CRPS
-(`10year`, `10year_insample`, `weather_2024`, `weather_1994`). The
-46-year rollout is not run per arm; it and the full selection metrics
-(10-yr bias, day-5 SSR, climate-skill overview, spectral power) are a
-dedicated offline eval on the selected winner after the runs finish.
+## Checkpoint selection and in-training inference
+
+Checkpoint selection is driven by a single weight-1.0 inference loop,
+`ace2_5yr_1996`, matching the ACE2-paper's selection inference: eight
+out-of-sample initial conditions spread through 1996 (inside the held-out
+1996–2010 gap), each rolled out 5 years deterministically
+(`n_forward_steps: 1826` at daily cadence, `n_ensemble_per_ic: 1`, ICs at
+06Z). Its selection metric is the time-mean of the inference period scored
+against the rollout's own target (`time_mean_norm/rmse/channel_mean`); no
+external time-mean reference is used. The full 5-year rollout stays inside
+the held-out gap, so selection is entirely out-of-sample.
+
+The `10year`, `10year_insample`, `weather_2024`, and `weather_1994` loops
+are retained as weight-0 diagnostics (10-year stability, day-5 SSR/CRPS)
+and no longer influence selection. The 46-year rollout is not run per arm;
+it and the full selection metrics (10-yr bias, day-5 SSR, climate-skill
+overview, spectral power) are a dedicated offline eval on the selected
+winner after the runs finish.
 
 ## Train/validation split (stitch-aware ACE2 split)
 
-Train window is the ACE2 window (1940–1995, 2011–2019, 2021–2025), but
-split at the 11 ERA5 production-stream boundaries so that no residual
-training sample straddles a stream stitch (a stitch produces a spurious
-tendency). This yields 14 `subset` segments in `train_loader`. Validation
-is 1996–1997 (a held-out gap year pair between the two train blocks).
+Train window matches the ACE2-paper data span (1940–1995, 2011–2019,
+2021–2022): the final segment ends 2022-12-31 (the ACE2 data ended there),
+not 2025. It is split at the ERA5 production-stream boundaries so that no
+residual training sample straddles a stream stitch (a stitch produces a
+spurious tendency); the daily-dataset seam report confirmed no stitch
+boundary falls in 2021–2025, so capping the final segment at 2022 needs no
+new split. This yields 14 `subset` segments in `train_loader`. Validation
+is 1996–1997 (a held-out gap year pair between the two train blocks),
+unchanged.

--- a/configs/baselines/stochastic-ace-bakeoff/arm1-90-10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm1-90-10-ec.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm1-90-10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm1-90-10-ec.yaml
@@ -405,7 +405,6 @@ stepper:
           use_mlp: true
           num_layers: 8
           operator_type: dhconv
-          clip_latent_global_means: true
       normalization:
         network:
           global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
@@ -432,6 +431,7 @@ stepper:
         - specific_total_water_7
         - Q2m
         - PRATEsfc
+        - total_frozen_precipitation_rate
         - ULWRFsfc
         - ULWRFtoa
         - DLWRFsfc
@@ -450,10 +450,6 @@ stepper:
       - global_mean_co2
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -489,10 +485,6 @@ stepper:
       out_names:
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -525,6 +517,10 @@ stepper:
       - northward_wind_5
       - northward_wind_6
       - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
       - LHTFLsfc
       - SHTFLsfc
       - PRATEsfc
@@ -537,6 +533,7 @@ stepper:
       - tendency_of_total_water_path_due_to_advection
       - TMP850
       - h500
+      - total_frozen_precipitation_rate
       global_mean_removal:
         kind: shared
         append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm1-90-10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm1-90-10-ec.yaml
@@ -1,0 +1,542 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm2-90-10-noec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm2-90-10-noec.yaml
@@ -1,0 +1,540 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm2-90-10-noec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm2-90-10-noec.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm2-90-10-noec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm2-90-10-noec.yaml
@@ -405,7 +405,6 @@ stepper:
           use_mlp: true
           num_layers: 8
           operator_type: dhconv
-          clip_latent_global_means: true
       normalization:
         network:
           global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
@@ -430,6 +429,7 @@ stepper:
         - specific_total_water_7
         - Q2m
         - PRATEsfc
+        - total_frozen_precipitation_rate
         - ULWRFsfc
         - ULWRFtoa
         - DLWRFsfc
@@ -448,10 +448,6 @@ stepper:
       - global_mean_co2
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -487,10 +483,6 @@ stepper:
       out_names:
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -523,6 +515,10 @@ stepper:
       - northward_wind_5
       - northward_wind_6
       - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
       - LHTFLsfc
       - SHTFLsfc
       - PRATEsfc
@@ -535,6 +531,7 @@ stepper:
       - tendency_of_total_water_path_due_to_advection
       - TMP850
       - h500
+      - total_frozen_precipitation_rate
       global_mean_removal:
         kind: shared
         append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm3-50-50-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm3-50-50-ec.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm3-50-50-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm3-50-50-ec.yaml
@@ -1,0 +1,542 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.5
+      energy_score_weight: 0.5
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm3-50-50-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm3-50-50-ec.yaml
@@ -405,7 +405,6 @@ stepper:
           use_mlp: true
           num_layers: 8
           operator_type: dhconv
-          clip_latent_global_means: true
       normalization:
         network:
           global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
@@ -432,6 +431,7 @@ stepper:
         - specific_total_water_7
         - Q2m
         - PRATEsfc
+        - total_frozen_precipitation_rate
         - ULWRFsfc
         - ULWRFtoa
         - DLWRFsfc
@@ -450,10 +450,6 @@ stepper:
       - global_mean_co2
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -489,10 +485,6 @@ stepper:
       out_names:
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -525,6 +517,10 @@ stepper:
       - northward_wind_5
       - northward_wind_6
       - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
       - LHTFLsfc
       - SHTFLsfc
       - PRATEsfc
@@ -537,6 +533,7 @@ stepper:
       - tendency_of_total_water_path_due_to_advection
       - TMP850
       - h500
+      - total_frozen_precipitation_rate
       global_mean_removal:
         kind: shared
         append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm4-90-10-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm4-90-10-ec-whiten-g0.5.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm4-90-10-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm4-90-10-ec-whiten-g0.5.yaml
@@ -1,0 +1,545 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+      energy_score_whitening:
+        kind: per_sample
+        exponent: 0.5
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm4-90-10-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm4-90-10-ec-whiten-g0.5.yaml
@@ -408,7 +408,6 @@ stepper:
           use_mlp: true
           num_layers: 8
           operator_type: dhconv
-          clip_latent_global_means: true
       normalization:
         network:
           global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
@@ -435,6 +434,7 @@ stepper:
         - specific_total_water_7
         - Q2m
         - PRATEsfc
+        - total_frozen_precipitation_rate
         - ULWRFsfc
         - ULWRFtoa
         - DLWRFsfc
@@ -453,10 +453,6 @@ stepper:
       - global_mean_co2
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -492,10 +488,6 @@ stepper:
       out_names:
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -528,6 +520,10 @@ stepper:
       - northward_wind_5
       - northward_wind_6
       - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
       - LHTFLsfc
       - SHTFLsfc
       - PRATEsfc
@@ -540,6 +536,7 @@ stepper:
       - tendency_of_total_water_path_due_to_advection
       - TMP850
       - h500
+      - total_frozen_precipitation_rate
       global_mean_removal:
         kind: shared
         append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm5-50-50-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm5-50-50-ec-whiten-g0.5.yaml
@@ -1,0 +1,545 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.5
+      energy_score_weight: 0.5
+      energy_score_whitening:
+        kind: per_sample
+        exponent: 0.5
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+          clip_latent_global_means: true
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm5-50-50-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm5-50-50-ec-whiten-g0.5.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm5-50-50-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm5-50-50-ec-whiten-g0.5.yaml
@@ -408,7 +408,6 @@ stepper:
           use_mlp: true
           num_layers: 8
           operator_type: dhconv
-          clip_latent_global_means: true
       normalization:
         network:
           global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
@@ -435,6 +434,7 @@ stepper:
         - specific_total_water_7
         - Q2m
         - PRATEsfc
+        - total_frozen_precipitation_rate
         - ULWRFsfc
         - ULWRFtoa
         - DLWRFsfc
@@ -453,10 +453,6 @@ stepper:
       - global_mean_co2
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -492,10 +488,6 @@ stepper:
       out_names:
       - PRESsfc
       - surface_temperature
-      - TMP2m
-      - Q2m
-      - UGRD10m
-      - VGRD10m
       - air_temperature_0
       - air_temperature_1
       - air_temperature_2
@@ -528,6 +520,10 @@ stepper:
       - northward_wind_5
       - northward_wind_6
       - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
       - LHTFLsfc
       - SHTFLsfc
       - PRATEsfc
@@ -540,6 +536,7 @@ stepper:
       - tendency_of_total_water_path_due_to_advection
       - TMP850
       - h500
+      - total_frozen_precipitation_rate
       global_mean_removal:
         kind: shared
         append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm6-80-10-sp10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm6-80-10-sp10-ec.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm6-80-10-sp10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm6-80-10-sp10-ec.yaml
@@ -1,0 +1,540 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.8
+      energy_score_weight: 0.1
+      spectral_power_crps_weight: 0.1
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - total_frozen_precipitation_rate
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      - total_frozen_precipitation_rate
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm7-90-0-sp10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm7-90-0-sp10-ec.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm7-90-0-sp10-ec.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm7-90-0-sp10-ec.yaml
@@ -1,0 +1,540 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.0
+      spectral_power_crps_weight: 0.1
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - total_frozen_precipitation_rate
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      - total_frozen_precipitation_rate
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/arm8-80-10-sp10-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm8-80-10-sp10-ec-whiten-g0.5.yaml
@@ -93,7 +93,7 @@ inference:
       histogram:
         enabled: true
   - name: 10year_insample
-    weight: 1.0
+    weight: 0.0
     epochs:
       start: 1
       step: 2
@@ -255,6 +255,45 @@ inference:
         enabled: false
       ipo_index:
         enabled: false
+  - name: ace2_5yr_1996
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 1826
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1996-01-01T06:00:00'
+          - '1996-02-15T06:00:00'
+          - '1996-04-01T06:00:00'
+          - '1996-05-15T06:00:00'
+          - '1996-07-01T06:00:00'
+          - '1996-08-15T06:00:00'
+          - '1996-10-01T06:00:00'
+          - '1996-11-15T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
 logging:
   log_to_screen: true
   log_to_wandb: true
@@ -352,7 +391,7 @@ train_loader:
         engine: zarr
         subset:
           start_time: '2021-01-01'
-          stop_time: '2025-12-31'
+          stop_time: '2022-12-31'
 validation:
   loader:
     batch_size: 32

--- a/configs/baselines/stochastic-ace-bakeoff/arm8-80-10-sp10-ec-whiten-g0.5.yaml
+++ b/configs/baselines/stochastic-ace-bakeoff/arm8-80-10-sp10-ec-whiten-g0.5.yaml
@@ -1,0 +1,543 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 80
+ema:
+  decay: 0.999
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T06:00:00'
+          - '2015-01-02T06:00:00'
+          - '2015-01-03T06:00:00'
+          - '2015-01-04T06:00:00'
+          - '2015-01-05T06:00:00'
+          - '2015-01-06T06:00:00'
+          - '2015-01-07T06:00:00'
+          - '2015-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 40
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T06:00:00'
+          - '1995-01-02T06:00:00'
+          - '1995-01-03T06:00:00'
+          - '1995-01-04T06:00:00'
+          - '1995-01-05T06:00:00'
+          - '1995-01-06T06:00:00'
+          - '1995-01-07T06:00:00'
+          - '1995-01-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T06:00:00'
+          - '2024-06-02T06:00:00'
+          - '2024-06-03T06:00:00'
+          - '2024-06-04T06:00:00'
+          - '2024-06-05T06:00:00'
+          - '2024-06-06T06:00:00'
+          - '2024-06-07T06:00:00'
+          - '2024-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T06:00:00'
+          - '1994-06-02T06:00:00'
+          - '1994-06-03T06:00:00'
+          - '1994-06-04T06:00:00'
+          - '1994-06-05T06:00:00'
+          - '1994-06-06T06:00:00'
+          - '1994-06-07T06:00:00'
+          - '1994-06-08T06:00:00'
+      dataset:
+        data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 8
+  prefetch_factor: 4
+  time_buffer: 1
+  dataset:
+    strict: false
+    concat:
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1940-01-01'
+          stop_time: '1943-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1944-01-01'
+          stop_time: '1948-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1949-01-01'
+          stop_time: '1953-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1954-01-01'
+          stop_time: '1958-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1959-01-01'
+          stop_time: '1963-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1964-01-01'
+          stop_time: '1968-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1969-01-01'
+          stop_time: '1973-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1974-01-01'
+          stop_time: '1978-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1995-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2011-01-01'
+          stop_time: '2014-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2015-01-01'
+          stop_time: '2019-12-31'
+      - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+        file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2021-01-01'
+          stop_time: '2025-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 3
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr
+          file_pattern: 2026-03-19-era5-1deg-8layer-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1996-01-01'
+            stop_time: '1997-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.8
+      energy_score_weight: 0.1
+      spectral_power_crps_weight: 0.1
+      energy_score_whitening:
+        kind: per_sample
+        exponent: 0.5
+    weights:
+      h500: 5
+stepper:
+  step:
+    type: single_module
+    config:
+      residual_prediction: true
+      builder:
+        type: NoiseConditionedSFNO
+        config:
+          embed_dim: 512
+          noise_embed_dim: 32
+          noise_type: isotropic
+          filter_type: linear
+          affine_norms: true
+          normalize_big_skip: true
+          filter_num_groups: 16
+          spectral_ratio: 0.125
+          use_mlp: true
+          num_layers: 8
+          operator_type: dhconv
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-03-19-era5-1deg-8layer-daily-stats-1990-2019/2026-03-19-era5-1deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        total_energy_budget_correction:
+          method: constant_temperature
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - total_frozen_precipitation_rate
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - HGTsfc
+      - global_mean_co2
+      - PRESsfc
+      - surface_temperature
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      out_names:
+      - PRESsfc
+      - surface_temperature
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      - total_frozen_precipitation_rate
+      global_mean_removal:
+        kind: shared
+        append_as_input: true

--- a/configs/baselines/stochastic-ace-bakeoff/run-train.sh
+++ b/configs/baselines/stochastic-ace-bakeoff/run-train.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Reference ACE training launcher. Canonical source:
+#   research/.claude/skills/launching-runs/run-train.reference.sh
+#
+# Baseline branches ADOPT this by copying it to
+# configs/<baseline>/run-train.sh and editing ONLY:
+#   (a) the BASELINE-SPECIFIC gantry block inside run_training(), and
+#   (b) the run_training() calls at the bottom.
+# Keep the GUARDRAILS block verbatim so it does not drift between baselines —
+# that is the whole point of having a canonical reference. `git grep` for the
+# block markers detects drift. The guardrails are mcgibbon-specific (wandb
+# attribution) and deliberately live in research/, NOT in the ace repo.
+#
+# Usage (run FROM the configs directory that contains this script):
+#   ./run-train.sh                  # launch every run_training call below
+#   ./run-train.sh no-residual      # launch only calls whose config filename
+#                                   # or job name contains "no-residual"
+#   ./run-train.sh seed1 seed2      # multiple substrings = OR
+#
+# The config filter lets you add a new arm to an existing baseline's script
+# and launch only that arm, without commenting out / relaunching the runs that
+# are already live.
+
+set -euo pipefail
+
+# === GUARDRAILS (copy verbatim from the reference; do not hand-edit) =========
+WANDB_IDENTITY="mcgibbon"   # the wandb username every run must attribute to
+
+SCRIPT_PATH=$(git rev-parse --show-prefix)   # repo-root-relative dir of this script
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BEAKER_USERNAME=$(beaker account whoami --format=json | jq -r '.[0].name')
+
+# WANDB attribution guard. The beaker job env does not carry WANDB_USERNAME, and
+# the beaker account (jeremym) makes wandb fall back to the API-key service
+# account, so an unset/null/jeremym value silently misattributes the run. Beaker
+# specs are immutable, so a miss costs a full stop+relaunch+rewrite-every-record
+# cycle — fail loud, before submit.
+WANDB_USERNAME=${WANDB_USERNAME:-$WANDB_IDENTITY}
+if [[ "$WANDB_USERNAME" != "$WANDB_IDENTITY" ]]; then
+  echo "ERROR: WANDB_USERNAME='$WANDB_USERNAME' but runs must attribute to '$WANDB_IDENTITY'." >&2
+  echo "       (BEAKER_USERNAME='$BEAKER_USERNAME' would misattribute to the wandb service account.)" >&2
+  echo "       Run:  export WANDB_USERNAME=$WANDB_IDENTITY   before launching." >&2
+  exit 1
+fi
+
+# cwd / path guard. An empty SCRIPT_PATH means the script was run from the repo
+# root (or outside the configs dir): CONFIG_PATH would become "/<config>.yaml"
+# and gantry would submit a doomed job even after local validate_config fails.
+if [[ -z "$SCRIPT_PATH" ]]; then
+  echo "ERROR: SCRIPT_PATH (git rev-parse --show-prefix) is empty." >&2
+  echo "       Invoke run-train.sh FROM its own configs directory, not the repo root." >&2
+  exit 1
+fi
+
+# Config-line filter. With no args every run_training call runs; with args, only
+# calls whose config filename OR job name contains one of the substrings.
+LAUNCH_FILTERS=("$@")
+should_run() {  # should_run <config_filename> <job_name>
+  [[ ${#LAUNCH_FILTERS[@]} -eq 0 ]] && return 0
+  local f
+  for f in "${LAUNCH_FILTERS[@]}"; do
+    [[ "$1" == *"$f"* || "$2" == *"$f"* ]] && return 0
+  done
+  return 1
+}
+
+# Post-launch attribution assertion. gantry submits asynchronously, so the wandb
+# run may not exist at submit time; call this once the run has registered (or as
+# a standalone follow-up check) to confirm wandb really recorded it under
+# WANDB_IDENTITY before you write records / move on.
+#   assert_wandb_attribution <wandb_run_id> [wandb_project]   # default ai2cm/ace
+assert_wandb_attribution() {
+  local run_id="$1" project="${2:-ai2cm/ace}"
+  python - "$run_id" "$project" "$WANDB_IDENTITY" <<'PY'
+import sys
+import wandb
+run_id, project, expected = sys.argv[1], sys.argv[2], sys.argv[3]
+got = wandb.Api().run(f"{project}/{run_id}").user.username
+assert got == expected, f"wandb run {run_id} attributed to {got!r}, expected {expected!r}"
+print(f"OK: wandb run {run_id} attributed to {got}")
+PY
+}
+# === END GUARDRAILS =========================================================
+
+cd "$REPO_ROOT"
+
+run_training() {
+  local config_filename="$1"
+  local job_name="$2"
+  local N_GPUS="${3:-1}"
+  local CONFIG_PATH="$SCRIPT_PATH/$config_filename"
+
+  should_run "$config_filename" "$job_name" || { echo "skip (filter): $job_name"; return 0; }
+
+  # path guard: the resolved local config must exist before we pay for gantry.
+  # (cwd is REPO_ROOT here, so CONFIG_PATH is the repo-relative path.)
+  if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "ERROR: config not found: $REPO_ROOT/$CONFIG_PATH" >&2
+    echo "       Check the filename and that you launched from the configs dir." >&2
+    exit 1
+  fi
+
+  echo "launching: $job_name  ($CONFIG_PATH)"
+
+  # --- BASELINE-SPECIFIC: edit only the block below for this baseline ---------
+  # Validate locally to fail fast on config bugs before paying for GPU spin-up.
+  # (Swap fme.ace -> fme.diffusion etc. as the baseline requires.)
+  python -m fme.ace.validate_config --config_type train "$CONFIG_PATH"
+
+  # Extract additional gantry flags from "# arg: ..." headers in the YAML.
+  local extra_args=()
+  while IFS= read -r line; do
+    [[ "$line" =~ ^#\ arg:\ (.*) ]] && extra_args+=(${BASH_REMATCH[1]})
+  done < "$CONFIG_PATH"
+
+  gantry run \
+    --name "$job_name" \
+    --description 'Run ACE training' \
+    --beaker-image "$(cat "$REPO_ROOT/latest_deps_only_image.txt")" \
+    --workspace ai2/ace \
+    --priority high \
+    --cluster ai2/jupiter \
+    --cluster ai2/titan \
+    --env WANDB_USERNAME="$WANDB_USERNAME" \
+    --env WANDB_NAME="$job_name" \
+    --env WANDB_JOB_TYPE=training \
+    --env WANDB_RUN_GROUP= \
+    --env GOOGLE_APPLICATION_CREDENTIALS=/tmp/google_application_credentials.json \
+    --env-secret WANDB_API_KEY=wandb-api-key-ai2cm-sa \
+    --dataset-secret google-credentials:/tmp/google_application_credentials.json \
+    --gpus "$N_GPUS" \
+    --shared-memory "$((N_GPUS * 50))GiB" \
+    --weka climate-default:/climate-default \
+    --budget ai2/atec-climate \
+    --allow-dirty \
+    --system-python \
+    --install "pip install --no-deps ." \
+    "${extra_args[@]}" \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.ace.train "$CONFIG_PATH"
+  # --- END BASELINE-SPECIFIC --------------------------------------------------
+}
+
+# Launch targets. Add a run_training call per arm; use the config filter arg to
+# launch a subset instead of commenting lines out:  ./run-train.sh <substring>
+run_training "arm1-90-10-ec.yaml"             "ace2s-bakeoff-arm1-90-10-ec-rs0"             4
+run_training "arm2-90-10-noec.yaml"           "ace2s-bakeoff-arm2-90-10-noec-rs0"           4
+run_training "arm3-50-50-ec.yaml"             "ace2s-bakeoff-arm3-50-50-ec-rs0"             4
+run_training "arm4-90-10-ec-whiten-g0.5.yaml" "ace2s-bakeoff-arm4-90-10-ec-whiten-g0.5-rs0" 4
+run_training "arm5-50-50-ec-whiten-g0.5.yaml" "ace2s-bakeoff-arm5-50-50-ec-whiten-g0.5-rs0" 4

--- a/configs/baselines/stochastic-ace-bakeoff/run-train.sh
+++ b/configs/baselines/stochastic-ace-bakeoff/run-train.sh
@@ -148,3 +148,6 @@ run_training "arm2-90-10-noec.yaml"           "ace2s-bakeoff-arm2-90-10-noec-rs0
 run_training "arm3-50-50-ec.yaml"             "ace2s-bakeoff-arm3-50-50-ec-rs0"             4
 run_training "arm4-90-10-ec-whiten-g0.5.yaml" "ace2s-bakeoff-arm4-90-10-ec-whiten-g0.5-rs0" 4
 run_training "arm5-50-50-ec-whiten-g0.5.yaml" "ace2s-bakeoff-arm5-50-50-ec-whiten-g0.5-rs0" 4
+run_training "arm6-80-10-sp10-ec.yaml"        "ace2s-bakeoff-arm6-80-10-sp10-ec-rs0"        4
+run_training "arm7-90-0-sp10-ec.yaml"         "ace2s-bakeoff-arm7-90-0-sp10-ec-rs0"         4
+run_training "arm8-80-10-sp10-ec-whiten-g0.5.yaml" "ace2s-bakeoff-arm8-80-10-sp10-ec-whiten-g0.5-rs0" 4

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -660,6 +660,70 @@ class CRPSLoss(torch.nn.Module):
         return [StandardLoss(get_crps(x, y, alpha=self.alpha))]
 
 
+class SpectralPowerCRPSLoss(torch.nn.Module):
+    """
+    Compute the CRPS of the per-degree log spectral power.
+
+    For each ensemble member and the target, the per-degree angular power
+    ``P_l = mean over valid orders m (real-SHT redundancy-weighted) of
+    |c_lm|^2`` is computed from the spherical-harmonic coefficients, and the
+    members' ``log P_l`` is scored against the target's with (almost-)fair
+    CRPS over the ensemble dimension. The term is phase-free: per-sample
+    spatial phase noise does not enter, so it provides a high-SNR gradient
+    toward correct per-scale amplitude even at degrees where the per-mode
+    signal is noise-dominated (a red spectrum starves those modes' energy
+    score gradients). Scoring log power makes the term scale-equitable across
+    the (red) spectrum. Returns a ``(B, C, L)`` tensor. When ``whitening`` is
+    given, the per-degree power CRPS is reweighted with the same operator the
+    energy score uses (:class:`SpectralWhitening`, computed from the detached
+    target spectrum), so whitening applies to this term too.
+    """
+
+    def __init__(
+        self,
+        sht: Callable[[torch.Tensor], torch.Tensor],
+        alpha: float = 1.0,
+        whitening: SpectralWhitening | None = None,
+    ):
+        super().__init__()
+        self.sht = sht
+        self.alpha = alpha
+        self._whitening = whitening
+        self.mode_area_weights: torch.Tensor | None = None
+
+    def _log_power(self, coeffs: torch.Tensor) -> torch.Tensor:
+        """(..., L, M) complex coefficients -> (..., L) log mean power over
+        valid orders (m <= l), with the real-SHT m>0 redundancy factor.
+        """
+        n_l, n_m = coeffs.shape[-2], coeffs.shape[-1]
+        real_dtype = coeffs.abs().dtype
+        if self.mode_area_weights is None:
+            l_idx = torch.arange(n_l, device=coeffs.device).unsqueeze(-1)
+            m_idx = torch.arange(n_m, device=coeffs.device).unsqueeze(0)
+            valid = (m_idx <= l_idx).to(real_dtype)  # (L, M)
+            redundancy = 2.0 * torch.ones(
+                n_l, n_m, device=coeffs.device, dtype=real_dtype
+            )
+            redundancy[:, 0] = 1.0
+            self.mode_area_weights = redundancy * valid  # (L, M)
+        w = self.mode_area_weights
+        tiny = torch.finfo(real_dtype).tiny
+        meanpow_l = (coeffs.abs() ** 2 * w).sum(dim=-1) / w.sum(dim=-1).clamp_min(tiny)
+        return torch.log(meanpow_l.clamp_min(tiny))
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> list[LossComponent]:
+        x_log_power = self._log_power(self.sht(x))  # (B, E, C, L)
+        y_hat = self.sht(y)  # (B, 1, C, L, M)
+        y_log_power = self._log_power(y_hat)  # (B, 1, C, L)
+        crps = get_crps(x_log_power, y_log_power, alpha=self.alpha)  # (B, C, L)
+        if self._whitening is not None:
+            # Same per-degree, magnitude-preserving reweight the energy score
+            # uses (SpectralWhitening.factor, computed from the detached target
+            # spectrum), applied to the per-degree power CRPS. factor -> (B,C,L,1).
+            crps = crps * self._whitening.factor(y_hat).squeeze(-1)  # (B, C, L)
+        return [StandardLoss(crps)]
+
+
 class FiniteDifferenceCRPSLoss(torch.nn.Module):
     """
     Computes the CRPS of the x and y finite differences of the input tensors,
@@ -725,6 +789,7 @@ class EnsembleLoss(torch.nn.Module):
         finite_difference_crps_weight: float = 0.0,
         finite_difference_crps_levels: int = 1,
         almost_fair_crps_alpha: float = 1.0,
+        spectral_power_crps_weight: float = 0.0,
         energy_score_whitening: SpectralWhitening | None = None,
     ):
         super().__init__()
@@ -737,6 +802,11 @@ class EnsembleLoss(torch.nn.Module):
             raise ValueError(
                 "finite_difference_crps_weight must be non-negative, "
                 f"got {finite_difference_crps_weight}"
+            )
+        if spectral_power_crps_weight < 0:
+            raise ValueError(
+                "spectral_power_crps_weight must be non-negative, "
+                f"got {spectral_power_crps_weight}"
             )
         if crps_weight + energy_score_weight == 0:
             raise ValueError(
@@ -757,6 +827,17 @@ class EnsembleLoss(torch.nn.Module):
             sht=sht,
             whitening=energy_score_whitening,
         )
+        if spectral_power_crps_weight > 0:
+            self.spectral_power_crps_loss: SpectralPowerCRPSLoss | None = (
+                SpectralPowerCRPSLoss(
+                    sht=sht,
+                    alpha=almost_fair_crps_alpha,
+                    whitening=energy_score_whitening,
+                )
+            )
+        else:
+            self.spectral_power_crps_loss = None
+        self.spectral_power_crps_weight = spectral_power_crps_weight
 
         self.crps_weight = crps_weight
         self.diff_crps_weight = finite_difference_crps_weight
@@ -777,6 +858,9 @@ class EnsembleLoss(torch.nn.Module):
         if self.diff_crps_loss is not None:
             for c in self.diff_crps_loss(gen_norm, target_norm):
                 components.append(type(c)(c.loss * self.diff_crps_weight))
+        if self.spectral_power_crps_loss is not None:
+            for c in self.spectral_power_crps_loss(gen_norm, target_norm):
+                components.append(type(c)(c.loss * self.spectral_power_crps_weight))
         return components
 
 

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -15,6 +15,7 @@ from fme.core.loss import (
     LossConfig,
     LossOutput,
     LpLoss,
+    SpectralPowerCRPSLoss,
     SpectralWhitening,
     SpectralWhiteningConfig,
     StandardLoss,
@@ -997,3 +998,101 @@ def test_ensemble_loss_with_whitening_builds_and_runs(whitening):
     out = loss(x, y)
     assert all(isinstance(c, LossComponent) for c in out)
     assert torch.isfinite(_components_total(out))
+
+
+def test_spectral_power_crps_phase_invariant():
+    """The spectral-power CRPS ignores phase: random phase rotations are a no-op."""
+    torch.manual_seed(0)
+    DEVICE = get_device()
+    n_l = n_m = 12
+    valid = _valid_mask(n_l, n_m, DEVICE).to(torch.cfloat)
+    gen = torch.randn(4, 2, 3, n_l, n_m, dtype=torch.cfloat, device=DEVICE) * valid
+    target = torch.randn(4, 1, 3, n_l, n_m, dtype=torch.cfloat, device=DEVICE) * valid
+    loss = SpectralPowerCRPSLoss(sht=lambda z: z)
+    base = _components_total(loss(gen, target))
+    angles = 2 * torch.pi * torch.rand(4, 2, 3, n_l, n_m, device=DEVICE)
+    phases = torch.exp(1j * angles)
+    rotated = _components_total(loss(gen * phases, target))
+    torch.testing.assert_close(base, rotated, rtol=1e-4, atol=1e-6)
+
+
+def test_spectral_power_crps_prefers_correct_amplitude():
+    """Members with the target's per-degree power beat spectrally damped members."""
+    torch.manual_seed(0)
+    DEVICE = get_device()
+    n_batch, n_l, n_m = 500, 12, 12
+    valid = _valid_mask(n_l, n_m, DEVICE).to(torch.cfloat)
+    red = (1.0 / (1.0 + torch.arange(n_l, device=DEVICE).float())).reshape(
+        1, 1, 1, -1, 1
+    )
+
+    def draw(shape):
+        return torch.randn(*shape, dtype=torch.cfloat, device=DEVICE) * red * valid
+
+    target = draw((n_batch, 1, 1, n_l, n_m))
+    matched = draw((n_batch, 2, 1, n_l, n_m))
+    damped = matched.clone()
+    damping = torch.linspace(1.0, 0.2, n_l, device=DEVICE).reshape(1, 1, 1, -1, 1)
+    damped = damped * damping
+    loss = SpectralPowerCRPSLoss(sht=lambda z: z)
+    matched_score = _components_total(loss(matched, target))
+    damped_score = _components_total(loss(damped, target))
+    assert matched_score < damped_score
+
+
+def test_ensemble_loss_with_spectral_power_crps_builds_and_runs():
+    """EnsembleLoss accepts spectral_power_crps_weight and adds a component."""
+    DEVICE = get_device()
+    n_lat, n_lon = 8, 16
+    ops = LatLonOperations(torch.ones((n_lat, n_lon), device=DEVICE))
+    base_config = LossConfig(
+        type="EnsembleLoss",
+        kwargs={"crps_weight": 0.9, "energy_score_weight": 0.1},
+    )
+    with_term = LossConfig(
+        type="EnsembleLoss",
+        kwargs={
+            "crps_weight": 0.9,
+            "energy_score_weight": 0.1,
+            "spectral_power_crps_weight": 0.05,
+        },
+    )
+    x = torch.rand(4, 2, 3, n_lat, n_lon, device=DEVICE)
+    y = torch.rand(4, 1, 3, n_lat, n_lon, device=DEVICE)
+    base_out = base_config.build(gridded_operations=ops)(x, y)
+    term_out = with_term.build(gridded_operations=ops)(x, y)
+    assert len(term_out) == len(base_out) + 1
+    total = _components_total(term_out)
+    assert torch.isfinite(total)
+
+
+def test_ensemble_loss_spectral_power_crps_whitening_reaches_power_term():
+    """energy_score_whitening reweights the spectral-power-CRPS term too, not
+    only the energy score. With energy_score_weight=0 the components are
+    [crps, spectral_power]; the plain-CRPS term is whitening-independent, so any
+    difference in the last (power) component proves whitening reaches it."""
+    torch.manual_seed(0)
+    DEVICE = get_device()
+    n_lat, n_lon = 8, 16
+    ops = LatLonOperations(torch.ones((n_lat, n_lon), device=DEVICE))
+    common = {
+        "crps_weight": 0.9,
+        "energy_score_weight": 0.0,
+        "spectral_power_crps_weight": 0.1,
+    }
+    no_whiten = LossConfig(type="EnsembleLoss", kwargs=dict(common))
+    with_whiten = LossConfig(
+        type="EnsembleLoss",
+        kwargs={
+            **common,
+            "energy_score_whitening": {"kind": "per_sample", "exponent": 0.5},
+        },
+    )
+    x = torch.rand(4, 2, 3, n_lat, n_lon, device=DEVICE)
+    y = torch.rand(4, 1, 3, n_lat, n_lon, device=DEVICE)
+    out_plain = no_whiten.build(gridded_operations=ops)(x, y)
+    out_whiten = with_whiten.build(gridded_operations=ops)(x, y)
+    assert len(out_plain) == 2 and len(out_whiten) == 2
+    power_plain = out_plain[-1].reduce_to_channel().mean()
+    power_whiten = out_whiten[-1].reduce_to_channel().mean()
+    assert not torch.allclose(power_plain, power_whiten, rtol=1e-4, atol=1e-6)


### PR DESCRIPTION
Phase 0 of the stochastic-ACE paper: a baseline bake-off to pick the stochastic-ACE recipe. Adds eight 1°/daily ERA5-only training configs plus a launcher and README under `configs/baselines/stochastic-ace-bakeoff/`, and ports a `SpectralPowerCRPSLoss` term onto `fme/core/loss.py` that three of the arms exercise. This PR does **not launch any runs**; Jeremy launches them via `run-train.sh`.

## Loss feature: `SpectralPowerCRPSLoss`

`fme/core/loss.py` gains `SpectralPowerCRPSLoss` (ported from calibration branch `49d326899` and adapted to `main`'s `SpectralWhitening` API). It scores the (almost-)fair CRPS of the per-degree log spectral power, so it is phase-free (per-sample spatial phase noise does not enter) and scale-equitable across the red spectrum, giving a high-SNR amplitude gradient at degrees where per-mode energy-score gradients are noise-starved. It was validated at small scale in the 2026-07-06 small-scale-calibration report (arm 2 there = `5k3fmlif`).

`EnsembleLoss` gains a non-negative-validated `spectral_power_crps_weight`; when positive it builds the term, passing the same `energy_score_whitening` operator so whitening (when enabled) reweights the per-degree power CRPS with the same operator the energy score uses. `LossConfig.build` needs no change — the weight flows through `kwargs`.

## Arms

All eight share one base config (arm 1); arms differ only in the loss weighting (`crps`/`es`/`sp` = `crps_weight`/`energy_score_weight`/`spectral_power_crps_weight`), the total-energy corrector, and spectral whitening.

| config | crps | es | sp | total-energy corrector | whitening |
|---|---|---|---|---|---|
| `arm1-90-10-ec.yaml` (base) | 0.9 | 0.1 | 0 | `constant_temperature` | none |
| `arm2-90-10-noec.yaml` | 0.9 | 0.1 | 0 | off | none |
| `arm3-50-50-ec.yaml` | 0.5 | 0.5 | 0 | `constant_temperature` | none |
| `arm4-90-10-ec-whiten-g0.5.yaml` | 0.9 | 0.1 | 0 | `constant_temperature` | `per_sample`, γ=0.5 |
| `arm5-50-50-ec-whiten-g0.5.yaml` | 0.5 | 0.5 | 0 | `constant_temperature` | `per_sample`, γ=0.5 |
| `arm6-80-10-sp10-ec.yaml` | 0.8 | 0.1 | 0.1 | `constant_temperature` | none |
| `arm7-90-0-sp10-ec.yaml` | 0.9 | 0.0 | 0.1 | `constant_temperature` | none |
| `arm8-80-10-sp10-ec-whiten-g0.5.yaml` | 0.8 | 0.1 | 0.1 | `constant_temperature` | `per_sample`, γ=0.5 |

Arms 6–8 add the spectral-power-CRPS term. Arm 7 sets `energy_score_weight` to 0 (the energy-score component is simply skipped; `crps + es` still sums positive). Arm 8 shares its γ=0.5 whitening operator between the energy score and the power term. `crps_weight`/`energy_score_weight`/`spectral_power_crps_weight`/`energy_score_whitening` live in `stepper_training.loss.kwargs`; the corrector toggle is `stepper.step.config.corrector.total_energy_budget_correction` (`constant_unaccounted_heating` defaults to 0.0). Every arm uses `seed: 0`.

## Base recipe

Matches Troy's run [nzccs8zd](https://wandb.ai/ai2cm/ace/runs/nzccs8zd): NoiseConditionedSFNO (embed_dim 512, 8 layers, spectral_ratio 0.125, isotropic noise, `clip_latent_global_means` off), residual prediction, EnsembleLoss (n_ensemble 2, n_forward_steps 1), shared global-mean removal, dry-air + moisture-budget correction, EMA 0.999, FusedAdam lr 1e-4, batch_size 8, 80 epochs, `h500: 5` per-channel loss weight, dataset `2026-03-19-era5-1deg-8layer-daily-1940-2025.zarr`. **40 inputs / 51 outputs**: the four near-surface fields (TMP2m, Q2m, UGRD10m, VGRD10m) are output-only diagnostics rather than inputs, and the model predicts `total_frozen_precipitation_rate`. Data is 06Z daily, so every inference IC is at `T06:00:00`.

## ACE2-paper train/val/inference split

The train/val/inference blocks are identical across all eight arms (only the loss block differs), aligned to the ACE2-paper ERA5 setup.

**Train split (stitch-aware).** Train window matches the ACE2-paper data span (1940–1995, 2011–2019, 2021–2022): the final segment ends `2022-12-31`, where the ACE2 data ended, rather than running to 2025. It is split at the ERA5 production-stream boundaries so that no residual training sample straddles a stream stitch (which produces a spurious tendency that would poison a residual target); the daily-dataset seam report confirmed no stitch boundary falls in 2021–2025, so capping the final segment at 2022 needs no new split. This yields 14 `subset` segments in `train_loader`. Validation is 1996–1997 (held-out between the two train blocks).

**Checkpoint selection (ACE2-paper inference).** Selection is driven by a single weight-1.0 inference loop, `ace2_5yr_1996`, matching the ACE2-paper's selection inference: eight out-of-sample initial conditions spread through 1996 (inside the held-out 1996–2010 gap), each rolled out 5 years deterministically (`n_forward_steps: 1826` at daily cadence, `n_ensemble_per_ic: 1`, ICs at 06Z). Its selection metric is the inference-period time-mean scored against the rollout's own target (`time_mean_norm/rmse/channel_mean`), with no external time-mean reference. The full rollout stays inside the held-out gap, so selection is entirely out-of-sample. The `10year`, `10year_insample`, `weather_2024`, and `weather_1994` loops are retained as weight-0 diagnostics (10-yr stability, day-5 SSR/CRPS) and no longer influence selection.

## Judgment calls flagged for review

1. **Dropped the 46-year monitoring blocks.** The `10year`, `10year_insample`, `weather_2024`, and `weather_1994` in-training inference loops are kept as weight-0 diagnostics (10-yr stability + day-5 SSR/CRPS); checkpoint selection is driven by the `ace2_5yr_1996` loop (above). Removed `long_46year` and `long_46year_constant_co2` — a 46-year rollout per arm is wasteful across eight arms. The full selection metrics (10-yr bias, day-5 SSR, climate-skill overview, spectral power) and the 46-year rollout will be a dedicated offline eval on the selected winner after the runs finish.
2. **4 GPUs assumed** per arm in `run-train.sh` (the 1°/daily precedent). Please confirm the GPU count before launch.

## Validation

All eight configs pass `python -m fme.ace.validate_config --config_type train <config>`. The loss tests pass (`fme/core/test_loss.py -k "spectral_power or ensemble_loss"`, 7 passed) and `mypy` is clean on the touched files.

Changes:
- `fme.core.loss.SpectralPowerCRPSLoss` — new loss module (per-degree log-power CRPS, optional shared whitening)
- `fme.core.loss.EnsembleLoss` — `spectral_power_crps_weight` param, validation, wiring in `forward`
- `fme/core/test_loss.py` — three ported spectral-power tests + one asserting whitening reaches the power term
- `configs/baselines/stochastic-ace-bakeoff/arm{1..8}-*.yaml` — the eight bake-off training configs (arms 6/7/8 new)
- `configs/baselines/stochastic-ace-bakeoff/run-train.sh` — launcher (guardrails copied verbatim from the research reference launcher; only the `run_training` calls are baseline-specific)
- `configs/baselines/stochastic-ace-bakeoff/README.md` — documents the arms, base recipe, split/selection rationale, and the spectral-power term

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (n/a)
