### PR TITLE
Update 4° CM4-like-AM4 random CO2 ensemble processing config

### DIFF
--- a/scripts/data_process/Makefile
+++ b/scripts/data_process/Makefile
@@ -358,7 +358,7 @@ e3smv3_piControl_100yr_coupled:
 
 .PHONY: cm4_like_am4_random_co2_ensemble_atmosphere
 cm4_like_am4_random_co2_ensemble_atmosphere:
-	./compute_dataset.sh --dataset --stats --config configs/CM4-like-AM4-random-CO2-ensemble-atmosphere-$(RESOLUTION)-8layer.yaml
+	./compute_dataset.sh --dataset --stats $(if $(filter 4deg,$(RESOLUTION)),--time-coarsen) --config configs/CM4-like-AM4-random-CO2-ensemble-atmosphere-$(RESOLUTION)-8layer.yaml
 
 .PHONY:
 cm4_like_am4_random_co2_ensemble_coupled:

--- a/scripts/data_process/configs/CM4-like-AM4-random-CO2-ensemble-atmosphere-4deg-8layer.yaml
+++ b/scripts/data_process/configs/CM4-like-AM4-random-CO2-ensemble-atmosphere-4deg-8layer.yaml
@@ -1,19 +1,19 @@
 runs:
-  random-CO2-1xCO2-ic_0001: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-1xCO2-ic_0001
-  random-CO2-2xCO2-ic_0001: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-2xCO2-ic_0001
-  random-CO2-4xCO2-ic_0001: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-4xCO2-ic_0001
-  random-CO2-1xCO2-ic_0002: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-1xCO2-ic_0002
-  random-CO2-2xCO2-ic_0002: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-2xCO2-ic_0002
-  random-CO2-4xCO2-ic_0002: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-4xCO2-ic_0002
-  random-CO2-1xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-1xCO2-ic_0003
-  random-CO2-2xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-2xCO2-ic_0003
-  random-CO2-4xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2025-11-24-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-4xCO2-ic_0003
-data_output_directory: gs://vcm-ml-intermediate/2025-12-02-CM4-like-AM4-random-CO2-4deg
+  random-CO2-1xCO2-ic_0001: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-1xCO2-ic_0001
+  random-CO2-2xCO2-ic_0001: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-2xCO2-ic_0001
+  random-CO2-4xCO2-ic_0001: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-4xCO2-ic_0001
+  random-CO2-1xCO2-ic_0002: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-1xCO2-ic_0002
+  random-CO2-2xCO2-ic_0002: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-2xCO2-ic_0002
+  random-CO2-4xCO2-ic_0002: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-4xCO2-ic_0002
+  random-CO2-1xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-1xCO2-ic_0003
+  random-CO2-2xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-2xCO2-ic_0003
+  random-CO2-4xCO2-ic_0003: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-like-AM4-random-CO2/regridded-zarrs/gaussian_grid_45_by_90/random-CO2-4xCO2-ic_0003
+data_output_directory: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2-4deg
 stats:
-  output_directory: gs://vcm-ml-intermediate/2025-12-02-CM4-like-AM4-random-CO2-4deg-stats
+  output_directory: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2-4deg-stats
   start_date: "0153-01-01T06:00:00"
   data_type: CM4
-  beaker_dataset: 2025-12-02-CM4-like-AM4-random-CO2-4deg-stats
+  beaker_dataset: 2026-06-19-CM4-like-AM4-random-CO2-4deg-stats
 dataset_computation:
   sharding:
     time_dim: 3600
@@ -88,12 +88,13 @@ dataset_computation:
       - total_vapor_sensible_heat_flux
       - downward_longwave_radiative_flux
       - net_surface_longwave_radiative_flux
+    full_state_soil.zarr:
       # below are vertically resolved soil layer variables -- need to be coarsened
       - total_moisture_content_of_soil_layer
       - temperature_of_soil_layer
     land_static.zarr:
       - land_fraction
-    ice_6hourly.zarr:
+    ice_6hourly_snap.zarr:
       - sea_ice_fraction
     scalar.zarr:
       - carbon_dioxide
@@ -117,8 +118,8 @@ dataset_computation:
       - total_moisture_content_of_soil_layer
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2025-12-02-CM4-like-AM4-random-CO2-4deg-daily
-  stats_output_directory: gs://vcm-ml-intermediate/2025-12-02-CM4-like-AM4-random-CO2-4deg-daily-stats
+  data_output_directory: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2-4deg-daily
+  stats_output_directory: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2-4deg-daily-stats
   snapshot_names:
     - PRESsfc
     - PRMSL


### PR DESCRIPTION
This PR updates the 4° CM4-like-AM4 random CO2 ensemble data processing configuration to point to data from the updated runs.

The associated argo job is currently running here: `compute-fme-dataset-ensemble-tfnvr`.
