### PR TITLE
  Fix wandb run naming in segmented inference

### DIFF
--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -47,6 +47,7 @@ from fme.core.generics.inference import get_record_to_wandb, run_inference
 from fme.core.labels import BatchLabels
 from fme.core.logging_utils import LoggingConfig
 from fme.core.timing import GlobalTimer
+from fme.core.wandb import WandB
 
 from .evaluator import resolve_variable_metadata
 
@@ -348,7 +349,6 @@ def main(
             with GlobalTimer():
                 return run_inference_from_config(config)
         else:
-            config.configure_logging(log_filename="inference_out.log")
             run_segmented_inference(config, segments)
 
 
@@ -486,6 +486,14 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
             "cannot re-broadcast it consistently. Run with n_ensemble_per_ic=1, "
             "or run a single non-segmented inference for ensemble runs."
         )
+    # Configure top-level logging without a wandb run; each segment owns its run.
+    top_level_logging = dataclasses.replace(config.logging, log_to_wandb=False)
+    top_level_logging.configure_logging(
+        config.experiment_dir,
+        "inference_out.log",
+        config=dataclasses.asdict(config),
+        resumable=False,
+    )
     logging.info(
         f"Starting segmented inference with {segments} segments. "
         f"Saving to {config.experiment_dir}."
@@ -505,6 +513,8 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
                 os.environ["WANDB_NAME"] = f"{original_wandb_name}-{segment_label}"
             with GlobalTimer():
                 run_inference_from_config(config_copy)
+            # Finish this segment's run so the next segment starts a fresh one.
+            WandB.get_instance().finish()
         config_copy.initial_condition = InitialConditionConfig(
             path=restart_path, engine="netcdf4"
         )

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -4,7 +4,6 @@ import dataclasses
 import datetime
 import os
 import pathlib
-import tempfile
 import unittest.mock
 
 import cftime
@@ -107,128 +106,97 @@ def save_stepper(
     torch.save({"stepper": stepper.get_state()}, path)
 
 
-def test_inference_segmented_entrypoint():
-    # we use tempfile here instead of pytest tmp_path fixture, because the latter causes
-    # issues with checking last modified time of files produced by the test.
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_path = pathlib.Path(tmp_dir)
-        forward_steps_in_memory = 2
-        in_names = ["prog", "forcing_var"]
-        out_names = ["prog", "diagnostic_var"]
-        stepper_path = tmp_path / "stepper"
-        horizontal = [DimSize("lat", 16), DimSize("lon", 32)]
+def _segmented_config_factory(tmp_path: pathlib.Path, *, log_to_wandb: bool):
+    """Write a PlusOne stepper, forcing data and initial condition into tmp_path,
+    returning a ``make_config(experiment_dir, n_forward_steps)`` builder."""
+    stepper_path = tmp_path / "stepper"
+    dim_sizes = DimSizes(
+        n_time=18, horizontal=[DimSize("lat", 16), DimSize("lon", 32)], nz_interface=4
+    )
+    save_stepper(
+        stepper_path,
+        in_names=["prog", "forcing_var"],
+        out_names=["prog", "diagnostic_var"],
+        mean=0.0,
+        std=1.0,
+        data_shape=dim_sizes.shape_nd,
+    )
+    data = FV3GFSData(
+        path=tmp_path, names=["forcing_var"], dim_sizes=dim_sizes, timestep_days=0.25
+    )
+    ic = xr.Dataset(
+        {
+            "prog": xr.DataArray(
+                np.random.rand(1, 16, 32).astype(np.float32),
+                dims=["sample", "lat", "lon"],
+            )
+        }
+    )
+    ic_path = tmp_path / "init_data" / "ic.nc"
+    ic_path.parent.mkdir()
+    ic["time"] = xr.DataArray(
+        [cftime.DatetimeProlepticGregorian(2000, 1, 1, 6)], dims=["sample"]
+    )
+    ic.to_netcdf(ic_path, mode="w")
 
-        dim_sizes = DimSizes(
-            n_time=18,
-            horizontal=horizontal,
-            nz_interface=4,
-        )
-        save_stepper(
-            stepper_path,
-            in_names=in_names,
-            out_names=out_names,
-            mean=0.0,
-            std=1.0,
-            data_shape=dim_sizes.shape_nd,
-        )
-        data = FV3GFSData(
-            path=tmp_path,
-            names=["forcing_var"],
-            dim_sizes=dim_sizes,
-            timestep_days=0.25,
-        )
-        initial_condition = xr.Dataset(
-            {
-                "prog": xr.DataArray(
-                    np.random.rand(2, 16, 32).astype(np.float32),
-                    dims=["sample", "lat", "lon"],
-                )
-            }
-        )
-
-        initial_condition_path = tmp_path / "init_data" / "ic.nc"
-        initial_condition_path.parent.mkdir()
-        initial_condition["time"] = xr.DataArray(
-            [
-                cftime.DatetimeProlepticGregorian(2000, 1, 1, 6),
-                cftime.DatetimeProlepticGregorian(2000, 1, 1, 18),
-            ],
-            dims=["sample"],
-        )
-        initial_condition.to_netcdf(initial_condition_path, mode="w")
-        forcing_loader = ForcingDataLoaderConfig(
-            dataset=data.inference_data_loader_config.dataset,
-            num_data_workers=0,
-        )
-
-        run_dir = tmp_path / "segmented_run"
+    def make_config(experiment_dir, n_forward_steps: int) -> str:
         config = fme.ace.InferenceConfig(
-            experiment_dir=str(run_dir),
-            n_forward_steps=3,
-            forward_steps_in_memory=forward_steps_in_memory,
+            experiment_dir=str(experiment_dir),
+            n_forward_steps=n_forward_steps,
+            forward_steps_in_memory=2,
             checkpoint_path=str(stepper_path),
             logging=LoggingConfig(
-                log_to_screen=True, log_to_file=False, log_to_wandb=False
+                log_to_screen=True, log_to_file=False, log_to_wandb=log_to_wandb
             ),
             initial_condition=InitialConditionConfig(
-                path=str(initial_condition_path),
+                path=str(ic_path),
                 start_indices=TimestampList(["2000-01-01T06:00:00"]),
             ),
-            forcing_loader=forcing_loader,
+            forcing_loader=ForcingDataLoaderConfig(
+                dataset=data.inference_data_loader_config.dataset, num_data_workers=0
+            ),
             data_writer=DataWriterConfig(
                 save_prediction_files=False,
                 save_monthly_files=False,
                 files=[FileWriterConfig("autoregressive")],
             ),
-            allow_incompatible_dataset=True,  # stepper checkpoint has arbitrary info  # noqa: E501
+            allow_incompatible_dataset=True,
         )
-
-        # run one segment of 3 steps
         config_path = str(tmp_path / "config.yaml")
         with open(config_path, "w") as f:
             yaml.dump(dataclasses.asdict(config), f)
-        main(config_path, 1)
+        return config_path
 
-        # run another segment of 3 steps, and ensure first segment is not being re-run
-        filename = os.path.join(
-            run_dir, "segment_0000", "autoregressive_predictions.nc"
-        )
-        before_second_segment_mtime = os.path.getmtime(filename)
-        main(config_path, 2)
-        after_second_segment_mtime = os.path.getmtime(filename)
-        assert before_second_segment_mtime == pytest.approx(after_second_segment_mtime)
+    return make_config
 
-        # do a non-segmented run of 6 steps
-        config.n_forward_steps = 6
-        config.experiment_dir = str(tmp_path / "non_segmented_run")
-        config_path = str(tmp_path / "config.yaml")
-        with open(config_path, "w") as f:
-            yaml.dump(dataclasses.asdict(config), f)
-        main(config_path)
 
-        # assert each segment generated output of correct duration
-        ds_two_segments_0 = xr.open_dataset(
-            run_dir / "segment_0000" / "autoregressive_predictions.nc",
-            decode_timedelta=False,
-        )
-        ds_two_segments_1 = xr.open_dataset(
-            run_dir / "segment_0001" / "autoregressive_predictions.nc",
-            decode_timedelta=False,
-        )
-        assert len(ds_two_segments_0.time) == len(ds_two_segments_1.time)
+def test_inference_segmented_entrypoint(tmp_path, monkeypatch):
+    """End-to-end: a segmented run reproduces the equivalent single run, and each
+    segment gets its own wandb run named ``<base>-segment_NNNN`` (issue #471)."""
+    make_config = _segmented_config_factory(tmp_path, log_to_wandb=True)
+    run_dir = tmp_path / "segmented_run"
+    single_dir = tmp_path / "non_segmented_run"
+    monkeypatch.setenv("WANDB_NAME", "myrun")
+    with mock_wandb() as wandb:
+        wandb.configure(log_to_wandb=True)
+        main(make_config(run_dir, 3), 2)
+        assert [run["name"] for run in wandb.runs] == [
+            "myrun-segment_0000",
+            "myrun-segment_0001",
+        ]
+        assert len({run["id"] for run in wandb.runs}) == 2  # distinct runs
+        # a single 6-step run should reproduce the two 3-step segments
+        main(make_config(single_dir, 6))
 
-        # Ensure the second half of the 6-step run matches the second segment of the
-        # 3-step run. Before comparing, drop init_time and time coordinates, since
-        # we don't expect these to match.
-        ds_one_segment = xr.open_dataset(
-            tmp_path / "non_segmented_run" / "autoregressive_predictions.nc",
-            decode_timedelta=False,
-        )
-        ds_two_segments_1 = ds_two_segments_1.drop_vars(["init_time", "time"])
-        ds_one_segment = ds_one_segment.drop_vars(["init_time", "time"])
-        xr.testing.assert_equal(
-            ds_two_segments_1, ds_one_segment.isel(time=slice(3, None))
-        )
+    def _predictions(path):
+        return xr.open_dataset(
+            path / "autoregressive_predictions.nc", decode_timedelta=False
+        ).drop_vars(["init_time", "time"])  # per-segment init_time differs
+
+    xr.testing.assert_equal(
+        _predictions(run_dir / "segment_0001"),
+        _predictions(single_dir).isel(time=slice(3, None)),
+    )
 
 
 def _run_inference_from_config_mock(config: fme.ace.InferenceConfig):
@@ -236,8 +204,6 @@ def _run_inference_from_config_mock(config: fme.ace.InferenceConfig):
         os.makedirs(config.experiment_dir)
     with open(os.path.join(config.experiment_dir, "restart.nc"), "w") as f:
         f.write("mock restart file")
-    with open(os.path.join(config.experiment_dir, "wandb_name_env_var"), "w") as f:
-        f.write(os.environ.get("WANDB_NAME", ""))
 
 
 def _get_mock_config(experiment_dir: str) -> fme.ace.InferenceConfig:
@@ -258,39 +224,29 @@ def _get_mock_config(experiment_dir: str) -> fme.ace.InferenceConfig:
     )
 
 
-def test_run_segmented_inference(tmp_path, monkeypatch):
-    WRITTEN_WANDB_NAME_FILENAME = "wandb_name_env_var"
+def test_run_segmented_inference(tmp_path):
+    """The loop runs missing segments and skips those whose restart already
+    exists, without re-running completed segments."""
     mock = unittest.mock.MagicMock(side_effect=_run_inference_from_config_mock)
     config = _get_mock_config(str(tmp_path))
 
     with unittest.mock.patch(
         "fme.ace.inference.inference.run_inference_from_config", new=mock
     ):
-        # run a single segment
-        monkeypatch.setenv("WANDB_NAME", "run_name")
         run_segmented_inference(config, 1)
         segment_dir = os.path.join(config.experiment_dir, "segment_0000")
-        expected_restart_path = os.path.join(segment_dir, "restart.nc")
-        assert os.path.exists(expected_restart_path)
+        assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
         assert mock.call_count == 1
-        with open(os.path.join(segment_dir, WRITTEN_WANDB_NAME_FILENAME)) as f:
-            assert f.read() == "run_name-segment_0000"
 
-        # rerun the same segment and ensure run_inference_from_config isn't called again
+        # rerunning the same segment does not call run_inference_from_config again
         run_segmented_inference(config, 1)
-        assert os.path.exists(expected_restart_path)
         assert mock.call_count == 1
 
-        # extend to three segments and ensure exactly three run_inference_from_config
-        # calls have been made
-        monkeypatch.setenv("WANDB_NAME", "run_name")
+        # extending to three segments runs exactly the two missing segments
         run_segmented_inference(config, 3)
         for i in range(3):
             segment_dir = os.path.join(config.experiment_dir, f"segment_{i:04d}")
-            expected_restart_path = os.path.join(segment_dir, "restart.nc")
-            assert os.path.exists(expected_restart_path)
-            with open(os.path.join(segment_dir, WRITTEN_WANDB_NAME_FILENAME)) as f:
-                assert f.read() == f"run_name-segment_{i:04d}"
+            assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
         assert mock.call_count == 3
 
 

--- a/fme/core/logging_utils.py
+++ b/fme/core/logging_utils.py
@@ -153,6 +153,9 @@ class LoggingConfig:
         notes = _get_wandb_notes(_get_beaker_id())
         wandb.init(
             config=config_copy,
+            # wandb reads WANDB_NAME only on the first init in a process, so pass
+            # it explicitly for later runs (e.g. segments) to be named correctly.
+            name=os.environ.get("WANDB_NAME"),
             project=self.project,
             entity=self.entity,
             experiment_dir=experiment_dir,

--- a/fme/core/testing/wandb.py
+++ b/fme/core/testing/wandb.py
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import os
 import random
 import string
 from collections.abc import Mapping
@@ -18,6 +19,11 @@ class MockWandB:
         self._last_step = 0
         self._id: str | None = None
         self._disk_logger: DiskMetricLogger | None = None
+        self._runs: list[dict[str, Any]] = []
+        # wandb reads WANDB_NAME only on the first init; model that one-time
+        # snapshot so an explicit `name` is needed to rename subsequent runs.
+        self._env_name_snapshot: str | None = None
+        self._env_name_snapshot_taken = False
 
     def configure(self, log_to_wandb: bool, metrics_log_dir: str | None = None):
         dist = Distributed.get_instance()
@@ -54,13 +60,21 @@ class MockWandB:
                 self._wandb_init(resume="never", **kwargs)
 
     def _wandb_init(
-        self, resume: Literal["must", "never"], id: str | None = None, **kwargs
+        self,
+        resume: Literal["must", "never"],
+        id: str | None = None,
+        name: str | None = None,
+        **kwargs,
     ):
         """
         Mocks the `wandb.init` behavior, specifically around initializing
         a run with `resume` and `id`.
         See https://docs.wandb.ai/guides/runs/resuming/.
         """
+        # Snapshot WANDB_NAME on the first init only; an explicit `name` wins.
+        if not self._env_name_snapshot_taken:
+            self._env_name_snapshot = os.environ.get("WANDB_NAME")
+            self._env_name_snapshot_taken = True
         if resume == "must":
             if id is None:
                 raise ValueError("resume='must' and id is None")
@@ -76,6 +90,8 @@ class MockWandB:
                         "resume='never' and id is None but previous id exists"
                     )
             self._id = _mock_wandb_id()
+            run_name = name if name is not None else self._env_name_snapshot
+            self._runs.append({"id": self._id, "name": run_name})
 
     def get_id(self) -> str:
         if self._id is None:
@@ -84,6 +100,17 @@ class MockWandB:
 
     def set_id(self, id: str):
         self._id = id
+
+    def finish(self):
+        # Reset per-run state so the next init starts fresh; the env-name
+        # snapshot persists, mirroring wandb's setup singleton across finish().
+        self._id = None
+        self._last_step = 0
+
+    @property
+    def runs(self) -> list[dict[str, Any]]:
+        """The runs started so far, each as ``{"id": ..., "name": ...}``."""
+        return self._runs
 
     def watch(self, modules):
         if self._enabled:

--- a/fme/core/wandb.py
+++ b/fme/core/wandb.py
@@ -160,6 +160,14 @@ class WandB:
                 logging.info(f"New non-resuming wandb run with id: {id_}.")
             self._id = id_
 
+    def finish(self):
+        """End the active run so the next `init` starts a new run rather than
+        reusing it (wandb returns the active run by default in scripts).
+        """
+        if self._enabled:
+            wandb.finish()
+        self._id = None
+
     def watch(self, modules):
         if self._enabled:
             wandb.watch(modules)


### PR DESCRIPTION
Segmented inference (`python -m fme.ace.inference <cfg> --segments N`) runs N segments sequentially in one process. It was meant to give each segment its own wandb run named `<base>-segment_NNNN`, but instead every segment logged to a single shared run: later segments restarted their step counter at 0 and clobbered earlier segments' metrics, leaving only the last segment's values. Two wandb behaviors combined to cause this: repeated `wandb.init()` in a process returns the already-active run by default (`reinit="return_previous"` in scripts), and `WANDB_NAME` is snapshotted only on the first init, so mutating it per segment was ignored. This fixes both so each segment gets its own correctly-named run.

Changes:
- `fme.core.wandb.WandB.finish`: ends the active run so the next `init` starts a new run rather than reusing it.
- `fme.core.logging_utils.LoggingConfig._configure_wandb`: passes `name=os.environ.get("WANDB_NAME")` to `wandb.init` explicitly. This is the shared init used by all entrypoints, but it is a no-op for every single-`init`-per-process path (training, evaluation, single inference): the explicit value is exactly what wandb already reads from `WANDB_NAME` on that first init, so run names are unchanged. It only has an effect when `WANDB_NAME` changes mid-process after the first init — i.e. the segmented case fixed here.
- `fme.ace.inference.run_segmented_inference`: finishes each segment's run, and configures top-level logging with wandb disabled so no run lingers before the first segment; the pre-loop `configure_logging` in `main` is removed.
- `fme.core.testing.MockWandB`: adds `finish()`, records started runs, and models wandb reading `WANDB_NAME` only once, so tests exercise the real per-init naming behavior.

Resumption is unaffected. Inference does not use wandb resumption (`resumable=False`), so a segment re-run after a preemption simply starts a fresh run with the same name — it never resumes an existing run. Training's resume path does a single init where the explicit `name` equals the value wandb would have read from the environment anyway, so a resumed run keeps its existing name exactly as before.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #471
