### PR TITLE
Decompose the v2 SFNO at encoder/processor/decoder cut-points (translate 5/6)

### DIFF
--- a/fme/core/models/conditional_sfno/sfnonet.py
+++ b/fme/core/models/conditional_sfno/sfnonet.py
@@ -768,9 +768,6 @@ class SphericalFourierNeuralOperatorNet(torch.nn.Module):
         return x
 
     def forward(self, x: torch.Tensor, context: Context):
-        # fme/translate/cutpoint.py mirrors the three stages below as separate
-        # modules and asserts bit-exact equivalence with this method, so changes
-        # here need a matching change there. Its tests will say so if not.
         # save big skip
         if self.big_skip:
             residual = self.residual_filter_up(self.residual_filter_down(x))

--- a/fme/core/models/conditional_sfno/sfnonet.py
+++ b/fme/core/models/conditional_sfno/sfnonet.py
@@ -768,6 +768,9 @@ class SphericalFourierNeuralOperatorNet(torch.nn.Module):
         return x
 
     def forward(self, x: torch.Tensor, context: Context):
+        # fme/translate/cutpoint.py mirrors the three stages below as separate
+        # modules and asserts bit-exact equivalence with this method, so changes
+        # here need a matching change there. Its tests will say so if not.
         # save big skip
         if self.big_skip:
             residual = self.residual_filter_up(self.residual_filter_down(x))

--- a/fme/translate/__init__.py
+++ b/fme/translate/__init__.py
@@ -14,6 +14,7 @@ from .components import (
     ComponentPoolConfig,
     TransformConfig,
 )
+from .cutpoint import SFNOCutPointConfig
 from .domains import DomainConfig, LatentChannels
 from .modules import (
     InterpolateTransformConfig,
@@ -29,6 +30,7 @@ __all__ = [
     "DomainConfig",
     "InterpolateTransformConfig",
     "LatentChannels",
+    "SFNOCutPointConfig",
     "SameGridTransformConfig",
     "TransformConfig",
     "TransformModuleConfig",

--- a/fme/translate/components.py
+++ b/fme/translate/components.py
@@ -132,8 +132,10 @@ class TransformConfig:
         n_out_channels: int,
         in_dataset_info: DatasetInfo,
         out_dataset_info: DatasetInfo,
+        for_load: bool = False,
     ) -> Module:
-        return self.module.build(
+        build = self.module.build_for_load if for_load else self.module.build
+        return build(
             n_in_channels=n_in_channels,
             n_out_channels=n_out_channels,
             in_dataset_info=in_dataset_info,
@@ -176,9 +178,16 @@ class TransformConfig:
         Used when reconstructing from a saved state: the weights are restored by
         a subsequent ``load_state``, so external initialization is skipped and,
         as with ``Stepper.from_state``, the reloaded module is left unfrozen.
+        Builders that read a checkpoint of their own at build time (the SFNO
+        cut-point parts' ``donor_checkpoint``) skip it here too, so a saved
+        component reloads without that checkpoint still existing.
         """
         module = self._build_raw(
-            n_in_channels, n_out_channels, in_dataset_info, out_dataset_info
+            n_in_channels,
+            n_out_channels,
+            in_dataset_info,
+            out_dataset_info,
+            for_load=True,
         )
         return module.wrap_module(Distributed.get_instance().wrap_module)
 
@@ -486,7 +495,16 @@ class ComponentPool:
             backbone.set_eval()
 
     def set_epoch(self, epoch: int) -> None:
-        # Transforms have no epoch-dependent state; only backbones react.
+        for transform in self._transforms.values():
+            # Mirrors Stepper.set_epoch: a transform holding the SFNO's
+            # post-encoder latent global-mean envelope needs it reset each
+            # epoch, and duck-typing is how the stepper finds those modules.
+            for submodule in transform.torch_module.modules():
+                request_reset = getattr(
+                    submodule, "request_latent_global_mean_envelope_reset", None
+                )
+                if callable(request_reset):
+                    request_reset()
         for backbone in self._backbones.values():
             backbone.set_epoch(epoch)
 

--- a/fme/translate/cutpoint.py
+++ b/fme/translate/cutpoint.py
@@ -38,6 +38,13 @@ the three parts reproduces the monolithic net's output *exactly* rather than
 approximately, for any configuration. ``test_cutpoint.py`` asserts that
 equivalence; it is what pins this module against changes to the net it mirrors.
 
+Bit-exactness also requires the encoder stage to consume no randomness, because
+the composed path runs it *before* the processor's noise draw while the monolith
+draws the noise first. That holds today: the only RNG-consuming op ahead of the
+blocks is ``pos_drop``, which is an ``nn.Identity`` because
+``NoiseConditionedSFNOBuilder`` does not expose ``drop_rate``. The equivalence
+test runs the parts in training mode, so it fails if that stops being true.
+
 The parts do not change resolution. Resolution-changing operators are separate
 registry entries (``interpolate`` and its successors) that a config chains
 around a cut-point part.
@@ -250,10 +257,16 @@ class SFNOCutPointConfig(TransformModuleConfig):
         part: Which stage to build.
         sfno: The donor's noise-conditioned SFNO configuration.
         donor_checkpoint: Path to an ACE stepper checkpoint to name-match this
-            part's parameters against. Every parameter of the built part must
-            be present in the donor, which holds when ``sfno`` is the donor's
-            own config. Applied before ``TransformConfig.parameter_init``, so
-            an explicit ``weights_path`` still wins over the donor.
+            part's parameters against. Every parameter of the built part must be
+            present in the donor *and* have the donor's shape, which holds when
+            ``sfno`` is the donor's own config and the cut-point domain declares
+            ``embed_dim`` plus the donor's input channels; anything else raises
+            rather than partly initializing the part. Applied before
+            ``TransformConfig.parameter_init``, so an explicit ``weights_path``
+            still wins over the donor. Only parameters are transferred, not
+            buffers: an encoder configured with ``clip_latent_global_means``
+            therefore starts with an empty envelope and relearns it over the
+            first training epoch rather than inheriting the donor's.
         donor_module_index: Index into the donor stepper's ``modules`` list.
         conditional: Whether to pass batch labels through to the context.
             Only the processor consumes context.
@@ -289,7 +302,9 @@ class SFNOCutPointConfig(TransformModuleConfig):
 
         Only the encoder sees it directly. The others recover it from the
         cut-point width, which carries the big-skip residual; when there is no
-        big skip they never need it (nothing they build is sized by it).
+        big skip they keep nothing sized by it, so any positive placeholder does
+        (``norm_big_skip`` is still *built* at that size when
+        ``normalize_big_skip`` is set, but no part keeps it without a big skip).
         """
         if self.part == "encoder":
             return n_in_channels
@@ -381,21 +396,41 @@ class SFNOCutPointConfig(TransformModuleConfig):
                 f"Donor checkpoint {self.donor_checkpoint!r} contains no module "
                 "weights."
             )
-        if self.donor_module_index >= len(weights):
+        if not 0 <= self.donor_module_index < len(weights):
             raise ValueError(
                 f"donor_module_index {self.donor_module_index} is out of range "
                 f"for a donor stepper with {len(weights)} module(s)."
             )
         donor = strip_leading_module(weights[self.donor_module_index])
-        missing = sorted(
-            name for name, _ in module.named_parameters() if name not in donor
-        )
+        missing = []
+        mismatched = []
+        for name, parameter in module.named_parameters():
+            if name not in donor:
+                missing.append(name)
+            elif donor[name].shape != parameter.shape:
+                mismatched.append(
+                    f"{name} (donor {tuple(donor[name].shape)}, "
+                    f"part {tuple(parameter.shape)})"
+                )
         if missing:
             raise ValueError(
                 f"The donor checkpoint {self.donor_checkpoint!r} has no weights "
                 f"for {len(missing)} parameter(s) of this sfno_cut_point "
-                f"{self.part!r}, e.g. {missing[:5]}. The 'sfno' block must be "
-                "the donor's own module configuration."
+                f"{self.part!r}, e.g. {sorted(missing)[:5]}. The 'sfno' block "
+                "must be the donor's own module configuration."
+            )
+        if mismatched:
+            # overwrite_weights would copy the leading slice of each of these and
+            # leave the rest at its random initialization, silently producing a
+            # part that is only partly the donor's.
+            raise ValueError(
+                f"The donor checkpoint {self.donor_checkpoint!r} has "
+                f"differently-shaped weights for {len(mismatched)} parameter(s) "
+                f"of this sfno_cut_point {self.part!r}: {sorted(mismatched)[:5]}. "
+                "The usual cause is a cut-point domain whose channel count is "
+                "not embed_dim plus the donor's own input channels. For a "
+                "deliberately partial load, use parameter_init.weights_path "
+                "instead of donor_checkpoint."
             )
         destination = set(module.state_dict())
         overwrite_weights(

--- a/fme/translate/cutpoint.py
+++ b/fme/translate/cutpoint.py
@@ -1,0 +1,468 @@
+"""Cut-point decomposition of the noise-conditioned SFNO.
+
+The v2 noise-conditioned SFNO
+(:class:`fme.ace.registry.stochastic_sfno.NoiseConditionedModel` wrapping a
+:class:`SphericalFourierNeuralOperatorNet`) is a monolithic module: physical
+input channels in, physical output channels out. Two pieces of planned work
+need to open it up and use its three stages as separate pool components:
+
+- the **latent-splice** transfer arm, which keeps a donor's *processor* frozen
+  and trains new learned transforms on either side of it, replacing the
+  donor's physical-variable interface; and
+- the **multi-scale warm-start**, which initializes all three components of a
+  multi-resolution composite from a plain ACE checkpoint.
+
+This module registers one :class:`TransformSelector` entry, ``sfno_cut_point``,
+whose ``part`` field selects which stage to build. All three parts are
+configured with the same ``sfno:`` block (the donor's
+:class:`NoiseConditionedSFNOBuilder` config), and each carries the *donor's*
+``state_dict`` names for its own parameters, so any subset of the three can be
+name-matched onto a donor ACE checkpoint via ``donor_checkpoint``.
+
+Cut-point interface
+-------------------
+
+Both cut-points carry a single tensor, because that is what a pool component
+consumes and produces. Its channels are the ``embed_dim`` latent followed by
+the big-skip residual (``in_chans`` channels, absent when ``big_skip`` is
+False), so a latent domain sitting at a cut-point declares
+``embed_dim + in_chans`` channels.
+
+Stage boundaries follow the monolithic ``forward`` with one deliberate
+regrouping: the big-skip normalization (``norm_big_skip``, a
+context-conditioned layer norm) moves from where the monolith computes it
+(alongside the residual, before the encoder) into the **processor**. That
+keeps every context-conditioned operation — all the blocks plus the skip
+normalization — inside the one component that draws the noise, so composing
+the three parts reproduces the monolithic net's output *exactly* rather than
+approximately, for any configuration. ``test_cutpoint.py`` asserts that
+equivalence; it is what pins this module against changes to the net it mirrors.
+
+The parts do not change resolution. Resolution-changing operators are separate
+registry entries (``interpolate`` and its successors) that a config chains
+around a cut-point part.
+"""
+
+import dataclasses
+from typing import Literal
+
+import torch
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNOBuilder
+from fme.ace.stepper.single_module import load_weights_and_history
+from fme.core.dataset_info import DatasetInfo
+from fme.core.distributed import Distributed
+from fme.core.labels import LabelEncoding
+from fme.core.models.conditional_sfno.layers import Context
+from fme.core.models.conditional_sfno.sfnonet import SphericalFourierNeuralOperatorNet
+from fme.core.registry.module import Module
+from fme.core.weight_ops import overwrite_weights, strip_leading_module
+
+from .modules import TransformModuleConfig, TransformSelector
+
+__all__ = ["SFNOCutPointConfig"]
+
+CutPointPart = Literal["encoder", "processor", "decoder"]
+_PARTS: tuple[CutPointPart, ...] = ("encoder", "processor", "decoder")
+
+
+class _SFNOEncoder(nn.Module):
+    """The monolith's input stage: encoder stack, position embedding, dropout.
+
+    Emits the ``embed_dim`` latent concatenated with the (unnormalized)
+    big-skip residual; the processor normalizes that residual, so that the
+    noise draw conditioning it is the same one the blocks see.
+    """
+
+    def __init__(
+        self,
+        net: SphericalFourierNeuralOperatorNet,
+        embed_dim: int,
+        big_skip: bool,
+        checkpointing: int,
+        clip_latent_global_means: bool,
+        img_shape: tuple[int, int],
+    ):
+        super().__init__()
+        self.encoder = net.encoder
+        self.pos_drop = net.pos_drop
+        self.pos_embed = net.pos_embed
+        if big_skip:
+            self.residual_filter_down = net.residual_filter_down
+            self.residual_filter_up = net.residual_filter_up
+        self._big_skip = big_skip
+        self._checkpointing = checkpointing
+        self._clip_latent_global_means = clip_latent_global_means
+        self._spatial_h_slice, self._spatial_w_slice = (
+            Distributed.get_instance().get_local_slices(img_shape)
+        )
+        if clip_latent_global_means:
+            self.register_buffer(
+                "_gm_min", torch.full((1, embed_dim, 1, 1), float("inf"))
+            )
+            self.register_buffer(
+                "_gm_max", torch.full((1, embed_dim, 1, 1), float("-inf"))
+            )
+            self._gm_reset_pending: bool = False
+
+    def request_latent_global_mean_envelope_reset(self) -> None:
+        if self._clip_latent_global_means:
+            self._gm_reset_pending = True
+
+    def _apply_global_mean_clip(self, x: torch.Tensor) -> torch.Tensor:
+        global_means = x.mean(dim=(-2, -1), keepdim=True)
+        if self.training:
+            with torch.no_grad():
+                if self._gm_reset_pending:
+                    self._gm_min.fill_(float("inf"))
+                    self._gm_max.fill_(float("-inf"))
+                    self._gm_reset_pending = False
+                batch_min = global_means.detach().amin(dim=0, keepdim=True)
+                batch_max = global_means.detach().amax(dim=0, keepdim=True)
+                dist = Distributed.get_instance()
+                dist.reduce_min(batch_min)
+                dist.reduce_max(batch_max)
+                self._gm_min.copy_(torch.minimum(self._gm_min, batch_min))
+                self._gm_max.copy_(torch.maximum(self._gm_max, batch_max))
+        elif torch.isfinite(self._gm_max).all():
+            clipped = torch.clamp(global_means, min=self._gm_min, max=self._gm_max)
+            x = x + (clipped - global_means)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self._big_skip:
+            residual = self.residual_filter_up(self.residual_filter_down(x))
+        if self._checkpointing >= 1:
+            latent = checkpoint(self.encoder, x)
+        else:
+            latent = self.encoder(x)
+        if self.pos_embed is not None:
+            latent = (
+                latent
+                + self.pos_embed[..., self._spatial_h_slice, self._spatial_w_slice]
+            )
+        latent = self.pos_drop(latent)
+        if self._clip_latent_global_means:
+            latent = self._apply_global_mean_clip(latent)
+        if self._big_skip:
+            return torch.cat((latent, residual), dim=1)
+        return latent
+
+
+class _SFNOProcessor(nn.Module):
+    """The monolith's FNO blocks, plus the big-skip normalization.
+
+    Takes and returns the cut-point tensor. The residual channels pass through
+    the blocks untouched; they are normalized here (not in the encoder) so the
+    normalization and the blocks share one noise draw, as in the monolith.
+    """
+
+    def __init__(
+        self,
+        net: SphericalFourierNeuralOperatorNet,
+        embed_dim: int,
+        big_skip: bool,
+        checkpointing: int,
+    ):
+        super().__init__()
+        self.blocks = net.blocks
+        if big_skip:
+            self.norm_big_skip = net.norm_big_skip
+        self._embed_dim = embed_dim
+        self._big_skip = big_skip
+        self._checkpointing = checkpointing
+
+    def forward(self, x: torch.Tensor, context: Context) -> torch.Tensor:
+        latent = x[:, : self._embed_dim]
+        if self._big_skip:
+            residual = self.norm_big_skip(x[:, self._embed_dim :], context=context)
+        for block in self.blocks:
+            if self._checkpointing >= 3:
+                latent = checkpoint(block, latent, context)
+            else:
+                latent = block(latent, context)
+        if self._big_skip:
+            return torch.cat((latent, residual), dim=1)
+        return latent
+
+
+class _SFNODecoder(nn.Module):
+    """The monolith's output stage: decoder stack and optional output filter."""
+
+    def __init__(
+        self,
+        net: SphericalFourierNeuralOperatorNet,
+        checkpointing: int,
+        filter_output: bool,
+    ):
+        super().__init__()
+        self.decoder = net.decoder
+        if filter_output:
+            self.filter_output_down = net.filter_output_down
+            self.filter_output_up = net.filter_output_up
+        self._checkpointing = checkpointing
+        self._filter_output = filter_output
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self._checkpointing >= 1:
+            out = checkpoint(self.decoder, x)
+        else:
+            out = self.decoder(x)
+        if self._filter_output:
+            out = self.filter_output_up(self.filter_output_down(out))
+        return out
+
+
+class _UnconditionalCutPoint(nn.Module):
+    """Holds a context-free part under the donor's ``conditional_model`` name.
+
+    The encoder and decoder parts consume no context, so they need none of
+    :class:`NoiseConditionedModel`'s noise machinery — but their parameters
+    must keep the donor's ``state_dict`` names, which are nested under
+    ``conditional_model``. The leading-dimension flattening matches
+    ``NoiseConditionedModel.forward`` so all three parts accept the same
+    shapes.
+    """
+
+    def __init__(self, conditional_model: nn.Module):
+        super().__init__()
+        self.conditional_model = conditional_model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conditional_model(x.reshape(-1, *x.shape[-3:]))
+
+
+@TransformSelector.register("sfno_cut_point")
+@dataclasses.dataclass
+class SFNOCutPointConfig(TransformModuleConfig):
+    """One stage of a decomposed noise-conditioned SFNO, as a pool component.
+
+    The ``sfno`` block is the *donor's* module config: all three parts of one
+    decomposition are configured with the same block, and each builds only the
+    parameters belonging to its stage. Channel counts come from the domains, so
+    the config validates that they agree with ``sfno.embed_dim`` and
+    ``sfno.big_skip`` (see the module docstring for the cut-point channel
+    layout).
+
+    Parameters:
+        part: Which stage to build.
+        sfno: The donor's noise-conditioned SFNO configuration.
+        donor_checkpoint: Path to an ACE stepper checkpoint to name-match this
+            part's parameters against. Every parameter of the built part must
+            be present in the donor, which holds when ``sfno`` is the donor's
+            own config. Applied before ``TransformConfig.parameter_init``, so
+            an explicit ``weights_path`` still wins over the donor.
+        donor_module_index: Index into the donor stepper's ``modules`` list.
+        conditional: Whether to pass batch labels through to the context.
+            Only the processor consumes context.
+    """
+
+    part: CutPointPart
+    sfno: NoiseConditionedSFNOBuilder = dataclasses.field(
+        default_factory=NoiseConditionedSFNOBuilder
+    )
+    donor_checkpoint: str | None = None
+    donor_module_index: int = 0
+    conditional: bool = False
+
+    def __post_init__(self):
+        if self.part not in _PARTS:
+            raise ValueError(
+                f"Unknown sfno_cut_point part {self.part!r}; expected one of "
+                f"{list(_PARTS)}."
+            )
+        if self.conditional and self.part != "processor":
+            raise ValueError(
+                "Only the processor part of an sfno_cut_point consumes context, "
+                f"so conditional=True is not meaningful for the {self.part!r} "
+                "part."
+            )
+
+    def _latent_channels(self, n_in_channels: int, n_out_channels: int) -> int:
+        """The cut-point tensor's channel count, from this part's domains."""
+        return n_out_channels if self.part == "encoder" else n_in_channels
+
+    def _donor_in_channels(self, n_in_channels: int, n_out_channels: int) -> int:
+        """The donor SFNO's input channel count, from this part's domains.
+
+        Only the encoder sees it directly. The others recover it from the
+        cut-point width, which carries the big-skip residual; when there is no
+        big skip they never need it (nothing they build is sized by it).
+        """
+        if self.part == "encoder":
+            return n_in_channels
+        if not self.sfno.big_skip:
+            return 0
+        return n_in_channels - self.sfno.embed_dim
+
+    def _validate_channels(self, n_in_channels: int, n_out_channels: int) -> None:
+        embed_dim = self.sfno.embed_dim
+        latent = self._latent_channels(n_in_channels, n_out_channels)
+        if self.part == "processor" and n_in_channels != n_out_channels:
+            raise ValueError(
+                "An sfno_cut_point processor maps the cut-point to itself, so "
+                "its input and output domains must have the same number of "
+                f"channels, got {n_in_channels} and {n_out_channels}."
+            )
+        if self.sfno.big_skip:
+            if latent <= embed_dim:
+                raise ValueError(
+                    f"An sfno_cut_point {self.part!r} with big_skip expects a "
+                    f"cut-point of embed_dim ({embed_dim}) plus the donor's "
+                    f"input channels, got {latent} channels."
+                )
+            if self.part == "encoder" and latent != embed_dim + n_in_channels:
+                raise ValueError(
+                    "An sfno_cut_point encoder with big_skip emits embed_dim "
+                    f"({embed_dim}) plus its own input channels "
+                    f"({n_in_channels}) = {embed_dim + n_in_channels} channels, "
+                    f"but its output domain declares {latent}."
+                )
+        elif latent != embed_dim:
+            raise ValueError(
+                f"An sfno_cut_point {self.part!r} without big_skip expects a "
+                f"cut-point of exactly embed_dim ({embed_dim}) channels, got "
+                f"{latent}."
+            )
+
+    def _build_part(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        dataset_info: DatasetInfo,
+    ) -> nn.Module:
+        """Build the donor SFNO and keep only this part's submodules."""
+        donor_in_channels = self._donor_in_channels(n_in_channels, n_out_channels)
+        built = self.sfno.build(
+            # Stages the part discards are still constructed here, so that the
+            # ones it keeps are built exactly as the donor builds them. Only
+            # the discarded stages' channel counts are free; they must be
+            # positive.
+            n_in_channels=max(donor_in_channels, 1),
+            n_out_channels=n_out_channels if self.part == "decoder" else 1,
+            dataset_info=dataset_info,
+        )
+        net = built.conditional_model
+        if self.part == "encoder":
+            return _UnconditionalCutPoint(
+                _SFNOEncoder(
+                    net,
+                    embed_dim=self.sfno.embed_dim,
+                    big_skip=self.sfno.big_skip,
+                    checkpointing=self.sfno.checkpointing,
+                    clip_latent_global_means=self.sfno.clip_latent_global_means,
+                    img_shape=dataset_info.img_shape,
+                )
+            )
+        if self.part == "decoder":
+            return _UnconditionalCutPoint(
+                _SFNODecoder(
+                    net,
+                    checkpointing=self.sfno.checkpointing,
+                    filter_output=self.sfno.filter_output,
+                )
+            )
+        # The processor keeps NoiseConditionedModel's noise machinery (and its
+        # state_dict names) and swaps the net it wraps for the blocks alone.
+        built.conditional_model = _SFNOProcessor(
+            net,
+            embed_dim=self.sfno.embed_dim,
+            big_skip=self.sfno.big_skip,
+            checkpointing=self.sfno.checkpointing,
+        )
+        return built
+
+    def _apply_donor_weights(self, module: nn.Module) -> None:
+        weights, _ = load_weights_and_history(self.donor_checkpoint)
+        if weights is None:
+            raise ValueError(
+                f"Donor checkpoint {self.donor_checkpoint!r} contains no module "
+                "weights."
+            )
+        if self.donor_module_index >= len(weights):
+            raise ValueError(
+                f"donor_module_index {self.donor_module_index} is out of range "
+                f"for a donor stepper with {len(weights)} module(s)."
+            )
+        donor = strip_leading_module(weights[self.donor_module_index])
+        missing = sorted(
+            name for name, _ in module.named_parameters() if name not in donor
+        )
+        if missing:
+            raise ValueError(
+                f"The donor checkpoint {self.donor_checkpoint!r} has no weights "
+                f"for {len(missing)} parameter(s) of this sfno_cut_point "
+                f"{self.part!r}, e.g. {missing[:5]}. The 'sfno' block must be "
+                "the donor's own module configuration."
+            )
+        destination = set(module.state_dict())
+        overwrite_weights(
+            {name: value for name, value in donor.items() if name in destination},
+            module,
+        )
+
+    def _build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+        load_donor: bool,
+    ) -> Module:
+        if in_dataset_info.img_shape != out_dataset_info.img_shape:
+            raise ValueError(
+                "An sfno_cut_point part does not change resolution, but got "
+                f"input grid {in_dataset_info.img_shape} and output grid "
+                f"{out_dataset_info.img_shape}. Chain it with a "
+                "resolution-changing transform instead."
+            )
+        if self.conditional and len(in_dataset_info.all_labels) == 0:
+            raise ValueError("Conditional predictions require labels")
+        self._validate_channels(n_in_channels, n_out_channels)
+        module = self._build_part(n_in_channels, n_out_channels, in_dataset_info)
+        if load_donor and self.donor_checkpoint is not None:
+            self._apply_donor_weights(module)
+        label_encoding = (
+            LabelEncoding(sorted(in_dataset_info.all_labels))
+            if self.conditional
+            else None
+        )
+        return Module(module, label_encoding=label_encoding)
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        return self._build(
+            n_in_channels,
+            n_out_channels,
+            in_dataset_info,
+            out_dataset_info,
+            load_donor=True,
+        )
+
+    def build_for_load(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        """Build without reading the donor checkpoint.
+
+        The weights are about to be restored from a saved state, so the donor
+        is not consulted — the component reloads without the donor checkpoint
+        still existing.
+        """
+        return self._build(
+            n_in_channels,
+            n_out_channels,
+            in_dataset_info,
+            out_dataset_info,
+            load_donor=False,
+        )

--- a/fme/translate/cutpoint.py
+++ b/fme/translate/cutpoint.py
@@ -45,6 +45,29 @@ blocks is ``pos_drop``, which is an ``nn.Identity`` because
 ``NoiseConditionedSFNOBuilder`` does not expose ``drop_rate``. The equivalence
 test runs the parts in training mode, so it fails if that stops being true.
 
+Why this mirrors ``forward`` instead of reusing it
+-------------------------------------------------
+
+The stage forwards below restate the monolith's control flow, which is
+duplication worth being uncomfortable about. Both ways of avoiding it are
+closed, so it is a considered choice rather than the easy one:
+
+- **Split ``forward`` into three methods and have each part hold a net and call
+  one of them.** A part holding a net holds *all* of its parameters, which
+  destroys the property the tests assert — that the three parts partition the
+  donor's parameters — and costs a 3x checkpoint, dead parameters in the
+  optimizer and EMA, and DDP unused-parameter errors. Stripping the unused
+  stages out of each net afterwards encodes the same structural knowledge this
+  module does, and leaves a net whose own ``forward`` no longer works.
+- **Make each stage its own ``nn.Module`` inside ``sfnonet.py``.** Owning the
+  stages as submodules adds a level of ``state_dict`` nesting whatever they are
+  named, so every existing SFNO checkpoint fails to load — the one hard
+  backwards-compatibility guarantee in AGENTS.md.
+
+So the mirror is pinned by the bit-exactness test rather than by construction,
+and ``SphericalFourierNeuralOperatorNet.forward`` carries a comment pointing
+here so the coupling is visible from the side that gets edited.
+
 The parts do not change resolution. Resolution-changing operators are separate
 registry entries (``interpolate`` and its successors) that a config chains
 around a cut-point part.

--- a/fme/translate/cutpoint.py
+++ b/fme/translate/cutpoint.py
@@ -459,7 +459,11 @@ class SFNOCutPointConfig(TransformModuleConfig):
                 f"The donor checkpoint {self.donor_checkpoint!r} has no weights "
                 f"for {len(missing)} parameter(s) of this sfno_cut_point "
                 f"{self.part!r}, e.g. {sorted(missing)[:5]}. The 'sfno' block "
-                "must be the donor's own module configuration."
+                "must be the donor's own module configuration. To add "
+                "parameters the donor does not have (LoRA adapters over a "
+                "non-LoRA donor, say), point parameter_init.weights_path at a "
+                "state_dict filtered to this part's names instead; it accepts "
+                "a subset, whereas donor_checkpoint requires an exact match."
             )
         if mismatched:
             # overwrite_weights would copy the leading slice of each of these and
@@ -469,10 +473,11 @@ class SFNOCutPointConfig(TransformModuleConfig):
                 f"The donor checkpoint {self.donor_checkpoint!r} has "
                 f"differently-shaped weights for {len(mismatched)} parameter(s) "
                 f"of this sfno_cut_point {self.part!r}: {sorted(mismatched)[:5]}. "
-                "The usual cause is a cut-point domain whose channel count is "
-                "not embed_dim plus the donor's own input channels. For a "
-                "deliberately partial load, use parameter_init.weights_path "
-                "instead of donor_checkpoint."
+                "The usual cause is an 'sfno' block that is not the donor's own "
+                "module configuration. For a deliberate partial load, point "
+                "parameter_init.weights_path at a state_dict filtered to this "
+                "part's parameter names; it accepts a subset of them, whereas "
+                "donor_checkpoint requires an exact match."
             )
         destination = set(module.state_dict())
         overwrite_weights(

--- a/fme/translate/cutpoint.py
+++ b/fme/translate/cutpoint.py
@@ -51,6 +51,7 @@ around a cut-point part.
 """
 
 import dataclasses
+from collections.abc import Mapping
 from typing import Literal
 
 import torch
@@ -73,6 +74,11 @@ __all__ = ["SFNOCutPointConfig"]
 
 CutPointPart = Literal["encoder", "processor", "decoder"]
 _PARTS: tuple[CutPointPart, ...] = ("encoder", "processor", "decoder")
+
+# The donor's first encoder convolution, whose input axis is the donor's own
+# input channel count. Present for any encoder_layers, and in every part's
+# donor checkpoint whether or not that part keeps the encoder.
+_DONOR_INPUT_WEIGHT = "conditional_model.encoder.0.weight"
 
 
 class _SFNOEncoder(nn.Module):
@@ -389,7 +395,38 @@ class SFNOCutPointConfig(TransformModuleConfig):
         )
         return built
 
-    def _apply_donor_weights(self, module: nn.Module) -> None:
+    def _validate_donor_width(
+        self, donor: Mapping[str, torch.Tensor], latent: int
+    ) -> None:
+        """Check the cut-point width against the donor's own input width.
+
+        The per-parameter shape check below catches a mis-declared cut-point
+        only when some parameter of *this* part is sized by the donor's input
+        channels. A lone processor — the latent-splice arm's central config —
+        keeps nothing sized by them unless ``normalize_big_skip`` is set, so
+        without this the arm's own configuration is the one case where an
+        over-wide latent domain passes silently. The donor's first encoder
+        convolution carries the width whether or not this part keeps it.
+        """
+        donor_input_weight = donor.get(_DONOR_INPUT_WEIGHT)
+        if donor_input_weight is None:
+            return
+        donor_in_channels = donor_input_weight.shape[1]
+        expected = self.sfno.embed_dim + (
+            donor_in_channels if self.sfno.big_skip else 0
+        )
+        if latent != expected:
+            raise ValueError(
+                f"An sfno_cut_point {self.part!r} loading donor "
+                f"{self.donor_checkpoint!r} sits at a cut-point of {latent} "
+                f"channels, but that donor takes {donor_in_channels} input "
+                f"channels, so its cut-point is {expected} "
+                f"(embed_dim {self.sfno.embed_dim}"
+                + (f" + {donor_in_channels}" if self.sfno.big_skip else "")
+                + ")."
+            )
+
+    def _apply_donor_weights(self, module: nn.Module, latent: int) -> None:
         weights, _ = load_weights_and_history(self.donor_checkpoint)
         if weights is None:
             raise ValueError(
@@ -402,6 +439,7 @@ class SFNOCutPointConfig(TransformModuleConfig):
                 f"for a donor stepper with {len(weights)} module(s)."
             )
         donor = strip_leading_module(weights[self.donor_module_index])
+        self._validate_donor_width(donor, latent)
         missing = []
         mismatched = []
         for name, parameter in module.named_parameters():
@@ -458,7 +496,9 @@ class SFNOCutPointConfig(TransformModuleConfig):
         self._validate_channels(n_in_channels, n_out_channels)
         module = self._build_part(n_in_channels, n_out_channels, in_dataset_info)
         if load_donor and self.donor_checkpoint is not None:
-            self._apply_donor_weights(module)
+            self._apply_donor_weights(
+                module, self._latent_channels(n_in_channels, n_out_channels)
+            )
         label_encoding = (
             LabelEncoding(sorted(in_dataset_info.all_labels))
             if self.conditional

--- a/fme/translate/cutpoint.py
+++ b/fme/translate/cutpoint.py
@@ -365,33 +365,37 @@ class SFNOCutPointConfig(TransformModuleConfig):
             n_out_channels=n_out_channels if self.part == "decoder" else 1,
             dataset_info=dataset_info,
         )
+        # Every shape and flag a part needs comes off the net it is built from,
+        # not from this config, so a part cannot disagree with the net whose
+        # submodules it holds. clip_latent_global_means is the exception: the
+        # net keeps it private, so it is read from the config.
         net = built.conditional_model
         if self.part == "encoder":
             return _UnconditionalCutPoint(
                 _SFNOEncoder(
                     net,
-                    embed_dim=self.sfno.embed_dim,
-                    big_skip=self.sfno.big_skip,
-                    checkpointing=self.sfno.checkpointing,
+                    embed_dim=net.embed_dim,
+                    big_skip=net.big_skip,
+                    checkpointing=net.checkpointing,
                     clip_latent_global_means=self.sfno.clip_latent_global_means,
-                    img_shape=dataset_info.img_shape,
+                    img_shape=net.img_shape,
                 )
             )
         if self.part == "decoder":
             return _UnconditionalCutPoint(
                 _SFNODecoder(
                     net,
-                    checkpointing=self.sfno.checkpointing,
-                    filter_output=self.sfno.filter_output,
+                    checkpointing=net.checkpointing,
+                    filter_output=net.filter_output,
                 )
             )
         # The processor keeps NoiseConditionedModel's noise machinery (and its
         # state_dict names) and swaps the net it wraps for the blocks alone.
         built.conditional_model = _SFNOProcessor(
             net,
-            embed_dim=self.sfno.embed_dim,
-            big_skip=self.sfno.big_skip,
-            checkpointing=self.sfno.checkpointing,
+            embed_dim=net.embed_dim,
+            big_skip=net.big_skip,
+            checkpointing=net.checkpointing,
         )
         return built
 

--- a/fme/translate/examples/README.md
+++ b/fme/translate/examples/README.md
@@ -15,10 +15,11 @@ to let the critique drive the design — they are not runnable.
 | `inference:` composites (one-backbone component chains, Stepper-compatible export) | 4 |
 | `latent_consistency` objective type, noise-conditioned encoder and latent-resampler registry entries | 6 |
 
-PR 5 (SFNO cut-point decomposition) doesn't appear in either config: it
-would show up as `parameter_init.weights_path` warm-starts on
-encoder/backbone/decoder, and as a bare-processor backbone in the
-latent-splice transfer variant.
+PR 5 (SFNO cut-point decomposition) doesn't appear in either config. It
+shows up as `sfno_cut_point` transforms with a `donor_checkpoint` — one
+per stage for the multi-scale warm-start, or the processor alone for the
+latent-splice transfer variant — over a latent domain declaring
+`embed_dim` plus the donor's input channels.
 
 - [multi-resolution-latent.yaml](multi-resolution-latent.yaml) —
   1°/2°/4° encoders/decoders into per-resolution latent domains, learned

--- a/fme/translate/modules.py
+++ b/fme/translate/modules.py
@@ -65,6 +65,26 @@ class TransformModuleConfig(abc.ABC):
         """
         ...
 
+    def build_for_load(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        """Build a module whose weights are about to be restored from a state.
+
+        Defaults to :meth:`build`. Override in builders that read an external
+        checkpoint at build time, so that reloading a saved component does not
+        depend on that checkpoint still existing.
+        """
+        return self.build(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            in_dataset_info=in_dataset_info,
+            out_dataset_info=out_dataset_info,
+        )
+
     @classmethod
     def from_state(cls, state: Mapping[str, Any]) -> "TransformModuleConfig":
         return dacite.from_dict(
@@ -106,6 +126,20 @@ class TransformSelector:
         out_dataset_info: DatasetInfo,
     ) -> Module:
         return self._instance.build(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            in_dataset_info=in_dataset_info,
+            out_dataset_info=out_dataset_info,
+        )
+
+    def build_for_load(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        in_dataset_info: DatasetInfo,
+        out_dataset_info: DatasetInfo,
+    ) -> Module:
+        return self._instance.build_for_load(
             n_in_channels=n_in_channels,
             n_out_channels=n_out_channels,
             in_dataset_info=in_dataset_info,

--- a/fme/translate/test_cutpoint.py
+++ b/fme/translate/test_cutpoint.py
@@ -1,0 +1,430 @@
+import dataclasses
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+from fme.ace.stepper.parameter_init import (
+    FrozenParameterConfig,
+    ParameterClassification,
+    ParameterInitializationConfig,
+)
+from fme.ace.stepper.single_module import Stepper, StepperConfig
+from fme.core.dataset_info import DatasetInfo
+from fme.core.registry.module import Module, ModuleSelector
+from fme.core.step import SingleModuleStepConfig, StepSelector
+from fme.core.testing import get_dataset_info, trivial_network_and_loss_normalization
+from fme.core.weight_ops import strip_leading_module
+from fme.translate.components import ComponentPool, ComponentPoolConfig, TransformConfig
+from fme.translate.cutpoint import SFNOCutPointConfig
+from fme.translate.domains import DomainConfig, LatentChannels
+from fme.translate.modules import TransformSelector
+
+IMG_SHAPE = (8, 16)
+EMBED_DIM = 4
+DONOR_NAMES = ["a", "b"]
+PARTS = ("encoder", "processor", "decoder")
+
+
+def _sfno_config(**overrides: Any) -> dict[str, Any]:
+    """A tiny noise-conditioned SFNO configuration, shared by donor and parts."""
+    return {
+        "embed_dim": EMBED_DIM,
+        "num_layers": 2,
+        "noise_embed_dim": 3,
+        **overrides,
+    }
+
+
+def _latent_channels(sfno: Mapping[str, Any]) -> int:
+    """The cut-point width: the latent, plus the big-skip residual."""
+    if sfno.get("big_skip", True):
+        return EMBED_DIM + len(DONOR_NAMES)
+    return EMBED_DIM
+
+
+def _dataset_info() -> DatasetInfo:
+    return get_dataset_info(img_shape=IMG_SHAPE)
+
+
+def _donor_stepper(sfno: Mapping[str, Any]) -> Stepper:
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="NoiseConditionedSFNO", config=dict(sfno)
+                    ),
+                    in_names=list(DONOR_NAMES),
+                    out_names=list(DONOR_NAMES),
+                    normalization=trivial_network_and_loss_normalization(DONOR_NAMES),
+                )
+            ),
+        ),
+    )
+    return config.get_stepper(dataset_info=_dataset_info())
+
+
+def _donor_checkpoint(tmp_path, sfno: Mapping[str, Any]) -> tuple[str, nn.Module]:
+    """Save a donor stepper checkpoint; return its path and monolithic module."""
+    stepper = _donor_stepper(sfno)
+    path = str(tmp_path / "donor.ckpt")
+    torch.save({"stepper": stepper.get_state()}, path)
+    return path, stepper.modules[0]
+
+
+def _part_config(
+    part: str, sfno: Mapping[str, Any], **overrides: Any
+) -> TransformSelector:
+    return TransformSelector(
+        type="sfno_cut_point",
+        config={"part": part, "sfno": dict(sfno), **overrides},
+    )
+
+
+def _build_part(
+    part: str,
+    sfno: Mapping[str, Any],
+    donor_checkpoint: str | None = None,
+    for_load: bool = False,
+) -> Module:
+    latent = _latent_channels(sfno)
+    n_in, n_out = {
+        "encoder": (len(DONOR_NAMES), latent),
+        "processor": (latent, latent),
+        "decoder": (latent, len(DONOR_NAMES)),
+    }[part]
+    selector = _part_config(part, sfno, donor_checkpoint=donor_checkpoint)
+    build = selector.build_for_load if for_load else selector.build
+    info = _dataset_info()
+    return build(
+        n_in_channels=n_in,
+        n_out_channels=n_out,
+        in_dataset_info=info,
+        out_dataset_info=info,
+    )
+
+
+def _build_parts(
+    sfno: Mapping[str, Any], donor_checkpoint: str | None = None
+) -> dict[str, Module]:
+    return {part: _build_part(part, sfno, donor_checkpoint) for part in PARTS}
+
+
+def _compose(parts: Mapping[str, Module], x: torch.Tensor) -> torch.Tensor:
+    return parts["decoder"](parts["processor"](parts["encoder"](x)))
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({}, id="defaults"),
+        pytest.param({"normalize_big_skip": True}, id="normalized_big_skip"),
+        pytest.param(
+            {"normalize_big_skip": True, "affine_norms": True}, id="affine_norms"
+        ),
+        pytest.param({"big_skip": False}, id="no_big_skip"),
+        pytest.param(
+            {"big_skip": False, "normalize_big_skip": True}, id="no_big_skip_normalized"
+        ),
+        pytest.param({"filter_output": True}, id="filter_output"),
+        pytest.param(
+            {"filter_residual": True, "normalize_big_skip": True}, id="filter_residual"
+        ),
+        pytest.param({"pos_embed": False}, id="no_pos_embed"),
+        pytest.param({"encoder_layers": 2}, id="encoder_layers"),
+        pytest.param({"noise_type": "isotropic"}, id="isotropic_noise"),
+        pytest.param(
+            {"global_layer_norm": True, "normalize_big_skip": True},
+            id="global_layer_norm",
+        ),
+        pytest.param(
+            {"context_pos_embed_dim": 2, "pos_embed": False}, id="context_pos_embed"
+        ),
+    ],
+)
+def test_composed_parts_reproduce_the_donor(tmp_path, overrides):
+    """encoder -> processor -> decoder is the monolithic net, to the bit.
+
+    This is the property that makes the decomposition a decomposition: it holds
+    only because every context-conditioned operation (the blocks and, when
+    configured, the big-skip normalization) sits in the processor, so the
+    composed path draws noise exactly once, as the monolith does.
+    """
+    sfno = _sfno_config(**overrides)
+    checkpoint, donor = _donor_checkpoint(tmp_path, sfno)
+    parts = _build_parts(sfno, donor_checkpoint=checkpoint)
+    x = torch.randn(3, len(DONOR_NAMES), *IMG_SHAPE)
+
+    torch.manual_seed(0)
+    expected = donor(x)
+    torch.manual_seed(0)
+    result = _compose(parts, x)
+
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+
+def test_parts_partition_the_donor_parameters(tmp_path):
+    """Every donor parameter lands in exactly one part."""
+    sfno = _sfno_config(normalize_big_skip=True)
+    _, donor = _donor_checkpoint(tmp_path, sfno)
+    donor_names = {name.removeprefix("module.") for name, _ in donor.named_parameters()}
+    part_names = {
+        part: {name for name, _ in module.torch_module.named_parameters()}
+        for part, module in _build_parts(sfno).items()
+    }
+
+    assert set().union(*part_names.values()) == donor_names
+    for first, second in [
+        ("encoder", "processor"),
+        ("encoder", "decoder"),
+        ("processor", "decoder"),
+    ]:
+        assert not part_names[first] & part_names[second]
+
+
+@pytest.mark.parametrize("part", PARTS)
+def test_donor_checkpoint_initializes_the_part(tmp_path, part):
+    sfno = _sfno_config(normalize_big_skip=True)
+    checkpoint, donor = _donor_checkpoint(tmp_path, sfno)
+    donor_state = strip_leading_module(donor.state_dict())
+
+    initialized = _build_part(part, sfno, donor_checkpoint=checkpoint)
+    for name, parameter in initialized.torch_module.named_parameters():
+        torch.testing.assert_close(parameter, donor_state[name], rtol=0, atol=0)
+
+    # Without the donor the part is randomly initialized, so the check above
+    # is not vacuous.
+    fresh = _build_part(part, sfno)
+    assert any(
+        not torch.equal(parameter, donor_state[name])
+        for name, parameter in fresh.torch_module.named_parameters()
+    )
+
+
+def test_build_for_load_ignores_the_donor_checkpoint(tmp_path):
+    """A saved component reloads without its donor checkpoint still existing."""
+    sfno = _sfno_config()
+    checkpoint, _ = _donor_checkpoint(tmp_path, sfno)
+    (tmp_path / "donor.ckpt").unlink()
+
+    with pytest.raises(FileNotFoundError):
+        _build_part("processor", sfno, donor_checkpoint=checkpoint)
+    _build_part("processor", sfno, donor_checkpoint=checkpoint, for_load=True)
+
+
+def test_donor_missing_part_weights_raises(tmp_path):
+    """A part configured differently from the donor is not silently accepted."""
+    checkpoint, _ = _donor_checkpoint(tmp_path, _sfno_config(num_layers=2))
+
+    with pytest.raises(ValueError, match="no weights for"):
+        _build_part("processor", _sfno_config(num_layers=3), checkpoint)
+
+
+@pytest.mark.parametrize(
+    "part, n_in_channels, n_out_channels, sfno_overrides, match",
+    [
+        pytest.param(
+            "encoder",
+            2,
+            EMBED_DIM + 3,
+            {},
+            "plus its own input channels",
+            id="encoder_out",
+        ),
+        pytest.param(
+            "processor",
+            EMBED_DIM + 2,
+            EMBED_DIM + 3,
+            {},
+            "same number of channels",
+            id="processor_asymmetric",
+        ),
+        pytest.param(
+            "decoder",
+            EMBED_DIM,
+            2,
+            {},
+            "plus the donor's input channels",
+            id="decoder_missing_skip",
+        ),
+        pytest.param(
+            "decoder",
+            EMBED_DIM + 2,
+            2,
+            {"big_skip": False},
+            "exactly embed_dim",
+            id="decoder_unexpected_skip",
+        ),
+    ],
+)
+def test_channel_mismatch_raises(
+    part, n_in_channels, n_out_channels, sfno_overrides, match
+):
+    info = _dataset_info()
+    with pytest.raises(ValueError, match=match):
+        _part_config(part, _sfno_config(**sfno_overrides)).build(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            in_dataset_info=info,
+            out_dataset_info=info,
+        )
+
+
+def test_resolution_change_raises():
+    """Cut-point parts stay on one grid; resizing is a separate transform."""
+    with pytest.raises(ValueError, match="does not change resolution"):
+        _part_config("encoder", _sfno_config()).build(
+            n_in_channels=len(DONOR_NAMES),
+            n_out_channels=EMBED_DIM + len(DONOR_NAMES),
+            in_dataset_info=get_dataset_info(img_shape=IMG_SHAPE),
+            out_dataset_info=get_dataset_info(img_shape=(4, 8)),
+        )
+
+
+@pytest.mark.parametrize("part", ["encoder", "decoder"])
+def test_conditional_rejected_for_context_free_parts(part):
+    with pytest.raises(ValueError, match="conditional=True is not meaningful"):
+        _part_config(part, _sfno_config(), conditional=True)
+
+
+def test_unknown_part_raises():
+    with pytest.raises(ValueError, match="Unknown sfno_cut_point part"):
+        SFNOCutPointConfig(part="processer")  # type: ignore[arg-type]
+
+
+def test_latent_global_mean_clip_matches_the_donor(tmp_path):
+    """The clip envelope tracks and applies as it does in the monolith."""
+    sfno = _sfno_config(clip_latent_global_means=True)
+    checkpoint, donor = _donor_checkpoint(tmp_path, sfno)
+    parts = _build_parts(sfno, donor_checkpoint=checkpoint)
+    modules = [donor, *(part.torch_module for part in parts.values())]
+
+    training = torch.randn(4, len(DONOR_NAMES), *IMG_SHAPE)
+    for module in modules:
+        module.train()
+    torch.manual_seed(0)
+    donor(training)
+    torch.manual_seed(0)
+    _compose(parts, training)
+
+    # The same decomposition with clipping off, to show the clip is not a no-op
+    # for an input far outside the envelope the training forward established.
+    unclipped = _build_parts(_sfno_config(), donor_checkpoint=checkpoint)
+    x = torch.randn(2, len(DONOR_NAMES), *IMG_SHAPE) + 50.0
+    for module in modules:
+        module.eval()
+
+    torch.manual_seed(1)
+    expected = donor(x)
+    torch.manual_seed(1)
+    result = _compose(parts, x)
+    torch.manual_seed(1)
+    without_clip = _compose(unclipped, x)
+
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+    assert not torch.allclose(result, without_clip)
+
+
+def _cut_point_pool_config(
+    checkpoint: str | None = None,
+    freeze_processor: bool = False,
+) -> ComponentPoolConfig:
+    """A pool holding one full decomposition: physical -> latent -> physical."""
+    sfno = _sfno_config()
+    frozen = (
+        ParameterInitializationConfig(
+            parameters=[
+                ParameterClassification(frozen=FrozenParameterConfig(include=["*"]))
+            ]
+        )
+        if freeze_processor
+        else ParameterInitializationConfig()
+    )
+    return ComponentPoolConfig(
+        domains={
+            "physical": DomainConfig(channels=list(DONOR_NAMES)),
+            "latent": DomainConfig(
+                channels=[LatentChannels(name="z", channels=_latent_channels(sfno))],
+                grid_like="physical",
+            ),
+        },
+        transforms={
+            "encoder": TransformConfig(
+                _part_config("encoder", sfno, donor_checkpoint=checkpoint),
+                "physical",
+                "latent",
+            ),
+            "processor": TransformConfig(
+                _part_config("processor", sfno, donor_checkpoint=checkpoint),
+                "latent",
+                "latent",
+                parameter_init=frozen,
+            ),
+            "decoder": TransformConfig(
+                _part_config("decoder", sfno, donor_checkpoint=checkpoint),
+                "latent",
+                "physical",
+            ),
+        },
+    )
+
+
+def test_pool_builds_a_decomposition_with_a_frozen_processor(tmp_path):
+    """The latent-splice shape: a frozen donor processor between trained parts."""
+    checkpoint, donor = _donor_checkpoint(tmp_path, _sfno_config())
+    pool = _cut_point_pool_config(checkpoint, freeze_processor=True).build(
+        {"physical": _dataset_info()}
+    )
+
+    donor_state = strip_leading_module(donor.state_dict())
+    processor = pool.transforms["processor"].torch_module
+    assert not any(parameter.requires_grad for parameter in processor.parameters())
+    for name, parameter in strip_leading_module(processor.state_dict()).items():
+        torch.testing.assert_close(parameter, donor_state[name], rtol=0, atol=0)
+    for name in ("encoder", "decoder"):
+        assert all(
+            parameter.requires_grad
+            for parameter in pool.transforms[name].torch_module.parameters()
+        )
+
+
+def test_pool_state_round_trips_without_the_donor(tmp_path):
+    checkpoint, _ = _donor_checkpoint(tmp_path, _sfno_config())
+    pool = _cut_point_pool_config(checkpoint).build({"physical": _dataset_info()})
+    state = pool.get_state()
+    (tmp_path / "donor.ckpt").unlink()
+
+    reloaded = ComponentPool.from_state(state)
+
+    x = torch.randn(2, len(DONOR_NAMES), *IMG_SHAPE)
+    torch.manual_seed(0)
+    expected = _compose(pool.transforms, x)
+    torch.manual_seed(0)
+    result = _compose(reloaded.transforms, x)
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+
+def test_pool_set_epoch_resets_the_clip_envelope():
+    """A cut-point encoder in the pool gets the per-epoch envelope reset."""
+    sfno = _sfno_config(clip_latent_global_means=True)
+    encoder = _build_part("encoder", sfno)
+    pool = ComponentPool(
+        config=ComponentPoolConfig(),
+        transforms={"encoder": encoder},
+        backbones={},
+        dataset_info={"physical": _dataset_info()},
+    )
+    part = encoder.torch_module.conditional_model
+
+    encoder.torch_module.train()
+    encoder(torch.randn(2, len(DONOR_NAMES), *IMG_SHAPE))
+    assert torch.isfinite(part._gm_max).all()
+
+    pool.set_epoch(1)
+    assert part._gm_reset_pending
+    encoder(torch.randn(2, len(DONOR_NAMES), *IMG_SHAPE))
+    assert not part._gm_reset_pending

--- a/fme/translate/test_cutpoint.py
+++ b/fme/translate/test_cutpoint.py
@@ -40,9 +40,10 @@ def _sfno_config(**overrides: Any) -> dict[str, Any]:
 
 def _latent_channels(sfno: Mapping[str, Any]) -> int:
     """The cut-point width: the latent, plus the big-skip residual."""
+    embed_dim = sfno.get("embed_dim", EMBED_DIM)
     if sfno.get("big_skip", True):
-        return EMBED_DIM + len(DONOR_NAMES)
-    return EMBED_DIM
+        return embed_dim + len(DONOR_NAMES)
+    return embed_dim
 
 
 def _dataset_info() -> DatasetInfo:
@@ -245,33 +246,51 @@ def test_donor_missing_part_weights_raises(tmp_path):
         _build_part("processor", _sfno_config(num_layers=3), checkpoint)
 
 
-@pytest.mark.parametrize("part", ["encoder", "decoder"])
-def test_donor_shape_mismatch_raises(tmp_path, part):
+@pytest.mark.parametrize("part", PARTS)
+@pytest.mark.parametrize("normalize_big_skip", [False, True])
+def test_donor_cut_point_width_mismatch_raises(tmp_path, part, normalize_big_skip):
     """A too-wide cut-point is not silently loaded a leading slice at a time.
 
     ``overwrite_weights`` copies the initial slice when the destination axis is
-    longer, so without a shape check a cut-point domain declaring more than
-    ``embed_dim`` plus the donor's input channels would build a part that is
-    only partly the donor's, with no error.
+    longer, so a cut-point domain declaring more than ``embed_dim`` plus the
+    donor's input channels would otherwise build a part that is only partly the
+    donor's, with no error. A lone processor is the case the per-parameter shape
+    check cannot see: with ``normalize_big_skip`` off it keeps no parameter
+    sized by the donor's input channels at all.
     """
-    sfno = _sfno_config()
+    sfno = _sfno_config(normalize_big_skip=normalize_big_skip)
     checkpoint, _ = _donor_checkpoint(tmp_path, sfno)
     # One channel more than the donor has, declared self-consistently so that
-    # _validate_channels passes and only the donor's shapes disagree.
+    # _validate_channels passes and only the donor disagrees.
     wide_physical = len(DONOR_NAMES) + 1
+    wide_latent = EMBED_DIM + wide_physical
     n_in, n_out = {
-        "encoder": (wide_physical, EMBED_DIM + wide_physical),
-        "decoder": (EMBED_DIM + wide_physical, len(DONOR_NAMES)),
+        "encoder": (wide_physical, wide_latent),
+        "processor": (wide_latent, wide_latent),
+        "decoder": (wide_latent, len(DONOR_NAMES)),
     }[part]
     info = _dataset_info()
 
-    with pytest.raises(ValueError, match="differently-shaped weights"):
+    with pytest.raises(ValueError, match="that donor takes"):
         _part_config(part, sfno, donor_checkpoint=checkpoint).build(
             n_in_channels=n_in,
             n_out_channels=n_out,
             in_dataset_info=info,
             out_dataset_info=info,
         )
+
+
+@pytest.mark.parametrize("part", PARTS)
+def test_donor_shape_mismatch_raises(tmp_path, part):
+    """A donor whose stage is shaped differently is rejected, not sliced.
+
+    A mismatched ``embed_dim`` leaves the cut-point width self-consistent, so
+    only the per-parameter shapes give the mismatch away.
+    """
+    checkpoint, _ = _donor_checkpoint(tmp_path, _sfno_config(embed_dim=EMBED_DIM))
+
+    with pytest.raises(ValueError, match="differently-shaped weights"):
+        _build_part(part, _sfno_config(embed_dim=EMBED_DIM + 1), checkpoint)
 
 
 @pytest.mark.parametrize(

--- a/fme/translate/test_cutpoint.py
+++ b/fme/translate/test_cutpoint.py
@@ -144,6 +144,11 @@ def _compose(parts: Mapping[str, Module], x: torch.Tensor) -> torch.Tensor:
         pytest.param(
             {"context_pos_embed_dim": 2, "pos_embed": False}, id="context_pos_embed"
         ),
+        # The parts mirror the monolith's checkpointing levels (>=1 wraps the
+        # encoder and decoder stacks, >=3 each block), so each level is a
+        # separate path through the mirrored forward.
+        pytest.param({"checkpointing": 1}, id="checkpointing_encoder_decoder"),
+        pytest.param({"checkpointing": 3}, id="checkpointing_blocks"),
     ],
 )
 def test_composed_parts_reproduce_the_donor(tmp_path, overrides):
@@ -164,6 +169,22 @@ def test_composed_parts_reproduce_the_donor(tmp_path, overrides):
     torch.manual_seed(0)
     result = _compose(parts, x)
 
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+
+def test_composed_parts_accept_an_ensemble_dimension(tmp_path):
+    """The parts flatten leading dimensions as ``NoiseConditionedModel`` does."""
+    sfno = _sfno_config()
+    checkpoint, donor = _donor_checkpoint(tmp_path, sfno)
+    parts = _build_parts(sfno, donor_checkpoint=checkpoint)
+    x = torch.randn(3, 2, len(DONOR_NAMES), *IMG_SHAPE)
+
+    torch.manual_seed(0)
+    expected = donor(x)
+    torch.manual_seed(0)
+    result = _compose(parts, x)
+
+    assert result.shape == (6, len(DONOR_NAMES), *IMG_SHAPE)
     torch.testing.assert_close(result, expected, rtol=0, atol=0)
 
 
@@ -222,6 +243,35 @@ def test_donor_missing_part_weights_raises(tmp_path):
 
     with pytest.raises(ValueError, match="no weights for"):
         _build_part("processor", _sfno_config(num_layers=3), checkpoint)
+
+
+@pytest.mark.parametrize("part", ["encoder", "decoder"])
+def test_donor_shape_mismatch_raises(tmp_path, part):
+    """A too-wide cut-point is not silently loaded a leading slice at a time.
+
+    ``overwrite_weights`` copies the initial slice when the destination axis is
+    longer, so without a shape check a cut-point domain declaring more than
+    ``embed_dim`` plus the donor's input channels would build a part that is
+    only partly the donor's, with no error.
+    """
+    sfno = _sfno_config()
+    checkpoint, _ = _donor_checkpoint(tmp_path, sfno)
+    # One channel more than the donor has, declared self-consistently so that
+    # _validate_channels passes and only the donor's shapes disagree.
+    wide_physical = len(DONOR_NAMES) + 1
+    n_in, n_out = {
+        "encoder": (wide_physical, EMBED_DIM + wide_physical),
+        "decoder": (EMBED_DIM + wide_physical, len(DONOR_NAMES)),
+    }[part]
+    info = _dataset_info()
+
+    with pytest.raises(ValueError, match="differently-shaped weights"):
+        _part_config(part, sfno, donor_checkpoint=checkpoint).build(
+            n_in_channels=n_in,
+            n_out_channels=n_out,
+            in_dataset_info=info,
+            out_dataset_info=info,
+        )
 
 
 @pytest.mark.parametrize(

--- a/fme/translate/test_cutpoint.py
+++ b/fme/translate/test_cutpoint.py
@@ -150,6 +150,15 @@ def _compose(parts: Mapping[str, Module], x: torch.Tensor) -> torch.Tensor:
         # separate path through the mirrored forward.
         pytest.param({"checkpointing": 1}, id="checkpointing_encoder_decoder"),
         pytest.param({"checkpointing": 3}, id="checkpointing_blocks"),
+        # Block-internal options. These sit wholly inside the processor, so they
+        # cannot reach the stage boundaries — covered so that argument does not
+        # have to be re-made by hand whenever a block option is added.
+        pytest.param({"use_mlp": False}, id="no_mlp"),
+        pytest.param({"lora_rank": 2}, id="lora"),
+        pytest.param({"filter_num_groups": 2}, id="filter_groups"),
+        pytest.param({"spectral_ratio": 0.5}, id="spectral_ratio"),
+        pytest.param({"local_blocks": [0]}, id="local_blocks"),
+        pytest.param({"filter_type": "makani-linear"}, id="makani_filter"),
     ],
 )
 def test_composed_parts_reproduce_the_donor(tmp_path, overrides):


### PR DESCRIPTION
The latent-splice transfer arm needs a donor's SFNO *processor* frozen between
learned transforms that replace the donor's physical-variable interface, and
the multi-scale warm-start needs all three of a composite's stages initialized
from a plain ACE checkpoint. Both need the monolithic noise-conditioned SFNO
opened up into separately-buildable, separately-freezable pool components whose
parameters keep the donor's `state_dict` names, so any subset of the three can
be name-matched onto a donor checkpoint.

`sfno_cut_point` is one `TransformSelector` entry with a `part` field selecting
the stage. All three parts are configured with the same `sfno:` block — the
donor's own `NoiseConditionedSFNOBuilder` config — and each builds only the
parameters belonging to its stage; together they partition the donor's
parameters exactly. Channel counts come from the domains and are validated
against `embed_dim`/`big_skip`, and against the donor's own input width when a
`donor_checkpoint` is configured.

Both cut-points carry a single tensor, because that is what a pool component
consumes and produces: the `embed_dim` latent followed by the big-skip residual
(absent when `big_skip` is False), so a latent domain at a cut-point declares
`embed_dim + in_chans` channels. Stage boundaries follow the monolithic
`forward` with one deliberate regrouping — the context-conditioned big-skip
normalization moves from the encoder (where the monolith computes it) into the
processor. That puts every context-conditioned operation in the one component
that draws the noise, so composing the three parts reproduces the monolith
bit-for-bit rather than approximately; the alternative leaves the skip
normalization conditioned on a second, independent noise draw. A parametrized
test asserts that equivalence across twenty configurations — big skip on/off,
normalized and affine skip norms, output and residual filtering, position
embeddings, isotropic noise, global layer norm, context position embeddings,
both gradient-checkpointing levels, a leading ensemble dimension, and six
block-internal options (no MLP, LoRA, grouped and reduced-ratio spectral
filters, a local DISCO block, the makani filter). It is what pins this module
against changes to the net it mirrors, and `forward` now carries a comment
pointing back at it.

The parts hold references to the submodules of a net built by the existing
builder, so the stages they keep are built exactly as the donor builds them,
and every shape and flag they need is read off that net rather than re-read
from the config. There are no changes under `fme/ace`, and the only change
under `fme/core` is that pointing comment.

Changes:
- `fme.translate.cutpoint.SFNOCutPointConfig`: the `sfno_cut_point` registry
  entry — `part`, the donor `sfno` block, `donor_checkpoint` (+
  `donor_module_index`), and `conditional` for the processor.
- Donor initialization filters the checkpoint to this part's names, and rejects
  a donor that is missing any of the part's parameters, that shapes any of them
  differently, or whose own input width disagrees with the declared cut-point.
  Without those checks `overwrite_weights` copies leading slices, so a
  mis-declared cut-point would build a part that is only partly the donor's
  with no error — the width check is what covers a lone frozen processor, which
  keeps no parameter sized by the donor's input channels. Initialization runs
  before `TransformConfig.parameter_init`, so an explicit `weights_path` still
  wins; buffers are deliberately not transferred, so a donor-warm-started
  `clip_latent_global_means` encoder relearns its envelope.
- `fme.translate.modules.TransformModuleConfig.build_for_load`: opt-out hook,
  defaulting to `build`, for builders that read a checkpoint of their own at
  build time. `TransformConfig.build_for_load` routes through it, so a saved
  component reloads without its donor checkpoint still existing.
- `fme.translate.ComponentPool.set_epoch`: fans the latent global-mean envelope
  reset out to transforms as `Stepper.set_epoch` does to its modules, which a
  cut-point encoder configured with `clip_latent_global_means` needs.
- `SphericalFourierNeuralOperatorNet.forward`: comment naming the module that
  mirrors it.
- `fme/translate/examples/README.md`: the PR 5 note now names the config shape.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated