### PR TITLE
Two-track SFNO: RH-input variant (saturation-normalized humidity on the local track)

### DIFF
--- a/configs/baselines/aimip-like/run-train.sh
+++ b/configs/baselines/aimip-like/run-train.sh
@@ -148,3 +148,5 @@ run_training "train-4deg-daily-v2-era5-only-noresid-noclip-noco2.yaml" "train-4d
 run_training "train-4deg-daily-v2-era5-only-noresid-noclip-notnorm.yaml" "train-4deg-daily-v2-era5-only-noresid-noclip-notnorm-rs0" 1
 run_training "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack.yaml" "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rs0" 1
 run_training "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-noco2.yaml" "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-noco2-rs0" 1
+run_training "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh.yaml" "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh-rs0" 1
+run_training "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh-noco2.yaml" "train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh-noco2-rs0" 1

--- a/configs/baselines/aimip-like/train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh-noco2.yaml
+++ b/configs/baselines/aimip-like/train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh-noco2.yaml
@@ -1,0 +1,554 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 120
+ema:
+  decay: 0.999
+train_aggregator:
+  ensemble_metrics: true
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T00:00:00'
+          - '2015-01-02T00:00:00'
+          - '2015-01-03T00:00:00'
+          - '2015-01-04T00:00:00'
+          - '2015-01-05T00:00:00'
+          - '2015-01-06T00:00:00'
+          - '2015-01-07T00:00:00'
+          - '2015-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T00:00:00'
+          - '1995-01-02T00:00:00'
+          - '1995-01-03T00:00:00'
+          - '1995-01-04T00:00:00'
+          - '1995-01-05T00:00:00'
+          - '1995-01-06T00:00:00'
+          - '1995-01-07T00:00:00'
+          - '1995-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T00:00:00'
+          - '2024-06-02T00:00:00'
+          - '2024-06-03T00:00:00'
+          - '2024-06-04T00:00:00'
+          - '2024-06-05T00:00:00'
+          - '2024-06-06T00:00:00'
+          - '2024-06-07T00:00:00'
+          - '2024-06-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T00:00:00'
+          - '1994-06-02T00:00:00'
+          - '1994-06-03T00:00:00'
+          - '1994-06-04T00:00:00'
+          - '1994-06-05T00:00:00'
+          - '1994-06-06T00:00:00'
+          - '1994-06-07T00:00:00'
+          - '1994-06-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: long_46year
+    weight: 0.0
+    epochs:
+      start: 4
+      step: 5
+    n_forward_steps: 16794
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1979-01-01T00:00:00'
+          - '1979-01-02T00:00:00'
+          - '1979-01-03T00:00:00'
+          - '1979-01-04T00:00:00'
+          - '1979-01-05T00:00:00'
+          - '1979-01-06T00:00:00'
+          - '1979-01-07T00:00:00'
+          - '1979-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        target: denorm
+        variables: *inference_variables
+      time_mean_norm:
+        target: norm
+        variables: *inference_variables
+      annual:
+        variables: *inference_variables
+      power_spectrum:
+        variables: *inference_variables
+      histogram:
+        enabled: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 4
+  prefetch_factor: 4
+  time_buffer: 8
+  time_buffer_pool_size: 32
+  dataset:
+    strict: false
+    # ERA5 production-stream stitch boundaries that fall inside the training
+    # window are placed on subset boundaries, so no sample pairs across a
+    # stream-to-stream jump (the global-mean 1-step finite difference at a
+    # stitch is a coherent, resolution-independent bias step, out of
+    # distribution as a residual target). See knowledge/era5-stitching-discontinuities.
+    concat:
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1993-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1995-01-01'
+          stop_time: '1999-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2000-01-01'
+          stop_time: '2009-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2010-01-01'
+          stop_time: '2013-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 16
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default
+          file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1994-01-01'
+            stop_time: '1994-12-31'
+        - data_path: /climate-default
+          file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '2014-01-01'
+            stop_time: '2014-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+stepper:
+  step:
+    type: two_track
+    config:
+      residual_prediction: false
+      # Express humidity as q/q_sat (RH-like, O(1), climate-invariant) as an
+      # ADDITIONAL input channel; q itself stays on the global track and is
+      # still predicted in physical q. Every derived relative_humidity_<level>
+      # channel is routed to the local (never-spectral) track by TwoTrackStep.
+      saturation_normalization:
+      - names:
+        - specific_total_water_*
+        prediction: false
+        input: append
+      builder:
+        embed_dim: 512
+        local_embed_dim: 256
+        noise_embed_dim: 32
+        noise_type: isotropic
+        filter_type: linear
+        affine_norms: true
+        normalize_big_skip: true
+        filter_num_groups: 16
+        spectral_ratio: 0.25
+        use_mlp: true
+        num_layers: 8
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      global_in_names:
+      - HGTsfc
+      - PRESsfc
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      local_in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      global_out_names:
+      - PRESsfc
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      local_out_names:
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa

--- a/configs/baselines/aimip-like/train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh.yaml
+++ b/configs/baselines/aimip-like/train-4deg-daily-v2-era5-only-noresid-noclip-twotrack-rh.yaml
@@ -1,0 +1,605 @@
+seed: 0
+experiment_dir: /results
+save_checkpoint: true
+checkpoint_every_n_batches: 5000
+validate_using_ema: true
+ema_checkpoint_save_epochs:
+  start: 5
+  step: 5
+max_epochs: 120
+ema:
+  decay: 0.999
+train_aggregator:
+  ensemble_metrics: true
+inference:
+  - name: 10year
+    weight: 0.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '2015-01-01T00:00:00'
+          - '2015-01-02T00:00:00'
+          - '2015-01-03T00:00:00'
+          - '2015-01-04T00:00:00'
+          - '2015-01-05T00:00:00'
+          - '2015-01-06T00:00:00'
+          - '2015-01-07T00:00:00'
+          - '2015-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: &inference_variables
+            - PRATEsfc
+            - TMP2m
+            - Q2m
+            - UGRD10m
+            - VGRD10m
+            - h500
+            - TMP850
+            - PRESsfc
+            - surface_temperature
+            - ULWRFsfc
+            - DLWRFsfc
+            - USWRFsfc
+            - DSWRFsfc
+            - ULWRFtoa
+            - USWRFtoa
+            - LHTFLsfc
+            - SHTFLsfc
+            - tendency_of_total_water_path_due_to_advection
+            - air_temperature_0
+            - air_temperature_1
+            - air_temperature_3
+            - air_temperature_7
+            - specific_total_water_0
+            - specific_total_water_1
+            - specific_total_water_3
+            - specific_total_water_7
+            - eastward_wind_0
+            - eastward_wind_1
+            - eastward_wind_3
+            - eastward_wind_7
+            - northward_wind_0
+            - northward_wind_1
+            - northward_wind_3
+            - northward_wind_7
+            - total_water_path
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: 10year_insample
+    weight: 1.0
+    epochs:
+      start: 1
+      step: 2
+    n_forward_steps: 3652
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1995-01-01T00:00:00'
+          - '1995-01-02T00:00:00'
+          - '1995-01-03T00:00:00'
+          - '1995-01-04T00:00:00'
+          - '1995-01-05T00:00:00'
+          - '1995-01-06T00:00:00'
+          - '1995-01-07T00:00:00'
+          - '1995-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      histogram:
+        enabled: true
+  - name: weather_2024
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '2024-06-01T00:00:00'
+          - '2024-06-02T00:00:00'
+          - '2024-06-03T00:00:00'
+          - '2024-06-04T00:00:00'
+          - '2024-06-05T00:00:00'
+          - '2024-06-06T00:00:00'
+          - '2024-06-07T00:00:00'
+          - '2024-06-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: weather_1994
+    weight: 0.0
+    n_forward_steps: 5
+    forward_steps_in_memory: 5
+    n_ensemble_per_ic: 8
+    loader:
+      start_indices:
+        times:
+          - '1994-06-01T00:00:00'
+          - '1994-06-02T00:00:00'
+          - '1994-06-03T00:00:00'
+          - '1994-06-04T00:00:00'
+          - '1994-06-05T00:00:00'
+          - '1994-06-06T00:00:00'
+          - '1994-06-07T00:00:00'
+          - '1994-06-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means:
+        - step: 5
+          target: denorm
+          name: day_5
+          variables: *inference_variables
+        - step: 5
+          target: norm
+          name: day_5_norm
+          variables: *inference_variables
+      ensembles:
+        - step: 5
+          name: day_5_ensemble
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      power_spectrum:
+        enabled: false
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        enabled: false
+        target: denorm
+      time_mean_norm:
+        enabled: false
+        target: norm
+      annual:
+        enabled: false
+      enso_index:
+        enabled: false
+      enso_coefficient:
+        enabled: false
+      ipo_index:
+        enabled: false
+  - name: long_46year
+    weight: 0.0
+    epochs:
+      start: 4
+      step: 5
+    n_forward_steps: 16794
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1979-01-01T00:00:00'
+          - '1979-01-02T00:00:00'
+          - '1979-01-03T00:00:00'
+          - '1979-01-04T00:00:00'
+          - '1979-01-05T00:00:00'
+          - '1979-01-06T00:00:00'
+          - '1979-01-07T00:00:00'
+          - '1979-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        target: denorm
+        variables: *inference_variables
+      time_mean_norm:
+        target: norm
+        variables: *inference_variables
+      annual:
+        variables: *inference_variables
+      power_spectrum:
+        variables: *inference_variables
+      histogram:
+        enabled: true
+  - name: long_46year_constant_co2
+    weight: 0.0
+    epochs:
+      start: 4
+      step: 5
+    n_forward_steps: 16794
+    forward_steps_in_memory: 73
+    n_ensemble_per_ic: 1
+    loader:
+      start_indices:
+        times:
+          - '1979-01-01T00:00:00'
+          - '1979-01-02T00:00:00'
+          - '1979-01-03T00:00:00'
+          - '1979-01-04T00:00:00'
+          - '1979-01-05T00:00:00'
+          - '1979-01-06T00:00:00'
+          - '1979-01-07T00:00:00'
+          - '1979-01-08T00:00:00'
+      dataset:
+        data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+      num_data_workers: 8
+      persistence_names:
+        - global_mean_co2
+    aggregator:
+      step_means: []
+      ensembles: []
+      mean_denorm:
+        enabled: false
+        target: denorm
+      mean_norm:
+        enabled: false
+        target: norm
+      zonal_mean:
+        enabled: false
+      time_mean_denorm:
+        target: denorm
+        variables: *inference_variables
+      time_mean_norm:
+        target: norm
+        variables: *inference_variables
+      annual:
+        variables: *inference_variables
+      power_spectrum:
+        variables: *inference_variables
+      histogram:
+        enabled: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace
+  entity: ai2cm
+train_loader:
+  batch_size: 8
+  num_data_workers: 4
+  prefetch_factor: 4
+  time_buffer: 8
+  time_buffer_pool_size: 32
+  dataset:
+    strict: false
+    # ERA5 production-stream stitch boundaries that fall inside the training
+    # window are placed on subset boundaries, so no sample pairs across a
+    # stream-to-stream jump (the global-mean 1-step finite difference at a
+    # stitch is a coherent, resolution-independent bias step, out of
+    # distribution as a residual target). See knowledge/era5-stitching-discontinuities.
+    concat:
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1979-01-01'
+          stop_time: '1986-03-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1986-04-01'
+          stop_time: '1993-07-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1993-08-01'
+          stop_time: '1993-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '1995-01-01'
+          stop_time: '1999-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2000-01-01'
+          stop_time: '2009-12-31'
+      - data_path: /climate-default
+        file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+        engine: zarr
+        subset:
+          start_time: '2010-01-01'
+          stop_time: '2013-12-31'
+validation:
+  loader:
+    batch_size: 32
+    num_data_workers: 8
+    prefetch_factor: 2
+    time_buffer: 16
+    dataset:
+      strict: false
+      concat:
+        - data_path: /climate-default
+          file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '1994-01-01'
+            stop_time: '1994-12-31'
+        - data_path: /climate-default
+          file_pattern: 2026-04-17-era5-4deg-8layer-daily-1940-2025.zarr
+          engine: zarr
+          subset:
+            start_time: '2014-01-01'
+            stop_time: '2014-12-31'
+optimization:
+  enable_automatic_mixed_precision: false
+  lr: 0.0001
+  optimizer_type: FusedAdam
+  use_gradient_accumulation: true
+  kwargs:
+    weight_decay: 0.01
+stepper_training:
+  n_ensemble: 2
+  n_forward_steps: 1
+  optimize_last_step_only: true
+  loss:
+    type: EnsembleLoss
+    kwargs:
+      crps_weight: 0.9
+      energy_score_weight: 0.1
+stepper:
+  step:
+    type: two_track
+    config:
+      residual_prediction: false
+      # Express humidity as q/q_sat (RH-like, O(1), climate-invariant) as an
+      # ADDITIONAL input channel; q itself stays on the global track and is
+      # still predicted in physical q. Every derived relative_humidity_<level>
+      # channel is routed to the local (never-spectral) track by TwoTrackStep.
+      saturation_normalization:
+      - names:
+        - specific_total_water_*
+        prediction: false
+        input: append
+      builder:
+        embed_dim: 512
+        local_embed_dim: 256
+        noise_embed_dim: 32
+        noise_type: isotropic
+        filter_type: linear
+        affine_norms: true
+        normalize_big_skip: true
+        filter_num_groups: 16
+        spectral_ratio: 0.25
+        use_mlp: true
+        num_layers: 8
+      normalization:
+        network:
+          global_means_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/scaling-full-field.nc
+        residual:
+          global_means_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/centering.nc
+          global_stds_path: /climate-default/2026-04-17-era5-4deg-8layer-daily-stats-1990-2019/2026-03-19-era5-4deg-8layer-1940-2025/scaling-residual.nc
+      ocean:
+        surface_temperature_name: surface_temperature
+        ocean_fraction_name: ocean_fraction
+      corrector:
+        conserve_dry_air: true
+        moisture_budget_correction: advection_and_precipitation
+        force_positive_names:
+        - specific_total_water_0
+        - specific_total_water_1
+        - specific_total_water_2
+        - specific_total_water_3
+        - specific_total_water_4
+        - specific_total_water_5
+        - specific_total_water_6
+        - specific_total_water_7
+        - Q2m
+        - PRATEsfc
+        - ULWRFsfc
+        - ULWRFtoa
+        - DLWRFsfc
+        - DSWRFsfc
+        - USWRFsfc
+        - USWRFtoa
+      next_step_forcing_names:
+      - DSWRFtoa
+      - global_mean_co2
+      global_in_names:
+      - HGTsfc
+      - PRESsfc
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      local_in_names:
+      - land_fraction
+      - ocean_fraction
+      - sea_ice_fraction
+      - DSWRFtoa
+      - global_mean_co2
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      global_out_names:
+      - PRESsfc
+      - air_temperature_0
+      - air_temperature_1
+      - air_temperature_2
+      - air_temperature_3
+      - air_temperature_4
+      - air_temperature_5
+      - air_temperature_6
+      - air_temperature_7
+      - specific_total_water_0
+      - specific_total_water_1
+      - specific_total_water_2
+      - specific_total_water_3
+      - specific_total_water_4
+      - specific_total_water_5
+      - specific_total_water_6
+      - specific_total_water_7
+      - eastward_wind_0
+      - eastward_wind_1
+      - eastward_wind_2
+      - eastward_wind_3
+      - eastward_wind_4
+      - eastward_wind_5
+      - eastward_wind_6
+      - eastward_wind_7
+      - northward_wind_0
+      - northward_wind_1
+      - northward_wind_2
+      - northward_wind_3
+      - northward_wind_4
+      - northward_wind_5
+      - northward_wind_6
+      - northward_wind_7
+      - tendency_of_total_water_path_due_to_advection
+      - TMP850
+      - h500
+      local_out_names:
+      - surface_temperature
+      - TMP2m
+      - Q2m
+      - UGRD10m
+      - VGRD10m
+      - LHTFLsfc
+      - SHTFLsfc
+      - PRATEsfc
+      - ULWRFsfc
+      - ULWRFtoa
+      - DLWRFsfc
+      - DSWRFsfc
+      - USWRFsfc
+      - USWRFtoa

--- a/fme/ace/step/test_two_track.py
+++ b/fme/ace/step/test_two_track.py
@@ -8,8 +8,13 @@ import yaml
 import fme
 from fme.ace.registry.two_track_sfno import TwoTrackSFNOBuilder
 from fme.ace.step.two_track import TwoTrackStep, TwoTrackStepConfig
+from fme.core.coordinates import HybridSigmaPressureCoordinate
 from fme.core.normalizer import NetworkAndLossNormalizationConfig
 from fme.core.step.args import StepArgs
+from fme.core.step.saturation_normalization import (
+    SaturationNormalizationConfig,
+    _relative_humidity_name,
+)
 from fme.core.step.step import StepSelector
 from fme.core.testing import get_dataset_info, trivial_network_and_loss_normalization
 
@@ -286,3 +291,201 @@ def test_example_baseline_state_round_trip_matches_output():
         out2 = step2.step(args=args).output
     for name in out1:
         torch.testing.assert_close(out1[name], out2[name])
+
+
+# ---------------------------------------------------------------------------
+# saturation_normalization: derived RH channels route to the local track
+# ---------------------------------------------------------------------------
+# A hybrid sigma-pressure coordinate with 2 layers (3 interfaces), so
+# saturation q_sat resolves at levels 0 and 1.
+_SAT_AK = torch.tensor([0.0, 0.0, 0.0])
+_SAT_BK = torch.tensor([0.0, 0.5, 1.0])
+
+
+def _sat_vertical_coordinate() -> HybridSigmaPressureCoordinate:
+    return HybridSigmaPressureCoordinate(ak=_SAT_AK.clone(), bk=_SAT_BK.clone())
+
+
+def _sat_dataset_info():
+    return get_dataset_info(
+        img_shape=IMG_SHAPE,
+        vertical_coordinate=_sat_vertical_coordinate(),
+        device=fme.get_device(),
+    )
+
+
+def _sat_config(**overrides) -> TwoTrackStepConfig:
+    # Global track carries humidity + temperature + surface pressure (so q_sat
+    # resolves); a single local field exercises the local-segment ordering.
+    global_names = [
+        "specific_total_water_0",
+        "specific_total_water_1",
+        "air_temperature_0",
+        "air_temperature_1",
+        "PRESsfc",
+    ]
+    names = global_names + ["l_in", "l_out"]
+    base = TwoTrackStepConfig(
+        builder=_builder(),
+        global_in_names=list(global_names),
+        local_in_names=["l_in"],
+        global_out_names=list(global_names),
+        local_out_names=["l_out"],
+        normalization=trivial_network_and_loss_normalization(names),
+    )
+    if overrides:
+        base = dataclasses.replace(base, **overrides)
+    return base
+
+
+def _sat_get_step(config: TwoTrackStepConfig) -> TwoTrackStep:
+    selector = StepSelector(type="two_track", config=dataclasses.asdict(config))
+    step = selector.get_step(_sat_dataset_info(), lambda _: None)
+    assert isinstance(step, TwoTrackStep)
+    return step
+
+
+def _sat_input(names, n_samples=2):
+    device = fme.get_device()
+    data = {}
+    for name in names:
+        if name.startswith("air_temperature"):
+            data[name] = torch.full((n_samples, *IMG_SHAPE), 285.0, device=device)
+        elif name == "PRESsfc":
+            data[name] = torch.full((n_samples, *IMG_SHAPE), 1.0e5, device=device)
+        elif name.startswith("specific_total_water"):
+            data[name] = torch.full((n_samples, *IMG_SHAPE), 0.005, device=device)
+        else:
+            data[name] = torch.rand(n_samples, *IMG_SHAPE, device=device)
+    return data
+
+
+def test_saturation_append_routes_derived_rh_to_local_track():
+    rh0, rh1 = _relative_humidity_name(0), _relative_humidity_name(1)
+    config = _sat_config(
+        saturation_normalization=[
+            SaturationNormalizationConfig(
+                names=["specific_total_water_*"], input="append", prediction=False
+            )
+        ]
+    )
+    n_global_in = len(config.global_in_names)
+    step = _sat_get_step(config)
+    # global segment (the first n_global_in packed names) is unchanged: the
+    # derived RH channels are appended after the local inputs, never before the
+    # split point the network uses to separate global from local.
+    assert step.in_packer.names[:n_global_in] == config.global_in_names
+    local_segment = step.in_packer.names[n_global_in:]
+    assert local_segment == ["l_in", rh0, rh1]
+    # local input channel count grew by the number of derived RH levels
+    assert len(local_segment) == len(config.local_in_names) + 2
+    # the raw q inputs stay on the (global) input side alongside the derived RH
+    assert "specific_total_water_0" in step.in_packer.names
+    assert "specific_total_water_1" in step.in_packer.names
+    # derived RH channels are never predicted on the output side
+    assert rh0 not in step.out_packer.names
+    assert rh1 not in step.out_packer.names
+    # identity normalizer statistics for the derived channels
+    for rh in (rh0, rh1):
+        torch.testing.assert_close(step.normalizer.means[rh].cpu(), torch.tensor(0.0))
+        torch.testing.assert_close(step.normalizer.stds[rh].cpu(), torch.tensor(1.0))
+
+
+def test_saturation_append_step_runs_end_to_end_in_q_space():
+    rh0, rh1 = _relative_humidity_name(0), _relative_humidity_name(1)
+    config = _sat_config(
+        saturation_normalization=[
+            SaturationNormalizationConfig(
+                names=["specific_total_water_*"], input="append"
+            )
+        ]
+    )
+    torch.manual_seed(0)
+    step = _sat_get_step(config)
+    output = step.step(
+        args=StepArgs(
+            input=_sat_input(step.input_names),
+            next_step_input_data=_sat_input(step.next_step_input_names),
+            labels=None,
+        ),
+    ).output
+    # public output is physical q; the derived RH channels stay internal
+    assert set(output) == set(config.out_names)
+    assert rh0 not in output
+    assert rh1 not in output
+    for name in config.out_names:
+        assert output[name].shape == (2, *IMG_SHAPE)
+        assert torch.isfinite(output[name]).all()
+
+
+def test_saturation_none_matches_plain_two_track_packers():
+    # saturation_normalization absent leaves the packers (and therefore the
+    # network sizing) byte-identical to the plain two-track step.
+    plain = _sat_get_step(_sat_config())
+    assert plain.in_packer.names == _sat_config().in_names
+    assert plain.out_packer.names == _sat_config().out_names
+
+
+def test_saturation_replace_input_is_rejected():
+    with pytest.raises(ValueError, match="input='replace' is not"):
+        _sat_get_step(
+            _sat_config(
+                saturation_normalization=[
+                    SaturationNormalizationConfig(
+                        names=["specific_total_water_*"], input="replace"
+                    )
+                ]
+            )
+        )
+
+
+def test_saturation_prediction_is_rejected():
+    with pytest.raises(ValueError, match="prediction=True is not"):
+        _sat_get_step(
+            _sat_config(
+                saturation_normalization=[
+                    SaturationNormalizationConfig(
+                        names=["specific_total_water_*"],
+                        input="append",
+                        prediction=True,
+                    )
+                ]
+            )
+        )
+
+
+def test_saturation_residual_prediction_coherence_is_validated():
+    # residual_prediction requires a prognostic field predicted in RH to be fed
+    # in RH too; prediction=True with input='append' is incoherent and rejected
+    # in __post_init__ (before the step-level replace/prediction guards).
+    with pytest.raises(ValueError, match="residual_prediction"):
+        _sat_config(
+            residual_prediction=True,
+            saturation_normalization=[
+                SaturationNormalizationConfig(
+                    names=["specific_total_water_*"],
+                    prediction=True,
+                    input="append",
+                )
+            ],
+        )
+
+
+def test_saturation_config_state_round_trip():
+    config = _sat_config(
+        saturation_normalization=[
+            SaturationNormalizationConfig(
+                names=["specific_total_water_*"], input="append", prediction=False
+            )
+        ]
+    )
+    restored = TwoTrackStepConfig.from_state(config.get_state())
+    assert restored.saturation_normalization is not None
+    assert len(restored.saturation_normalization) == 1
+    entry = restored.saturation_normalization[0]
+    assert entry.names == ["specific_total_water_*"]
+    assert entry.input == "append"
+    assert entry.prediction is False
+    # a rebuilt step from the restored config routes RH to the local track
+    step = _sat_get_step(restored)
+    assert _relative_humidity_name(0) in step.in_packer.names

--- a/fme/ace/step/two_track.py
+++ b/fme/ace/step/two_track.py
@@ -22,6 +22,14 @@ from fme.core.registry import CorrectorSelector
 from fme.core.registry.module import Module
 from fme.core.step.args import StepArgs
 from fme.core.step.output import StepOutput
+from fme.core.step.saturation_normalization import (
+    SaturationNormalization,
+    SaturationNormalizationConfig,
+    add_identity_names,
+    build_saturation_normalization,
+    derived_normalization_names,
+    resolve_all_fields,
+)
 from fme.core.step.single_module import step_with_adjustments
 from fme.core.step.step import StepABC, StepConfigABC, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
@@ -54,6 +62,18 @@ class TwoTrackStepConfig(StepConfigABC):
         next_step_forcing_names: Forcing variables taken from the output step.
         prescribed_prognostic_names: Prognostic names overwritten from forcing.
         residual_prediction: Whether to use residual prediction.
+        saturation_normalization: Optional list of rules expressing humidity
+            fields in a relative-humidity-like ``q / q_sat`` space (see
+            ``fme.core.step.saturation_normalization``). Every derived
+            ``relative_humidity_<level>`` channel is routed to the local
+            (never-spectral) track, since the point of the two-track split is to
+            keep the pointwise RH representation off the spherical-harmonic
+            path. Only ``input='append'`` with ``prediction=False`` is
+            supported here: the source ``q`` stays on its declared track and the
+            derived RH rides as an additional local input. ``input='replace'``
+            and ``prediction=True`` would move the source ``q`` across tracks and
+            are rejected in ``TwoTrackStep`` (use the single-module step for
+            those).
     """
 
     builder: TwoTrackSFNOBuilder
@@ -69,6 +89,7 @@ class TwoTrackStepConfig(StepConfigABC):
     next_step_forcing_names: list[str] = dataclasses.field(default_factory=list)
     prescribed_prognostic_names: list[str] = dataclasses.field(default_factory=list)
     residual_prediction: bool = False
+    saturation_normalization: list[SaturationNormalizationConfig] | None = None
 
     def __post_init__(self):
         in_overlap = set(self.global_in_names) & set(self.local_in_names)
@@ -85,6 +106,29 @@ class TwoTrackStepConfig(StepConfigABC):
             )
         self.in_names = self.global_in_names + self.local_in_names
         self.out_names = self.global_out_names + self.local_out_names
+        if self.saturation_normalization is not None:
+            # resolve_all_fields validates each rule (patterns matching nothing,
+            # missing level suffix, input/prediction referencing a side the
+            # field is not on, derived-name collisions) and rejects a field or
+            # derived channel appearing in more than one rule.
+            saturation_fields = resolve_all_fields(
+                self.saturation_normalization, self.in_names, self.out_names
+            )
+            if self.residual_prediction:
+                # Residual prediction adds the input to the output in network
+                # space, so a prognostic field predicted in RH must also be fed
+                # in RH (and vice versa) for the residual base to be defined.
+                in_set, out_set = set(self.in_names), set(self.out_names)
+                for field in saturation_fields:
+                    prognostic = field.name in in_set and field.name in out_set
+                    if prognostic and field.rh_out != field.rh_in:
+                        raise ValueError(
+                            "saturation_normalization with residual_prediction "
+                            f"requires prognostic field '{field.name}' to be RH "
+                            "on both input and output: prediction=True must pair "
+                            f"with input='replace'. Got prediction={field.rh_out}"
+                            f", input replaces q={field.rh_in}."
+                        )
         for name in self.prescribed_prognostic_names:
             if name not in self.out_names:
                 raise ValueError(
@@ -117,10 +161,14 @@ class TwoTrackStepConfig(StepConfigABC):
             extra_names = []
         if extra_residual_scaled_names is None:
             extra_residual_scaled_names = []
-        return self.normalization.get_loss_normalizer(
+        loss_normalizer = self.normalization.get_loss_normalizer(
             names=self._normalize_names + extra_names,
             residual_scaled_names=self.prognostic_names + extra_residual_scaled_names,
         )
+        # Derived RH channels are O(1) and need identity statistics in the loss
+        # scaler (they are otherwise dropped, as the normalizer filters to known
+        # names).
+        return add_identity_names(loss_normalizer, self.saturation_derived_names)
 
     @classmethod
     def from_state(cls, state) -> "TwoTrackStepConfig":
@@ -132,6 +180,18 @@ class TwoTrackStepConfig(StepConfigABC):
     def _normalize_names(self) -> list[str]:
         """Names of variables which require normalization (inputs/outputs)."""
         return list(set(self.in_names).union(self.output_names))
+
+    @property
+    def saturation_derived_names(self) -> list[str]:
+        """Derived RH channel names (internal), which need identity normalizer
+        statistics in the network and loss normalizers.
+        """
+        if self.saturation_normalization is None:
+            return []
+        fields = resolve_all_fields(
+            self.saturation_normalization, self.in_names, self.out_names
+        )
+        return derived_normalization_names(fields)
 
     @property
     def input_names(self) -> list[str]:
@@ -189,6 +249,9 @@ class TwoTrackStepConfig(StepConfigABC):
         logging.info("Initializing two-track stepper from provided config")
         corrector = self.corrector.get_corrector(dataset_info)
         normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        # Register the derived RH channels (identity) so they survive the
+        # normalizer's name filter on the network input and output.
+        normalizer = add_identity_names(normalizer, self.saturation_derived_names)
         return TwoTrackStep(
             config=self,
             dataset_info=dataset_info,
@@ -215,11 +278,54 @@ class TwoTrackStep(StepABC):
         init_weights: Callable[[list[nn.Module]], None],
     ):
         super().__init__()
+        self._saturation_normalization: SaturationNormalization | None = (
+            build_saturation_normalization(
+                config.saturation_normalization,
+                dataset_info.atmosphere_vertical_coordinate,
+                config.in_names,
+                config.out_names,
+            )
+        )
+        # Saturation normalization carries humidity under derived RH channel
+        # names; those channels always ride the local (never-spectral) track, so
+        # they are appended after the local segment on each side. Only the
+        # append/prediction-off case is supported: moving the source q across
+        # tracks (replace on input, prediction on output) is rejected here.
+        derived_input_names: list[str] = []
+        derived_output_names: list[str] = []
+        if self._saturation_normalization is not None:
+            assert config.saturation_normalization is not None
+            fields = resolve_all_fields(
+                config.saturation_normalization, config.in_names, config.out_names
+            )
+            for field in fields:
+                if field.rh_in:  # input='replace' removes the source q channel
+                    raise ValueError(
+                        "saturation_normalization input='replace' is not "
+                        f"supported by the two-track step (field '{field.name}'): "
+                        "it would move the source q off its declared track. Use "
+                        "input='append' (RH rides as an extra local input) or the "
+                        "single-module step."
+                    )
+                if field.rh_out:  # prediction=True swaps the source q on output
+                    raise ValueError(
+                        "saturation_normalization prediction=True is not "
+                        f"supported by the two-track step (field '{field.name}'): "
+                        "it would move the predicted q off its declared track. "
+                        "Use prediction=False or the single-module step."
+                    )
+                if field.rh_extra:  # input='append'
+                    derived_input_names.append(field.rh_name)
         # Packing order matches the network's split: global inputs first, then
-        # local. The network splits the input tensor at len(global_in_names)
-        # and returns [global_out | local_out].
-        self.in_packer = Packer(config.global_in_names + config.local_in_names)
-        self.out_packer = Packer(config.global_out_names + config.local_out_names)
+        # local (with any derived RH channels appended to the local segment).
+        # The network splits the input tensor at len(global_in_names) and
+        # returns [global_out | local_out].
+        self.in_packer = Packer(
+            config.global_in_names + config.local_in_names + derived_input_names
+        )
+        self.out_packer = Packer(
+            config.global_out_names + config.local_out_names + derived_output_names
+        )
         self._normalizer = normalizer
         if config.ocean is not None:
             self.ocean: Ocean | None = config.ocean.build(
@@ -230,9 +336,9 @@ class TwoTrackStep(StepABC):
 
         net = config.builder.build_two_track(
             global_in_channels=len(config.global_in_names),
-            local_in_channels=len(config.local_in_names),
+            local_in_channels=len(config.local_in_names) + len(derived_input_names),
             global_out_channels=len(config.global_out_names),
-            local_out_channels=len(config.local_out_names),
+            local_out_channels=len(config.local_out_names) + len(derived_output_names),
             dataset_info=dataset_info,
         )
         # Wrap in Module so the tensor boundary stays single-tensor in / single
@@ -307,6 +413,15 @@ class TwoTrackStep(StepABC):
             )
             return self.out_packer.unpack(output_tensor, axis=self.CHANNEL_DIM)
 
+        # Residual prediction adds the input to the output in network space, so
+        # prognostic fields predicted in RH use their derived channel name there
+        # (a no-op with the supported prediction=False routing).
+        prognostic_names = self.prognostic_names
+        if self._saturation_normalization is not None:
+            prognostic_names = self._saturation_normalization.residual_names(
+                prognostic_names
+            )
+
         return step_with_adjustments(
             input=args.input,
             next_step_input_data=args.next_step_input_data,
@@ -315,8 +430,9 @@ class TwoTrackStep(StepABC):
             corrector=self._corrector,
             ocean=self.ocean,
             residual_prediction=self._config.residual_prediction,
-            prognostic_names=self.prognostic_names,
+            prognostic_names=prognostic_names,
             prescribed_prognostic_names=self._config.prescribed_prognostic_names,
+            saturation_normalization=self._saturation_normalization,
             stepper_state=args.stepper_state,
         )
 

--- a/fme/core/humidity.py
+++ b/fme/core/humidity.py
@@ -1,0 +1,52 @@
+import torch
+
+from fme.core.constants import FREEZING_TEMPERATURE_KELVIN, RDGAS, RVGAS
+
+# Ratio of the gas constant of dry air to that of water vapor (~0.622).
+EPSILON_WATER_VAPOR = RDGAS / RVGAS
+
+
+def bolton_saturation_vapor_pressure(temperature_kelvin: torch.Tensor) -> torch.Tensor:
+    """Saturation vapor pressure over liquid water from the Bolton (1980) formula.
+
+    Returns ``e_s = 6.112 * exp(17.67 * T_C / (T_C + 243.5))`` in hPa, where
+    ``T_C`` is temperature in degrees Celsius.
+
+    Args:
+        temperature_kelvin: Temperature in Kelvin.
+
+    Returns:
+        Saturation vapor pressure in hPa, same shape as input.
+    """
+    t_c = temperature_kelvin - FREEZING_TEMPERATURE_KELVIN
+    return 6.112 * torch.exp(17.67 * t_c / (t_c + 243.5))
+
+
+def saturation_specific_humidity(
+    temperature_kelvin: torch.Tensor,
+    pressure_pa: torch.Tensor,
+) -> torch.Tensor:
+    """Saturation specific humidity over liquid water in kg/kg.
+
+    Derived from the Bolton (1980) saturation vapor pressure ``e_s`` and the
+    ambient pressure ``p`` as
+
+        q_sat = eps * e_s / (p - (1 - eps) * e_s),
+
+    where ``eps = R_dry / R_vapor``.  ``e_s`` is converted from hPa (the unit
+    returned by :func:`bolton_saturation_vapor_pressure`) to Pa so it matches
+    ``pressure_pa``.
+
+    Args:
+        temperature_kelvin: Temperature in Kelvin.
+        pressure_pa: Ambient pressure in Pa, broadcastable to the temperature.
+
+    Returns:
+        Saturation specific humidity in kg/kg, broadcast to the common shape.
+    """
+    e_s_pa = bolton_saturation_vapor_pressure(temperature_kelvin) * 100.0
+    return (
+        EPSILON_WATER_VAPOR
+        * e_s_pa
+        / (pressure_pa - (1.0 - EPSILON_WATER_VAPOR) * e_s_pa)
+    )

--- a/fme/core/match_names.py
+++ b/fme/core/match_names.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterable
+from fnmatch import fnmatchcase
+
+
+def match_names(patterns: Iterable[str], candidates: Iterable[str]) -> list[str]:
+    """Resolve fnmatch wildcard patterns against a set of candidate names.
+
+    Each pattern is matched case-sensitively (``fnmatchcase``) against every
+    candidate, so a pattern with no wildcard characters behaves as an exact
+    name match.  Every pattern must match at least one candidate or a
+    ``ValueError`` is raised; this turns typos and stale config names — which
+    would otherwise silently select nothing — into errors.
+
+    Args:
+        patterns: fnmatch patterns (e.g. ``["specific_total_water_*"]``).
+        candidates: the names to match against.
+
+    Returns:
+        The matched candidate names, de-duplicated and in candidate order.
+    """
+    candidate_list = list(candidates)
+    matched: list[str] = []
+    seen: set[str] = set()
+    for pattern in patterns:
+        pattern_matches = [c for c in candidate_list if fnmatchcase(c, pattern)]
+        if not pattern_matches:
+            raise ValueError(
+                f"pattern '{pattern}' matched none of the available names: "
+                f"{candidate_list}"
+            )
+        for name in pattern_matches:
+            if name not in seen:
+                seen.add(name)
+                matched.append(name)
+    return matched

--- a/fme/core/step/saturation_normalization.py
+++ b/fme/core/step/saturation_normalization.py
@@ -1,0 +1,406 @@
+"""Saturation-normalized (RH-like) humidity representation.
+
+A paired forward/inverse transform, sibling to ``GlobalMeanRemoval``, that
+expresses humidity fields as ``q / q_sat`` — a relative-humidity-like quantity
+that is dimensionless and O(1) at every level, latitude, and climate, and so
+stays in-sample as the climate warms.  See the saturation-normalized-humidity
+investigation for the (climate-invariance) rationale.
+
+Saturation specific humidity ``q_sat`` is computed per model level from the raw
+(pre-global-mean-removal) input temperature and surface pressure together with
+the hybrid sigma-pressure vertical coordinate, using the Bolton (1980) helper in
+``fme.core.humidity``.
+
+The RH-like representation is carried through the network under a *derived*
+channel name (``relative_humidity_<level>``) rather than the source humidity
+name.  These derived names are internal: they appear in the input/output packers
+and in the network and loss normalizers (with identity statistics, since
+``q / q_sat`` is already O(1) — 0 means dry, 1 means saturated — and needs no
+further normalization), but they are never exposed in the public ``in_names`` /
+``out_names`` / prognostic-name lists.  ``forward_transform`` rewrites the source
+humidity into its derived name in the network input; ``inverse_transform``
+rewrites the derived prediction back to the source humidity, so the step's public
+output stays in physical ``q`` space.
+
+Using a distinct derived name (rather than overloading the source field's name
+and statistics) keeps the input and prediction sides independent: a field can be
+RH on the input, on the output, both, or neither.
+
+Each configured rule (:class:`SaturationNormalizationConfig`) carries three
+independently settable knobs:
+
+- ``names``: which humidity fields to act on (fnmatch wildcards, resolved by
+  ``fme.core.match_names.match_names``, which errors on zero matches).
+- ``prediction``: whether the network predicts the field in ``q / q_sat`` space.
+  With residual prediction the residual is then taken in the transformed
+  variable, since the residual add happens in normalized space under the derived
+  name.
+- ``input``: ``none`` | ``replace`` | ``append`` — whether the network input
+  carries the RH-like channel, and if so whether it replaces the raw ``q`` input
+  channel or rides alongside it as an additional channel.
+"""
+
+import dataclasses
+from collections.abc import Iterable
+from typing import Literal
+
+import torch
+
+from fme.core.atmosphere_data import (
+    ATMOSPHERE_FIELD_NAME_PREFIXES,
+    HasAtmosphereVerticalIntegral,
+)
+from fme.core.humidity import saturation_specific_humidity
+from fme.core.match_names import match_names
+from fme.core.normalizer import StandardNormalizer
+from fme.core.stacker import Stacker
+from fme.core.typing_ import TensorDict, TensorMapping
+
+_TEMPERATURE_PREFIXES = ATMOSPHERE_FIELD_NAME_PREFIXES["air_temperature"]
+_SURFACE_PRESSURE_NAMES = ATMOSPHERE_FIELD_NAME_PREFIXES["surface_pressure"]
+
+_RELATIVE_HUMIDITY_PREFIX = "relative_humidity_"
+
+
+def _relative_humidity_name(level: int) -> str:
+    return f"{_RELATIVE_HUMIDITY_PREFIX}{level}"
+
+
+def _parse_level(name: str) -> int | None:
+    match = Stacker.LEVEL_PATTERN.search(name)
+    return int(match.group(1)) if match is not None else None
+
+
+def _resolve_temperature_name(level: int, in_names: list[str]) -> str:
+    for prefix in _TEMPERATURE_PREFIXES:
+        candidate = f"{prefix}{level}"
+        if candidate in in_names:
+            return candidate
+    raise ValueError(
+        f"saturation_normalization needs an input temperature at level {level} "
+        f"(one of {[f'{p}{level}' for p in _TEMPERATURE_PREFIXES]}), but none is "
+        f"in in_names."
+    )
+
+
+def _resolve_surface_pressure_name(in_names: list[str]) -> str:
+    for name in _SURFACE_PRESSURE_NAMES:
+        if name in in_names:
+            return name
+    raise ValueError(
+        f"saturation_normalization needs a surface pressure input (one of "
+        f"{_SURFACE_PRESSURE_NAMES}), but none is in in_names: {in_names}."
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _SaturationField:
+    """A resolved humidity field and how it is carried in network space."""
+
+    name: str  # source humidity field (public)
+    rh_name: str  # derived relative-humidity channel (internal)
+    level: int
+    temperature_name: str
+    rh_in: bool  # the network input for this field is q / q_sat (replaces q)
+    rh_extra: bool  # an extra q / q_sat input channel rides alongside q
+    rh_out: bool  # the network predicts this field in q / q_sat space
+
+
+@dataclasses.dataclass
+class SaturationNormalizationState:
+    """Opaque token from ``forward_transform`` consumed by ``inverse_transform``
+    on the same instance.
+
+    Carries the per-field ``q_sat`` (computed from the input-step temperature
+    and pressure) used to convert a predicted RH field back to ``q``.
+    """
+
+    qsat: dict[str, torch.Tensor]
+
+
+@dataclasses.dataclass
+class SaturationNormalizationConfig:
+    """One saturation-normalization rule.
+
+    Parameters:
+        names: Humidity field names or fnmatch patterns to act on (e.g.
+            ``["specific_total_water_*"]``).  Each pattern must match at least
+            one input/output field.
+        prediction: Whether the network predicts the matched fields in
+            ``q / q_sat`` space.
+        input: Whether the network input carries the RH-like channel:
+            ``none`` (raw ``q`` only), ``replace`` (feed ``q / q_sat`` in place
+            of ``q``), or ``append`` (an extra ``q / q_sat`` channel alongside
+            ``q``).
+    """
+
+    names: list[str]
+    prediction: bool = False
+    input: Literal["none", "replace", "append"] = "none"
+
+    def validate_names(self, in_names: list[str], out_names: list[str]) -> None:
+        resolve_entry_fields(self, in_names, out_names)
+
+
+def resolve_entry_fields(
+    config: SaturationNormalizationConfig,
+    in_names: list[str],
+    out_names: list[str],
+) -> list[_SaturationField]:
+    """Resolve one config entry to per-field descriptors, validating coherence.
+
+    Raises ``ValueError`` for: patterns matching nothing, fields without a level
+    suffix, input/prediction modes referencing a side the field is not on, and
+    a derived ``relative_humidity_<level>`` name colliding with a real field.
+    """
+    candidate_names = list(dict.fromkeys(list(in_names) + list(out_names)))
+    matched = match_names(config.names, candidate_names)
+    rh_in = config.input == "replace"
+    rh_extra = config.input == "append"
+    rh_out = config.prediction
+    fields: list[_SaturationField] = []
+    for name in matched:
+        level = _parse_level(name)
+        if level is None:
+            raise ValueError(
+                f"saturation_normalization field '{name}' must end in '_<level>' "
+                "so its level and temperature can be resolved."
+            )
+        in_input = name in in_names
+        in_output = name in out_names
+        if config.input != "none" and not in_input:
+            raise ValueError(
+                f"saturation_normalization input='{config.input}' for '{name}', "
+                f"but it is not an input field: {in_names}."
+            )
+        if rh_out and not in_output:
+            raise ValueError(
+                f"saturation_normalization prediction=True for '{name}', but it "
+                f"is not an output field: {out_names}."
+            )
+        rh_name = _relative_humidity_name(level)
+        if rh_name in candidate_names:
+            raise ValueError(
+                f"saturation_normalization derived channel '{rh_name}' for "
+                f"'{name}' collides with an existing field name."
+            )
+        temperature_name = _resolve_temperature_name(level, in_names)
+        fields.append(
+            _SaturationField(
+                name=name,
+                rh_name=rh_name,
+                level=level,
+                temperature_name=temperature_name,
+                rh_in=rh_in,
+                rh_extra=rh_extra,
+                rh_out=rh_out,
+            )
+        )
+    return fields
+
+
+def resolve_all_fields(
+    configs: Iterable[SaturationNormalizationConfig],
+    in_names: list[str],
+    out_names: list[str],
+) -> list[_SaturationField]:
+    """Resolve every config entry and reject a source field or derived name
+    appearing in more than one entry.
+    """
+    fields: list[_SaturationField] = []
+    seen_source: set[str] = set()
+    seen_rh: set[str] = set()
+    for config in configs:
+        for field in resolve_entry_fields(config, in_names, out_names):
+            if field.name in seen_source:
+                raise ValueError(
+                    f"saturation_normalization field '{field.name}' appears in "
+                    "more than one entry."
+                )
+            if field.rh_name in seen_rh:
+                raise ValueError(
+                    f"saturation_normalization derived channel '{field.rh_name}' "
+                    "is produced by more than one field."
+                )
+            seen_source.add(field.name)
+            seen_rh.add(field.rh_name)
+            fields.append(field)
+    return fields
+
+
+def derived_normalization_names(fields: Iterable[_SaturationField]) -> list[str]:
+    """Derived RH channel names that the normalizer/scaler must carry (identity).
+
+    A field contributes its derived name if it is RH on the input (replace or
+    append) or on the output (prediction).
+    """
+    names: list[str] = []
+    for field in fields:
+        if field.rh_in or field.rh_extra or field.rh_out:
+            names.append(field.rh_name)
+    return names
+
+
+def add_identity_names(
+    normalizer: StandardNormalizer, names: Iterable[str]
+) -> StandardNormalizer:
+    """Return a copy of ``normalizer`` with ``names`` added at mean 0, std 1.
+
+    Derived RH channels are O(1) and are fed to / produced by the network
+    without further normalization, so the (network and loss) normalizers carry
+    them with identity statistics.
+    """
+    names = list(names)
+    if not names:
+        return normalizer
+    means = dict(normalizer.means)
+    stds = dict(normalizer.stds)
+    for name in names:
+        means[name] = torch.zeros(())
+        stds[name] = torch.ones(())
+    return StandardNormalizer(
+        means=means,
+        stds=stds,
+        fill_nans_on_normalize=normalizer.fill_nans_on_normalize,
+        fill_nans_on_denormalize=normalizer.fill_nans_on_denormalize,
+    )
+
+
+class SaturationNormalization:
+    """Forward/inverse ``q <-> q / q_sat`` transform over a set of fields."""
+
+    def __init__(
+        self,
+        fields: list[_SaturationField],
+        surface_pressure_name: str,
+        vertical_coordinate: HasAtmosphereVerticalIntegral,
+    ):
+        self._fields = fields
+        self._surface_pressure_name = surface_pressure_name
+        self._vertical_coordinate = vertical_coordinate
+
+    @property
+    def derived_names(self) -> list[str]:
+        return derived_normalization_names(self._fields)
+
+    def input_packer_names(self, in_names: list[str]) -> list[str]:
+        """The network input channel names: ``replace`` fields swap ``q`` for the
+        derived RH name, ``append`` fields add the derived RH name after the
+        inputs.
+        """
+        replace_map = {f.name: f.rh_name for f in self._fields if f.rh_in}
+        names = [replace_map.get(name, name) for name in in_names]
+        names += [f.rh_name for f in self._fields if f.rh_extra]
+        return names
+
+    def output_packer_names(self, out_names: list[str]) -> list[str]:
+        """The network output channel names: ``prediction`` fields swap ``q`` for
+        the derived RH name.
+        """
+        predict_map = {f.name: f.rh_name for f in self._fields if f.rh_out}
+        return [predict_map.get(name, name) for name in out_names]
+
+    def residual_names(self, prognostic_names: list[str]) -> list[str]:
+        """Translate prognostic names to network space for residual prediction:
+        ``prediction`` fields use the derived RH name.
+        """
+        predict_map = {f.name: f.rh_name for f in self._fields if f.rh_out}
+        return [predict_map.get(name, name) for name in prognostic_names]
+
+    def _compute_qsat(self, raw_input: TensorMapping) -> dict[str, torch.Tensor]:
+        if self._surface_pressure_name not in raw_input:
+            raise ValueError(
+                f"surface pressure '{self._surface_pressure_name}' is required by "
+                "saturation_normalization but is not present in the input."
+            )
+        surface_pressure = raw_input[self._surface_pressure_name]
+        # interface_pressure appends the vertical dimension as the last axis,
+        # length n_layers + 1; layer k spans interfaces k and k + 1.
+        interface_pressure = self._vertical_coordinate.interface_pressure(
+            surface_pressure
+        )
+        qsat: dict[str, torch.Tensor] = {}
+        for field in self._fields:
+            if field.temperature_name not in raw_input:
+                raise ValueError(
+                    f"temperature '{field.temperature_name}' is required by "
+                    f"saturation_normalization for '{field.name}' but is not "
+                    "present in the input."
+                )
+            temperature = raw_input[field.temperature_name]
+            layer_pressure = 0.5 * (
+                interface_pressure[..., field.level]
+                + interface_pressure[..., field.level + 1]
+            )
+            qsat[field.name] = saturation_specific_humidity(temperature, layer_pressure)
+        return qsat
+
+    def forward_transform(
+        self,
+        raw_input: TensorMapping,
+        network_input: TensorMapping,
+    ) -> tuple[TensorDict, SaturationNormalizationState]:
+        """Rewrite humidity fields into their derived ``q / q_sat`` channel.
+
+        ``q_sat`` is computed from ``raw_input`` (the raw, pre-global-mean-removal
+        input) so it reflects the true input-step temperature and pressure.  The
+        derived RH channel is written for ``replace`` and ``append`` fields; for
+        ``replace`` the source ``q`` channel is removed.
+        """
+        qsat = self._compute_qsat(raw_input)
+        result = dict(network_input)
+        for field in self._fields:
+            if not (field.rh_in or field.rh_extra):
+                continue
+            # Saturation fields are forbidden from overlapping global mean
+            # removal, so the network_input value here is the raw q.
+            result[field.rh_name] = result[field.name] / qsat[field.name]
+            if field.rh_in:
+                del result[field.name]
+        return result, SaturationNormalizationState(qsat=qsat)
+
+    def inverse_transform(
+        self,
+        output: TensorDict,
+        state: SaturationNormalizationState,
+    ) -> TensorDict:
+        """Rewrite predicted derived ``q / q_sat`` channels back to ``q``.
+
+        Uses the input-step ``q_sat`` cached in ``state`` (the same anchoring as
+        the forward transform).
+        """
+        result = dict(output)
+        for field in self._fields:
+            if field.rh_out and field.rh_name in result:
+                result[field.name] = result.pop(field.rh_name) * state.qsat[field.name]
+        return result
+
+
+def build_saturation_normalization(
+    configs: list[SaturationNormalizationConfig] | None,
+    vertical_coordinate: HasAtmosphereVerticalIntegral | None,
+    in_names: list[str],
+    out_names: list[str],
+) -> SaturationNormalization | None:
+    """Build the transform from config, or return ``None`` when not configured."""
+    if not configs:
+        return None
+    fields = resolve_all_fields(configs, in_names, out_names)
+    if vertical_coordinate is None:
+        raise ValueError(
+            "saturation_normalization requires a vertical coordinate to compute "
+            "saturation specific humidity, but none is available."
+        )
+    n_layers = len(vertical_coordinate.get_ak()) - 1
+    for field in fields:
+        if not 0 <= field.level < n_layers:
+            raise ValueError(
+                f"saturation_normalization field '{field.name}' is at level "
+                f"{field.level}, outside the {n_layers} model layers."
+            )
+    surface_pressure_name = _resolve_surface_pressure_name(in_names)
+    return SaturationNormalization(
+        fields=fields,
+        surface_pressure_name=surface_pressure_name,
+        vertical_coordinate=vertical_coordinate,
+    )

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -31,6 +31,10 @@ from fme.core.step.global_mean_removal import (
     extra_channel_source_field,
 )
 from fme.core.step.output import StepOutput
+from fme.core.step.saturation_normalization import (
+    SaturationNormalization,
+    SaturationNormalizationState,
+)
 from fme.core.step.secondary_decoder import (
     NoSecondaryDecoder,
     SecondaryDecoder,
@@ -600,6 +604,7 @@ def step_with_adjustments(
     prognostic_names: list[str],
     prescribed_prognostic_names: list[str] | None = None,
     global_mean_removal: GlobalMeanRemoval | None = None,
+    saturation_normalization: SaturationNormalization | None = None,
     data_mask: TensorMapping | None = None,
     stepper_state: StepperState | None = None,
 ) -> StepOutput:
@@ -629,6 +634,13 @@ def step_with_adjustments(
             before the normalizer and ``inverse_transform`` after
             denormalization but before the corrector/ocean/prescribed steps,
             so those adjustments operate in physical space.
+        saturation_normalization: Optional transform that expresses humidity
+            fields in a relative-humidity-like ``q / q_sat`` space. When
+            provided, ``forward_transform`` is applied to the (post-GMR)
+            network input before normalization, and ``inverse_transform`` maps
+            the denormalized output back to ``q`` before the global-mean-removal
+            inverse and the corrector/ocean/prescribed steps. Default ``None``
+            leaves behavior byte-identical to omitting it.
         data_mask: Per-variable boolean masks passed to
             ``global_mean_removal.forward_transform``.
         stepper_state: Per-sample state carried across step calls. The
@@ -645,21 +657,33 @@ def step_with_adjustments(
     if prescribed_prognostic_names is None:
         prescribed_prognostic_names = []
     gmr_state: GlobalMeanRemovalState | None = None
+    network_input: TensorMapping = input
     if global_mean_removal is not None:
         network_input, gmr_state = global_mean_removal.forward_transform(
             input, data_mask
         )
-        input_norm = normalizer.normalize(network_input)
+    sat_state: SaturationNormalizationState | None = None
+    if saturation_normalization is not None:
+        # q_sat is computed from the raw (pre-GMR) input; the RH-like values are
+        # written into the post-GMR network input (humidity fields are forbidden
+        # from overlapping GMR, so they are unchanged by it).
+        network_input, sat_state = saturation_normalization.forward_transform(
+            input, network_input
+        )
+    input_norm = normalizer.normalize(network_input)
+    if global_mean_removal is not None:
+        assert gmr_state is not None
         # Synthetic GMR channels are produced in normalized space; merge
         # them in after normalization so the network sees a single uniform
         # input dict.
         input_norm = {**input_norm, **global_mean_removal.extras_normalized(gmr_state)}
-    else:
-        input_norm = normalizer.normalize(input)
     output_norm = network_calls(input_norm)
     if residual_prediction:
         output_norm = add_names(input_norm, output_norm, prognostic_names)
     output = normalizer.denormalize(output_norm)
+    if saturation_normalization is not None:
+        assert sat_state is not None
+        output = saturation_normalization.inverse_transform(output, sat_state)
     if global_mean_removal is not None:
         assert gmr_state is not None
         output = global_mean_removal.inverse_transform(output, gmr_state)

--- a/fme/core/step/test_saturation_normalization.py
+++ b/fme/core/step/test_saturation_normalization.py
@@ -1,0 +1,301 @@
+import pytest
+import torch
+
+from fme.core.coordinates import HybridSigmaPressureCoordinate
+from fme.core.device import move_tensordict_to_device
+from fme.core.humidity import saturation_specific_humidity
+from fme.core.step.saturation_normalization import (
+    SaturationNormalizationConfig,
+    _relative_humidity_name,
+    build_saturation_normalization,
+    resolve_all_fields,
+)
+
+# Two-layer hybrid sigma-pressure coordinate: interface pressures are
+# [0, 0.5 * ps, ps], so layer 0 sits at 0.25 * ps and layer 1 at 0.75 * ps.
+_AK = torch.tensor([0.0, 0.0, 0.0])
+_BK = torch.tensor([0.0, 0.5, 1.0])
+
+_RH1 = _relative_humidity_name(1)
+
+
+def _vertical_coordinate() -> HybridSigmaPressureCoordinate:
+    return HybridSigmaPressureCoordinate(ak=_AK.clone(), bk=_BK.clone())
+
+
+def _build_transform(configs, in_names, out_names):
+    return build_saturation_normalization(
+        configs, _vertical_coordinate(), in_names, out_names
+    )
+
+
+def _expected_qsat(temperature: float, surface_pressure: float, level: int):
+    layer_pressure = 0.5 * (
+        (_AK[level] + _BK[level] * surface_pressure)
+        + (_AK[level + 1] + _BK[level + 1] * surface_pressure)
+    )
+    return saturation_specific_humidity(torch.tensor(temperature), layer_pressure)
+
+
+# ── transform behavior ──────────────────────────────────────────────────
+
+
+def test_forward_replace_writes_derived_rh_and_round_trips():
+    names = ["specific_total_water_1", "air_temperature_1", "PRESsfc"]
+    config = SaturationNormalizationConfig(
+        names=["specific_total_water_1"], prediction=True, input="replace"
+    )
+    transform = _build_transform([config], names, names)
+    q, temperature, ps = 0.006, 290.0, 1.0e5
+    raw = move_tensordict_to_device(
+        {
+            "specific_total_water_1": torch.full((2, 4, 4), q),
+            "air_temperature_1": torch.full((2, 4, 4), temperature),
+            "PRESsfc": torch.full((2, 4, 4), ps),
+        }
+    )
+    result, state = transform.forward_transform(raw, raw)
+    qsat = _expected_qsat(temperature, ps, level=1)
+    # the source q channel is replaced by the derived RH channel
+    assert "specific_total_water_1" not in result
+    torch.testing.assert_close(
+        result[_RH1].cpu(), torch.full((2, 4, 4), (q / qsat).item())
+    )
+    torch.testing.assert_close(result["air_temperature_1"], raw["air_temperature_1"])
+    # the network predicts the derived channel; inverse maps it back to q
+    restored = transform.inverse_transform(result, state)
+    assert _RH1 not in restored
+    torch.testing.assert_close(
+        restored["specific_total_water_1"], raw["specific_total_water_1"]
+    )
+
+
+def test_forward_append_adds_derived_rh_and_keeps_q():
+    names = ["specific_total_water_1", "air_temperature_1", "PRESsfc"]
+    config = SaturationNormalizationConfig(
+        names=["specific_total_water_1"], prediction=False, input="append"
+    )
+    transform = _build_transform([config], names, names)
+    assert transform.derived_names == [_RH1]
+    q, temperature, ps = 0.006, 290.0, 1.0e5
+    raw = move_tensordict_to_device(
+        {
+            "specific_total_water_1": torch.full((1, 4, 4), q),
+            "air_temperature_1": torch.full((1, 4, 4), temperature),
+            "PRESsfc": torch.full((1, 4, 4), ps),
+        }
+    )
+    result, state = transform.forward_transform(raw, raw)
+    # raw q kept, derived RH added alongside it
+    torch.testing.assert_close(
+        result["specific_total_water_1"], raw["specific_total_water_1"]
+    )
+    qsat = _expected_qsat(temperature, ps, level=1)
+    torch.testing.assert_close(
+        result[_RH1].cpu(), torch.full((1, 4, 4), (q / qsat).item())
+    )
+    # append does not predict RH, so inverse is a no-op
+    restored = transform.inverse_transform(result, state)
+    torch.testing.assert_close(
+        restored["specific_total_water_1"], raw["specific_total_water_1"]
+    )
+
+
+def test_qsat_is_per_level():
+    names = [
+        "specific_total_water_0",
+        "specific_total_water_1",
+        "air_temperature_0",
+        "air_temperature_1",
+        "PRESsfc",
+    ]
+    config = SaturationNormalizationConfig(
+        names=["specific_total_water_*"], prediction=True, input="replace"
+    )
+    transform = _build_transform([config], names, names)
+    ps = 1.0e5
+    raw = move_tensordict_to_device(
+        {
+            "specific_total_water_0": torch.full((1, 2, 2), 0.001),
+            "specific_total_water_1": torch.full((1, 2, 2), 0.006),
+            "air_temperature_0": torch.full((1, 2, 2), 240.0),
+            "air_temperature_1": torch.full((1, 2, 2), 290.0),
+            "PRESsfc": torch.full((1, 2, 2), ps),
+        }
+    )
+    result, _ = transform.forward_transform(raw, raw)
+    qsat0 = _expected_qsat(240.0, ps, level=0)
+    qsat1 = _expected_qsat(290.0, ps, level=1)
+    torch.testing.assert_close(
+        result[_relative_humidity_name(0)].cpu(),
+        torch.full((1, 2, 2), (0.001 / qsat0).item()),
+    )
+    torch.testing.assert_close(
+        result[_relative_humidity_name(1)].cpu(),
+        torch.full((1, 2, 2), (0.006 / qsat1).item()),
+    )
+
+
+def test_packer_and_residual_name_mapping():
+    in_names = ["specific_total_water_0", "specific_total_water_1", "T_0", "T_1", "PS"]
+    out_names = ["specific_total_water_0", "specific_total_water_1"]
+    configs = [
+        SaturationNormalizationConfig(
+            names=["specific_total_water_0"], prediction=True, input="replace"
+        ),
+        SaturationNormalizationConfig(
+            names=["specific_total_water_1"], prediction=False, input="append"
+        ),
+    ]
+    transform = _build_transform(configs, in_names, out_names)
+    rh0, rh1 = _relative_humidity_name(0), _relative_humidity_name(1)
+    # replace swaps q->rh in place; append adds rh after the inputs
+    assert transform.input_packer_names(in_names) == [
+        rh0,
+        "specific_total_water_1",
+        "T_0",
+        "T_1",
+        "PS",
+        rh1,
+    ]
+    # only the predicted field is swapped on the output side
+    assert transform.output_packer_names(out_names) == [
+        rh0,
+        "specific_total_water_1",
+    ]
+    assert set(transform.derived_names) == {rh0, rh1}
+    assert transform.residual_names(out_names) == [rh0, "specific_total_water_1"]
+
+
+def test_build_returns_none_without_config():
+    assert build_saturation_normalization(None, _vertical_coordinate(), [], []) is None
+    assert build_saturation_normalization([], _vertical_coordinate(), [], []) is None
+
+
+def test_build_requires_vertical_coordinate():
+    config = SaturationNormalizationConfig(
+        names=["specific_total_water_0"], input="append"
+    )
+    names = ["specific_total_water_0", "air_temperature_0", "PRESsfc"]
+    with pytest.raises(ValueError, match="vertical coordinate"):
+        build_saturation_normalization([config], None, names, names)
+
+
+def test_build_rejects_level_outside_model():
+    config = SaturationNormalizationConfig(
+        names=["specific_total_water_5"], input="append"
+    )
+    names = ["specific_total_water_5", "air_temperature_5", "PRESsfc"]
+    with pytest.raises(ValueError, match="outside the 2 model layers"):
+        _build_transform([config], names, names)
+
+
+# ── config validation ───────────────────────────────────────────────────
+#
+# resolve_all_fields carries the per-rule validation (patterns, sides, level
+# suffix, derived-name collisions, cross-rule duplicates). The step configs
+# call it from their __post_init__; the step-level residual-coherence check and
+# end-to-end routing are exercised in fme/ace/step/test_two_track.py.
+
+
+def test_validation_zero_match_raises():
+    names = ["specific_total_water_0", "air_temperature_0", "PRESsfc"]
+    with pytest.raises(ValueError, match="matched none"):
+        resolve_all_fields(
+            [SaturationNormalizationConfig(names=["does_not_exist_*"])], names, names
+        )
+
+
+def test_validation_prediction_requires_output():
+    in_names = ["specific_total_water_0", "air_temperature_0", "PRESsfc"]
+    out_names = ["air_temperature_0"]
+    with pytest.raises(ValueError, match="not an output"):
+        resolve_all_fields(
+            [
+                SaturationNormalizationConfig(
+                    names=["specific_total_water_0"], prediction=True
+                )
+            ],
+            in_names,
+            out_names,
+        )
+
+
+def test_validation_input_requires_input():
+    in_names = ["air_temperature_0", "PRESsfc"]
+    out_names = ["specific_total_water_0", "air_temperature_0"]
+    with pytest.raises(ValueError, match="not an input"):
+        resolve_all_fields(
+            [
+                SaturationNormalizationConfig(
+                    names=["specific_total_water_0"], input="replace"
+                )
+            ],
+            in_names,
+            out_names,
+        )
+
+
+def test_validation_field_without_level_suffix_raises():
+    names = ["specific_total_water", "air_temperature_0", "PRESsfc"]
+    with pytest.raises(ValueError, match="must end in '_<level>'"):
+        resolve_all_fields(
+            [SaturationNormalizationConfig(names=["specific_total_water"])],
+            names,
+            names,
+        )
+
+
+def test_validation_duplicate_field_across_entries_raises():
+    names = ["specific_total_water_0", "air_temperature_0", "PRESsfc"]
+    with pytest.raises(ValueError, match="more than one entry"):
+        resolve_all_fields(
+            [
+                SaturationNormalizationConfig(
+                    names=["specific_total_water_0"], input="append"
+                ),
+                SaturationNormalizationConfig(
+                    names=["specific_total_water_*"], input="append"
+                ),
+            ],
+            names,
+            names,
+        )
+
+
+def test_validation_derived_name_collision_raises():
+    # a real relative_humidity_0 field collides with the derived channel
+    names = [
+        "specific_total_water_0",
+        "relative_humidity_0",
+        "air_temperature_0",
+        "PRESsfc",
+    ]
+    with pytest.raises(ValueError, match="collides with an existing field"):
+        resolve_all_fields(
+            [
+                SaturationNormalizationConfig(
+                    names=["specific_total_water_0"], input="append"
+                )
+            ],
+            names,
+            names,
+        )
+
+
+def test_validation_prediction_append_allowed():
+    # prediction and input are independent knobs: predicting RH while feeding an
+    # appended RH channel (raw q kept) resolves without error.
+    names = ["specific_total_water_0", "air_temperature_0", "PRESsfc"]
+    fields = resolve_all_fields(
+        [
+            SaturationNormalizationConfig(
+                names=["specific_total_water_0"], prediction=True, input="append"
+            )
+        ],
+        names,
+        names,
+    )
+    assert len(fields) == 1
+    assert fields[0].rh_out is True
+    assert fields[0].rh_extra is True

--- a/fme/core/test_humidity.py
+++ b/fme/core/test_humidity.py
@@ -1,0 +1,69 @@
+import torch
+
+from fme.core.constants import RDGAS, RVGAS
+from fme.core.humidity import (
+    bolton_saturation_vapor_pressure,
+    saturation_specific_humidity,
+)
+
+
+def test_bolton_at_freezing_point():
+    # Bolton (1980) yields exactly 6.112 hPa at T_C = 0.
+    result = bolton_saturation_vapor_pressure(torch.tensor(273.15))
+    torch.testing.assert_close(result, torch.tensor(6.112))
+
+
+def test_bolton_monotonic_in_temperature():
+    temps = torch.linspace(250.0, 320.0, 10)
+    es = bolton_saturation_vapor_pressure(temps)
+    diffs = es[1:] - es[:-1]
+    assert (diffs > 0).all()
+
+
+def test_bolton_reference_value_at_300k():
+    # Bolton (1980): T_C = 26.85; e_s ≈ 6.112 * exp(17.67 * 26.85 / 270.35)
+    # ≈ 35.30 hPa
+    result = bolton_saturation_vapor_pressure(torch.tensor(300.0))
+    torch.testing.assert_close(result, torch.tensor(35.345211), rtol=1e-5, atol=1e-4)
+
+
+def test_bolton_preserves_shape():
+    t = torch.full((2, 3, 4), 285.0)
+    es = bolton_saturation_vapor_pressure(t)
+    assert es.shape == t.shape
+
+
+def test_saturation_specific_humidity_worked_example():
+    # At T = 300 K, e_s ≈ 35.345 hPa = 3534.5 Pa. At p = 1000 hPa = 1e5 Pa,
+    # q_sat = eps * e_s / (p - (1 - eps) * e_s).
+    t = torch.tensor(300.0)
+    p = torch.tensor(1.0e5)
+    eps = RDGAS / RVGAS
+    e_s = bolton_saturation_vapor_pressure(t) * 100.0
+    expected = eps * e_s / (p - (1.0 - eps) * e_s)
+    result = saturation_specific_humidity(t, p)
+    torch.testing.assert_close(result, expected)
+    # sanity: a warm near-surface value is a small positive mixing ratio
+    assert 0.01 < result.item() < 0.04
+
+
+def test_saturation_specific_humidity_increases_with_temperature():
+    p = torch.full((5,), 1.0e5)
+    t = torch.linspace(250.0, 305.0, 5)
+    qsat = saturation_specific_humidity(t, p)
+    assert (qsat[1:] - qsat[:-1] > 0).all()
+
+
+def test_saturation_specific_humidity_decreases_with_pressure():
+    t = torch.full((5,), 290.0)
+    p = torch.linspace(3.0e4, 1.0e5, 5)
+    qsat = saturation_specific_humidity(t, p)
+    # at fixed temperature, higher pressure means lower saturation mixing ratio
+    assert (qsat[1:] - qsat[:-1] < 0).all()
+
+
+def test_saturation_specific_humidity_broadcasts():
+    t = torch.full((2, 3, 4), 285.0)
+    p = torch.full((2, 3, 4), 9.0e4)
+    qsat = saturation_specific_humidity(t, p)
+    assert qsat.shape == (2, 3, 4)

--- a/fme/core/test_match_names.py
+++ b/fme/core/test_match_names.py
@@ -1,0 +1,41 @@
+import pytest
+
+from fme.core.match_names import match_names
+
+
+def test_exact_match():
+    assert match_names(["air_temperature_0"], ["air_temperature_0", "PRESsfc"]) == [
+        "air_temperature_0"
+    ]
+
+
+def test_wildcard_matches_in_candidate_order():
+    candidates = [
+        "specific_total_water_0",
+        "PRESsfc",
+        "specific_total_water_1",
+        "specific_total_water_2",
+    ]
+    assert match_names(["specific_total_water_*"], candidates) == [
+        "specific_total_water_0",
+        "specific_total_water_1",
+        "specific_total_water_2",
+    ]
+
+
+def test_zero_matches_raises():
+    with pytest.raises(ValueError, match="matched none"):
+        match_names(["does_not_exist_*"], ["air_temperature_0"])
+
+
+def test_results_deduplicated_across_overlapping_patterns():
+    candidates = ["specific_total_water_0", "specific_total_water_1"]
+    result = match_names(
+        ["specific_total_water_*", "specific_total_water_0"], candidates
+    )
+    assert result == ["specific_total_water_0", "specific_total_water_1"]
+
+
+def test_case_sensitive():
+    with pytest.raises(ValueError, match="matched none"):
+        match_names(["AIR_TEMPERATURE_0"], ["air_temperature_0"])


### PR DESCRIPTION
Adds an RH-input variant of the two-track (global/local latent) SFNO. The base of this PR is the non-RH two-track experiment branch (`experiment/2026-07-17-local-global-sfno-oos`), so the diff isolates exactly what the RH representation adds on top of the two-track baseline.

The research question: expressing humidity as `q/q_sat` (a relative-humidity-like, O(1), climate-invariant channel) keeps humidity in-sample as the climate warms. The two-track point is that this pointwise RH representation must ride the local (never-spectral) track, off the spherical-harmonic path — so every derived `relative_humidity_<level>` channel is routed there.

Changes:
- `fme.core.humidity`, `fme.core.match_names`, `fme.core.step.saturation_normalization` — self-contained modules ported verbatim (`saturation_specific_humidity`, fnmatch name resolution, and the paired forward/inverse `q <-> q/q_sat` transform carrying humidity under internal `relative_humidity_<level>` channels with identity normalizer stats).
- `fme.core.step.single_module.step_with_adjustments` — gains an optional `saturation_normalization` parameter. Default `None` leaves behavior byte-identical to before (the L=0 single-track parity of the two-track PR is untouched). When set, `forward_transform` runs on the network input before normalization and `inverse_transform` maps the denormalized output back to `q` before the GMR inverse / corrector / ocean, so those adjustments operate in physical `q` space.
- `fme.ace.step.two_track.TwoTrackStepConfig` / `TwoTrackStep` — new `saturation_normalization` field, validated in `__post_init__` (via `resolve_all_fields`, mirroring the residual-prediction coherence check). Derived RH names get identity stats in the network and loss normalizers. The step packs derived input channels **after** the local segment (`in_packer = global_in + local_in + derived_input`), so they land in the local track that the network splits off at `len(global_in_names)`, and grows `local_in_channels` accordingly. Prognostic names are remapped through `residual_names`.
- Two new aimip-like training arms (`...-twotrack-rh`, `...-twotrack-rh-noco2`) with `saturation_normalization: [{names: [specific_total_water_*], input: append, prediction: false}]` — `q` stays on the global track and is still predicted in physical `q`; RH rides as an additional local input. Both pass `fme.ace.validate_config` and register a `run_training` call.

Scope / deviations:
- Only `input: append` with `prediction: false` is fully supported by the two-track step — the case this experiment needs. `input: replace` and `prediction: true` would move the source `q` across tracks (an ambiguous cross-track routing), so both are rejected with a clear error rather than guessed at; use the single-module step for those.
- The ported `test_saturation_normalization.py` step-level tests were rewritten to exercise `resolve_all_fields` directly and the two-track step, since the rh-branch's `single_module` config wiring (and its `SharedGlobalMeanRemovalConfig.qsat_scaled_names`) was deliberately **not** ported (it is a stale revert on an old main). The transform-behavior and build tests are kept verbatim; two-track routing, end-to-end, and validation tests live in `test_two_track.py`.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated