### PR TITLE
Small fix to `StaticSpatialMaskingConfig` docs

### DIFF
--- a/fme/core/spatial_masking.py
+++ b/fme/core/spatial_masking.py
@@ -48,7 +48,7 @@ class StaticSpatialMaskingConfig:
 
     Parameters:
         mask_value: Value of the mask variable in masked regions. Either 0 or 1.
-        fill_value: A float fill value to use outside of masked regions. Can also be
+        fill_value: A float fill value to use inside of masked regions. Can also be
             "mean", in which case the normalizer means are used as channel-specific
             fill values.
         exclude_names_and_prefixes: Names (2D variables) and prefixes (3D variables)


### PR DESCRIPTION
Fixes incorrect wording on the `fill_value` description in the `StaticSpatialMaskingConfig`. The fill value is used _inside_ of masked regions, not 'outside' of them (i.e., valid regions).

Changes:
- No API changes, docs only.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated