### PR TITLE
Enforce downscaling prediction always uses same patch size as trained on

### DIFF
--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -38,31 +38,22 @@ class Evaluator:
         model: DiffusionModel | DenoisingMoEPredictor | PatchPredictor,
         experiment_dir: str,
         n_samples: int,
-        patch_data: bool = False,
     ) -> None:
         self.data = data
         self.model = model
         self.experiment_dir = experiment_dir
         self.n_samples = n_samples
         self.dist = Distributed.get_instance()
-        self.patch_data = patch_data
 
     def run(self):
         aggregator = GenerationAggregator(
             self.data.dims,
             self.model.downscale_factor,
-            include_positional_comparisons=False if self.patch_data else True,
+            include_positional_comparisons=True,
             percentiles=[99.99, 99.9999],
         )
 
-        if self.patch_data:
-            batch_generator = self.data.get_patched_generator(
-                coarse_yx_patch_extent=self.model.coarse_shape,
-            )
-        else:
-            batch_generator = self.data.get_generator()
-
-        for i, batch in enumerate(batch_generator):
+        for i, batch in enumerate(self.data.get_generator()):
             with torch.no_grad():
                 logging.info(f"Generating predictions on batch {i + 1}")
                 outputs = self.model.generate_on_batch(batch, n_samples=self.n_samples)
@@ -211,7 +202,7 @@ class EvaluatorConfig:
             name="evaluator",
         )
         evaluator_model: DiffusionModel | DenoisingMoEPredictor | PatchPredictor
-        if self.patch.divide_generation and self.patch.composite_prediction:
+        if self.patch.needs_patch_predictor:
             evaluator_model = PatchPredictor(
                 model,
                 coarse_yx_patch_extent=model.coarse_shape,
@@ -220,19 +211,11 @@ class EvaluatorConfig:
         else:
             evaluator_model = model
 
-        if self.patch.divide_generation and not self.patch.composite_prediction:
-            # Subdivide evaluation into patches, do not composite them together
-            # No maps will be saved for this configuration.
-            patch_data = True
-        else:
-            patch_data = False
-
         return Evaluator(
             data=dataset,
             model=evaluator_model,
             experiment_dir=self.experiment_dir,
             n_samples=self.n_samples,
-            patch_data=patch_data,
         )
 
     def _build_event_evaluator(

--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -205,7 +205,6 @@ class EvaluatorConfig:
         if self.patch.needs_patch_predictor:
             evaluator_model = PatchPredictor(
                 model,
-                coarse_yx_patch_extent=model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         else:
@@ -243,7 +242,6 @@ class EvaluatorConfig:
         ):
             evaluator_model = PatchPredictor(
                 model=model,
-                coarse_yx_patch_extent=model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         else:

--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -25,6 +25,7 @@ from fme.downscaling.predictors import (
     DenoisingMoEPredictor,
     PatchPredictionConfig,
     PatchPredictor,
+    check_input_shape_supported,
 )
 from fme.downscaling.requirements import DataRequirements
 from fme.downscaling.typing_ import FineResCoarseResPair
@@ -203,6 +204,12 @@ class EvaluatorConfig:
         coarse_lon = dataset.coarse_extent_latlon_coords.lon
         # No-op when coarse_lon does not cross the prime meridian.
         model = model.with_rolled_lon(coarse_lon)
+        check_input_shape_supported(
+            model.coarse_shape,
+            dataset.coarse_shape,
+            self.patch,
+            name="evaluator",
+        )
         evaluator_model: DiffusionModel | DenoisingMoEPredictor | PatchPredictor
         if self.patch.divide_generation and self.patch.composite_prediction:
             evaluator_model = PatchPredictor(
@@ -242,6 +249,12 @@ class EvaluatorConfig:
         coarse_lon = dataset.coarse_extent_latlon_coords.lon
         # No-op when coarse_lon does not cross the prime meridian.
         model = model.with_rolled_lon(coarse_lon)
+        check_input_shape_supported(
+            model.coarse_shape,
+            dataset.coarse_shape,
+            self.patch,
+            name=f"event {event_config.name}",
+        )
         if (dataset.coarse_shape[0] > model.coarse_shape[0]) or (
             dataset.coarse_shape[1] > model.coarse_shape[1]
         ):

--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -207,7 +207,6 @@ class EvaluatorConfig:
         if self.patch.divide_generation and self.patch.composite_prediction:
             evaluator_model = PatchPredictor(
                 model,
-                coarse_yx_patch_extent=model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         else:
@@ -247,7 +246,6 @@ class EvaluatorConfig:
         ):
             evaluator_model = PatchPredictor(
                 model=model,
-                coarse_yx_patch_extent=model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         else:

--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -202,7 +202,9 @@ class EvaluatorConfig:
             name="evaluator",
         )
         evaluator_model: DiffusionModel | DenoisingMoEPredictor | PatchPredictor
-        if self.patch.needs_patch_predictor:
+        if (dataset.coarse_shape[0] > model.coarse_shape[0]) or (
+            dataset.coarse_shape[1] > model.coarse_shape[1]
+        ):
             evaluator_model = PatchPredictor(
                 model,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,

--- a/fme/downscaling/inference/inference.py
+++ b/fme/downscaling/inference/inference.py
@@ -19,6 +19,7 @@ from ..predictors import (
     DenoisingMoEPredictor,
     PatchPredictionConfig,
     PatchPredictor,
+    check_input_shape_supported,
 )
 from .output import DownscalingOutput, EventConfig, TimeRangeConfig
 from .work_items import LoadedSliceWorkItem
@@ -76,38 +77,21 @@ class Downscaler:
         input_shape = (len(coarse_coords.lat), len(coarse_coords.lon))
         # No-op when coarse_lon does not cross the prime meridian.
         base_model = self.model.with_rolled_lon(coarse_coords.lon)
-        model_patch_shape = base_model.coarse_shape
-
-        if model_patch_shape == input_shape:
-            # short circuit, no patching necessary
+        check_input_shape_supported(
+            base_model.coarse_shape,
+            input_shape,
+            output.patch,
+            name=f"output {output.name}",
+        )
+        if tuple(base_model.coarse_shape) == tuple(input_shape):
+            # exact match, no patching necessary
             return base_model
-        elif any(
-            expected > actual
-            for expected, actual in zip(model_patch_shape, input_shape)
-        ):
-            # we don't support generating regions smaller than the model patch size
-            raise ValueError(
-                f"Model coarse shape {model_patch_shape} is larger than "
-                f"actual input shape {input_shape} for output {output.name}."
-                "We do not support generating outputs with a smaller spatial extent"
-                " than the model's trained patch size. Please adjust the spatial extent"
-                " to be at least as large as the model's input patch size."
-            )
-        elif output.patch.needs_patch_predictor:
-            # Use a patch predictor
-            logging.info(f"Using PatchPredictor for output: {output.name}")
-            return PatchPredictor(
-                model=base_model,
-                coarse_horizontal_overlap=output.patch.coarse_horizontal_overlap,
-            )
-        else:
-            # User should enable patching
-            raise ValueError(
-                f"Model coarse shape {model_patch_shape} does not match "
-                f"actual input shape {input_shape} for output {output.name}, "
-                "and patch prediction is not configured. Generation for larger domains "
-                "requires patch prediction."
-            )
+        # larger extent with composite patch prediction configured
+        logging.info(f"Using PatchPredictor for output: {output.name}")
+        return PatchPredictor(
+            model=base_model,
+            coarse_horizontal_overlap=output.patch.coarse_horizontal_overlap,
+        )
 
     def _on_device_generator(self, loader):
         for loaded_item in loader:

--- a/fme/downscaling/inference/inference.py
+++ b/fme/downscaling/inference/inference.py
@@ -83,10 +83,9 @@ class Downscaler:
             output.patch,
             name=f"output {output.name}",
         )
-        if tuple(base_model.coarse_shape) == tuple(input_shape):
-            # exact match, no patching necessary
+        if output.patch.needs_patch_predictor is False:
             return base_model
-        # larger extent with composite patch prediction configured
+
         logging.info(f"Using PatchPredictor for output: {output.name}")
         return PatchPredictor(
             model=base_model,

--- a/fme/downscaling/inference/inference.py
+++ b/fme/downscaling/inference/inference.py
@@ -83,7 +83,7 @@ class Downscaler:
             output.patch,
             name=f"output {output.name}",
         )
-        if output.patch.needs_patch_predictor is False:
+        if base_model.coarse_shape == input_shape:
             return base_model
 
         logging.info(f"Using PatchPredictor for output: {output.name}")

--- a/fme/downscaling/inference/test_inference.py
+++ b/fme/downscaling/inference/test_inference.py
@@ -324,7 +324,7 @@ def generation_config(tmp_path, loader_config, checkpointed_model_config):  # no
         experiment_dir=str(output_dir),
         outputs=[region_config, event_config],
         logging=LoggingConfig(log_to_screen=True, log_to_wandb=False),
-        patch=PatchPredictionConfig(divide_generation=True),
+        patch=PatchPredictionConfig(divide_generation=True, composite_prediction=True),
     )
 
 

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -209,17 +209,6 @@ class Downscaler:
             )
         return base_model
 
-    @property
-    def batch_generator(self):
-        if self.patch.needs_patch_data_generator:
-            return self.data.get_patched_generator(
-                yx_patch_extent=self.model.coarse_shape,
-                overlap=self.patch.coarse_horizontal_overlap,
-                drop_partial_patches=False,
-            )
-        else:
-            return self.data.get_generator()
-
     def save_netcdf_data(self, ds: xr.Dataset):
         if self.dist.is_root():
             # no slashes allowed in netcdf variable names
@@ -231,7 +220,7 @@ class Downscaler:
     def run(self):
         generation_model = self._get_generation_model()
         aggregator: NoTargetAggregator | None = None
-        for i, batch in enumerate(self.batch_generator):
+        for i, batch in enumerate(self.data.get_generator()):
             if aggregator is None:
                 fine_coords = generation_model.get_fine_coords_for_batch(batch)
                 aggregator = NoTargetAggregator(
@@ -249,7 +238,7 @@ class Downscaler:
                 coarse = {k: v.unsqueeze(1) for k, v in batch.data.items()}
                 aggregator.record_batch(prediction, coarse, batch.time)
 
-        # dataset build ensures non-empty batch_generator
+        # dataset build ensures a non-empty generator
         assert aggregator is not None
         logs = aggregator.get_wandb()
         wandb = WandB.get_instance()

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -121,12 +121,12 @@ class EventDownscaler:
             self.patch,
             name=f"event {self.event_name}",
         )
-        if self.patch.needs_patch_predictor:
-            return PatchPredictor(
-                base_model,
-                coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
-            )
-        return base_model
+        if base_model.coarse_shape == self.data.shape:
+            return base_model
+        return PatchPredictor(
+            base_model,
+            coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
+        )
 
     def run(self):
         logging.info(f"Running {self.event_name} event downscaling...")

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -124,7 +124,6 @@ class EventDownscaler:
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 base_model,
-                self.data.shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         return base_model
@@ -204,7 +203,6 @@ class Downscaler:
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 model=base_model,
-                coarse_yx_patch_extent=base_model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         return base_model

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -117,7 +117,6 @@ class EventDownscaler:
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 base_model,
-                self.data.shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         return base_model
@@ -191,7 +190,6 @@ class Downscaler:
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 model=base_model,
-                coarse_yx_patch_extent=base_model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         return base_model

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -29,6 +29,7 @@ from fme.downscaling.predictors import (
     DenoisingMoEPredictor,
     PatchPredictionConfig,
     PatchPredictor,
+    check_input_shape_supported,
 )
 from fme.downscaling.requirements import DataRequirements
 from fme.downscaling.typing_ import FineResCoarseResPair
@@ -114,6 +115,12 @@ class EventDownscaler:
         coarse_lon = self.data.coarse_extent_latlon_coords.lon
         # No-op when coarse_lon does not cross the prime meridian.
         base_model = self.model.with_rolled_lon(coarse_lon)
+        check_input_shape_supported(
+            base_model.coarse_shape,
+            self.data.shape,
+            self.patch,
+            name=f"event {self.event_name}",
+        )
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 base_model,
@@ -188,6 +195,12 @@ class Downscaler:
         coarse_lon = self.data.coarse_extent_latlon_coords.lon
         # No-op when coarse_lon does not cross the prime meridian.
         base_model = self.model.with_rolled_lon(coarse_lon)
+        check_input_shape_supported(
+            base_model.coarse_shape,
+            self.data.shape,
+            self.patch,
+            name="downscaler output",
+        )
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 model=base_model,

--- a/fme/downscaling/predictors/__init__.py
+++ b/fme/downscaling/predictors/__init__.py
@@ -1,4 +1,8 @@
-from .composite import PatchPredictionConfig, PatchPredictor
+from .composite import (
+    PatchPredictionConfig,
+    PatchPredictor,
+    check_input_shape_supported,
+)
 from .serial_denoising import (
     DenoisingExpertCheckpointConfig,
     DenoisingMoEBundledConfig,
@@ -13,4 +17,5 @@ __all__ = [
     "DenoisingMoEPredictor",
     "PatchPredictionConfig",
     "PatchPredictor",
+    "check_input_shape_supported",
 ]

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -54,25 +54,18 @@ class PatchPredictor:
     def __init__(
         self,
         model: DiffusionModel | DenoisingMoEPredictor,
-        coarse_yx_patch_extent: tuple[int, int] | None = None,
         coarse_horizontal_overlap: int = 1,
     ):
         """
         Args:
             model: the model to use for generating predictions.
-            coarse_yx_patch_extent: The shape of the coarse region passed
-                to the downscaling model for prediction. If None, will be
-                inferred from model.coarse_shape.
             coarse_horizontal_overlap: the number of pixels to overlap
                 between patches in the coarse data.
         """
         self.model = model
         self.modules = self.model.modules
 
-        if coarse_yx_patch_extent is None:
-            coarse_yx_patch_extent = self.model.coarse_shape
-
-        self.coarse_yx_patch_extent = coarse_yx_patch_extent
+        self.coarse_yx_patch_extent = self.model.coarse_shape
         self.downscale_factor = self.model.downscale_factor
         self.coarse_horizontal_overlap = coarse_horizontal_overlap
 

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -29,16 +29,6 @@ class PatchPredictionConfig:
     coarse_horizontal_overlap: int = 1
 
     @property
-    def needs_patch_data_generator(self):
-        # If final predictions are not composited together, the BatchData is divided
-        # into patches before being passed to the top level no-target generation call.
-        # If final predictions are composited together, the BatchData is divided
-        # into patches within the PatchPredictor's generation method.
-        if self.divide_generation and not self.composite_prediction:
-            return True
-        return False
-
-    @property
     def needs_patch_predictor(self):
         if self.divide_generation and self.composite_prediction:
             return True

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -170,6 +170,57 @@ class PatchPredictor:
         return prediction
 
 
+def check_input_shape_supported(
+    model_coarse_shape: tuple[int, int],
+    input_shape: tuple[int, int],
+    patch: PatchPredictionConfig,
+    name: str = "",
+) -> None:
+    """
+    Raise if a coarse ``input_shape`` cannot be generated for the given model
+    patch size and patch configuration.
+
+    While models are probably capable of generating any domain size, we haven't
+    tested domains smaller than the model patch size, so we raise an error in
+    that case, and prompt the user to use patching for larger domains because
+    that provides better generations.
+
+    Args:
+        model_coarse_shape: the ``(lat, lon)`` coarse patch size the model was
+            trained on.
+        input_shape: the ``(lat, lon)`` extent of the coarse input to generate on.
+        patch: the patch-prediction configuration.
+        name: optional label used in error messages to identify the caller
+            (e.g. an output or event name).
+
+    Returns None for the supported cases: an exact match (no patching needed), or
+    a larger extent with composite patch prediction configured.
+    """
+    model_shape = tuple(model_coarse_shape)
+    in_shape = tuple(input_shape)
+    suffix = f" for {name}" if name else ""
+    if model_shape == in_shape:
+        # exact match, no patching necessary
+        return
+    if any(expected > actual for expected, actual in zip(model_shape, in_shape)):
+        # we don't support generating regions smaller than the model patch size
+        raise ValueError(
+            f"Model coarse shape {model_shape} is larger than "
+            f"actual input shape {in_shape}{suffix}. "
+            "We do not support generating outputs with a smaller spatial extent"
+            " than the model's trained patch size. Please adjust the spatial extent"
+            " to be at least as large as the model's input patch size."
+        )
+    if not patch.needs_patch_predictor:
+        # larger extent but patching not configured
+        raise ValueError(
+            f"Model coarse shape {model_shape} does not match "
+            f"actual input shape {in_shape}{suffix}, "
+            "and patch prediction is not configured. Generation for larger domains "
+            "requires patch prediction."
+        )
+
+
 def _get_full_extent_from_patches(patches: list[Patch]) -> tuple[int, int]:
     # input patches should have int start/stop values
     y_max = max(patch.input_slice.y.stop for patch in patches)

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -72,7 +72,7 @@ class PatchPredictor:
         self.coarse_horizontal_overlap = coarse_horizontal_overlap
 
     @property
-    def coarse_shape(self):
+    def coarse_shape(self) -> tuple[int, int]:
         return self.coarse_yx_patch_extent
 
     @property
@@ -171,28 +171,28 @@ def check_input_shape_supported(
     patch: PatchPredictionConfig,
     name: str = "",
 ) -> None:
-    model_shape = tuple(model_coarse_shape)
     in_shape = tuple(input_shape)
     suffix = f" for {name}" if name else ""
-    if model_shape == in_shape:
+    if model_coarse_shape == in_shape:
         return
     if any(
         model_input_size > data_input_size
-        for model_input_size, data_input_size in zip(model_shape, in_shape)
+        for model_input_size, data_input_size in zip(model_coarse_shape, in_shape)
     ):
         raise ValueError(
-            f"Model coarse shape {model_shape} is larger than "
+            f"Model coarse shape {model_coarse_shape} is larger than "
             f"actual input shape {in_shape}{suffix}. "
             "We do not support generating outputs with a smaller spatial extent"
             " than the model's trained patch size. Please adjust the spatial extent"
-            f" to be at least as large as the model's input patch size {model_shape}."
+            " to be at least as large as the model's input patch size "
+            f"{model_coarse_shape}."
         )
     # If data shape is larger than model input shape, currently require patch prediction
     # as the models predict very biased results for out-of-sample input shapes.
     if not patch.needs_patch_predictor:
         raise ValueError(
             f"Input datashape {in_shape}{suffix} is larger than the model input patch "
-            f"size {model_shape} and patch prediction is not configured. "
+            f"size {model_coarse_shape} and patch prediction is not configured. "
             "Generation for larger domains requires patch prediction configured with "
             "composite_prediction=True and divide_generation=True."
         )

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -49,6 +49,8 @@ class PatchPredictor:
     """
     Model prediction wrapper for generating a full-extent prediction
     by dividing the input into a grid of patches.
+
+    Patch size is inferred from the model's coarse_shape used in training.
     """
 
     def __init__(

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -20,6 +20,10 @@ class PatchPredictionConfig:
             input data extent for generation.
         composite_prediction: if True, recombines the smaller prediction
             regions into the original full region as a single sample.
+            Both divide_generation and composite_prediction must be
+            True or both False. Previously, divide_generation=True and
+            composite_prediction=False were allowed; this is no longer
+            supported.
         coarse_horizontal_overlap: number of pixels to overlap in the
             coarse data.
     """
@@ -171,17 +175,16 @@ def check_input_shape_supported(
     patch: PatchPredictionConfig,
     name: str = "",
 ) -> None:
-    in_shape = tuple(input_shape)
     suffix = f" for {name}" if name else ""
-    if model_coarse_shape == in_shape:
+    if model_coarse_shape == input_shape:
         return
     if any(
         model_input_size > data_input_size
-        for model_input_size, data_input_size in zip(model_coarse_shape, in_shape)
+        for model_input_size, data_input_size in zip(model_coarse_shape, input_shape)
     ):
         raise ValueError(
             f"Model coarse shape {model_coarse_shape} is larger than "
-            f"actual input shape {in_shape}{suffix}. "
+            f"actual input shape {input_shape}{suffix}. "
             "We do not support generating outputs with a smaller spatial extent"
             " than the model's trained patch size. Please adjust the spatial extent"
             " to be at least as large as the model's input patch size "
@@ -191,8 +194,8 @@ def check_input_shape_supported(
     # as the models predict very biased results for out-of-sample input shapes.
     if not patch.needs_patch_predictor:
         raise ValueError(
-            f"Input datashape {in_shape}{suffix} is larger than the model input patch "
-            f"size {model_coarse_shape} and patch prediction is not configured. "
+            f"Input datashape {input_shape}{suffix} is larger than the model input "
+            f"patch size {model_coarse_shape} and patch prediction is not configured. "
             "Generation for larger domains requires patch prediction configured with "
             "composite_prediction=True and divide_generation=True."
         )

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -28,6 +28,16 @@ class PatchPredictionConfig:
     composite_prediction: bool = False
     coarse_horizontal_overlap: int = 1
 
+    def __post_init__(self):
+        if self.divide_generation and not self.composite_prediction:
+            raise ValueError(
+                "divide_generation=True requires composite_prediction=True."
+            )
+        if not self.divide_generation and self.composite_prediction:
+            raise ValueError(
+                "composite_prediction=True requires divide_generation=True."
+            )
+
     @property
     def needs_patch_predictor(self):
         if self.divide_generation and self.composite_prediction:
@@ -166,48 +176,30 @@ def check_input_shape_supported(
     patch: PatchPredictionConfig,
     name: str = "",
 ) -> None:
-    """
-    Raise if a coarse ``input_shape`` cannot be generated for the given model
-    patch size and patch configuration.
-
-    While models are probably capable of generating any domain size, we haven't
-    tested domains smaller than the model patch size, so we raise an error in
-    that case, and prompt the user to use patching for larger domains because
-    that provides better generations.
-
-    Args:
-        model_coarse_shape: the ``(lat, lon)`` coarse patch size the model was
-            trained on.
-        input_shape: the ``(lat, lon)`` extent of the coarse input to generate on.
-        patch: the patch-prediction configuration.
-        name: optional label used in error messages to identify the caller
-            (e.g. an output or event name).
-
-    Returns None for the supported cases: an exact match (no patching needed), or
-    a larger extent with composite patch prediction configured.
-    """
     model_shape = tuple(model_coarse_shape)
     in_shape = tuple(input_shape)
     suffix = f" for {name}" if name else ""
     if model_shape == in_shape:
-        # exact match, no patching necessary
         return
-    if any(expected > actual for expected, actual in zip(model_shape, in_shape)):
-        # we don't support generating regions smaller than the model patch size
+    if any(
+        model_input_size > data_input_size
+        for model_input_size, data_input_size in zip(model_shape, in_shape)
+    ):
         raise ValueError(
             f"Model coarse shape {model_shape} is larger than "
             f"actual input shape {in_shape}{suffix}. "
             "We do not support generating outputs with a smaller spatial extent"
             " than the model's trained patch size. Please adjust the spatial extent"
-            " to be at least as large as the model's input patch size."
+            f" to be at least as large as the model's input patch size {model_shape}."
         )
+    # If data shape is larger than model input shape, currently require patch prediction
+    # as the models predict very biased results for out-of-sample input shapes.
     if not patch.needs_patch_predictor:
-        # larger extent but patching not configured
         raise ValueError(
-            f"Model coarse shape {model_shape} does not match "
-            f"actual input shape {in_shape}{suffix}, "
-            "and patch prediction is not configured. Generation for larger domains "
-            "requires patch prediction."
+            f"Input datashape {in_shape}{suffix} is larger than the model input patch "
+            f"size {model_shape} and patch prediction is not configured. "
+            "Generation for larger domains requires patch prediction configured with "
+            "composite_prediction=True and divide_generation=True."
         )
 
 

--- a/fme/downscaling/predictors/test_composite.py
+++ b/fme/downscaling/predictors/test_composite.py
@@ -132,7 +132,6 @@ def test_SpatialCompositePredictor_generate_on_batch(patch_size_coarse):
 
     predictor = PatchPredictor(
         DummyModel(coarse_shape=patch_size_coarse, downscale_factor=downscale_factor),  # type: ignore
-        coarse_extent,
         coarse_horizontal_overlap=1,
     )
     n_samples_generate = 2
@@ -161,7 +160,6 @@ def test_SpatialCompositePredictor_generate_on_batch_no_target(patch_size_coarse
     )
     predictor = PatchPredictor(
         DummyModel(coarse_shape=patch_size_coarse, downscale_factor=2),  # type: ignore
-        coarse_extent,
         coarse_horizontal_overlap=1,
     )
     n_samples_generate = 2

--- a/fme/downscaling/predictors/test_composite.py
+++ b/fme/downscaling/predictors/test_composite.py
@@ -163,7 +163,6 @@ def test_SpatialCompositePredictor_generate_on_batch(patch_size_coarse):
 
     predictor = PatchPredictor(
         DummyModel(coarse_shape=patch_size_coarse, downscale_factor=downscale_factor),  # type: ignore
-        coarse_extent,
         coarse_horizontal_overlap=1,
     )
     n_samples_generate = 2
@@ -192,7 +191,6 @@ def test_SpatialCompositePredictor_generate_on_batch_no_target(patch_size_coarse
     )
     predictor = PatchPredictor(
         DummyModel(coarse_shape=patch_size_coarse, downscale_factor=2),  # type: ignore
-        coarse_extent,
         coarse_horizontal_overlap=1,
     )
     n_samples_generate = 2

--- a/fme/downscaling/predictors/test_composite.py
+++ b/fme/downscaling/predictors/test_composite.py
@@ -199,3 +199,20 @@ def test_SpatialCompositePredictor_generate_on_batch_no_target(patch_size_coarse
         coarse_batch_data, n_samples=n_samples_generate
     )
     assert prediction["x"].shape == (batch_size, n_samples_generate, 8, 8)
+
+
+@pytest.mark.parametrize(
+    "divide_generation, composite_prediction, error_submessage",
+    [
+        (True, False, "divide_generation=True requires composite_prediction=True."),
+        (False, True, "composite_prediction=True requires divide_generation=True."),
+    ],
+)
+def test_PatchPredictionConfig_disallowed_configs(
+    divide_generation, composite_prediction, error_submessage
+):
+    with pytest.raises(ValueError, match=error_submessage):
+        PatchPredictionConfig(
+            divide_generation=divide_generation,
+            composite_prediction=composite_prediction,
+        )

--- a/fme/downscaling/predictors/test_composite.py
+++ b/fme/downscaling/predictors/test_composite.py
@@ -11,7 +11,9 @@ from fme.downscaling.data.patching import get_patches
 from fme.downscaling.data.utils import BatchedLatLonCoordinates
 from fme.downscaling.models import ModelOutputs
 from fme.downscaling.predictors.composite import (
+    PatchPredictionConfig,
     PatchPredictor,
+    check_input_shape_supported,
     composite_patch_predictions,
 )
 
@@ -41,6 +43,35 @@ def test_composite_predictions():
                 device=predictions[0]["x"].device,
             ),
         )
+
+
+_COMPOSITE_PATCH = PatchPredictionConfig(
+    divide_generation=True, composite_prediction=True
+)
+_NO_PATCH = PatchPredictionConfig()
+
+
+def test_check_input_shape_supported_exact_match():
+    """Exact match is supported regardless of patch config (does not raise)."""
+    check_input_shape_supported((16, 16), (16, 16), _NO_PATCH)
+
+
+def test_check_input_shape_supported_larger_with_composite():
+    """A larger extent is supported when composite patch prediction is configured."""
+    check_input_shape_supported((16, 16), (32, 32), _COMPOSITE_PATCH)
+
+
+@pytest.mark.parametrize("input_shape", [(8, 16), (16, 8), (8, 8)])
+def test_check_input_shape_supported_raises_when_too_small(input_shape):
+    """Raise when the input is smaller than the model patch in any dimension."""
+    with pytest.raises(ValueError, match="smaller spatial extent"):
+        check_input_shape_supported((16, 16), input_shape, _COMPOSITE_PATCH)
+
+
+def test_check_input_shape_supported_raises_when_larger_without_patching():
+    """Raise when the extent differs from the patch but patching isn't configured."""
+    with pytest.raises(ValueError, match="requires patch prediction"):
+        check_input_shape_supported((16, 16), (32, 32), _NO_PATCH)
 
 
 class DummyModel:

--- a/fme/downscaling/test_evaluator.py
+++ b/fme/downscaling/test_evaluator.py
@@ -216,6 +216,52 @@ def test_evaluator_rolls_for_seam_crossing(tmp_path):
     assert (experiment_dir / "evaluator_maps_and_metrics.nc").exists()
 
 
+def test_evaluator_raises_when_larger_without_patching(tmp_path):
+    """The default evaluator refuses a region larger than the model patch when
+    patch prediction is not configured."""
+    coarse_shape = (4, 4)
+    downscale_factor = 2
+    fine_shape = (
+        coarse_shape[0] * downscale_factor,
+        coarse_shape[1] * downscale_factor,
+    )
+    paths = global_data_paths_helper(tmp_path)
+    full_fine_coords = LatLonCoordinates(
+        lat=cell_centered_coordinate(0.0, 8.0, coarse_shape[0] * downscale_factor),
+        lon=cell_centered_coordinate(0.0, 360.0, 8 * downscale_factor),
+    )
+    model = _seam_crossing_model_config(fine_shape).build(
+        coarse_shape=coarse_shape,
+        downscale_factor=downscale_factor,
+        full_fine_coords=full_fine_coords,
+        static_inputs=StaticInputs(fields=[], coords=full_fine_coords),
+    )
+    experiment_dir = tmp_path / "output"
+    experiment_dir.mkdir()
+    checkpoint_path = experiment_dir / "latest.ckpt"
+    torch.save({"model": model.get_state()}, checkpoint_path)
+
+    config = evaluator.EvaluatorConfig(
+        model=CheckpointModelConfig(checkpoint_path=str(checkpoint_path)),
+        experiment_dir=str(experiment_dir),
+        data=PairedDataLoaderConfig(
+            fine=[XarrayDataConfig(paths.fine)],
+            coarse=[XarrayDataConfig(paths.coarse)],
+            batch_size=2,
+            num_data_workers=0,
+            strict_ensemble=False,
+            # Full extent is 4x8 coarse, larger than the (4, 4) model in lon.
+            lat_extent=ClosedInterval(0.0, 8.0),
+            lon_extent=ClosedInterval(0.0, 360.0),
+        ),
+        logging=LoggingConfig(),
+        n_samples=2,
+        # default patch: no composite patch prediction configured
+    )
+    with pytest.raises(ValueError, match="requires patch prediction"):
+        config._build_default_evaluator()
+
+
 @pytest.mark.parametrize(
     "evaluator_model_config, num_samples",
     [

--- a/fme/downscaling/test_evaluator.py
+++ b/fme/downscaling/test_evaluator.py
@@ -218,42 +218,27 @@ def test_evaluator_rolls_for_seam_crossing(tmp_path):
 
 def test_evaluator_raises_when_larger_without_patching(tmp_path):
     """The default evaluator refuses a region larger than the model patch when
-    patch prediction is not configured."""
-    coarse_shape = (4, 4)
-    downscale_factor = 2
-    fine_shape = (
-        coarse_shape[0] * downscale_factor,
-        coarse_shape[1] * downscale_factor,
-    )
-    paths = global_data_paths_helper(tmp_path)
-    full_fine_coords = LatLonCoordinates(
-        lat=cell_centered_coordinate(0.0, 8.0, coarse_shape[0] * downscale_factor),
-        lon=cell_centered_coordinate(0.0, 360.0, 8 * downscale_factor),
-    )
-    model = _seam_crossing_model_config(fine_shape).build(
-        coarse_shape=coarse_shape,
-        downscale_factor=downscale_factor,
-        full_fine_coords=full_fine_coords,
-        static_inputs=StaticInputs(fields=[], coords=full_fine_coords),
-    )
-    experiment_dir = tmp_path / "output"
-    experiment_dir.mkdir()
-    checkpoint_path = experiment_dir / "latest.ckpt"
-    torch.save({"model": model.get_state()}, checkpoint_path)
+    patch prediction is not configured.
+
+    The model and data are mocked so the shape check in ``_build_default_evaluator``
+    is exercised without building a real model or dataset. The lower-level check is
+    covered directly in test_composite.py; this verifies the evaluator wiring.
+    """
+    model_config = unittest.mock.MagicMock()
+    built_model = model_config.build.return_value
+    built_model.coarse_shape = (4, 4)
+    # with_rolled_lon is a no-op here; return the same model.
+    built_model.with_rolled_lon.return_value = built_model
+
+    data_config = unittest.mock.MagicMock()
+    dataset = data_config.build.return_value
+    # Full extent is 4x8 coarse, larger than the (4, 4) model in lon.
+    dataset.coarse_shape = (4, 8)
 
     config = evaluator.EvaluatorConfig(
-        model=CheckpointModelConfig(checkpoint_path=str(checkpoint_path)),
-        experiment_dir=str(experiment_dir),
-        data=PairedDataLoaderConfig(
-            fine=[XarrayDataConfig(paths.fine)],
-            coarse=[XarrayDataConfig(paths.coarse)],
-            batch_size=2,
-            num_data_workers=0,
-            strict_ensemble=False,
-            # Full extent is 4x8 coarse, larger than the (4, 4) model in lon.
-            lat_extent=ClosedInterval(0.0, 8.0),
-            lon_extent=ClosedInterval(0.0, 360.0),
-        ),
+        model=model_config,
+        experiment_dir=str(tmp_path),
+        data=data_config,
         logging=LoggingConfig(),
         n_samples=2,
         # default patch: no composite patch prediction configured

--- a/fme/downscaling/test_evaluator.py
+++ b/fme/downscaling/test_evaluator.py
@@ -227,12 +227,10 @@ def test_evaluator_raises_when_larger_without_patching(tmp_path):
     model_config = unittest.mock.MagicMock()
     built_model = model_config.build.return_value
     built_model.coarse_shape = (4, 4)
-    # with_rolled_lon is a no-op here; return the same model.
-    built_model.with_rolled_lon.return_value = built_model
+    built_model.with_rolled_lon.return_value = built_model  # same model, no roll
 
     data_config = unittest.mock.MagicMock()
     dataset = data_config.build.return_value
-    # Full extent is 4x8 coarse, larger than the (4, 4) model in lon.
     dataset.coarse_shape = (4, 8)
 
     config = evaluator.EvaluatorConfig(
@@ -241,7 +239,6 @@ def test_evaluator_raises_when_larger_without_patching(tmp_path):
         data=data_config,
         logging=LoggingConfig(),
         n_samples=2,
-        # default patch: no composite patch prediction configured
     )
     with pytest.raises(ValueError, match="requires patch prediction"):
         config._build_default_evaluator()

--- a/fme/downscaling/test_predict.py
+++ b/fme/downscaling/test_predict.py
@@ -225,6 +225,82 @@ def test_predictor_runs_seam_crossing(tmp_path, cls):
         assert value.shape[-2:] == fine_shape
 
 
+def _build_model_and_data_at_extent(tmp_path, lat_extent, lon_extent):
+    """A (4, 4)-patch model plus GriddedData subset to the given extent."""
+    coarse_shape = (4, 4)
+    downscale_factor = 2
+    fine_shape = (
+        coarse_shape[0] * downscale_factor,
+        coarse_shape[1] * downscale_factor,
+    )
+    paths = global_data_paths_helper(tmp_path)
+    full_fine_coords = LatLonCoordinates(
+        lat=cell_centered_coordinate(0.0, 8.0, fine_shape[0]),
+        lon=cell_centered_coordinate(0.0, 360.0, fine_shape[1]),
+    )
+    model = get_model_config(
+        coarse_shape, downscale_factor, use_fine_topography=False
+    ).build(
+        coarse_shape=coarse_shape,
+        downscale_factor=downscale_factor,
+        full_fine_coords=full_fine_coords,
+        static_inputs=StaticInputs(fields=[], coords=full_fine_coords),
+    )
+    data = DataLoaderConfig(
+        coarse=[XarrayDataConfig(str(paths.coarse))],
+        batch_size=2,
+        num_data_workers=0,
+        strict_ensemble=False,
+        lat_extent=lat_extent,
+        lon_extent=lon_extent,
+    ).build(
+        requirements=DataRequirements(
+            fine_names=[], coarse_names=["var0", "var1"], n_timesteps=1
+        ),
+    )
+    return model, data
+
+
+@pytest.mark.parametrize("cls", [predict.Downscaler, predict.EventDownscaler])
+def test_predictor_raises_when_domain_too_small(tmp_path, cls):
+    """The predict entrypoints refuse a region smaller than the model patch."""
+    # lat/lon (0, 4)/(0, 90) selects a 2x2 coarse region, smaller than the (4, 4) model.
+    model, data = _build_model_and_data_at_extent(
+        tmp_path, ClosedInterval(0.0, 4.0), ClosedInterval(0.0, 90.0)
+    )
+    kwargs = dict(data=data, model=model, experiment_dir=str(tmp_path), n_samples=2)
+    downscaler = (
+        cls(event_name="evt", **kwargs)
+        if cls is predict.EventDownscaler
+        else cls(**kwargs)
+    )
+    with pytest.raises(ValueError, match="smaller spatial extent"):
+        downscaler._get_generation_model()
+
+
+@pytest.mark.parametrize("cls", [predict.Downscaler, predict.EventDownscaler])
+def test_predictor_raises_when_larger_without_patching(tmp_path, cls):
+    """A region larger than the model patch requires patch prediction."""
+    # Full extent is 4x8 coarse, larger than the (4, 4) model in lon.
+    model, data = _build_model_and_data_at_extent(
+        tmp_path, ClosedInterval(0.0, 8.0), ClosedInterval(0.0, 360.0)
+    )
+    kwargs = dict(
+        data=data,
+        model=model,
+        experiment_dir=str(tmp_path),
+        n_samples=2,
+        patch=PatchPredictionConfig(),  # no patch prediction configured
+    )
+    downscaler = (
+        cls(event_name="evt", **kwargs)
+        if cls is predict.EventDownscaler
+        else cls(**kwargs)
+    )
+    with pytest.raises(ValueError, match="requires patch prediction"):
+        downscaler._get_generation_model()
+
+
 @pytest.mark.medium_duration
 def test_predictor_renaming(
     tmp_path,

--- a/fme/downscaling/test_predict.py
+++ b/fme/downscaling/test_predict.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -225,49 +226,27 @@ def test_predictor_runs_seam_crossing(tmp_path, cls):
         assert value.shape[-2:] == fine_shape
 
 
-def _build_model_and_data_at_extent(tmp_path, lat_extent, lon_extent):
-    """A (4, 4)-patch model plus GriddedData subset to the given extent."""
-    coarse_shape = (4, 4)
-    downscale_factor = 2
-    fine_shape = (
-        coarse_shape[0] * downscale_factor,
-        coarse_shape[1] * downscale_factor,
-    )
-    paths = global_data_paths_helper(tmp_path)
-    full_fine_coords = LatLonCoordinates(
-        lat=cell_centered_coordinate(0.0, 8.0, fine_shape[0]),
-        lon=cell_centered_coordinate(0.0, 360.0, fine_shape[1]),
-    )
-    model = get_model_config(
-        coarse_shape, downscale_factor, use_fine_topography=False
-    ).build(
-        coarse_shape=coarse_shape,
-        downscale_factor=downscale_factor,
-        full_fine_coords=full_fine_coords,
-        static_inputs=StaticInputs(fields=[], coords=full_fine_coords),
-    )
-    data = DataLoaderConfig(
-        coarse=[XarrayDataConfig(str(paths.coarse))],
-        batch_size=2,
-        num_data_workers=0,
-        strict_ensemble=False,
-        lat_extent=lat_extent,
-        lon_extent=lon_extent,
-    ).build(
-        requirements=DataRequirements(
-            fine_names=[], coarse_names=["var0", "var1"], n_timesteps=1
-        ),
-    )
+def _mock_model_and_data(model_coarse_shape, data_shape):
+    """Mock a built model and GriddedData for the shape check in
+    _get_generation_model, avoiding a real model or dataset build.
+
+    The lower-level check is covered directly in test_composite.py; these tests
+    verify the predict entrypoints wire the shapes into that check.
+    """
+    model = MagicMock()
+    model.coarse_shape = model_coarse_shape
+    # with_rolled_lon is a no-op here; return the same model.
+    model.with_rolled_lon.return_value = model
+    data = MagicMock()
+    data.shape = data_shape
     return model, data
 
 
 @pytest.mark.parametrize("cls", [predict.Downscaler, predict.EventDownscaler])
 def test_predictor_raises_when_domain_too_small(tmp_path, cls):
     """The predict entrypoints refuse a region smaller than the model patch."""
-    # lat/lon (0, 4)/(0, 90) selects a 2x2 coarse region, smaller than the (4, 4) model.
-    model, data = _build_model_and_data_at_extent(
-        tmp_path, ClosedInterval(0.0, 4.0), ClosedInterval(0.0, 90.0)
-    )
+    # data 2x2 coarse is smaller than the (4, 4) model.
+    model, data = _mock_model_and_data((4, 4), (2, 2))
     kwargs = dict(data=data, model=model, experiment_dir=str(tmp_path), n_samples=2)
     downscaler = (
         cls(event_name="evt", **kwargs)
@@ -281,10 +260,8 @@ def test_predictor_raises_when_domain_too_small(tmp_path, cls):
 @pytest.mark.parametrize("cls", [predict.Downscaler, predict.EventDownscaler])
 def test_predictor_raises_when_larger_without_patching(tmp_path, cls):
     """A region larger than the model patch requires patch prediction."""
-    # Full extent is 4x8 coarse, larger than the (4, 4) model in lon.
-    model, data = _build_model_and_data_at_extent(
-        tmp_path, ClosedInterval(0.0, 8.0), ClosedInterval(0.0, 360.0)
-    )
+    # data 4x8 coarse is larger than the (4, 4) model in lon.
+    model, data = _mock_model_and_data((4, 4), (4, 8))
     kwargs = dict(
         data=data,
         model=model,


### PR DESCRIPTION
It is easy for a user to configure the input regions in `downscaling.predict` or `downscaling.inference` to be smaller or larger than the patch size used to train the model. In these cases (if patching is not configured for larger regions) the model will happily run on the different input shape but produce very biased outputs. This PR add a helper function to check the coarse data shape against the model's coarse input shape in those two entrypoints (inference entrypoint already checked for this) and raise an error in those cases. Inference is updated to use this same function for its check.

- Enforced that `PatchPredictorConfig. divide_generation, composite_prediction` must be either both True or both False. In practice, we don't mix True/False in any of the inference/predict/evaluator entrypoints.
- Added helper function `check_input_shape_supported` which is used across inference/predict/evaluator entrypoints to enforce that either i) prediction region is same size as the model training patch size, or ii) regions larger than the input size are divided into the model training patch size and later composited together. 

- [x] Tests added 