### PR TITLE
Fix annual aggregator year-completeness threshold

### DIFF
--- a/fme/ace/aggregator/inference/annual.py
+++ b/fme/ace/aggregator/inference/annual.py
@@ -408,9 +408,16 @@ def to_dataset(data: TensorMapping, time: xr.DataArray) -> xr.Dataset:
     return xr.Dataset(data_vars, coords={"valid_time": time})
 
 
-def _get_min_samples(timestep: datetime.timedelta) -> int:
-    steps_per_day = datetime.timedelta(days=1) // timestep
-    return 362 * steps_per_day
+# A year is kept in the annual mean series only if it holds more samples than
+# this many days' worth. 350 leaves ~15 days of slack below a full year so that
+# a rollout whose initial condition is nudged a few days into a year keeps its
+# first year, while genuinely partial (e.g. mid-year-start) years are dropped.
+MIN_COMPLETE_YEAR_DAYS = 350
+
+
+def _get_min_samples(timestep: datetime.timedelta) -> float:
+    steps_per_day = datetime.timedelta(days=1) / timestep
+    return MIN_COMPLETE_YEAR_DAYS * steps_per_day
 
 
 @dataclasses.dataclass

--- a/fme/ace/aggregator/inference/annual.py
+++ b/fme/ace/aggregator/inference/annual.py
@@ -410,7 +410,7 @@ def to_dataset(data: TensorMapping, time: xr.DataArray) -> xr.Dataset:
 
 # A year is kept in the annual mean series only if it holds more samples than
 # this many days' worth. 350 leaves ~15 days of slack below a full year so that
-# a rollout whose initial condition is nudged a few days into a year keeps its
+# a rollout whose initial condition is offset a few days into a year keeps its
 # first year, while genuinely partial (e.g. mid-year-start) years are dropped.
 MIN_COMPLETE_YEAR_DAYS = 350
 

--- a/fme/ace/aggregator/inference/test_annual.py
+++ b/fme/ace/aggregator/inference/test_annual.py
@@ -393,6 +393,108 @@ def test_annual_aggregator():
     assert isinstance(logs["test/a"], plt.Figure)
 
 
+FIVE_DAILY_TIMESTEP = datetime.timedelta(days=5)
+
+
+def _get_kept_years(
+    start: cftime.DatetimeNoLeap,
+    timestep: datetime.timedelta,
+    n_time: int,
+) -> list[int]:
+    """Record a single-sample rollout of random data starting at ``start`` and
+    return the years retained in the annual mean series."""
+    n_lat, n_lon = 2, 2
+    agg = GlobalMeanAnnualAggregator(
+        ops=LatLonOperations(torch.ones(n_lat, n_lon).to(fme.get_device())),
+        timestep=timestep,
+    )
+    data = {"a": torch.randn(1, n_time, n_lat, n_lon, device=get_device())}
+    time = xr.DataArray(
+        [[start + i * timestep for i in range(n_time)]],
+        dims=["sample", "time"],
+    )
+    batch = InferenceBatchData(
+        prediction=data,
+        prediction_norm={},
+        target=None,
+        target_norm=None,
+        time=time,
+        i_time_start=0,
+    )
+    agg.record_batch(batch)
+    ds = agg.get_gathered_means()
+    assert ds is not None
+    return list(ds["year"].values)
+
+
+def test_annual_aggregator_drops_trailing_final_instant_year_five_daily():
+    # 73 five-day steps span a noleap year, so sample 146 lands exactly on
+    # 2002-01-01: the trailing year holds a single sample and must be dropped.
+    years = _get_kept_years(
+        cftime.DatetimeNoLeap(2000, 1, 1), FIVE_DAILY_TIMESTEP, n_time=147
+    )
+    assert years == [2000, 2001]
+
+
+def test_annual_aggregator_drops_partial_midyear_start_five_daily():
+    # a rollout genuinely starting in July covers only ~184 days of its first
+    # year, which must be dropped.
+    years = _get_kept_years(
+        cftime.DatetimeNoLeap(2000, 7, 1), FIVE_DAILY_TIMESTEP, n_time=37 + 73
+    )
+    assert years == [2001]
+
+
+def test_annual_aggregator_keeps_nudged_start_year_six_hourly():
+    # a rollout starting a few days into the year (e.g. a nudged initial
+    # condition) covers 360 of 365 days of its first year, which is kept.
+    years = _get_kept_years(
+        cftime.DatetimeNoLeap(2000, 1, 6), TIMESTEP, n_time=360 * 4 + 1460
+    )
+    assert years == [2000, 2001]
+
+
+def test_annual_aggregator_drops_february_start_year_six_hourly():
+    # a start well past the nudging allowance covers only 334 days of its
+    # first year, which must still be dropped.
+    years = _get_kept_years(
+        cftime.DatetimeNoLeap(2000, 2, 1), TIMESTEP, n_time=334 * 4 + 1460
+    )
+    assert years == [2001]
+
+
+def test_paired_annual_aggregator_drops_trailing_final_instant_year_five_daily():
+    # both target and prediction series must apply the same completeness rule
+    n_lat, n_lon = 2, 2
+    n_time = 147
+    agg = PairedGlobalMeanAnnualAggregator(
+        ops=LatLonOperations(torch.ones(n_lat, n_lon).to(fme.get_device())),
+        timestep=FIVE_DAILY_TIMESTEP,
+    )
+    data = {"a": torch.randn(1, n_time, n_lat, n_lon, device=get_device())}
+    target = {"a": torch.randn(1, n_time, n_lat, n_lon, device=get_device())}
+    time = xr.DataArray(
+        [
+            [
+                cftime.DatetimeNoLeap(2000, 1, 1) + i * FIVE_DAILY_TIMESTEP
+                for i in range(n_time)
+            ]
+        ],
+        dims=["sample", "time"],
+    )
+    batch = InferenceBatchData(
+        prediction=data,
+        prediction_norm={},
+        target=target,
+        target_norm=None,
+        time=time,
+        i_time_start=0,
+    )
+    agg.record_batch(batch)
+    ds = agg.get_dataset()
+    assert list(ds["year"].values) == [2000, 2001]
+
+
 def test_annual_aggregator_with_nans():
     torch.manual_seed(0)
     n_lat = 4

--- a/fme/ace/aggregator/inference/test_annual.py
+++ b/fme/ace/aggregator/inference/test_annual.py
@@ -445,9 +445,10 @@ def test_annual_aggregator_drops_partial_midyear_start_five_daily():
     assert years == [2001]
 
 
-def test_annual_aggregator_keeps_nudged_start_year_six_hourly():
-    # a rollout starting a few days into the year (e.g. a nudged initial
-    # condition) covers 360 of 365 days of its first year, which is kept.
+def test_annual_aggregator_keeps_offset_start_year_six_hourly():
+    # a rollout starting a few days into the year (e.g. an initial condition
+    # offset to skip leading invalid data) covers 360 of 365 days of its
+    # first year, which is kept.
     years = _get_kept_years(
         cftime.DatetimeNoLeap(2000, 1, 6), TIMESTEP, n_time=360 * 4 + 1460
     )
@@ -455,7 +456,7 @@ def test_annual_aggregator_keeps_nudged_start_year_six_hourly():
 
 
 def test_annual_aggregator_drops_february_start_year_six_hourly():
-    # a start well past the nudging allowance covers only 334 days of its
+    # a start well past the offset allowance covers only 334 days of its
     # first year, which must still be dropped.
     years = _get_kept_years(
         cftime.DatetimeNoLeap(2000, 2, 1), TIMESTEP, n_time=334 * 4 + 1460


### PR DESCRIPTION
The annual global-mean inference aggregator keeps a year in the annual mean series only if it has more than a threshold number of samples, but the threshold was computed with floor division of `timedelta(days=1)` by the timestep — silently zero for timesteps of one day or longer. Ocean (5-daily) annual series therefore retained near-empty partial years, including trailing years holding only the rollout's final end-of-interval instant, which land at wildly unphysical values and disagree with the 6-hourly atmosphere series from the same experiment about which years exist. Separately, the 362-day cutoff dropped near-complete first years from rollouts whose initial condition is offset a few days into a year. This PR computes the threshold with true division so it applies at any timestep, and lowers the cutoff to 350 days so offset first years are kept.

Behavior changes: annual series at timesteps of one day or longer now drop partial years (previously all years were kept); annual series now keep years with more than 350 days of samples that the 362-day cutoff previously dropped. Interior full years are unaffected.

Changes:
- `fme.ace.aggregator.inference.annual._get_min_samples`: threshold computed with true (not floor) division of timedeltas; cutoff extracted to a named constant `MIN_COMPLETE_YEAR_DAYS = 350` with the offset-start rationale documented at the definition.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #1385
