### PR TITLE
Add cBottle-style label dropout for combined-source training

### DIFF
--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -741,7 +741,15 @@ class BatchData:
         horizontal_dims: list[str] | None = None,
         label_encoding: LabelEncoding | None = None,
         allow_missing_variables: bool = False,
+        label_dropout_rate: float = 0.0,
     ) -> "BatchData":
+        """Collate sampled dataset items into a ``BatchData``.
+
+        ``label_dropout_rate`` is the probability that each sample has its source
+        label withheld (replaced by the empty/all-zeros label), so the model learns
+        an unconditional mode. It has no effect when ``label_encoding is None`` and
+        should be left at 0 on the validation/inference paths.
+        """
         (
             sample_data,
             sample_times,
@@ -764,7 +772,17 @@ class BatchData:
                 raise ValueError("label_encoding must be provided if labels are used.")
             labels = None
         else:
-            labels = label_encoding.encode(list(sample_labels), device="cpu")
+            encoded_labels = list(sample_labels)
+            if label_dropout_rate > 0.0:
+                # cBottle-style label dropout: withhold each dropped sample's label
+                # by replacing it with the empty set, which encodes to an all-zeros
+                # one-hot row (the unconditional state).
+                dropped = torch.rand(len(encoded_labels)) < label_dropout_rate
+                encoded_labels = [
+                    set() if drop else label_set
+                    for drop, label_set in zip(dropped.tolist(), encoded_labels)
+                ]
+            labels = label_encoding.encode(encoded_labels, device="cpu")
         return BatchData.new_on_cpu(
             data=batch_data,
             time=batch_time,

--- a/fme/ace/data_loading/config.py
+++ b/fme/ace/data_loading/config.py
@@ -40,6 +40,12 @@ class DataLoaderConfig:
             Each pool slot holds one window of
             ``batch_size * (time_buffer + n_timesteps)`` tensors in memory.
             Requires ``time_buffer > 0``.
+        label_dropout_rate: Probability, in [0, 1], that each training sample has
+            its source label withheld (replaced by the empty/all-zeros label). This
+            is cBottle-style label dropout: it forces the model to learn a genuine
+            unconditional mode alongside the per-source conditional ones. Applied
+            per-sample on the training path only (never validation or inference),
+            and a no-op when the dataset has no labels (``available_labels is None``).
 
     Note:
         Setting `time_buffer` to a value greater than 0 results in pre-loading
@@ -66,6 +72,7 @@ class DataLoaderConfig:
     sample_with_replacement: int | None = None
     time_buffer: int = 0
     time_buffer_pool_size: int = 1
+    label_dropout_rate: float = 0.0
 
     @property
     def using_labels(self) -> bool:
@@ -112,6 +119,11 @@ class DataLoaderConfig:
                 "time_buffer_pool_size > 1 requires time_buffer > 0. "
                 f"Got time_buffer={self.time_buffer}, "
                 f"time_buffer_pool_size={self.time_buffer_pool_size}"
+            )
+        if not 0.0 <= self.label_dropout_rate <= 1.0:
+            raise ValueError(
+                "label_dropout_rate must be in [0, 1]. "
+                f"Got {self.label_dropout_rate}"
             )
 
     @property

--- a/fme/ace/data_loading/getters.py
+++ b/fme/ace/data_loading/getters.py
@@ -33,10 +33,12 @@ class CollateFn:
         horizontal_dims: list[str],
         label_encoding: LabelEncoding | None = None,
         allow_missing_variables: bool = False,
+        label_dropout_rate: float = 0.0,
     ):
         self.horizontal_dims = horizontal_dims
         self.label_encoding = label_encoding
         self.allow_missing_variables = allow_missing_variables
+        self.label_dropout_rate = label_dropout_rate
 
     def __call__(self, samples: Sequence[DatasetItem]) -> BatchData:
         return BatchData.from_sample_tuples(
@@ -44,6 +46,7 @@ class CollateFn:
             horizontal_dims=self.horizontal_dims,
             label_encoding=self.label_encoding,
             allow_missing_variables=self.allow_missing_variables,
+            label_dropout_rate=self.label_dropout_rate,
         )
 
 
@@ -124,6 +127,10 @@ def get_gridded_data(
     else:
         label_encoding = None
 
+    # Label dropout is a training-only augmentation; never withhold labels on the
+    # validation path so validation metrics use the true per-source conditioning.
+    label_dropout_rate = config.label_dropout_rate if train else 0.0
+
     dataloader = get_data_loader(
         dataset=dataset,
         batch_size=batch_size,
@@ -139,6 +146,7 @@ def get_gridded_data(
             list(properties.horizontal_coordinates.dims),
             label_encoding,
             allow_missing_variables=requirements.allow_missing_variables,
+            label_dropout_rate=label_dropout_rate,
         ),
         multiprocessing_context=mp_context,
         persistent_workers=persistent_workers,

--- a/fme/ace/data_loading/test_batch_data.py
+++ b/fme/ace/data_loading/test_batch_data.py
@@ -18,7 +18,7 @@ from fme.ace.requirements import InitialConditionRequirements
 from fme.core.corrector.state import CorrectorState
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
-from fme.core.labels import BatchLabels
+from fme.core.labels import BatchLabels, LabelEncoding
 from fme.core.random_state import RandomState
 from fme.core.step.step_diagnostics import StepDiagnostics
 from fme.core.stepper_state import StepperState
@@ -309,6 +309,71 @@ def test_from_sample_tuples_raises_on_mismatched_epochs(epoch_1: int, epoch_2: i
 
     with pytest.raises(ValueError, match="same epoch"):
         BatchData.from_sample_tuples([sample1, sample2])
+
+
+def _labeled_sample(label_set: set[str] | None):
+    return (
+        {"x": torch.zeros(2, 3)},
+        xr.DataArray([0, 1]),
+        label_set,
+        0,
+        None,
+    )
+
+
+def test_from_sample_tuples_label_dropout_rate_one_zeros_all_labels():
+    """label_dropout_rate=1.0 withholds every sample's label (all-zeros rows)."""
+    encoding = LabelEncoding(["src_a", "src_b"])
+    samples = [_labeled_sample({"src_a"}), _labeled_sample({"src_b"})]
+    torch.manual_seed(0)
+    batch = BatchData.from_sample_tuples(
+        samples, label_encoding=encoding, label_dropout_rate=1.0
+    )
+    assert batch.labels is not None
+    assert batch.labels.names == ["src_a", "src_b"]
+    torch.testing.assert_close(batch.labels.tensor, torch.zeros(2, 2))
+
+
+def test_from_sample_tuples_label_dropout_rate_zero_preserves_labels():
+    """label_dropout_rate=0.0 leaves the encoded labels unchanged."""
+    encoding = LabelEncoding(["src_a", "src_b"])
+    samples = [_labeled_sample({"src_a"}), _labeled_sample({"src_b"})]
+    batch = BatchData.from_sample_tuples(
+        samples, label_encoding=encoding, label_dropout_rate=0.0
+    )
+    expected = encoding.encode([{"src_a"}, {"src_b"}], device="cpu")
+    assert batch.labels == expected
+
+
+def test_from_sample_tuples_label_dropout_is_per_sample_and_deterministic():
+    """Dropout is drawn per sample; a seeded run zeros exactly the drawn rows."""
+    encoding = LabelEncoding(["src_a", "src_b"])
+    label_sets: list[set[str]] = [{"src_a"}, {"src_a", "src_b"}, {"src_b"}, {"src_a"}]
+    samples = [_labeled_sample(s) for s in label_sets]
+
+    seed = 12345
+    torch.manual_seed(seed)
+    batch = BatchData.from_sample_tuples(
+        samples, label_encoding=encoding, label_dropout_rate=0.5
+    )
+
+    # Replay the same RNG draw to know which rows were withheld.
+    torch.manual_seed(seed)
+    dropped = (torch.rand(len(samples)) < 0.5).tolist()
+    # The seed is chosen so the mask is mixed, exercising the per-sample path.
+    assert any(dropped) and not all(dropped)
+    expected_sets = [set() if d else s for d, s in zip(dropped, label_sets)]
+    expected = encoding.encode(expected_sets, device="cpu")
+    assert batch.labels == expected
+
+
+def test_from_sample_tuples_label_dropout_no_labels_is_noop():
+    """A rate > 0 with no label_encoding must not crash and yields no labels."""
+    samples = [_labeled_sample(None), _labeled_sample(None)]
+    batch = BatchData.from_sample_tuples(
+        samples, label_encoding=None, label_dropout_rate=1.0
+    )
+    assert batch.labels is None
 
 
 @pytest.mark.parametrize(

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -397,6 +397,65 @@ def test_xarray_loader_labels(tmp_path, tmp_path_factory):
         raise AssertionError("Did not see unlabelled data in batches")
 
 
+def _labelled_loader_config(tmp_path, tmp_path_factory, label_dropout_rate):
+    _create_dataset_on_disk(tmp_path)
+    other_path = tmp_path_factory.mktemp("other")
+    _create_dataset_on_disk(other_path, filename="other_source.nc")
+    return DataLoaderConfig(
+        dataset=ConcatDatasetConfig(
+            concat=[
+                XarrayDataConfig(
+                    data_path=tmp_path, file_pattern="data*.nc", labels=["labelled"]
+                ),
+                XarrayDataConfig(
+                    data_path=other_path,
+                    file_pattern="other_source*.nc",
+                    n_repeats=1,
+                    labels=[],
+                ),
+            ]
+        ),
+        batch_size=1,
+        num_data_workers=0,
+        label_dropout_rate=label_dropout_rate,
+    )
+
+
+def test_xarray_loader_label_dropout_train_withholds_all_labels(
+    tmp_path, tmp_path_factory
+):
+    """With label_dropout_rate=1.0 the training loader emits only zeroed labels."""
+    config = _labelled_loader_config(tmp_path, tmp_path_factory, label_dropout_rate=1.0)
+    requirements = DataRequirements(["foo"], 2)
+    torch.manual_seed(0)
+    data = get_gridded_data(config, True, requirements)  # type: ignore
+    for batch in data.loader:
+        assert batch.labels is not None
+        assert batch.labels.names == ["labelled"]
+        assert torch.sum(batch.labels.tensor) == 0
+
+
+def test_xarray_loader_label_dropout_disabled_on_validation(tmp_path, tmp_path_factory):
+    """label_dropout_rate is ignored on the validation path (train=False)."""
+    config = _labelled_loader_config(tmp_path, tmp_path_factory, label_dropout_rate=1.0)
+    requirements = DataRequirements(["foo"], 2)
+    torch.manual_seed(0)
+    data = get_gridded_data(config, False, requirements)  # type: ignore
+    seen_labelled = False
+    for batch in data.loader:
+        assert batch.labels is not None
+        if torch.sum(batch.labels.tensor) > 0:
+            seen_labelled = True
+    assert seen_labelled, "validation labels must be preserved despite dropout rate"
+
+
+def test_data_loader_config_rejects_label_dropout_out_of_range(
+    tmp_path, tmp_path_factory
+):
+    with pytest.raises(ValueError, match="label_dropout_rate must be in"):
+        _labelled_loader_config(tmp_path, tmp_path_factory, label_dropout_rate=1.5)
+
+
 def test_xarray_loader_using_merged_dataset_errors_if_different_time(
     tmp_path, tmp_path_factory
 ):

--- a/fme/ace/test_train.py
+++ b/fme/ace/test_train.py
@@ -167,6 +167,7 @@ def _get_test_yaml_files(
     batch_size: int = 2,
     sample_with_replacement: int | None = 10,
     lr_tuning: LRTuningConfig | None = None,
+    label_dropout_rate: float = 0.0,
 ):
     if derived_forcings is None:
         derived_forcings = DerivedForcingsConfig()
@@ -354,6 +355,7 @@ def _get_test_yaml_files(
             num_data_workers=0,
             time_buffer=time_buffer,
             sample_with_replacement=sample_with_replacement,
+            label_dropout_rate=label_dropout_rate,
         ),
         validation=_make_validation_entries(
             valid_data_path=valid_data_path,
@@ -504,6 +506,7 @@ def _setup(
     multi_validation: bool = False,
     use_variable_masking: bool = False,
     lr_tuning: LRTuningConfig | None = None,
+    label_dropout_rate: float = 0.0,
 ):
     if not path.exists():
         path.mkdir()
@@ -615,6 +618,7 @@ def _setup(
         multi_validation=multi_validation,
         partial_train_data_path=partial_data_dir,
         lr_tuning=lr_tuning,
+        label_dropout_rate=label_dropout_rate,
     )
     return train_config_filename, inference_config_filename
 
@@ -1089,6 +1093,35 @@ def test_train_without_inline_inference(tmp_path):
     assert "val_extra/mean/loss" in epoch_logs
     val_extra_output = tmp_path / "results" / "output" / "val_extra" / "epoch_0001"
     assert val_extra_output.exists()
+
+
+@pytest.mark.medium_duration
+def test_train_with_label_dropout(tmp_path):
+    """A conditional model trains end-to-end with full label dropout.
+
+    With label_dropout_rate=1.0 every training sample is fed the all-zeros
+    (unconditional) label, so this exercises the label-dropout data path and
+    confirms the ConditionalLayerNorm forward handles the withheld-label state
+    without error. NoiseConditionedSFNO is the conditional (labelled) nettype.
+    """
+    train_config, _ = _setup(
+        tmp_path,
+        "NoiseConditionedSFNO",
+        log_to_wandb=True,
+        timestep_days=40,
+        n_time=22,
+        inference_forward_steps=20,  # must be even
+        skip_inline_inference=True,
+        label_dropout_rate=1.0,
+    )
+    with mock_wandb() as wandb:
+        train_main(yaml_config=train_config)
+        wandb_logs = wandb.get_logs()
+    assert any("val/mean/loss" in epoch_logs for epoch_logs in wandb_logs)
+    best_checkpoint_path = (
+        tmp_path / "results" / "training_checkpoints" / "best_ckpt.tar"
+    )
+    assert best_checkpoint_path.exists()
 
 
 @pytest.mark.medium_duration


### PR DESCRIPTION
Combined-source (multi-dataset) training conditions the model on a per-source label via the `LabelEncoding` → `ConditionalLayerNorm` path. To let such a model learn a genuine *unconditional* mode alongside its per-source conditional ones, this adds cBottle-style label dropout ([arXiv:2505.06474](https://arxiv.org/pdf/2505.06474)): on a configured fraction of training samples, the per-source label is withheld and the model sees the empty/all-zeros label instead. This is a data-loading feature only — no model-architecture change.

Changes:
- `fme.ace.data_loading.config.DataLoaderConfig`: add `label_dropout_rate` (default `0.0`), validated to `[0, 1]` in `__post_init__`.
- `fme.ace.data_loading.batch_data.BatchData.from_sample_tuples`: before encoding, draw a per-sample `Bernoulli(label_dropout_rate)` mask and replace each dropped sample's label set with the empty set. The empty set encodes to an all-zeros one-hot row (via the existing `LabelEncoding.encode` path) — a per-sample route to the unconditional state, rather than zeroing the whole batch.
- `fme.ace.data_loading.getters`: thread `label_dropout_rate` through `CollateFn`; in `get_gridded_data`, apply it only when `train=True` (forced to `0.0` on the validation path, so validation metrics keep true per-source conditioning).

Zero-init / identity finding: the label-conditioning Linear layers are zero-initialized, so an all-zeros one-hot yields identity (additive-zero) conditioning at init — no change was needed. In `ConditionalLayerNorm.forward` the one-hot enters additively as `scale += W_scale_labels(labels)` and `bias += W_bias_labels(labels)`; `reset_parameters` sets both `W_scale_labels` and `W_bias_labels` weight *and* bias to `0.0` (`fme/core/models/conditional_sfno/layers.py`), and the swin conditioning path's `adaln_labels` is likewise zeros-initialized (`fme/core/models/swin_transformer/swin_layers.py`). An all-zeros one-hot therefore contributes only the (zero-at-init) label-bias term, which is exactly identity conditioning. After training, the withheld state maps to the learned label-bias term, shared across all unconditional samples and distinct from any active one-hot combination — that is the unconditional mode.

No-op guard: when the dataset has no labels (`available_labels is None` ⇒ `label_encoding is None`, e.g. `builder.conditional: false`), the dropout branch is never reached, so `from_sample_tuples` returns `labels=None`; a `label_dropout_rate > 0` then has no effect and does not crash.

Tests:
- `test_batch_data.py`: `label_dropout_rate=1.0` zeros all labels; `0.0` leaves them unchanged; a seeded run is per-sample and deterministic; `rate>0` with no `label_encoding` is a no-op.
- `test_data_loader.py`: through `get_gridded_data`, `rate=1.0` on the train path emits only zeroed labels; the validation path preserves labels despite `rate=1.0`; an out-of-range rate is rejected.
- `test_train.py::test_train_with_label_dropout`: a `NoiseConditionedSFNO` (conditional) model trains end-to-end with `label_dropout_rate=1.0`, confirming the `ConditionalLayerNorm` forward handles the withheld-label state.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated