### PR TITLE
Switch to datetime-based directory labels for segmented inference

### DIFF
--- a/fme/ace/inference/__main__.py
+++ b/fme/ace/inference/__main__.py
@@ -1,7 +1,7 @@
 from fme.core.cli import get_parser
 from fme.core.distributed.distributed import Distributed
 
-from .inference import main
+from .inference import DEFAULT_SEGMENT_LABEL_FORMAT, main
 
 if __name__ == "__main__":
     parser = get_parser()
@@ -11,12 +11,29 @@ if __name__ == "__main__":
         default=None,
         help=(
             "If provided, number of times to repeat the inference in time, "
-            "saving each segment in a separate folder labeled as "
-            "'segment_0000', 'segment_0001' etc. "
+            "saving each segment in a separate folder labeled by the start "
+            "time of its first (or only) ensemble member. "
             "WARNING: this feature is experimental and its API is subject "
-            "to change.",
+            "to change."
+        ),
+    )
+    parser.add_argument(
+        "--segment-label-format",
+        type=str,
+        default=DEFAULT_SEGMENT_LABEL_FORMAT,
+        help=(
+            "strftime format used to render each segment's start time into its "
+            "folder/wandb-run label. Only used when --segments is provided. "
+            "Defaults to hour precision; pass a more precise format (e.g. "
+            "'%%Y%%m%%dT%%H%%M%%S') if the timestep or initial condition time "
+            "require it."
         ),
     )
     args = parser.parse_args()
     with Distributed.context():
-        main(args.yaml_config, segments=args.segments, override_dotlist=args.override)
+        main(
+            args.yaml_config,
+            segments=args.segments,
+            override_dotlist=args.override,
+            segment_label_format=args.segment_label_format,
+        )

--- a/fme/ace/inference/__main__.py
+++ b/fme/ace/inference/__main__.py
@@ -25,8 +25,8 @@ if __name__ == "__main__":
             "strftime format used to render each segment's start time into its "
             "folder/wandb-run label. Only used when --segments is provided. "
             "Defaults to hour precision; pass a more precise format (e.g. "
-            "'%%Y%%m%%dT%%H%%M%%S') if the timestep or initial condition time "
-            "require it."
+            "'segment_%%Y%%m%%dT%%H%%M%%S') if the timestep or initial "
+            "condition time require it."
         ),
     )
     args = parser.parse_args()

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -495,8 +495,24 @@ def _get_segment_label(
     n_forward_steps: int,
     segment_label_format: str,
 ) -> str:
-    segment_start_time = initialization_time + timestep * segment * n_forward_steps
-    return segment_start_time.strftime(segment_label_format)
+    segment_length = n_forward_steps * timestep
+    current_start_time = initialization_time + segment * segment_length
+    current_label = current_start_time.strftime(segment_label_format)
+
+    if segment > 0:
+        previous_start_time = initialization_time + (segment - 1) * segment_length
+        previous_label = previous_start_time.strftime(segment_label_format)
+        if previous_label == current_label:
+            raise ValueError(
+                f"Consecutive segments have the same label ({previous_label!r} "
+                f"and {current_label!r}), meaning the current segment would "
+                f"overwrite the previous segment. Please use a more precise "
+                f"--segment-label-format than the current one "
+                f"({segment_label_format!r}) when submitting your segmented "
+                f"run to avoid this error."
+            )
+
+    return current_label
 
 
 def run_segmented_inference(

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -55,8 +55,9 @@ StartIndices = InferenceInitialConditionIndices | ExplicitIndices | TimestampLis
 
 # Truncated to hour precision: segment start times in existing runs have always
 # been at least 6h apart, so finer precision would just add visual noise. Pass a
-# more precise segment_label_format (e.g. "%Y%m%dT%H%M%S") if that stops holding.
-DEFAULT_SEGMENT_LABEL_FORMAT = "%Y%m%dT%H"
+# more precise segment_label_format (e.g. "segment_%Y%m%dT%H%M%S") if that stops
+# holding.
+DEFAULT_SEGMENT_LABEL_FORMAT = "segment_%Y%m%dT%H"
 
 
 @dataclasses.dataclass
@@ -515,8 +516,8 @@ def run_segmented_inference(
             member—into its directory/wandb-run label. Defaults to hour precision,
             which is truncated (not rounded), so distinct segment start times that
             share an hour would collide; pass a more precise format
-            (e.g. ``"%Y%m%dT%H%M%S"``) if that's a concern for your timestep or
-            initial condition time.
+            (e.g. ``"segment_%Y%m%dT%H%M%S"``) if that's a concern for your timestep
+            or initial condition time.
 
     Note:
         This is useful when running very long simulations or when saving a large

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -53,6 +53,11 @@ from .evaluator import resolve_variable_metadata
 
 StartIndices = InferenceInitialConditionIndices | ExplicitIndices | TimestampList
 
+# Truncated to hour precision: segment start times in existing runs have always
+# been at least 6h apart, so finer precision would just add visual noise. Pass a
+# more precise segment_label_format (e.g. "%Y%m%dT%H%M%S") if that stops holding.
+DEFAULT_SEGMENT_LABEL_FORMAT = "%Y%m%dT%H"
+
 
 @dataclasses.dataclass
 class InitialConditionConfig:
@@ -336,6 +341,7 @@ def main(
     yaml_config: str,
     segments: int | None = None,
     override_dotlist: Sequence[str] | None = None,
+    segment_label_format: str = DEFAULT_SEGMENT_LABEL_FORMAT,
 ):
     config_data = prepare_config(yaml_config, override=override_dotlist)
     config = dacite.from_dict(
@@ -349,7 +355,7 @@ def main(
             with GlobalTimer():
                 return run_inference_from_config(config)
         else:
-            run_segmented_inference(config, segments)
+            run_segmented_inference(config, segments, segment_label_format)
 
 
 def run_inference_from_config(config: InferenceConfig):
@@ -463,7 +469,40 @@ def run_inference_from_config(config: InferenceConfig):
     logger.log_to_current_step(timer.get_durations(), label="")
 
 
-def run_segmented_inference(config: InferenceConfig, segments: int):
+def _get_initialization_time_and_timestep(
+    config: InferenceConfig,
+) -> tuple[cftime.datetime, datetime.timedelta]:
+    # Loading the stepper is expensive, but it is necessary to get the timestep
+    # and prognostic names. We only call this function once before the
+    # segmented loop starts to minimize the overhead.
+    stepper = config.load_stepper()
+    initial_condition = get_initial_condition(
+        config.initial_condition.get_dataset(),
+        InitialConditionRequirements(
+            prognostic_names=stepper.prognostic_names,
+            labels=config.labels,
+        ),
+    )
+    initialization_time = initial_condition.as_batch_data().time.isel(sample=0).item()
+    return initialization_time, stepper.training_dataset_info.timestep
+
+
+def _get_segment_label(
+    initialization_time: cftime.datetime,
+    timestep: datetime.timedelta,
+    segment: int,
+    n_forward_steps: int,
+    segment_label_format: str,
+) -> str:
+    segment_start_time = initialization_time + timestep * segment * n_forward_steps
+    return segment_start_time.strftime(segment_label_format)
+
+
+def run_segmented_inference(
+    config: InferenceConfig,
+    segments: int,
+    segment_label_format: str = DEFAULT_SEGMENT_LABEL_FORMAT,
+):
     """Run inference in multiple segments.
 
     Args:
@@ -471,12 +510,19 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
             provided initial condition configuration will only be used for the first
             segment.
         segments: total number of segments desired. Only missing segments will be run.
+        segment_label_format: strftime format used to render each segment's start
+            time—specifically, the start time of the first (or only) ensemble
+            member—into its directory/wandb-run label. Defaults to hour precision,
+            which is truncated (not rounded), so distinct segment start times that
+            share an hour would collide; pass a more precise format
+            (e.g. ``"%Y%m%dT%H%M%S"``) if that's a concern for your timestep or
+            initial condition time.
 
     Note:
         This is useful when running very long simulations or when saving a large
         amount of output data to disk. The simulation outputs will be split across
         multiple folders, each corresponding to one of the segments and labeled by
-        the segment number.
+        the start time of its first (or only) ensemble member.
     """
     if config.n_ensemble_per_ic > 1:
         raise ValueError(
@@ -500,8 +546,18 @@ def run_segmented_inference(config: InferenceConfig, segments: int):
     )
     config_copy = copy.deepcopy(config)
     original_wandb_name = os.environ.get("WANDB_NAME")
+
+    initialization_time, timestep = _get_initialization_time_and_timestep(config)
+    n_forward_steps = config.n_forward_steps
+
     for segment in range(segments):
-        segment_label = f"segment_{segment:04d}"
+        segment_label = _get_segment_label(
+            initialization_time,
+            timestep,
+            segment,
+            n_forward_steps,
+            segment_label_format,
+        )
         segment_dir = os.path.join(config.experiment_dir, segment_label)
         restart_path = os.path.join(segment_dir, "restart.nc")
         if exists(restart_path):

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -26,6 +26,7 @@ from fme.ace.inference.data_writer.dataset_metadata import DatasetMetadata
 from fme.ace.inference.data_writer.file_writer import FileWriterConfig
 from fme.ace.inference.inference import (
     InitialConditionConfig,
+    _get_segment_label,
     get_initial_condition,
     main,
     run_segmented_inference,
@@ -310,6 +311,24 @@ def test_run_segmented_inference_custom_segment_label_format(tmp_path):
             segment_dir = os.path.join(config.experiment_dir, label)
             assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
         assert mock.call_count == 2
+
+
+def test_get_segment_label_raises_on_collision():
+    initialization_time = cftime.DatetimeProlepticGregorian(2000, 1, 1, 6)
+    timestep = datetime.timedelta(minutes=15)
+    n_forward_steps = 3  # segments start 45min apart
+
+    # hour-precision format is too coarse to distinguish 45min-apart segments
+    with pytest.raises(ValueError, match="same label"):
+        _get_segment_label(
+            initialization_time, timestep, 1, n_forward_steps, "%Y%m%dT%H"
+        )
+
+    # minute-precision format distinguishes them fine
+    label = _get_segment_label(
+        initialization_time, timestep, 1, n_forward_steps, "%Y%m%dT%H%M"
+    )
+    assert label == "20000101T0645"
 
 
 def save_noise_conditioned_stepper(

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -181,8 +181,8 @@ def test_inference_segmented_entrypoint(tmp_path, monkeypatch):
         wandb.configure(log_to_wandb=True)
         main(make_config(run_dir, 3), 2)
         assert [run["name"] for run in wandb.runs] == [
-            "myrun-20000101T06",
-            "myrun-20000102T00",
+            "myrun-segment_20000101T06",
+            "myrun-segment_20000102T00",
         ]
         assert len({run["id"] for run in wandb.runs}) == 2  # distinct runs
         # a single 6-step run should reproduce the two 3-step segments
@@ -194,7 +194,7 @@ def test_inference_segmented_entrypoint(tmp_path, monkeypatch):
         ).drop_vars(["init_time", "time"])  # per-segment init_time differs
 
     xr.testing.assert_equal(
-        _predictions(run_dir / "20000102T00"),
+        _predictions(run_dir / "segment_20000102T00"),
         _predictions(single_dir).isel(time=slice(3, None)),
     )
 
@@ -269,9 +269,9 @@ def test_run_segmented_inference(tmp_path):
 
     # n_forward_steps=3, TIMESTEP=6h: segment start times step by 18h.
     segment_labels = [
-        "20000101T06",
-        "20000102T00",
-        "20000102T18",
+        "segment_20000101T06",
+        "segment_20000102T00",
+        "segment_20000102T18",
     ]
 
     with unittest.mock.patch(
@@ -463,7 +463,7 @@ def test_segmented_stochastic_inference_matches_single_run(tmp_path):
     # The second segment (steps 4-6) must match the single run's steps 4-6. Drop
     # the time coordinates, which differ by construction (per-segment init_time).
     ds_segment_1 = xr.open_dataset(
-        two_seg_dir / "20000102T00" / "autoregressive_predictions.nc",
+        two_seg_dir / "segment_20000102T00" / "autoregressive_predictions.nc",
         decode_timedelta=False,
     ).drop_vars(["init_time", "time"])
     ds_single = xr.open_dataset(
@@ -478,7 +478,7 @@ def test_segmented_stochastic_inference_matches_single_run(tmp_path):
     two_seg_seed1_dir = tmp_path / "two_segments_seed1"
     run(make_config(str(two_seg_seed1_dir), n_forward_steps=3, seed=1), segments=2)
     ds_segment_1_seed1 = xr.open_dataset(
-        two_seg_seed1_dir / "20000102T00" / "autoregressive_predictions.nc",
+        two_seg_seed1_dir / "segment_20000102T00" / "autoregressive_predictions.nc",
         decode_timedelta=False,
     ).drop_vars(["init_time", "time"])
     assert not np.allclose(

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -172,7 +172,7 @@ def _segmented_config_factory(tmp_path: pathlib.Path, *, log_to_wandb: bool):
 
 def test_inference_segmented_entrypoint(tmp_path, monkeypatch):
     """End-to-end: a segmented run reproduces the equivalent single run, and each
-    segment gets its own wandb run named ``<base>-segment_NNNN`` (issue #471)."""
+    segment gets its own wandb run named ``<base>-<start time>`` (issue #471)."""
     make_config = _segmented_config_factory(tmp_path, log_to_wandb=True)
     run_dir = tmp_path / "segmented_run"
     single_dir = tmp_path / "non_segmented_run"
@@ -181,8 +181,8 @@ def test_inference_segmented_entrypoint(tmp_path, monkeypatch):
         wandb.configure(log_to_wandb=True)
         main(make_config(run_dir, 3), 2)
         assert [run["name"] for run in wandb.runs] == [
-            "myrun-segment_0000",
-            "myrun-segment_0001",
+            "myrun-20000101T06",
+            "myrun-20000102T00",
         ]
         assert len({run["id"] for run in wandb.runs}) == 2  # distinct runs
         # a single 6-step run should reproduce the two 3-step segments
@@ -194,7 +194,7 @@ def test_inference_segmented_entrypoint(tmp_path, monkeypatch):
         ).drop_vars(["init_time", "time"])  # per-segment init_time differs
 
     xr.testing.assert_equal(
-        _predictions(run_dir / "segment_0001"),
+        _predictions(run_dir / "20000102T00"),
         _predictions(single_dir).isel(time=slice(3, None)),
     )
 
@@ -224,17 +224,61 @@ def _get_mock_config(experiment_dir: str) -> fme.ace.InferenceConfig:
     )
 
 
+def _mock_config_with_real_checkpoint_and_ic(
+    tmp_path: pathlib.Path, timestep: datetime.timedelta = TIMESTEP
+) -> fme.ace.InferenceConfig:
+    """A mock config (see _get_mock_config) with a real stepper checkpoint and
+    initial condition standing in for the placeholder ones, since
+    _get_initialization_time_and_timestep loads both to compute each segment's
+    timestamped directory label (anchored to the first, or only, ensemble
+    member's start time)."""
+    stepper_path = tmp_path / "stepper"
+    save_stepper(
+        stepper_path,
+        in_names=["prog"],
+        out_names=["prog"],
+        mean=0.0,
+        std=1.0,
+        data_shape=[4, 8],
+        timestep=timestep,
+    )
+    ic_path = tmp_path / "ic.nc"
+    ic = xr.Dataset(
+        {
+            "prog": xr.DataArray(
+                np.zeros((1, 4, 8), dtype=np.float32), dims=["sample", "lat", "lon"]
+            )
+        }
+    )
+    ic["time"] = xr.DataArray(
+        [cftime.DatetimeProlepticGregorian(2000, 1, 1, 6)], dims=["sample"]
+    )
+    ic.to_netcdf(ic_path)
+
+    config = _get_mock_config(str(tmp_path))
+    config.checkpoint_path = str(stepper_path)
+    config.initial_condition = InitialConditionConfig(path=str(ic_path))
+    return config
+
+
 def test_run_segmented_inference(tmp_path):
     """The loop runs missing segments and skips those whose restart already
     exists, without re-running completed segments."""
     mock = unittest.mock.MagicMock(side_effect=_run_inference_from_config_mock)
-    config = _get_mock_config(str(tmp_path))
+    config = _mock_config_with_real_checkpoint_and_ic(tmp_path)
+
+    # n_forward_steps=3, TIMESTEP=6h: segment start times step by 18h.
+    segment_labels = [
+        "20000101T06",
+        "20000102T00",
+        "20000102T18",
+    ]
 
     with unittest.mock.patch(
         "fme.ace.inference.inference.run_inference_from_config", new=mock
     ):
         run_segmented_inference(config, 1)
-        segment_dir = os.path.join(config.experiment_dir, "segment_0000")
+        segment_dir = os.path.join(config.experiment_dir, segment_labels[0])
         assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
         assert mock.call_count == 1
 
@@ -244,10 +288,28 @@ def test_run_segmented_inference(tmp_path):
 
         # extending to three segments runs exactly the two missing segments
         run_segmented_inference(config, 3)
-        for i in range(3):
-            segment_dir = os.path.join(config.experiment_dir, f"segment_{i:04d}")
+        for label in segment_labels:
+            segment_dir = os.path.join(config.experiment_dir, label)
             assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
         assert mock.call_count == 3
+
+
+def test_run_segmented_inference_custom_segment_label_format(tmp_path):
+    mock = unittest.mock.MagicMock(side_effect=_run_inference_from_config_mock)
+    config = _mock_config_with_real_checkpoint_and_ic(
+        tmp_path, timestep=datetime.timedelta(minutes=15)
+    )
+
+    # n_forward_steps=3, timestep=15min: segments start 45min apart, which the
+    # default "%Y%m%dT%H" format would fold onto the same "T06" label.
+    with unittest.mock.patch(
+        "fme.ace.inference.inference.run_inference_from_config", new=mock
+    ):
+        run_segmented_inference(config, 2, segment_label_format="%Y%m%dT%H%M")
+        for label in ["20000101T0600", "20000101T0645"]:
+            segment_dir = os.path.join(config.experiment_dir, label)
+            assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
+        assert mock.call_count == 2
 
 
 def save_noise_conditioned_stepper(
@@ -401,7 +463,7 @@ def test_segmented_stochastic_inference_matches_single_run(tmp_path):
     # The second segment (steps 4-6) must match the single run's steps 4-6. Drop
     # the time coordinates, which differ by construction (per-segment init_time).
     ds_segment_1 = xr.open_dataset(
-        two_seg_dir / "segment_0001" / "autoregressive_predictions.nc",
+        two_seg_dir / "20000102T00" / "autoregressive_predictions.nc",
         decode_timedelta=False,
     ).drop_vars(["init_time", "time"])
     ds_single = xr.open_dataset(
@@ -416,7 +478,7 @@ def test_segmented_stochastic_inference_matches_single_run(tmp_path):
     two_seg_seed1_dir = tmp_path / "two_segments_seed1"
     run(make_config(str(two_seg_seed1_dir), n_forward_steps=3, seed=1), segments=2)
     ds_segment_1_seed1 = xr.open_dataset(
-        two_seg_seed1_dir / "segment_0001" / "autoregressive_predictions.nc",
+        two_seg_seed1_dir / "20000102T00" / "autoregressive_predictions.nc",
         decode_timedelta=False,
     ).drop_vars(["init_time", "time"])
     assert not np.allclose(


### PR DESCRIPTION
This PR switches from labeling subdirectories in segmented runs with the segment number to labeling them with the start date of the first (or only) ensemble member of the segment.

Changes:
- Segment directories by default are now labeled with the start date of the first (or only) ensemble member of the segment, using the `strftime` format of `"%Y%m%dT%H"`.
- Adds a command line option, `--segment-label-format`, to the inference entrypoint to modify this `strftime` format if desired, e.g. if using a sub-hourly timestep for instance.

- [x] Tests added
