### PR TITLE
Remove just added `--segment-label-format` option

### DIFF
--- a/fme/ace/inference/__main__.py
+++ b/fme/ace/inference/__main__.py
@@ -1,7 +1,7 @@
 from fme.core.cli import get_parser
 from fme.core.distributed.distributed import Distributed
 
-from .inference import DEFAULT_SEGMENT_LABEL_FORMAT, main
+from .inference import main
 
 if __name__ == "__main__":
     parser = get_parser()
@@ -17,23 +17,10 @@ if __name__ == "__main__":
             "to change."
         ),
     )
-    parser.add_argument(
-        "--segment-label-format",
-        type=str,
-        default=DEFAULT_SEGMENT_LABEL_FORMAT,
-        help=(
-            "strftime format used to render each segment's start time into its "
-            "folder/wandb-run label. Only used when --segments is provided. "
-            "Defaults to hour precision; pass a more precise format (e.g. "
-            "'segment_%%Y%%m%%dT%%H%%M%%S') if the timestep or initial "
-            "condition time require it."
-        ),
-    )
     args = parser.parse_args()
     with Distributed.context():
         main(
             args.yaml_config,
             segments=args.segments,
             override_dotlist=args.override,
-            segment_label_format=args.segment_label_format,
         )

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -54,10 +54,9 @@ from .evaluator import resolve_variable_metadata
 StartIndices = InferenceInitialConditionIndices | ExplicitIndices | TimestampList
 
 # Truncated to hour precision: segment start times in existing runs have always
-# been at least 6h apart, so finer precision would just add visual noise. Pass a
-# more precise segment_label_format (e.g. "segment_%Y%m%dT%H%M%S") if that stops
-# holding.
-DEFAULT_SEGMENT_LABEL_FORMAT = "segment_%Y%m%dT%H"
+# been at least 6h apart, so finer precision would just add visual noise. We can
+# reconsider if this changes.
+SEGMENT_LABEL_FORMAT = "segment_%Y%m%dT%H"
 
 
 @dataclasses.dataclass
@@ -342,7 +341,6 @@ def main(
     yaml_config: str,
     segments: int | None = None,
     override_dotlist: Sequence[str] | None = None,
-    segment_label_format: str = DEFAULT_SEGMENT_LABEL_FORMAT,
 ):
     config_data = prepare_config(yaml_config, override=override_dotlist)
     config = dacite.from_dict(
@@ -356,7 +354,7 @@ def main(
             with GlobalTimer():
                 return run_inference_from_config(config)
         else:
-            run_segmented_inference(config, segments, segment_label_format)
+            run_segmented_inference(config, segments)
 
 
 def run_inference_from_config(config: InferenceConfig):
@@ -493,33 +491,27 @@ def _get_segment_label(
     timestep: datetime.timedelta,
     segment: int,
     n_forward_steps: int,
-    segment_label_format: str,
 ) -> str:
     segment_length = n_forward_steps * timestep
     current_start_time = initialization_time + segment * segment_length
-    current_label = current_start_time.strftime(segment_label_format)
+    current_label = current_start_time.strftime(SEGMENT_LABEL_FORMAT)
 
     if segment > 0:
         previous_start_time = initialization_time + (segment - 1) * segment_length
-        previous_label = previous_start_time.strftime(segment_label_format)
+        previous_label = previous_start_time.strftime(SEGMENT_LABEL_FORMAT)
         if previous_label == current_label:
             raise ValueError(
                 f"Consecutive segments have the same label ({previous_label!r} "
                 f"and {current_label!r}), meaning the current segment would "
-                f"overwrite the previous segment. Please use a more precise "
-                f"--segment-label-format than the current one "
-                f"({segment_label_format!r}) when submitting your segmented "
-                f"run to avoid this error."
+                f"overwrite the previous segment. Please open an issue on "
+                f"GitHub if having greater temporal precision in segmented run "
+                f"directory labels is an important use-case for you."
             )
 
     return current_label
 
 
-def run_segmented_inference(
-    config: InferenceConfig,
-    segments: int,
-    segment_label_format: str = DEFAULT_SEGMENT_LABEL_FORMAT,
-):
+def run_segmented_inference(config: InferenceConfig, segments: int):
     """Run inference in multiple segments.
 
     Args:
@@ -527,13 +519,6 @@ def run_segmented_inference(
             provided initial condition configuration will only be used for the first
             segment.
         segments: total number of segments desired. Only missing segments will be run.
-        segment_label_format: strftime format used to render each segment's start
-            time—specifically, the start time of the first (or only) ensemble
-            member—into its directory/wandb-run label. Defaults to hour precision,
-            which is truncated (not rounded), so distinct segment start times that
-            share an hour would collide; pass a more precise format
-            (e.g. ``"segment_%Y%m%dT%H%M%S"``) if that's a concern for your timestep
-            or initial condition time.
 
     Note:
         This is useful when running very long simulations or when saving a large
@@ -573,7 +558,6 @@ def run_segmented_inference(
             timestep,
             segment,
             n_forward_steps,
-            segment_label_format,
         )
         segment_dir = os.path.join(config.experiment_dir, segment_label)
         restart_path = os.path.join(segment_dir, "restart.nc")

--- a/fme/ace/inference/test_segmented.py
+++ b/fme/ace/inference/test_segmented.py
@@ -295,24 +295,6 @@ def test_run_segmented_inference(tmp_path):
         assert mock.call_count == 3
 
 
-def test_run_segmented_inference_custom_segment_label_format(tmp_path):
-    mock = unittest.mock.MagicMock(side_effect=_run_inference_from_config_mock)
-    config = _mock_config_with_real_checkpoint_and_ic(
-        tmp_path, timestep=datetime.timedelta(minutes=15)
-    )
-
-    # n_forward_steps=3, timestep=15min: segments start 45min apart, which the
-    # default "%Y%m%dT%H" format would fold onto the same "T06" label.
-    with unittest.mock.patch(
-        "fme.ace.inference.inference.run_inference_from_config", new=mock
-    ):
-        run_segmented_inference(config, 2, segment_label_format="%Y%m%dT%H%M")
-        for label in ["20000101T0600", "20000101T0645"]:
-            segment_dir = os.path.join(config.experiment_dir, label)
-            assert os.path.exists(os.path.join(segment_dir, "restart.nc"))
-        assert mock.call_count == 2
-
-
 def test_get_segment_label_raises_on_collision():
     initialization_time = cftime.DatetimeProlepticGregorian(2000, 1, 1, 6)
     timestep = datetime.timedelta(minutes=15)
@@ -320,15 +302,7 @@ def test_get_segment_label_raises_on_collision():
 
     # hour-precision format is too coarse to distinguish 45min-apart segments
     with pytest.raises(ValueError, match="same label"):
-        _get_segment_label(
-            initialization_time, timestep, 1, n_forward_steps, "%Y%m%dT%H"
-        )
-
-    # minute-precision format distinguishes them fine
-    label = _get_segment_label(
-        initialization_time, timestep, 1, n_forward_steps, "%Y%m%dT%H%M"
-    )
-    assert label == "20000101T0645"
+        _get_segment_label(initialization_time, timestep, 1, n_forward_steps)
 
 
 def save_noise_conditioned_stepper(


### PR DESCRIPTION
After further discussion following #1382 we decided it would be best to keep the directory structure of segmented runs as predictable as possible.  We therefore remove the option to change the format. For now we lock in the hourly precision timestamp for better human readability, but we could consider changing that in the future if a need ever comes up for a model with a sub-hourly timestep or if it ever makes sense to start from initial conditions misaligned from the ACE timestep.

Changes:
- Removes the just added `--segment-label-format` option from the `inference` entrypoint.

- [x] Tests added
