### PR TITLE
Remove coarse_yx_patch_extent arg from `PatchPredictor` init 

### DIFF
--- a/fme/downscaling/evaluator.py
+++ b/fme/downscaling/evaluator.py
@@ -207,7 +207,6 @@ class EvaluatorConfig:
         if self.patch.divide_generation and self.patch.composite_prediction:
             evaluator_model = PatchPredictor(
                 model,
-                coarse_yx_patch_extent=model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         else:
@@ -247,7 +246,6 @@ class EvaluatorConfig:
         ):
             evaluator_model = PatchPredictor(
                 model=model,
-                coarse_yx_patch_extent=model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         else:

--- a/fme/downscaling/predict.py
+++ b/fme/downscaling/predict.py
@@ -117,7 +117,6 @@ class EventDownscaler:
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 base_model,
-                self.data.shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         return base_model
@@ -191,7 +190,6 @@ class Downscaler:
         if self.patch.needs_patch_predictor:
             return PatchPredictor(
                 model=base_model,
-                coarse_yx_patch_extent=base_model.coarse_shape,
                 coarse_horizontal_overlap=self.patch.coarse_horizontal_overlap,
             )
         return base_model

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -54,25 +54,18 @@ class PatchPredictor:
     def __init__(
         self,
         model: DiffusionModel | DenoisingMoEPredictor,
-        coarse_yx_patch_extent: tuple[int, int] | None = None,
         coarse_horizontal_overlap: int = 1,
     ):
         """
         Args:
             model: the model to use for generating predictions.
-            coarse_yx_patch_extent: The shape of the coarse region passed
-                to the downscaling model for prediction. If None, will be
-                inferred from model.coarse_shape.
             coarse_horizontal_overlap: the number of pixels to overlap
                 between patches in the coarse data.
         """
         self.model = model
         self.modules = self.model.modules
 
-        if coarse_yx_patch_extent is None:
-            coarse_yx_patch_extent = self.model.coarse_shape
-
-        self.coarse_yx_patch_extent = coarse_yx_patch_extent
+        self.coarse_yx_patch_extent = self.model.coarse_shape
         self.downscale_factor = self.model.downscale_factor
         self.coarse_horizontal_overlap = coarse_horizontal_overlap
 

--- a/fme/downscaling/predictors/composite.py
+++ b/fme/downscaling/predictors/composite.py
@@ -49,6 +49,8 @@ class PatchPredictor:
     """
     Model prediction wrapper for generating a full-extent prediction
     by dividing the input into a grid of patches.
+
+    Patch size is inferred from the model's coarse_shape used in training.
     """
 
     def __init__(

--- a/fme/downscaling/predictors/test_composite.py
+++ b/fme/downscaling/predictors/test_composite.py
@@ -132,7 +132,6 @@ def test_SpatialCompositePredictor_generate_on_batch(patch_size_coarse):
 
     predictor = PatchPredictor(
         DummyModel(coarse_shape=patch_size_coarse, downscale_factor=downscale_factor),  # type: ignore
-        coarse_extent,
         coarse_horizontal_overlap=1,
     )
     n_samples_generate = 2
@@ -161,7 +160,6 @@ def test_SpatialCompositePredictor_generate_on_batch_no_target(patch_size_coarse
     )
     predictor = PatchPredictor(
         DummyModel(coarse_shape=patch_size_coarse, downscale_factor=2),  # type: ignore
-        coarse_extent,
         coarse_horizontal_overlap=1,
     )
     n_samples_generate = 2


### PR DESCRIPTION
This is a small refactor that enforces that the patch size used in the `PatchPredictor` is always the same as the model coarse shape. This PR precedes https://github.com/ai2cm/ace/pull/1375 which adds a hard requirement to downscaling inference to disallow model predictions on ranges or patches that are not equal to the trained input data size (leads to large errors).