### PR TITLE
Add translate named data streams and paired-by-time multi-resolution loading

### DIFF
--- a/fme/core/distributed/distributed.py
+++ b/fme/core/distributed/distributed.py
@@ -205,13 +205,27 @@ class Distributed:
         dataset: torch.utils.data.Dataset,
         shuffle: bool,
         drop_last: bool = False,
+        seed_offset: int = 0,
     ) -> torch.utils.data.Sampler:
+        """
+        Get a sampler over ``dataset`` for this rank.
+
+        Args:
+            dataset: The dataset to sample from.
+            shuffle: Whether to shuffle the samples.
+            drop_last: Whether to drop the incomplete tail of the dataset.
+            seed_offset: Added to the distributed seed. Two samplers built with
+                different offsets produce different permutations of
+                equal-length datasets in the same epoch; leave it at 0 unless
+                sampling several datasets that must be shuffled independently
+                of one another rather than in lockstep.
+        """
         return torch.utils.data.DistributedSampler(
             dataset,
             shuffle=shuffle,
             num_replicas=self._distributed.total_data_parallel_ranks,
             rank=self._distributed.data_parallel_rank,
-            seed=self._seed,
+            seed=self._seed + seed_offset,
             drop_last=drop_last,
         )
 

--- a/fme/core/distributed/parallel_tests/test_get_sampler.py
+++ b/fme/core/distributed/parallel_tests/test_get_sampler.py
@@ -135,3 +135,23 @@ def test_get_sampler_seed_reproducibility():
     second = list(dist.get_sampler(dataset, shuffle=True))
 
     assert first == second
+
+
+@pytest.mark.parallel
+def test_get_sampler_seed_offset_gives_independent_order():
+    """
+    Two samplers over equal-length datasets shuffle in lockstep unless they
+    are given different seed offsets.
+    """
+    dist = Distributed.get_instance()
+    n_dp = dist.total_data_parallel_ranks
+    dataset = _make_dataset(8 * n_dp)
+
+    set_seed(42)
+    baseline = list(dist.get_sampler(dataset, shuffle=True))
+    same_offset = list(dist.get_sampler(dataset, shuffle=True, seed_offset=0))
+    other_offset = list(dist.get_sampler(dataset, shuffle=True, seed_offset=1))
+
+    assert same_offset == baseline
+    assert other_offset != baseline
+    assert sorted(other_offset) == sorted(baseline)

--- a/fme/translate/__init__.py
+++ b/fme/translate/__init__.py
@@ -5,7 +5,8 @@ This package sits at the coupled/downscaling tier: it may import ``fme.core``,
 shared abstraction of a named pool of components (trainable transforms /
 encoders / decoders wrapped around a backbone stepper) mapping between named
 domains, used by the transfer learning and multi-resolution latent-stepping
-programs.
+programs, plus the named data streams (:mod:`fme.translate.data`) that pair with
+those domains.
 """
 
 from .components import (
@@ -13,6 +14,16 @@ from .components import (
     ComponentPool,
     ComponentPoolConfig,
     TransformConfig,
+)
+from .data import (
+    ObjectiveDataRequirements,
+    StreamConfig,
+    StreamRequirements,
+    TranslateBatchData,
+    TranslateDataLoaderConfig,
+    TranslateDataRequirements,
+    TranslateGriddedData,
+    get_gridded_data,
 )
 from .domains import DomainConfig, LatentChannels
 from .modules import (
@@ -29,8 +40,16 @@ __all__ = [
     "DomainConfig",
     "InterpolateTransformConfig",
     "LatentChannels",
+    "ObjectiveDataRequirements",
     "SameGridTransformConfig",
+    "StreamConfig",
+    "StreamRequirements",
     "TransformConfig",
     "TransformModuleConfig",
     "TransformSelector",
+    "TranslateBatchData",
+    "TranslateDataLoaderConfig",
+    "TranslateDataRequirements",
+    "TranslateGriddedData",
+    "get_gridded_data",
 ]

--- a/fme/translate/data/__init__.py
+++ b/fme/translate/data/__init__.py
@@ -1,0 +1,29 @@
+"""Named data streams and the multi-stream loader that samples them.
+
+A *stream* is one named source of data bound to one component-pool domain (see
+:mod:`fme.translate.domains`). Several streams may serve one domain — ERA5 and
+IFS both feeding ``atmos_1deg`` — so the stream ``name`` (the handle objectives
+reference) is distinct from the ``domain`` it serves, and defaults to it.
+
+Which streams are sampled at the same valid times is *derived*, never
+configured: the objectives declare what each of them needs
+(:class:`ObjectiveDataRequirements`), and
+:meth:`TranslateDataRequirements.from_objectives` merges those into per-stream
+:class:`fme.ace.requirements.DataRequirements` plus the *pairing groups* —
+connected components of the graph in which every objective ties together the
+streams it consumes. Streams in a group are sampled at the same valid times;
+groups are sampled independently of one another. A sampling knob in the config
+could contradict the objectives; a derivation cannot.
+"""
+
+from .requirements import (
+    ObjectiveDataRequirements,
+    StreamRequirements,
+    TranslateDataRequirements,
+)
+
+__all__ = [
+    "ObjectiveDataRequirements",
+    "StreamRequirements",
+    "TranslateDataRequirements",
+]

--- a/fme/translate/data/__init__.py
+++ b/fme/translate/data/__init__.py
@@ -16,6 +16,7 @@ groups are sampled independently of one another. A sampling knob in the config
 could contradict the objectives; a derivation cannot.
 """
 
+from .batch_data import TranslateBatchData, TranslateCollateFn
 from .requirements import (
     ObjectiveDataRequirements,
     StreamRequirements,
@@ -25,5 +26,7 @@ from .requirements import (
 __all__ = [
     "ObjectiveDataRequirements",
     "StreamRequirements",
+    "TranslateBatchData",
+    "TranslateCollateFn",
     "TranslateDataRequirements",
 ]

--- a/fme/translate/data/__init__.py
+++ b/fme/translate/data/__init__.py
@@ -17,6 +17,11 @@ could contradict the objectives; a derivation cannot.
 """
 
 from .batch_data import TranslateBatchData, TranslateCollateFn
+from .config import StreamConfig, TranslateDataLoaderConfig
+from .dataloader import TranslateDataLoader
+from .dataset import PairedStreamDataset
+from .getters import get_gridded_data
+from .gridded_data import TranslateGriddedData
 from .requirements import (
     ObjectiveDataRequirements,
     StreamRequirements,
@@ -25,8 +30,14 @@ from .requirements import (
 
 __all__ = [
     "ObjectiveDataRequirements",
+    "PairedStreamDataset",
+    "StreamConfig",
     "StreamRequirements",
     "TranslateBatchData",
     "TranslateCollateFn",
+    "TranslateDataLoader",
+    "TranslateDataLoaderConfig",
     "TranslateDataRequirements",
+    "TranslateGriddedData",
+    "get_gridded_data",
 ]

--- a/fme/translate/data/batch_data.py
+++ b/fme/translate/data/batch_data.py
@@ -1,0 +1,146 @@
+"""A batch of named data streams, and its collate function.
+
+:class:`TranslateBatchData` generalizes
+:class:`fme.coupled.data_loading.batch_data.CoupledBatchData` from two fixed
+components to an arbitrary set of named streams: where the coupled type has
+``ocean_data`` and ``atmosphere_data`` fields and fans every method out over
+both, this one holds a ``dict[str, BatchData]`` and fans out over its keys.
+
+The surface is deliberately narrower than the coupled type's — per-stream
+access, device movement, and the ``epoch`` a trainer needs. Time-window
+manipulation (``prepend``, ``get_start``, ``remove_initial_condition``) is done
+per stream by the objectives, which know which of their streams is the input,
+the target, and the forcing; hoisting those onto a whole-batch fan-out would
+apply them to streams that should not receive them.
+"""
+
+import dataclasses
+from collections.abc import Iterator, Mapping, Sequence
+
+from fme.ace.data_loading.batch_data import BatchData
+from fme.core.dataset.dataset import DatasetItem
+from fme.core.labels import LabelEncoding
+
+__all__ = ["TranslateBatchData", "TranslateCollateFn"]
+
+
+@dataclasses.dataclass
+class TranslateBatchData:
+    """A batch holding one :class:`BatchData` per named data stream.
+
+    Parameters:
+        streams: The batch's per-stream data, keyed by stream name.
+    """
+
+    streams: dict[str, BatchData]
+
+    def __post_init__(self):
+        if not self.streams:
+            raise ValueError("A TranslateBatchData must hold at least one stream.")
+        epochs = {name: batch.epoch for name, batch in self.streams.items()}
+        if len(set(epochs.values())) > 1:
+            raise ValueError(
+                "All streams in a batch must carry the same epoch (they are "
+                f"drawn in step by the trainer), got {epochs}."
+            )
+
+    @property
+    def epoch(self) -> int | None:
+        """The epoch every stream in this batch was drawn in.
+
+        Consumed by ace's ``LossSchedule.init_for_epoch``, which needs the epoch
+        of the data rather than of the trainer loop.
+        """
+        return next(iter(self.streams.values())).epoch
+
+    def __getitem__(self, name: str) -> BatchData:
+        return self.streams[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.streams
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.streams)
+
+    def __len__(self) -> int:
+        return len(self.streams)
+
+    def to_device(self) -> "TranslateBatchData":
+        return TranslateBatchData(
+            streams={name: batch.to_device() for name, batch in self.streams.items()}
+        )
+
+    def to_cpu(self) -> "TranslateBatchData":
+        return TranslateBatchData(
+            streams={name: batch.to_cpu() for name, batch in self.streams.items()}
+        )
+
+    def pin_memory(self) -> "TranslateBatchData":
+        """Page-lock every stream's tensors; called by torch's DataLoader."""
+        self.streams = {
+            name: batch.pin_memory() for name, batch in self.streams.items()
+        }
+        return self
+
+    @classmethod
+    def merge(cls, batches: Sequence["TranslateBatchData"]) -> "TranslateBatchData":
+        """Combine batches over disjoint stream sets into one.
+
+        Used to assemble the independently-sampled pairing groups' batches into
+        the single batch a training step sees.
+        """
+        streams: dict[str, BatchData] = {}
+        for batch in batches:
+            overlap = sorted(set(batch.streams) & set(streams))
+            if overlap:
+                raise ValueError(
+                    f"Cannot merge batches sharing the streams {overlap}; each "
+                    "stream belongs to exactly one pairing group."
+                )
+            streams.update(batch.streams)
+        return cls(streams=streams)
+
+
+class TranslateCollateFn:
+    """Collates per-stream samples into a :class:`TranslateBatchData`.
+
+    One instance serves one pairing group: its keys are that group's streams,
+    and it is called with the group's paired samples (see
+    :class:`fme.translate.data.dataset.PairedStreamDataset`). Defined at module
+    level so it can be pickled to data-loader worker processes.
+    """
+
+    def __init__(
+        self,
+        horizontal_dims: Mapping[str, list[str]],
+        label_encodings: Mapping[str, LabelEncoding | None],
+    ):
+        """
+        Args:
+            horizontal_dims: Each stream's horizontal dimension names, used
+                when writing batches to netCDF.
+            label_encodings: Each stream's label encoding, or None for a stream
+                whose dataset provides no labels.
+        """
+        if set(horizontal_dims) != set(label_encodings):
+            raise ValueError(
+                "horizontal_dims and label_encodings must cover the same "
+                f"streams, got {sorted(horizontal_dims)} and "
+                f"{sorted(label_encodings)}."
+            )
+        self.horizontal_dims = dict(horizontal_dims)
+        self.label_encodings = dict(label_encodings)
+
+    def __call__(
+        self, samples: Sequence[Mapping[str, DatasetItem]]
+    ) -> TranslateBatchData:
+        return TranslateBatchData(
+            streams={
+                name: BatchData.from_sample_tuples(
+                    [sample[name] for sample in samples],
+                    horizontal_dims=dims,
+                    label_encoding=self.label_encodings[name],
+                )
+                for name, dims in self.horizontal_dims.items()
+            }
+        )

--- a/fme/translate/data/batch_data.py
+++ b/fme/translate/data/batch_data.py
@@ -25,8 +25,14 @@ __all__ = ["TranslateBatchData", "TranslateCollateFn"]
 
 
 @dataclasses.dataclass
-class TranslateBatchData:
+class TranslateBatchData(Mapping[str, BatchData]):
     """A batch holding one :class:`BatchData` per named data stream.
+
+    A read-only ``Mapping`` from stream name to that stream's data, since that
+    is how objectives will reach their streams: ``batch["era5_1deg"]``,
+    ``batch.items()``, ``**batch``. Inheriting ``Mapping`` rather than
+    hand-rolling the surface keeps ``keys``/``values``/``items``/``get`` in
+    agreement with ``__getitem__``.
 
     Parameters:
         streams: The batch's per-stream data, keyed by stream name.
@@ -56,9 +62,6 @@ class TranslateBatchData:
     def __getitem__(self, name: str) -> BatchData:
         return self.streams[name]
 
-    def __contains__(self, name: str) -> bool:
-        return name in self.streams
-
     def __iter__(self) -> Iterator[str]:
         return iter(self.streams)
 
@@ -76,7 +79,14 @@ class TranslateBatchData:
         )
 
     def pin_memory(self) -> "TranslateBatchData":
-        """Page-lock every stream's tensors; called by torch's DataLoader."""
+        """Page-lock every stream's tensors *in place*, and return self.
+
+        Deliberately unlike ``to_device``/``to_cpu``, which return copies:
+        ``BatchData.pin_memory`` and ``fme.coupled``'s both mutate and return
+        self, because torch's DataLoader calls this on a batch it has just
+        collated and is about to hand over, so no other holder of the un-pinned
+        tensors can be surprised. Do not call it on a batch someone else keeps.
+        """
         self.streams = {
             name: batch.pin_memory() for name, batch in self.streams.items()
         }

--- a/fme/translate/data/config.py
+++ b/fme/translate/data/config.py
@@ -1,0 +1,122 @@
+"""Configuration of the translate training/validation data: a list of streams.
+
+Field names and defaults mirror :class:`fme.ace.data_loading.config.DataLoaderConfig`
+so the ``train_data:`` block reads like ace's. What it adds is the ``streams``
+list, and what it deliberately lacks is any sampling knob: which streams are
+sampled together is derived from objective co-occurrence (see
+:mod:`fme.translate.data.requirements`).
+"""
+
+import dataclasses
+
+from fme.core.dataset.concat import ConcatDatasetConfig
+from fme.core.dataset.dataset import DatasetABC
+from fme.core.dataset.merged import MergeDatasetConfig
+from fme.core.dataset.properties import DatasetProperties
+from fme.core.dataset.schedule import IntSchedule
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.core.distributed import Distributed
+
+__all__ = ["StreamConfig", "TranslateDataLoaderConfig"]
+
+
+@dataclasses.dataclass
+class StreamConfig:
+    """One named data stream, bound to the domain it provides.
+
+    Parameters:
+        domain: Name of the component-pool domain this stream serves. Several
+            streams may serve one domain (ERA5 and IFS both feeding
+            ``atmos_1deg``); they must then describe compatible datasets, which
+            is checked when the loader is built.
+        dataset: The underlying ace dataset configuration.
+        name: The handle objectives use to reference this stream. Defaults to
+            ``domain``, which is what you want when one stream serves the
+            domain; name it explicitly when the source rather than the domain is
+            the natural handle.
+    """
+
+    domain: str
+    dataset: ConcatDatasetConfig | MergeDatasetConfig | XarrayDataConfig
+    name: str | None = None
+
+    def __post_init__(self):
+        if not self.domain:
+            raise ValueError("A stream must name a non-empty domain.")
+        if self.name is not None and not self.name:
+            raise ValueError(
+                f"Stream for domain {self.domain!r} has an empty name; omit "
+                "`name` to default it to the domain."
+            )
+
+    @property
+    def stream_name(self) -> str:
+        """The stream's name, defaulting to its domain.
+
+        Distinct from the ``name`` field so the field keeps exactly what the
+        user wrote (and round-trips through ``dataclasses.asdict``) while
+        callers get a resolved ``str``.
+        """
+        return self.domain if self.name is None else self.name
+
+    def get_dataset(
+        self, names: list[str], n_timesteps: IntSchedule
+    ) -> tuple[DatasetABC, DatasetProperties]:
+        return self.dataset.build(names, n_timesteps)
+
+
+@dataclasses.dataclass
+class TranslateDataLoaderConfig:
+    """Configuration for a translate training or validation data loader.
+
+    Parameters:
+        streams: The data streams to load, in any order. Stream names (see
+            :attr:`StreamConfig.stream_name`) must be unique.
+        batch_size: Number of samples per batch, per stream. Must be divisible
+            by the number of data-parallel ranks.
+        num_data_workers: Number of parallel workers to use for data loading.
+        prefetch_factor: How many batches a single data worker will attempt to
+            hold in host memory at a given time.
+
+    Note:
+        ace's ``time_buffer`` window-reuse options are not offered here. They
+        draw several output batches from one preloaded window, which would break
+        the index pairing that keeps a group's streams on a shared time index.
+    """
+
+    streams: list[StreamConfig]
+    batch_size: int
+    num_data_workers: int = 0
+    prefetch_factor: int | None = None
+
+    def __post_init__(self):
+        if not self.streams:
+            raise ValueError("At least one data stream must be configured.")
+        names = [stream.stream_name for stream in self.streams]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise ValueError(
+                "Stream names must be unique (they are the handles objectives "
+                f"reference); found duplicates: {duplicates}. Set an explicit "
+                "`name` on streams sharing a domain."
+            )
+        dist = Distributed.get_instance()
+        if self.batch_size % dist.total_data_parallel_ranks != 0:
+            raise ValueError(
+                "batch_size must be divisible by the number of data-parallel "
+                f"workers, got {self.batch_size} and "
+                f"{dist.total_data_parallel_ranks}"
+            )
+        self._zarr_engine_used = any(
+            stream.dataset.zarr_engine_used for stream in self.streams
+        )
+
+    @property
+    def stream_configs(self) -> dict[str, StreamConfig]:
+        """The streams keyed by name."""
+        return {stream.stream_name: stream for stream in self.streams}
+
+    @property
+    def zarr_engine_used(self) -> bool:
+        """Whether any configured stream reads through the Zarr engine."""
+        return self._zarr_engine_used

--- a/fme/translate/data/config.py
+++ b/fme/translate/data/config.py
@@ -74,7 +74,9 @@ class TranslateDataLoaderConfig:
             :attr:`StreamConfig.stream_name`) must be unique.
         batch_size: Number of samples per batch, per stream. Must be divisible
             by the number of data-parallel ranks.
-        num_data_workers: Number of parallel workers to use for data loading.
+        num_data_workers: Number of parallel workers to use for data loading,
+            per pairing group. Each group has its own loader, so the process
+            count and prefetched host memory scale with the number of groups.
         prefetch_factor: How many batches a single data worker will attempt to
             hold in host memory at a given time.
 

--- a/fme/translate/data/dataloader.py
+++ b/fme/translate/data/dataloader.py
@@ -1,0 +1,21 @@
+"""The per-pairing-group data loader.
+
+One :class:`TranslateDataLoader` serves one pairing group: it batches that
+group's :class:`~fme.translate.data.dataset.PairedStreamDataset` into a
+:class:`~fme.translate.data.batch_data.TranslateBatchData` over the group's
+streams. Everything it does beyond typing —
+``subset``/``set_epoch``/``alternate_shuffle``/``batch_size``/``n_samples``/
+``log_info`` — comes from :class:`fme.core.generics.dataloader.GenericDataLoader`,
+exactly as :class:`fme.coupled.data_loading.dataloader.CoupledDataLoader` does.
+It must not add required constructor arguments, because ``GenericDataLoader.subset``
+re-instantiates it with only ``dataset``, ``sampler`` and ``collate_fn``.
+"""
+
+from fme.core.generics.dataloader import GenericDataLoader
+from fme.translate.data.batch_data import TranslateBatchData
+
+__all__ = ["TranslateDataLoader"]
+
+
+class TranslateDataLoader(GenericDataLoader[TranslateBatchData]):
+    pass

--- a/fme/translate/data/dataset.py
+++ b/fme/translate/data/dataset.py
@@ -1,0 +1,139 @@
+"""An N-stream dataset whose streams share one time index.
+
+One :class:`PairedStreamDataset` backs one pairing group: index *i* yields one
+sample from every stream in the group, all starting at the same valid time.
+
+This is a translate-local class rather than a reuse of
+:class:`fme.downscaling.data.datasets.FineCoarsePairedDataset`, which is
+hard-wired to a fine/coarse pair and to single-timestep items (its
+``BatchItemDatasetAdapter`` squeezes the time dimension away), so it cannot
+carry the time windows a forward-prediction objective needs. The closest
+in-repo analogue is :class:`fme.coupled.data_loading.data_typing.CoupledDataset`
+— also index-paired, also validating alignment at construction — but likewise
+fixed at two named components. What is reused instead is the machinery beneath
+both: :class:`fme.core.generics.dataset.GenericDataset`, whose
+:class:`~fme.core.generics.dataloader.GenericDataLoader` supplies subsetting,
+epoch propagation and shuffle control.
+"""
+
+from collections.abc import Iterator, Mapping
+
+import numpy as np
+import xarray as xr
+
+from fme.core.dataset.dataset import DatasetABC, DatasetItem
+from fme.core.generics.dataset import GenericDataset
+
+__all__ = ["PairedStreamDataset"]
+
+
+def _assert_start_times_match(
+    reference_name: str,
+    reference_times: xr.CFTimeIndex,
+    name: str,
+    times: xr.CFTimeIndex,
+) -> None:
+    """Raise unless two streams' sample start times agree index by index."""
+    if reference_times.equals(times):
+        return
+    unequal = np.flatnonzero(np.asarray(reference_times) != np.asarray(times))
+    if unequal.size > 0:
+        index = int(unequal[0])
+        detail = (
+            f"at sample index {index}, {reference_name!r} starts at "
+            f"{reference_times[index]} but {name!r} starts at {times[index]}"
+        )
+    else:
+        detail = (
+            f"their time indexes compare unequal: {reference_times!r} versus "
+            f"{times!r}"
+        )
+    raise ValueError(
+        f"Streams {reference_name!r} and {name!r} are sampled at the same valid "
+        f"times because they co-occur in an objective, but {detail}. Align them, "
+        "e.g. with a `subset:` on the stream that starts earlier."
+    )
+
+
+class PairedStreamDataset(GenericDataset[dict[str, DatasetItem]]):
+    """Several data streams sampled at one shared time index.
+
+    Sample *i* is ``{stream_name: sample_i}`` over every stream. Because the
+    streams are paired by index, they must agree on their timestep and on their
+    sample start times; both are checked here, at build time, with the
+    offending stream pair named.
+
+    The dataset's length is the minimum over its streams, since windows of
+    different lengths (objectives asking for different ``n_timesteps``) leave
+    different numbers of valid start times.
+    """
+
+    def __init__(self, datasets: Mapping[str, DatasetABC]):
+        """
+        Args:
+            datasets: The group's per-stream datasets, keyed by stream name.
+        """
+        if not datasets:
+            raise ValueError("A PairedStreamDataset requires at least one stream.")
+        self._datasets = dict(datasets)
+        self._length = min(len(dataset) for dataset in self._datasets.values())
+        self._validate()
+
+    def _validate(self) -> None:
+        names = list(self._datasets)
+        reference_name = names[0]
+        reference = self._datasets[reference_name]
+        reference_timestep = reference.properties.timestep
+        reference_times = reference.sample_start_times[: self._length]
+        for name in names[1:]:
+            dataset = self._datasets[name]
+            timestep = dataset.properties.timestep
+            if timestep != reference_timestep:
+                raise ValueError(
+                    "Streams sampled at the same valid times must have the same "
+                    f"timestep, but stream {reference_name!r} has timestep "
+                    f"{reference_timestep} and stream {name!r} has timestep "
+                    f"{timestep}. Pairing them by sample index would compare "
+                    "different times. (Coarsening one stream in time, so the "
+                    "two share a timestep, is the fix; an integer-ratio pairing "
+                    "like fme.coupled's n_steps_fast is a deliberate "
+                    "non-feature here until an objective needs it.)"
+                )
+            _assert_start_times_match(
+                reference_name,
+                reference_times,
+                name,
+                dataset.sample_start_times[: self._length],
+            )
+
+    @property
+    def stream_names(self) -> list[str]:
+        return list(self._datasets)
+
+    def __getitem__(self, index) -> dict[str, DatasetItem]:
+        return {name: dataset[index] for name, dataset in self._datasets.items()}
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __iter__(self) -> Iterator[dict[str, DatasetItem]]:
+        for index in range(self._length):
+            yield self[index]
+
+    def set_epoch(self, epoch: int) -> None:
+        for dataset in self._datasets.values():
+            dataset.set_epoch(epoch)
+
+    def enable_shared_memory(self) -> None:
+        for dataset in self._datasets.values():
+            dataset.enable_shared_memory()
+
+    @property
+    def first_time(self):
+        """Start time of the first sample, shared by every stream."""
+        return next(iter(self._datasets.values())).sample_start_times[0]
+
+    @property
+    def last_time(self):
+        """Start time of the last sample, shared by every stream."""
+        return next(iter(self._datasets.values())).sample_start_times[self._length - 1]

--- a/fme/translate/data/dataset.py
+++ b/fme/translate/data/dataset.py
@@ -16,7 +16,7 @@ both: :class:`fme.core.generics.dataset.GenericDataset`, whose
 epoch propagation and shuffle control.
 """
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Mapping
 
 import numpy as np
 import xarray as xr
@@ -106,19 +106,11 @@ class PairedStreamDataset(GenericDataset[dict[str, DatasetItem]]):
                 dataset.sample_start_times[: self._length],
             )
 
-    @property
-    def stream_names(self) -> list[str]:
-        return list(self._datasets)
-
     def __getitem__(self, index) -> dict[str, DatasetItem]:
         return {name: dataset[index] for name, dataset in self._datasets.items()}
 
     def __len__(self) -> int:
         return self._length
-
-    def __iter__(self) -> Iterator[dict[str, DatasetItem]]:
-        for index in range(self._length):
-            yield self[index]
 
     def set_epoch(self, epoch: int) -> None:
         for dataset in self._datasets.values():

--- a/fme/translate/data/getters.py
+++ b/fme/translate/data/getters.py
@@ -128,6 +128,11 @@ def get_gridded_data(
         Data over every configured stream, one batch carrying all of them.
     """
     _validate_streams_match_requirements(config, requirements)
+    Distributed.get_instance().require_no_spatial_parallelism(
+        "The translate data loader does not scatter batches spatially: each "
+        "stream would have to be scattered against its own grid, which no "
+        "translate module supports yet. Run without spatial parallelism."
+    )
     stream_configs = config.stream_configs
     datasets: dict[str, DatasetABC] = {}
     properties: dict[str, DatasetProperties] = {}

--- a/fme/translate/data/getters.py
+++ b/fme/translate/data/getters.py
@@ -1,0 +1,166 @@
+"""Building a :class:`TranslateGriddedData` from a config and the objectives'
+requirements.
+
+The shape mirrors :func:`fme.ace.data_loading.getters.get_gridded_data`: build
+the datasets, get a distributed sampler, hand both to a data loader, wrap it.
+What is multi-stream about it is that there is one dataset per stream, one
+paired dataset and loader per pairing group, and a distinct sampler seed per
+group.
+"""
+
+import logging
+from collections.abc import Mapping
+
+from fme.core.dataset.dataset import DatasetABC
+from fme.core.dataset.properties import DatasetProperties
+from fme.core.device import using_gpu
+from fme.core.distributed import Distributed
+from fme.core.labels import LabelEncoding
+from fme.translate.data.batch_data import TranslateCollateFn
+from fme.translate.data.config import TranslateDataLoaderConfig
+from fme.translate.data.dataloader import TranslateDataLoader
+from fme.translate.data.dataset import PairedStreamDataset
+from fme.translate.data.gridded_data import TranslateGriddedData
+from fme.translate.data.requirements import TranslateDataRequirements
+
+__all__ = ["get_gridded_data"]
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_streams_match_requirements(
+    config: TranslateDataLoaderConfig, requirements: TranslateDataRequirements
+) -> None:
+    configured = set(config.stream_configs)
+    required = set(requirements.streams)
+    unknown = sorted(required - configured)
+    if unknown:
+        raise ValueError(
+            f"The objectives reference data streams that are not configured: "
+            f"{unknown}. Configured streams are {sorted(configured)}."
+        )
+    unused = sorted(configured - required)
+    if unused:
+        raise ValueError(
+            f"These data streams are configured but no objective consumes them: "
+            f"{unused}. Remove them, or check the stream names the objectives "
+            "reference."
+        )
+
+
+def _build_group_loader(
+    config: TranslateDataLoaderConfig,
+    datasets: Mapping[str, DatasetABC],
+    label_encodings: Mapping[str, LabelEncoding | None],
+    properties: Mapping[str, DatasetProperties],
+    train: bool,
+    group_index: int,
+    n_groups: int,
+) -> TranslateDataLoader:
+    dataset = PairedStreamDataset(datasets)
+    dist = Distributed.get_instance()
+    # Each group gets its own seed offset so equal-length groups are not handed
+    # the same permutation, which would silently index-pair streams that are
+    # meant to be sampled independently.
+    sampler = dist.get_sampler(
+        dataset.torch_dataset, shuffle=train, seed_offset=group_index
+    )
+
+    if config.zarr_engine_used and config.num_data_workers > 0:
+        # GCSFS and S3FS are not fork-safe, and reading zarr with async from
+        # weka also requires forkserver.
+        mp_context: str | None = "forkserver"
+        persistent_workers = True
+        dataset.enable_shared_memory()
+    else:
+        mp_context = None
+        persistent_workers = False
+
+    # DataLoader's own default for prefetch_factor is not None, so it must be
+    # left unset rather than passed as None.
+    kwargs = (
+        {}
+        if config.prefetch_factor is None
+        else {"prefetch_factor": config.prefetch_factor}
+    )
+    loader = TranslateDataLoader(
+        dataset=dataset,
+        collate_fn=TranslateCollateFn(
+            horizontal_dims={
+                name: list(properties[name].horizontal_coordinates.dims)
+                for name in datasets
+            },
+            label_encodings={name: label_encodings[name] for name in datasets},
+        ),
+        sampler=sampler,
+        batch_size=dist.local_batch_size(int(config.batch_size)),
+        num_workers=config.num_data_workers,
+        drop_last=True,
+        pin_memory=using_gpu(),
+        multiprocessing_context=mp_context,
+        persistent_workers=persistent_workers,
+        **kwargs,
+    )
+    if len(loader) == 0:
+        raise ValueError(
+            f"No batches in the loader for pairing group {group_index} of "
+            f"{n_groups} (streams {sorted(datasets)}): {loader.n_samples} "
+            f"samples at batch size {loader.batch_size}."
+        )
+    return loader
+
+
+def get_gridded_data(
+    config: TranslateDataLoaderConfig,
+    requirements: TranslateDataRequirements,
+    train: bool,
+) -> TranslateGriddedData:
+    """Build the multi-stream data loader.
+
+    Args:
+        config: The configured data streams and batching.
+        requirements: The merged objective requirements, which decide what each
+            stream loads and which streams share a time index.
+        train: Whether the loader is for training rather than validation data;
+            if True, samples are shuffled.
+
+    Returns:
+        Data over every configured stream, one batch carrying all of them.
+    """
+    _validate_streams_match_requirements(config, requirements)
+    stream_configs = config.stream_configs
+    datasets: dict[str, DatasetABC] = {}
+    properties: dict[str, DatasetProperties] = {}
+    label_encodings: dict[str, LabelEncoding | None] = {}
+    for name, stream in stream_configs.items():
+        stream_requirements = requirements.streams[name]
+        dataset, stream_properties = stream.get_dataset(
+            stream_requirements.names, stream_requirements.n_timesteps_schedule
+        )
+        datasets[name] = dataset
+        properties[name] = stream_properties
+        available_labels = stream.dataset.available_labels
+        label_encodings[name] = (
+            None
+            if available_labels is None
+            else LabelEncoding(sorted(available_labels))
+        )
+
+    groups = requirements.pairing_groups
+    group_loaders = [
+        _build_group_loader(
+            config=config,
+            datasets={name: datasets[name] for name in group},
+            label_encodings=label_encodings,
+            properties=properties,
+            train=train,
+            group_index=group_index,
+            n_groups=len(groups),
+        )
+        for group_index, group in enumerate(groups)
+    ]
+    return TranslateGriddedData(
+        group_loaders=group_loaders,
+        stream_properties=properties,
+        stream_domains={name: stream.domain for name, stream in stream_configs.items()},
+    )

--- a/fme/translate/data/gridded_data.py
+++ b/fme/translate/data/gridded_data.py
@@ -119,9 +119,12 @@ class TranslateGriddedData(GriddedDataABC[TranslateBatchData]):
     ):
         """
         Args:
-            group_loaders: One loader per pairing group. Their streams must
-                partition ``stream_properties``, and they must share a batch
-                size.
+            group_loaders: One loader per pairing group. They must share a batch
+                size, and their streams must partition ``stream_properties`` —
+                not checked here, since a loader does not expose its streams;
+                :func:`fme.translate.data.getters.get_gridded_data` gets it from
+                ``TranslateDataRequirements``, whose groups are validated to
+                partition its streams.
             stream_properties: Each stream's dataset properties. Data can be on
                 any device.
             stream_domains: The domain each stream serves.

--- a/fme/translate/data/gridded_data.py
+++ b/fme/translate/data/gridded_data.py
@@ -1,0 +1,236 @@
+"""The multi-stream training/validation data container.
+
+:class:`TranslateGriddedData` is a :class:`GriddedDataABC` over
+:class:`TranslateBatchData`. It holds one loader per pairing group and zips
+them: each group is shuffled independently, and one batch carries every stream.
+It also exposes ``dataset_info`` keyed by *domain* — the pairing key
+``ComponentPoolConfig.build`` consumes — which is not part of the ABC but is the
+convention every ace package's training entry point follows.
+"""
+
+import logging
+from collections.abc import Iterator, Mapping, Sequence
+
+from fme.core.dataset.data_typing import VariableMetadata
+from fme.core.dataset.properties import DatasetProperties
+from fme.core.dataset_info import DatasetInfo, IncompatibleDatasetInfo
+from fme.core.generics.data import DataLoader, GriddedDataABC, SizedMap
+from fme.translate.data.batch_data import TranslateBatchData
+from fme.translate.data.dataloader import TranslateDataLoader
+
+__all__ = ["TranslateGriddedData"]
+
+
+class ZippedGroupLoader:
+    """Zips the pairing groups' loaders into one loader over all streams.
+
+    Iteration stops with the shortest group, so ``__len__`` is the minimum over
+    the groups: a group with fewer batches would otherwise have to be re-drawn
+    mid-epoch, correlating its samples within the epoch.
+    """
+
+    def __init__(self, loaders: Sequence[DataLoader[TranslateBatchData]]):
+        if not loaders:
+            raise ValueError("At least one pairing group's loader is required.")
+        self._loaders = list(loaders)
+
+    def __len__(self) -> int:
+        return min(len(loader) for loader in self._loaders)
+
+    def __iter__(self) -> Iterator[TranslateBatchData]:
+        for group_batches in zip(*self._loaders):
+            yield TranslateBatchData.merge(group_batches)
+
+
+def _dataset_info(properties: DatasetProperties) -> DatasetInfo:
+    return DatasetInfo(
+        horizontal_coordinates=properties.horizontal_coordinates,
+        vertical_coordinate=properties.vertical_coordinate,
+        spatial_mask_provider=properties.spatial_mask_provider,
+        timestep=properties.timestep,
+        variable_metadata=properties.variable_metadata,
+        all_labels=properties.all_labels,
+    )
+
+
+def _domain_dataset_info(
+    domain: str, entries: Sequence[tuple[str, DatasetProperties]]
+) -> DatasetInfo:
+    """One ``DatasetInfo`` for a domain, from the streams that serve it.
+
+    Streams sharing a domain must describe compatible datasets (same grid,
+    vertical coordinate, mask and timestep), checked with
+    ``DatasetInfo.assert_compatible_with``. Their variable metadata and labels
+    are unioned; on a key present in both with conflicting metadata the later
+    stream wins and ``assert_compatible_with`` logs a warning, matching how ace
+    merges metadata across datasets.
+    """
+    reference_name, reference = entries[0]
+    info = _dataset_info(reference)
+    variable_metadata: dict[str, VariableMetadata] = dict(reference.variable_metadata)
+    all_labels: set[str] | None = (
+        set(reference.all_labels) if reference.all_labels is not None else None
+    )
+    for name, properties in entries[1:]:
+        try:
+            info.assert_compatible_with(_dataset_info(properties))
+        except IncompatibleDatasetInfo as err:
+            raise ValueError(
+                f"Streams {reference_name!r} and {name!r} both serve domain "
+                f"{domain!r} but describe incompatible datasets: {err}"
+            ) from err
+        variable_metadata.update(properties.variable_metadata)
+        if properties.all_labels is not None:
+            all_labels = set(properties.all_labels) | (all_labels or set())
+    return DatasetInfo(
+        horizontal_coordinates=reference.horizontal_coordinates,
+        vertical_coordinate=reference.vertical_coordinate,
+        spatial_mask_provider=reference.spatial_mask_provider,
+        timestep=reference.timestep,
+        variable_metadata=variable_metadata,
+        all_labels=all_labels,
+    )
+
+
+class TranslateGriddedData(GriddedDataABC[TranslateBatchData]):
+    """Multi-stream data as required for translate training.
+
+    All data exposed from this class is on the current device.
+
+    Semantics under unequal pairing groups: ``n_batches`` is the minimum over
+    the groups, and ``n_samples`` is ``n_batches * batch_size`` — that is, the
+    number of samples drawn *per group*, not summed across groups, so it stays
+    the count a per-batch metric divides by. The groups are shuffled
+    independently: each group's sampler is built with its own ``seed_offset``,
+    without which two equal-length groups would be handed the same permutation
+    and so be index-paired in fact while claiming to be independent.
+
+    Batches are moved to the device but not spatially scattered, following
+    ``fme.coupled``: spatial model parallelism would need each stream scattered
+    against its own grid, which no translate module supports yet. Data-parallel
+    sharding is handled, by the per-group distributed samplers.
+    """
+
+    def __init__(
+        self,
+        group_loaders: Sequence[TranslateDataLoader],
+        stream_properties: Mapping[str, DatasetProperties],
+        stream_domains: Mapping[str, str],
+    ):
+        """
+        Args:
+            group_loaders: One loader per pairing group. Their streams must
+                partition ``stream_properties``, and they must share a batch
+                size.
+            stream_properties: Each stream's dataset properties. Data can be on
+                any device.
+            stream_domains: The domain each stream serves.
+        """
+        if not group_loaders:
+            raise ValueError("At least one pairing group's loader is required.")
+        if set(stream_properties) != set(stream_domains):
+            raise ValueError(
+                "stream_properties and stream_domains must cover the same "
+                f"streams, got {sorted(stream_properties)} and "
+                f"{sorted(stream_domains)}."
+            )
+        batch_sizes = {loader.batch_size for loader in group_loaders}
+        if len(batch_sizes) != 1:
+            raise ValueError(
+                f"All pairing groups must share a batch size, got {batch_sizes}."
+            )
+        self._group_loaders = list(group_loaders)
+        self._batch_size = batch_sizes.pop()
+        self._properties = {
+            name: properties.to_device()
+            for name, properties in stream_properties.items()
+        }
+        self._stream_domains = dict(stream_domains)
+        domain_entries: dict[str, list[tuple[str, DatasetProperties]]] = {}
+        for name, properties in self._properties.items():
+            domain_entries.setdefault(self._stream_domains[name], []).append(
+                (name, properties)
+            )
+        self._dataset_info = {
+            domain: _domain_dataset_info(domain, entries)
+            for domain, entries in domain_entries.items()
+        }
+
+    @property
+    def dataset_info(self) -> Mapping[str, DatasetInfo]:
+        """Per-domain dataset information, keyed by domain name.
+
+        One entry per data-backed domain: this is what
+        ``ComponentPoolConfig.build`` consumes to pair components with data.
+        """
+        return self._dataset_info
+
+    @property
+    def stream_domains(self) -> Mapping[str, str]:
+        """The domain each stream serves."""
+        return self._stream_domains
+
+    @property
+    def variable_metadata(self) -> Mapping[str, Mapping[str, VariableMetadata]]:
+        """Each stream's variable metadata, keyed by stream name.
+
+        Kept per stream rather than flattened: two streams at different
+        resolutions carry the same variable names, so a flat merge would hide
+        one stream's metadata behind another's.
+        """
+        return {
+            name: properties.variable_metadata
+            for name, properties in self._properties.items()
+        }
+
+    @property
+    def loader(self) -> DataLoader[TranslateBatchData]:
+        return self._on_device(ZippedGroupLoader(self._group_loaders))
+
+    def subset_loader(
+        self, start_batch: int | None = None, stop_batch: int | None = None
+    ) -> DataLoader[TranslateBatchData]:
+        return self._on_device(
+            ZippedGroupLoader(
+                [
+                    loader.subset(start_batch=start_batch, stop_batch=stop_batch)
+                    for loader in self._group_loaders
+                ]
+            )
+        )
+
+    def _on_device(
+        self, base_loader: DataLoader[TranslateBatchData]
+    ) -> DataLoader[TranslateBatchData]:
+        return SizedMap(lambda batch: batch.to_device(), base_loader)
+
+    @property
+    def n_samples(self) -> int:
+        return self.n_batches * self.batch_size
+
+    @property
+    def n_batches(self) -> int:
+        return min(len(loader) for loader in self._group_loaders)
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    def set_epoch(self, epoch: int):
+        """Set the epoch on every group's dataset and sampler."""
+        for loader in self._group_loaders:
+            loader.set_epoch(epoch)
+
+    def alternate_shuffle(self):
+        """Change every group's random shuffle for the current epoch."""
+        for loader in self._group_loaders:
+            loader.alternate_shuffle()
+
+    def log_info(self, name: str):
+        logging.info(
+            f"{name} data: {self.n_batches} batches of {self.batch_size} samples "
+            f"per stream, over {len(self._group_loaders)} independently sampled "
+            f"pairing group(s) covering {len(self._properties)} stream(s)."
+        )
+        for group_index, loader in enumerate(self._group_loaders):
+            loader.log_info(f"{name} pairing group {group_index}")

--- a/fme/translate/data/gridded_data.py
+++ b/fme/translate/data/gridded_data.py
@@ -8,6 +8,7 @@ It also exposes ``dataset_info`` keyed by *domain* — the pairing key
 convention every ace package's training entry point follows.
 """
 
+import itertools
 import logging
 from collections.abc import Iterator, Mapping, Sequence
 
@@ -60,25 +61,38 @@ def _domain_dataset_info(
 
     Streams sharing a domain must describe compatible datasets (same grid,
     vertical coordinate, mask and timestep), checked with
-    ``DatasetInfo.assert_compatible_with``. Their variable metadata and labels
-    are unioned; on a key present in both with conflicting metadata the later
-    stream wins and ``assert_compatible_with`` logs a warning, matching how ace
-    merges metadata across datasets.
+    ``DatasetInfo.assert_compatible_with`` over every *ordered* pair. Both
+    aspects of that matter:
+
+    - every pair, not each stream against the first one, because
+      ``assert_compatible_with`` skips a comparison either side declines to make
+      (a ``NullVerticalCoordinate`` opts out of the vertical check), so a stream
+      can be compatible with the first while disagreeing with a third;
+    - both directions, because the timestep comparison is guarded on the
+      *caller's* timestep being set. Checking one way only would let a stream
+      with no inferred timestep silently pass against one that has it — and,
+      since the returned info takes its coordinates from ``entries[0]``, publish
+      that ``None`` for the whole domain.
+
+    Only after those checks do the shared fields of ``entries[0]`` describe every
+    stream. Variable metadata and labels are unioned; on a key present in two
+    streams with conflicting metadata the later one wins and
+    ``assert_compatible_with`` logs a warning, matching how ace merges metadata
+    across datasets.
     """
-    reference_name, reference = entries[0]
-    info = _dataset_info(reference)
-    variable_metadata: dict[str, VariableMetadata] = dict(reference.variable_metadata)
-    all_labels: set[str] | None = (
-        set(reference.all_labels) if reference.all_labels is not None else None
-    )
-    for name, properties in entries[1:]:
+    infos = [(name, _dataset_info(properties)) for name, properties in entries]
+    for (name, info), (other_name, other) in itertools.permutations(infos, 2):
         try:
-            info.assert_compatible_with(_dataset_info(properties))
+            info.assert_compatible_with(other)
         except IncompatibleDatasetInfo as err:
             raise ValueError(
-                f"Streams {reference_name!r} and {name!r} both serve domain "
+                f"Streams {name!r} and {other_name!r} both serve domain "
                 f"{domain!r} but describe incompatible datasets: {err}"
             ) from err
+    reference = entries[0][1]
+    variable_metadata: dict[str, VariableMetadata] = {}
+    all_labels: set[str] | None = None
+    for _, properties in entries:
         variable_metadata.update(properties.variable_metadata)
         if properties.all_labels is not None:
             all_labels = set(properties.all_labels) | (all_labels or set())

--- a/fme/translate/data/requirements.py
+++ b/fme/translate/data/requirements.py
@@ -54,11 +54,12 @@ class StreamRequirements:
 
     @property
     def n_timesteps_schedule(self) -> IntSchedule:
-        # Delegate so the int-or-schedule union is normalized in exactly one
-        # place, ace's DataRequirements.
-        return DataRequirements(
-            names=list(self.names), n_timesteps=self.n_timesteps
-        ).n_timesteps_schedule
+        # The int-or-schedule union is the shape a config author writes (a plain
+        # int being the common case), so narrowing it needs this check; the same
+        # one ace's DataRequirements.n_timesteps_schedule makes.
+        if isinstance(self.n_timesteps, IntSchedule):
+            return self.n_timesteps
+        return IntSchedule.from_constant(self.n_timesteps)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/fme/translate/data/requirements.py
+++ b/fme/translate/data/requirements.py
@@ -164,14 +164,30 @@ class TranslateDataRequirements:
 
     def __post_init__(self):
         grouped = [name for group in self.pairing_groups for name in group]
+        # Checked before the partition check, which would otherwise report a
+        # duplicated stream as a partition mismatch.
+        if len(set(grouped)) != len(grouped):
+            raise ValueError(
+                f"A stream may appear in only one pairing group; got {grouped}."
+            )
         if sorted(grouped) != sorted(self.streams):
             raise ValueError(
                 "pairing_groups must partition the streams; got groups over "
                 f"{sorted(grouped)} for streams {sorted(self.streams)}."
             )
-        if len(set(grouped)) != len(grouped):
+        missing_allowed = sorted(
+            name
+            for name, requirements in self.streams.items()
+            if requirements.allow_missing_variables
+        )
+        if missing_allowed:
+            # The loader passes no allow_missing_variables through to
+            # DatasetABC.build, so honoring it would need plumbing in
+            # StreamConfig.get_dataset; refuse rather than silently load
+            # every variable.
             raise ValueError(
-                f"A stream may appear in only one pairing group; got {grouped}."
+                "allow_missing_variables is not supported by the translate data "
+                f"loader, but is set on streams {missing_allowed}."
             )
 
     @classmethod

--- a/fme/translate/data/requirements.py
+++ b/fme/translate/data/requirements.py
@@ -1,0 +1,204 @@
+"""What the objectives need from the data streams, and how it merges.
+
+This module is the seam between the objectives (which know what they consume)
+and the data layer (which knows how to load it). Each objective declares an
+:class:`ObjectiveDataRequirements` — for every stream it consumes, the variables
+it reads and how long a time window it needs.
+:meth:`TranslateDataRequirements.from_objectives` merges the whole objective
+list into
+
+- one :class:`~fme.ace.requirements.DataRequirements` per stream, and
+- the *pairing groups*: which streams must be sampled at the same valid times.
+
+Pairing is derived rather than configured. Every objective ties together the
+streams it consumes (a translation objective comparing 1° and 2° fields of the
+same state is meaningless if the two are drawn from different times), so the
+co-occurrence graph's connected components are exactly the sets that must share
+a time index. Streams that never co-occur are sampled independently, which is
+what the transfer-learning program's ERA5 and SHiELD streams want.
+
+Nothing here depends on the component pool: the loader takes its variable names
+from these requirements, not from the pool's domain channel lists.
+"""
+
+import dataclasses
+from collections.abc import Mapping, Sequence
+
+from fme.ace.requirements import DataRequirements
+from fme.core.dataset.schedule import IntMilestone, IntSchedule
+
+__all__ = [
+    "ObjectiveDataRequirements",
+    "StreamRequirements",
+    "TranslateDataRequirements",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class StreamRequirements:
+    """One objective's need from one data stream.
+
+    Parameters:
+        names: Names of the variables the objective reads from this stream.
+        n_timesteps: Number of timesteps per sample window, including the
+            initial condition(s). May be an :class:`IntSchedule` for an
+            objective whose rollout length grows over epochs.
+    """
+
+    names: list[str]
+    n_timesteps: int | IntSchedule = 1
+
+    def __post_init__(self):
+        if not self.names:
+            raise ValueError("StreamRequirements requires at least one variable name.")
+
+    @property
+    def n_timesteps_schedule(self) -> IntSchedule:
+        # Delegate so the int-or-schedule union is normalized in exactly one
+        # place, ace's DataRequirements.
+        return DataRequirements(
+            names=list(self.names), n_timesteps=self.n_timesteps
+        ).n_timesteps_schedule
+
+
+@dataclasses.dataclass(frozen=True)
+class ObjectiveDataRequirements:
+    """One objective's needs, keyed by stream name.
+
+    Parameters:
+        streams: What this objective needs from each stream it consumes. Every
+            stream named here is tied to every other one: they will be sampled
+            at the same valid times.
+    """
+
+    streams: Mapping[str, StreamRequirements]
+
+    def __post_init__(self):
+        if not self.streams:
+            raise ValueError("An objective must consume at least one data stream.")
+
+
+def _ordered_union(name_lists: Sequence[Sequence[str]]) -> list[str]:
+    """The union of ``name_lists`` in first-seen order."""
+    result: list[str] = []
+    seen: set[str] = set()
+    for names in name_lists:
+        for name in names:
+            if name not in seen:
+                seen.add(name)
+                result.append(name)
+    return result
+
+
+def _pointwise_max(schedules: Sequence[IntSchedule]) -> IntSchedule:
+    """The schedule taking the maximum of ``schedules`` at every epoch.
+
+    A max (rather than an error on disagreement) is the correct merge because
+    ace loads a window of the scheduled length and each objective samples a
+    prefix of it: loading the longest window any objective asks for serves them
+    all. The merged schedule's milestones are the union of the inputs'.
+    """
+    epochs = sorted({milestone.epoch for s in schedules for milestone in s.milestones})
+    start_value = max(s.get_value(0) for s in schedules)
+    milestones: list[IntMilestone] = []
+    previous = start_value
+    for epoch in epochs:
+        value = max(s.get_value(epoch) for s in schedules)
+        if value != previous:
+            milestones.append(IntMilestone(epoch=epoch, value=value))
+            previous = value
+    return IntSchedule(start_value=start_value, milestones=milestones)
+
+
+def _pairing_groups(
+    objectives: Sequence[ObjectiveDataRequirements],
+) -> list[list[str]]:
+    """Connected components of the stream co-occurrence graph.
+
+    Each objective connects the streams it consumes; the components are the
+    groups sampled at a shared time index. Grouping is transitive: objectives
+    (a, b) and (b, c) put all three in one group. A stream no multi-stream
+    objective touches is its own singleton group.
+
+    Groups, and the streams within each group, are ordered by first appearance
+    in ``objectives`` so the result is deterministic.
+    """
+    parent: dict[str, str] = {}
+    first_seen: list[str] = []
+
+    def find(name: str) -> str:
+        root = name
+        while parent[root] != root:
+            root = parent[root]
+        while parent[name] != root:
+            parent[name], name = root, parent[name]
+        return root
+
+    for objective in objectives:
+        names = list(objective.streams)
+        for name in names:
+            if name not in parent:
+                parent[name] = name
+                first_seen.append(name)
+        for other in names[1:]:
+            parent[find(other)] = find(names[0])
+
+    groups: dict[str, list[str]] = {}
+    for name in first_seen:
+        groups.setdefault(find(name), []).append(name)
+    return list(groups.values())
+
+
+@dataclasses.dataclass(frozen=True)
+class TranslateDataRequirements:
+    """The whole objective list's needs, as the data layer consumes them.
+
+    Parameters:
+        streams: Merged requirements for each stream any objective consumes.
+        pairing_groups: Partition of ``streams`` into sets sampled at the same
+            valid times. Each group is sampled independently of the others.
+    """
+
+    streams: Mapping[str, DataRequirements]
+    pairing_groups: Sequence[Sequence[str]]
+
+    def __post_init__(self):
+        grouped = [name for group in self.pairing_groups for name in group]
+        if sorted(grouped) != sorted(self.streams):
+            raise ValueError(
+                "pairing_groups must partition the streams; got groups over "
+                f"{sorted(grouped)} for streams {sorted(self.streams)}."
+            )
+        if len(set(grouped)) != len(grouped):
+            raise ValueError(
+                f"A stream may appear in only one pairing group; got {grouped}."
+            )
+
+    @classmethod
+    def from_objectives(
+        cls, objectives: Sequence[ObjectiveDataRequirements]
+    ) -> "TranslateDataRequirements":
+        """Merge each objective's needs into per-stream requirements and groups.
+
+        Per stream, the variable names are the ordered union of what the
+        objectives read and the window length is the pointwise maximum of their
+        schedules. The pairing groups come from objective co-occurrence.
+        """
+        if not objectives:
+            raise ValueError("At least one objective is required to load data.")
+        names: dict[str, list[Sequence[str]]] = {}
+        schedules: dict[str, list[IntSchedule]] = {}
+        for objective in objectives:
+            for stream_name, stream in objective.streams.items():
+                names.setdefault(stream_name, []).append(stream.names)
+                schedules.setdefault(stream_name, []).append(
+                    stream.n_timesteps_schedule
+                )
+        streams = {
+            stream_name: DataRequirements(
+                names=_ordered_union(names[stream_name]),
+                n_timesteps=_pointwise_max(schedules[stream_name]),
+            )
+            for stream_name in names
+        }
+        return cls(streams=streams, pairing_groups=_pairing_groups(objectives))

--- a/fme/translate/data/test_batch_data.py
+++ b/fme/translate/data/test_batch_data.py
@@ -18,6 +18,23 @@ def test_streams_are_accessible_by_name():
     assert batch["era5"] is batch.streams["era5"]
 
 
+def test_batch_is_a_mapping_of_streams():
+    """The surface objectives will reach their streams through."""
+    era5, shield = _batch(), _batch()
+    batch = TranslateBatchData(streams={"era5": era5, "shield": shield})
+    assert sorted(batch.keys()) == ["era5", "shield"]
+    assert dict(batch.items()) == {"era5": era5, "shield": shield}
+    assert list(batch.values()) == [era5, shield]
+    assert batch.get("missing") is None
+    assert {**batch} == {"era5": era5, "shield": shield}
+
+
+def test_missing_stream_raises_key_error():
+    batch = TranslateBatchData(streams={"era5": _batch()})
+    with pytest.raises(KeyError):
+        batch["shield"]
+
+
 def test_epoch_is_the_shared_epoch():
     batch = TranslateBatchData(streams={"era5": _batch(epoch=7), "s": _batch(epoch=7)})
     assert batch.epoch == 7
@@ -51,6 +68,16 @@ def test_merge_rejects_a_stream_in_two_groups():
                 TranslateBatchData(streams={"a": _batch()}),
             ]
         )
+
+
+def test_device_moves_copy_rather_than_mutate():
+    """``pin_memory`` mutating in place is the documented exception to this;
+    it cannot be exercised here because it requires CUDA."""
+    batch = TranslateBatchData(streams={"era5": _batch()})
+    moved = batch.to_cpu()
+    assert moved is not batch
+    assert moved.streams is not batch.streams
+    assert batch.to_device() is not batch
 
 
 def test_collate_fn_requires_matching_stream_sets():

--- a/fme/translate/data/test_batch_data.py
+++ b/fme/translate/data/test_batch_data.py
@@ -1,0 +1,60 @@
+import pytest
+
+from fme.ace.data_loading.batch_data import BatchData
+from fme.translate.data.batch_data import TranslateBatchData, TranslateCollateFn
+
+
+def _batch(epoch: int | None = 0, img_shape: tuple[int, int] = (4, 8)) -> BatchData:
+    return BatchData.new_for_testing(
+        names=["temp"], n_samples=2, n_timesteps=2, img_shape=img_shape, epoch=epoch
+    )
+
+
+def test_streams_are_accessible_by_name():
+    batch = TranslateBatchData(streams={"era5": _batch(), "shield": _batch()})
+    assert "era5" in batch
+    assert len(batch) == 2
+    assert sorted(batch) == ["era5", "shield"]
+    assert batch["era5"] is batch.streams["era5"]
+
+
+def test_epoch_is_the_shared_epoch():
+    batch = TranslateBatchData(streams={"era5": _batch(epoch=7), "s": _batch(epoch=7)})
+    assert batch.epoch == 7
+
+
+def test_epoch_disagreement_raises():
+    with pytest.raises(ValueError, match="same epoch"):
+        TranslateBatchData(streams={"a": _batch(epoch=0), "b": _batch(epoch=1)})
+
+
+def test_empty_batch_raises():
+    with pytest.raises(ValueError, match="at least one stream"):
+        TranslateBatchData(streams={})
+
+
+def test_merge_combines_disjoint_stream_sets():
+    merged = TranslateBatchData.merge(
+        [
+            TranslateBatchData(streams={"a": _batch(), "b": _batch()}),
+            TranslateBatchData(streams={"c": _batch()}),
+        ]
+    )
+    assert sorted(merged) == ["a", "b", "c"]
+
+
+def test_merge_rejects_a_stream_in_two_groups():
+    with pytest.raises(ValueError, match="sharing the streams"):
+        TranslateBatchData.merge(
+            [
+                TranslateBatchData(streams={"a": _batch()}),
+                TranslateBatchData(streams={"a": _batch()}),
+            ]
+        )
+
+
+def test_collate_fn_requires_matching_stream_sets():
+    with pytest.raises(ValueError, match="same streams"):
+        TranslateCollateFn(
+            horizontal_dims={"a": ["lat", "lon"]}, label_encodings={"b": None}
+        )

--- a/fme/translate/data/test_data_loader.py
+++ b/fme/translate/data/test_data_loader.py
@@ -1,0 +1,368 @@
+"""Tests for the translate multi-stream, paired-by-time data loader.
+
+Data is synthesized on disk as tiny netCDF files via ``fme.ace.testing``; no
+real dataset is read.
+"""
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from fme.ace.testing import DimSizes, save_nd_netcdf
+from fme.core.coordinates import DimSize
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.core.rand import set_seed
+from fme.core.typing_ import Slice
+from fme.translate.data.config import StreamConfig, TranslateDataLoaderConfig
+from fme.translate.data.getters import get_gridded_data
+from fme.translate.data.requirements import (
+    ObjectiveDataRequirements,
+    StreamRequirements,
+    TranslateDataRequirements,
+)
+
+NAMES = ["temp", "humidity"]
+# 1°/2°/4°-shaped grids, scaled down to keep the synthetic files tiny.
+SHAPES = {"era5_1deg": (16, 32), "era5_2deg": (8, 16), "era5_4deg": (4, 8)}
+
+
+def _write_stream(
+    path: pathlib.Path,
+    img_shape: tuple[int, int],
+    n_times: int,
+    names: list[str] = NAMES,
+    timestep_days: float = 1.0,
+) -> XarrayDataConfig:
+    """Write one stream's netCDF file and return the config that reads it."""
+    path.mkdir(parents=True, exist_ok=True)
+    save_nd_netcdf(
+        path / "data.nc",
+        dim_sizes=DimSizes(
+            n_time=n_times,
+            horizontal=[DimSize("lat", img_shape[0]), DimSize("lon", img_shape[1])],
+            nz_interface=3,
+        ),
+        variable_names=names,
+        timestep_days=timestep_days,
+    )
+    return XarrayDataConfig(data_path=str(path))
+
+
+def _multi_resolution_config(
+    tmp_path: pathlib.Path, n_times: int = 8, batch_size: int = 2
+) -> TranslateDataLoaderConfig:
+    """Three streams of the same state at three resolutions, identical times."""
+    return TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                name=name,
+                domain=name.replace("era5_", "atmos_"),
+                dataset=_write_stream(tmp_path / name, shape, n_times),
+            )
+            for name, shape in SHAPES.items()
+        ],
+        batch_size=batch_size,
+    )
+
+
+def _requirements(
+    *objectives: dict[str, list[str]], n_timesteps: int = 1
+) -> TranslateDataRequirements:
+    """Requirements for objectives each consuming the named streams."""
+    return TranslateDataRequirements.from_objectives(
+        [
+            ObjectiveDataRequirements(
+                streams={
+                    stream: StreamRequirements(names=names, n_timesteps=n_timesteps)
+                    for stream, names in objective.items()
+                }
+            )
+            for objective in objectives
+        ]
+    )
+
+
+def _start_times(batch, stream: str) -> np.ndarray:
+    return batch[stream].time.isel(time=0).values
+
+
+def test_every_batch_carries_all_paired_streams_at_matching_times(tmp_path):
+    """The multi-resolution story: one objective over three resolutions."""
+    config = _multi_resolution_config(tmp_path)
+    data = get_gridded_data(
+        config,
+        _requirements({name: NAMES for name in SHAPES}),
+        train=True,
+    )
+    assert data.batch_size == 2
+    assert data.n_batches == 4  # 8 times, window of 1, batch of 2
+    assert data.n_samples == 8
+
+    batches = list(data.loader)
+    assert len(batches) == data.n_batches
+    for batch in batches:
+        assert sorted(batch) == sorted(SHAPES)
+        for name, shape in SHAPES.items():
+            assert batch[name].data["temp"].shape == (2, 1, *shape)
+        reference = _start_times(batch, "era5_1deg")
+        for name in SHAPES:
+            np.testing.assert_array_equal(_start_times(batch, name), reference)
+
+
+def test_independently_sampled_streams_are_not_time_locked(tmp_path):
+    """The transfer-learning story: no objective reads both streams."""
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                domain="era5", dataset=_write_stream(tmp_path / "a", (4, 8), 9)
+            ),
+            StreamConfig(
+                domain="shield_c96", dataset=_write_stream(tmp_path / "b", (4, 8), 9)
+            ),
+        ],
+        batch_size=1,
+    )
+    requirements = _requirements({"era5": NAMES}, {"shield_c96": NAMES})
+    assert requirements.pairing_groups == [["era5"], ["shield_c96"]]
+
+    set_seed(0)
+    data = get_gridded_data(config, requirements, train=True)
+    era5 = np.concatenate([_start_times(b, "era5") for b in data.loader])
+    shield = np.concatenate([_start_times(b, "shield_c96") for b in data.loader])
+
+    # Both groups cover the same times, but in different orders: they are
+    # genuinely shuffled independently rather than index-paired.
+    assert not np.array_equal(era5, shield)
+    np.testing.assert_array_equal(np.sort(era5), np.sort(shield))
+
+
+def test_misaligned_times_within_a_pairing_group_raise(tmp_path):
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                domain="fine", dataset=_write_stream(tmp_path / "f", (8, 16), 6)
+            ),
+            StreamConfig(
+                domain="coarse",
+                # starts one timestep later than the fine stream
+                dataset=XarrayDataConfig(
+                    data_path=str(_write_stream(tmp_path / "c", (4, 8), 6).data_path),
+                    subset=Slice(start=1),
+                ),
+            ),
+        ],
+        batch_size=2,
+    )
+    with pytest.raises(ValueError, match="at sample index 0"):
+        get_gridded_data(config, _requirements({"fine": NAMES, "coarse": NAMES}), True)
+
+
+def test_misalignment_between_independent_streams_is_allowed(tmp_path):
+    """Same two misaligned streams, but no objective consumes both."""
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                domain="fine", dataset=_write_stream(tmp_path / "f", (8, 16), 6)
+            ),
+            StreamConfig(
+                domain="coarse",
+                dataset=XarrayDataConfig(
+                    data_path=str(_write_stream(tmp_path / "c", (4, 8), 6).data_path),
+                    subset=Slice(start=1),
+                ),
+            ),
+        ],
+        batch_size=2,
+    )
+    data = get_gridded_data(
+        config, _requirements({"fine": NAMES}, {"coarse": NAMES}), train=True
+    )
+    assert data.n_batches == 2  # the shorter (subset) group has 5 samples
+
+
+def test_mismatched_timestep_within_a_pairing_group_raises(tmp_path):
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                domain="daily",
+                dataset=_write_stream(tmp_path / "d", (4, 8), 8, timestep_days=1.0),
+            ),
+            StreamConfig(
+                domain="two_daily",
+                dataset=_write_stream(tmp_path / "t", (4, 8), 8, timestep_days=2.0),
+            ),
+        ],
+        batch_size=2,
+    )
+    with pytest.raises(ValueError, match="must have the same timestep"):
+        get_gridded_data(
+            config, _requirements({"daily": NAMES, "two_daily": NAMES}), True
+        )
+
+
+def test_group_length_is_the_minimum_over_its_streams(tmp_path):
+    """Objectives asking different window lengths leave different sample counts."""
+    config = _multi_resolution_config(tmp_path, n_times=8, batch_size=1)
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            ObjectiveDataRequirements(
+                streams={
+                    "era5_1deg": StreamRequirements(names=NAMES, n_timesteps=1),
+                    "era5_2deg": StreamRequirements(names=NAMES, n_timesteps=1),
+                    # a 4-step rollout leaves 8 - 4 + 1 = 5 start times
+                    "era5_4deg": StreamRequirements(names=NAMES, n_timesteps=4),
+                }
+            )
+        ]
+    )
+    data = get_gridded_data(config, requirements, train=False)
+    assert data.n_batches == 5
+
+
+def test_validation_loader_is_not_shuffled(tmp_path):
+    config = _multi_resolution_config(tmp_path, n_times=8, batch_size=1)
+    data = get_gridded_data(
+        config, _requirements({name: NAMES for name in SHAPES}), train=False
+    )
+    times = np.concatenate([_start_times(b, "era5_1deg") for b in data.loader])
+    np.testing.assert_array_equal(times, np.sort(times))
+
+
+def test_subset_loader_selects_a_batch_range(tmp_path):
+    config = _multi_resolution_config(tmp_path, n_times=8, batch_size=2)
+    data = get_gridded_data(
+        config, _requirements({name: NAMES for name in SHAPES}), train=False
+    )
+    all_batches = list(data.loader)
+    subset = list(data.subset_loader(start_batch=1, stop_batch=3))
+    assert len(subset) == 2
+    for offset, batch in enumerate(subset):
+        np.testing.assert_array_equal(
+            _start_times(batch, "era5_1deg"),
+            _start_times(all_batches[offset + 1], "era5_1deg"),
+        )
+
+
+def test_set_epoch_reaches_every_stream(tmp_path):
+    config = _multi_resolution_config(tmp_path, n_times=8, batch_size=2)
+    data = get_gridded_data(
+        config, _requirements({name: NAMES for name in SHAPES}), train=True
+    )
+    data.set_epoch(3)
+    batch = next(iter(data.loader))
+    assert batch.epoch == 3
+    assert all(stream.epoch == 3 for stream in batch.streams.values())
+
+
+def test_alternate_shuffle_changes_the_order(tmp_path):
+    config = _multi_resolution_config(tmp_path, n_times=8, batch_size=1)
+    data = get_gridded_data(
+        config, _requirements({name: NAMES for name in SHAPES}), train=True
+    )
+    data.set_epoch(0)
+    before = np.concatenate([_start_times(b, "era5_1deg") for b in data.loader])
+    data.alternate_shuffle()
+    after = np.concatenate([_start_times(b, "era5_1deg") for b in data.loader])
+    assert not np.array_equal(before, after)
+
+
+def test_dataset_info_is_keyed_by_domain(tmp_path):
+    config = _multi_resolution_config(tmp_path)
+    data = get_gridded_data(
+        config, _requirements({name: NAMES for name in SHAPES}), train=True
+    )
+    assert sorted(data.dataset_info) == ["atmos_1deg", "atmos_2deg", "atmos_4deg"]
+    for name, shape in SHAPES.items():
+        domain = name.replace("era5_", "atmos_")
+        assert data.dataset_info[domain].img_shape == shape
+
+
+def test_streams_sharing_a_domain_give_one_dataset_info(tmp_path):
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                name="era5",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "e", (4, 8), 6),
+            ),
+            StreamConfig(
+                name="ifs",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "i", (4, 8), 6),
+            ),
+        ],
+        batch_size=2,
+    )
+    data = get_gridded_data(
+        config, _requirements({"era5": NAMES}, {"ifs": NAMES}), train=True
+    )
+    assert list(data.dataset_info) == ["atmos"]
+    assert data.stream_domains == {"era5": "atmos", "ifs": "atmos"}
+
+
+def test_streams_sharing_a_domain_must_be_compatible(tmp_path):
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                name="era5",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "e", (4, 8), 6),
+            ),
+            StreamConfig(
+                name="ifs",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "i", (8, 16), 6),
+            ),
+        ],
+        batch_size=2,
+    )
+    with pytest.raises(ValueError, match="both serve domain 'atmos'"):
+        get_gridded_data(config, _requirements({"era5": NAMES}, {"ifs": NAMES}), True)
+
+
+def test_stream_no_objective_consumes_raises(tmp_path):
+    config = _multi_resolution_config(tmp_path)
+    with pytest.raises(ValueError, match="no objective consumes them"):
+        get_gridded_data(
+            config, _requirements({"era5_1deg": NAMES, "era5_2deg": NAMES}), True
+        )
+
+
+def test_objective_referencing_an_unconfigured_stream_raises(tmp_path):
+    config = _multi_resolution_config(tmp_path)
+    with pytest.raises(ValueError, match="not configured"):
+        get_gridded_data(
+            config,
+            _requirements({**{name: NAMES for name in SHAPES}, "era5_8deg": NAMES}),
+            True,
+        )
+
+
+def test_stream_name_defaults_to_domain():
+    stream = StreamConfig(domain="atmos_1deg", dataset=XarrayDataConfig(data_path="/x"))
+    assert stream.stream_name == "atmos_1deg"
+    named = StreamConfig(
+        domain="atmos_1deg", dataset=XarrayDataConfig(data_path="/x"), name="era5"
+    )
+    assert named.stream_name == "era5"
+
+
+def test_duplicate_stream_names_are_rejected():
+    with pytest.raises(ValueError, match="must be unique"):
+        TranslateDataLoaderConfig(
+            streams=[
+                StreamConfig(domain="atmos", dataset=XarrayDataConfig(data_path="/a")),
+                StreamConfig(
+                    domain="other",
+                    dataset=XarrayDataConfig(data_path="/b"),
+                    name="atmos",
+                ),
+            ],
+            batch_size=2,
+        )
+
+
+def test_no_streams_is_rejected():
+    with pytest.raises(ValueError, match="At least one data stream"):
+        TranslateDataLoaderConfig(streams=[], batch_size=2)

--- a/fme/translate/data/test_data_loader.py
+++ b/fme/translate/data/test_data_loader.py
@@ -11,6 +11,7 @@ import pytest
 
 from fme.ace.testing import DimSizes, save_nd_netcdf
 from fme.core.coordinates import DimSize
+from fme.core.dataset.schedule import IntMilestone, IntSchedule
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.rand import set_seed
 from fme.core.typing_ import Slice
@@ -218,6 +219,45 @@ def test_group_length_is_the_minimum_over_its_streams(tmp_path):
     )
     data = get_gridded_data(config, requirements, train=False)
     assert data.n_batches == 5
+
+
+def test_scheduled_window_growth_keeps_the_group_length(tmp_path):
+    """A stream whose window grows over epochs keeps its start-time count.
+
+    A group's length and its start-time alignment are computed once, when the
+    ``PairedStreamDataset`` is built, so they are only correct if a stream's
+    number of valid start times is fixed by its schedule's *longest* window
+    rather than by the current epoch's.
+    """
+    config = _multi_resolution_config(tmp_path, n_times=8, batch_size=1)
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            ObjectiveDataRequirements(
+                streams={
+                    "era5_1deg": StreamRequirements(names=NAMES, n_timesteps=1),
+                    "era5_2deg": StreamRequirements(names=NAMES, n_timesteps=1),
+                    "era5_4deg": StreamRequirements(
+                        names=NAMES,
+                        n_timesteps=IntSchedule(
+                            start_value=1,
+                            milestones=[IntMilestone(epoch=2, value=4)],
+                        ),
+                    ),
+                }
+            )
+        ]
+    )
+    data = get_gridded_data(config, requirements, train=False)
+    window_lengths = {}
+    for epoch in [0, 1, 2, 5]:
+        data.set_epoch(epoch)
+        # 8 - 4 + 1, set by the longest scheduled window, at every epoch
+        assert data.n_batches == 5
+        assert len(list(data.loader)) == 5
+        batch = next(iter(data.loader))
+        window_lengths[epoch] = batch["era5_4deg"].data["temp"].shape[1]
+    # the window itself does grow at the milestone; only the count is fixed
+    assert window_lengths == {0: 1, 1: 1, 2: 4, 5: 4}
 
 
 def test_validation_loader_is_not_shuffled(tmp_path):

--- a/fme/translate/data/test_data_loader.py
+++ b/fme/translate/data/test_data_loader.py
@@ -34,6 +34,9 @@ def _write_stream(
     n_times: int,
     names: list[str] = NAMES,
     timestep_days: float = 1.0,
+    nz_interface: int = 3,
+    save_vertical_coordinate: bool = True,
+    infer_timestep: bool = True,
 ) -> XarrayDataConfig:
     """Write one stream's netCDF file and return the config that reads it."""
     path.mkdir(parents=True, exist_ok=True)
@@ -42,12 +45,13 @@ def _write_stream(
         dim_sizes=DimSizes(
             n_time=n_times,
             horizontal=[DimSize("lat", img_shape[0]), DimSize("lon", img_shape[1])],
-            nz_interface=3,
+            nz_interface=nz_interface,
         ),
         variable_names=names,
         timestep_days=timestep_days,
+        save_vertical_coordinate=save_vertical_coordinate,
     )
-    return XarrayDataConfig(data_path=str(path))
+    return XarrayDataConfig(data_path=str(path), infer_timestep=infer_timestep)
 
 
 def _multi_resolution_config(
@@ -359,6 +363,65 @@ def test_streams_sharing_a_domain_must_be_compatible(tmp_path):
     )
     with pytest.raises(ValueError, match="both serve domain 'atmos'"):
         get_gridded_data(config, _requirements({"era5": NAMES}, {"ifs": NAMES}), True)
+
+
+def test_streams_sharing_a_domain_are_compared_pairwise(tmp_path):
+    """Compatibility with the first stream does not imply mutual compatibility.
+
+    ``no_levels`` has a ``NullVerticalCoordinate``, which opts out of the
+    vertical-coordinate comparison, so it is compatible with both of the others
+    while they disagree with each other.
+    """
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                name="no_levels",
+                domain="atmos",
+                dataset=_write_stream(
+                    tmp_path / "n", (4, 8), 6, save_vertical_coordinate=False
+                ),
+            ),
+            StreamConfig(
+                name="two_levels",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "t", (4, 8), 6, nz_interface=3),
+            ),
+            StreamConfig(
+                name="three_levels",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "h", (4, 8), 6, nz_interface=4),
+            ),
+        ],
+        batch_size=2,
+    )
+    requirements = _requirements(
+        {"no_levels": NAMES}, {"two_levels": NAMES}, {"three_levels": NAMES}
+    )
+    with pytest.raises(ValueError, match="vertical_coordinate is not compatible"):
+        get_gridded_data(config, requirements, train=True)
+
+
+def test_a_stream_without_a_timestep_cannot_mask_one_that_has_it(tmp_path):
+    """The domain must not publish the reference stream's missing timestep."""
+    config = TranslateDataLoaderConfig(
+        streams=[
+            StreamConfig(
+                name="no_timestep",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "n", (4, 8), 6, infer_timestep=False),
+            ),
+            StreamConfig(
+                name="daily",
+                domain="atmos",
+                dataset=_write_stream(tmp_path / "d", (4, 8), 6),
+            ),
+        ],
+        batch_size=2,
+    )
+    with pytest.raises(ValueError, match="timestep is not compatible"):
+        get_gridded_data(
+            config, _requirements({"no_timestep": NAMES}, {"daily": NAMES}), True
+        )
 
 
 def test_stream_no_objective_consumes_raises(tmp_path):

--- a/fme/translate/data/test_example_configs.py
+++ b/fme/translate/data/test_example_configs.py
@@ -1,0 +1,56 @@
+"""The example configs' data blocks must parse.
+
+``fme/translate/examples/`` holds the intended config surface for the whole PR
+series, reviewed before the code existed. These tests hold this PR's blocks —
+``train_data:`` and ``validation_data:`` — to what those examples say.
+"""
+
+import pathlib
+
+import dacite
+import pytest
+import yaml
+
+from fme.translate.data.config import TranslateDataLoaderConfig
+
+EXAMPLES = pathlib.Path(__file__).parents[1] / "examples"
+
+
+def _load(example: str, block: str) -> TranslateDataLoaderConfig:
+    with open(EXAMPLES / example) as f:
+        config = yaml.safe_load(f)
+    return dacite.from_dict(
+        data_class=TranslateDataLoaderConfig,
+        data=config[block],
+        config=dacite.Config(strict=True),
+    )
+
+
+@pytest.mark.parametrize(
+    "example, block",
+    [
+        (example, block)
+        for example in ["multi-resolution-latent.yaml", "transfer-learning.yaml"]
+        for block in ["train_data", "validation_data"]
+    ],
+)
+def test_example_data_block_parses(example, block):
+    config = _load(example, block)
+    assert len(config.streams) >= 2
+    assert config.batch_size == 16
+
+
+def test_multi_resolution_streams_are_explicitly_named():
+    config = _load("multi-resolution-latent.yaml", "train_data")
+    assert list(config.stream_configs) == ["era5_1deg", "era5_2deg", "era5_4deg"]
+    assert [stream.domain for stream in config.streams] == [
+        "atmos_1deg",
+        "atmos_2deg",
+        "atmos_4deg",
+    ]
+
+
+def test_transfer_learning_stream_names_default_to_their_domains():
+    config = _load("transfer-learning.yaml", "train_data")
+    assert all(stream.name is None for stream in config.streams)
+    assert list(config.stream_configs) == ["era5", "shield_c96"]

--- a/fme/translate/data/test_pool_integration.py
+++ b/fme/translate/data/test_pool_integration.py
@@ -1,0 +1,128 @@
+"""End-to-end test of the stream -> domain -> component pairing key.
+
+The loader publishes ``dataset_info`` keyed by domain name; that mapping is
+exactly what :meth:`ComponentPoolConfig.build` consumes to bind each component
+to a grid. This exercises the whole chain on tiny synthetic multi-resolution
+data: load, build the pool against the loader's dataset_info, and push one
+loaded batch through a transform built that way.
+"""
+
+import dataclasses
+
+import pytest
+import torch
+
+from fme.ace.stepper.single_module import StepperConfig
+from fme.core.registry.module import ModuleSelector
+from fme.core.step import SingleModuleStepConfig, StepSelector
+from fme.core.testing import trivial_network_and_loss_normalization
+from fme.translate.components import (
+    BackboneConfig,
+    ComponentPoolConfig,
+    TransformConfig,
+)
+from fme.translate.data.getters import get_gridded_data
+from fme.translate.data.test_data_loader import (
+    NAMES,
+    SHAPES,
+    _multi_resolution_config,
+    _requirements,
+)
+from fme.translate.domains import DomainConfig, LatentChannels
+from fme.translate.modules import TransformSelector
+
+N_LATENT = 4
+LATENT_NAMES = [f"z_{i}" for i in range(N_LATENT)]
+
+
+def _interpolate() -> TransformSelector:
+    return TransformSelector(type="interpolate", config={})
+
+
+def _latent_stepper() -> StepperConfig:
+    return StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="SphericalFourierNeuralOperatorNet",
+                        config={"scale_factor": 1, "embed_dim": 2, "num_layers": 1},
+                    ),
+                    in_names=LATENT_NAMES,
+                    out_names=LATENT_NAMES,
+                    normalization=trivial_network_and_loss_normalization(LATENT_NAMES),
+                )
+            ),
+        ),
+    )
+
+
+def _pool_config() -> ComponentPoolConfig:
+    """A 1°/2°/4° pool: per-resolution encoders into a 4°-grid latent."""
+    return ComponentPoolConfig(
+        domains={
+            "atmos_1deg": DomainConfig(channels=list(NAMES)),
+            "atmos_2deg": DomainConfig(channels=list(NAMES)),
+            "atmos_4deg": DomainConfig(channels=list(NAMES)),
+            "latent": DomainConfig(
+                channels=[LatentChannels(name="z", channels=N_LATENT)],
+                grid_like="atmos_4deg",
+            ),
+        },
+        transforms={
+            f"encoder_{resolution}": TransformConfig(
+                module=_interpolate(),
+                in_domain=f"atmos_{resolution}",
+                out_domain="latent",
+            )
+            for resolution in ["1deg", "2deg", "4deg"]
+        }
+        | {
+            "decoder_4deg": TransformConfig(
+                module=_interpolate(), in_domain="latent", out_domain="atmos_4deg"
+            )
+        },
+        backbones={
+            "stepper": BackboneConfig(domain="latent", stepper=_latent_stepper())
+        },
+    )
+
+
+@pytest.mark.medium_duration
+def test_loader_dataset_info_builds_a_multi_resolution_pool(tmp_path):
+    data = get_gridded_data(
+        _multi_resolution_config(tmp_path),
+        _requirements({name: NAMES for name in SHAPES}),
+        train=True,
+    )
+    pool = _pool_config().build(data.dataset_info)
+
+    # Every domain, including the latent one that inherits its grid, resolved to
+    # the grid of the stream bound to it.
+    for name, shape in SHAPES.items():
+        domain = name.replace("era5_", "atmos_")
+        assert pool.dataset_info[domain].img_shape == shape
+    assert pool.dataset_info["latent"].img_shape == SHAPES["era5_4deg"]
+
+    # A component built against the 1° domain's grid consumes a 1° batch and
+    # lands on the latent (4°) grid.
+    batch = next(iter(data.loader))["era5_1deg"]
+    fields = torch.cat([batch.data[name][:, 0].unsqueeze(1) for name in NAMES], dim=1)
+    assert fields.shape == (data.batch_size, len(NAMES), *SHAPES["era5_1deg"])
+    latent = pool.transforms["encoder_1deg"](fields)
+    assert latent.shape == (data.batch_size, N_LATENT, *SHAPES["era5_4deg"])
+
+
+@pytest.mark.medium_duration
+def test_pool_build_rejects_a_domain_no_stream_serves(tmp_path):
+    """A domain the loader publishes nothing for is caught by the pool."""
+    data = get_gridded_data(
+        _multi_resolution_config(tmp_path),
+        _requirements({"era5_1deg": NAMES, "era5_2deg": NAMES, "era5_4deg": NAMES}),
+        train=True,
+    )
+    config = _pool_config()
+    config.domains["atmos_8deg"] = DomainConfig(channels=list(NAMES))
+    with pytest.raises(ValueError, match="Missing dataset_info"):
+        config.build(data.dataset_info)

--- a/fme/translate/data/test_requirements.py
+++ b/fme/translate/data/test_requirements.py
@@ -1,5 +1,6 @@
 import pytest
 
+from fme.ace.requirements import DataRequirements
 from fme.core.dataset.schedule import IntMilestone, IntSchedule
 from fme.translate.data.requirements import (
     ObjectiveDataRequirements,
@@ -124,4 +125,27 @@ def test_pairing_groups_must_partition_streams():
     with pytest.raises(ValueError, match="must partition the streams"):
         TranslateDataRequirements(
             streams=requirements.streams, pairing_groups=[["era5"], ["missing"]]
+        )
+
+
+def test_a_stream_in_two_pairing_groups_is_rejected():
+    requirements = TranslateDataRequirements.from_objectives(
+        [_objective(era5=StreamRequirements(names=["temp"]))]
+    )
+    with pytest.raises(ValueError, match="only one pairing group"):
+        TranslateDataRequirements(
+            streams=requirements.streams, pairing_groups=[["era5"], ["era5"]]
+        )
+
+
+def test_allow_missing_variables_is_rejected():
+    """The loader ignores the flag, so carrying it set would load silently wrong."""
+    with pytest.raises(ValueError, match="allow_missing_variables is not supported"):
+        TranslateDataRequirements(
+            streams={
+                "era5": DataRequirements(
+                    names=["temp"], n_timesteps=1, allow_missing_variables=True
+                )
+            },
+            pairing_groups=[["era5"]],
         )

--- a/fme/translate/data/test_requirements.py
+++ b/fme/translate/data/test_requirements.py
@@ -1,0 +1,127 @@
+import pytest
+
+from fme.core.dataset.schedule import IntMilestone, IntSchedule
+from fme.translate.data.requirements import (
+    ObjectiveDataRequirements,
+    StreamRequirements,
+    TranslateDataRequirements,
+)
+
+
+def _objective(**streams: StreamRequirements) -> ObjectiveDataRequirements:
+    return ObjectiveDataRequirements(streams=streams)
+
+
+def test_merges_variable_names_as_ordered_union():
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            _objective(era5_1deg=StreamRequirements(names=["temp", "humidity"])),
+            _objective(era5_1deg=StreamRequirements(names=["humidity", "wind"])),
+        ]
+    )
+    assert requirements.streams["era5_1deg"].names == ["temp", "humidity", "wind"]
+
+
+def test_merges_n_timesteps_as_pointwise_max_over_schedules():
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            # constant window of 3
+            _objective(era5=StreamRequirements(names=["temp"], n_timesteps=3)),
+            # 1 until epoch 4, then 5
+            _objective(
+                era5=StreamRequirements(
+                    names=["temp"],
+                    n_timesteps=IntSchedule(
+                        start_value=1, milestones=[IntMilestone(epoch=4, value=5)]
+                    ),
+                )
+            ),
+        ]
+    )
+    schedule = requirements.streams["era5"].n_timesteps_schedule
+    assert schedule.get_value(0) == 3
+    assert schedule.get_value(3) == 3
+    assert schedule.get_value(4) == 5
+    assert schedule.get_value(10) == 5
+
+
+def test_streams_in_one_objective_are_one_pairing_group():
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            _objective(
+                fine=StreamRequirements(names=["temp"]),
+                coarse=StreamRequirements(names=["temp"]),
+            )
+        ]
+    )
+    assert [sorted(group) for group in requirements.pairing_groups] == [
+        ["coarse", "fine"]
+    ]
+
+
+def test_pairing_is_transitive_across_objectives():
+    """Objectives over (a, b) and (b, c) put all three on one time index."""
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            _objective(
+                era5_1deg=StreamRequirements(names=["temp"]),
+                era5_2deg=StreamRequirements(names=["temp"]),
+            ),
+            _objective(
+                era5_2deg=StreamRequirements(names=["temp"]),
+                era5_4deg=StreamRequirements(names=["temp"]),
+            ),
+        ]
+    )
+    assert [sorted(group) for group in requirements.pairing_groups] == [
+        ["era5_1deg", "era5_2deg", "era5_4deg"]
+    ]
+
+
+def test_streams_that_never_co_occur_are_independent_singletons():
+    """The transfer-learning shape: no objective reads both streams."""
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            _objective(era5=StreamRequirements(names=["temp"])),
+            _objective(shield_c96=StreamRequirements(names=["temp"])),
+        ]
+    )
+    assert requirements.pairing_groups == [["era5"], ["shield_c96"]]
+
+
+def test_pairing_groups_are_deterministically_ordered():
+    requirements = TranslateDataRequirements.from_objectives(
+        [
+            _objective(
+                b=StreamRequirements(names=["temp"]),
+                a=StreamRequirements(names=["temp"]),
+            ),
+            _objective(c=StreamRequirements(names=["temp"])),
+        ]
+    )
+    assert requirements.pairing_groups == [["b", "a"], ["c"]]
+
+
+def test_no_objectives_raises():
+    with pytest.raises(ValueError, match="At least one objective"):
+        TranslateDataRequirements.from_objectives([])
+
+
+def test_objective_with_no_streams_raises():
+    with pytest.raises(ValueError, match="at least one data stream"):
+        ObjectiveDataRequirements(streams={})
+
+
+def test_stream_requirements_with_no_names_raises():
+    with pytest.raises(ValueError, match="at least one variable name"):
+        StreamRequirements(names=[])
+
+
+def test_pairing_groups_must_partition_streams():
+    requirements = TranslateDataRequirements.from_objectives(
+        [_objective(era5=StreamRequirements(names=["temp"]))]
+    )
+    with pytest.raises(ValueError, match="must partition the streams"):
+        TranslateDataRequirements(
+            streams=requirements.streams, pairing_groups=[["era5"], ["missing"]]
+        )

--- a/fme/translate/examples/README.md
+++ b/fme/translate/examples/README.md
@@ -2,11 +2,12 @@
 
 Full example training configurations for the two target programs of the
 `fme/translate` PR series, written against the *intended* config surface
-through the whole series. The `component_pool:` and
-`train_data:`/`validation_data:` blocks are implemented; everything else
-is the shape the follow-on PRs must parse. They exist to be critiqued
-now, before more code exists, and to let the critique drive the design —
-they are not runnable.
+through the whole series. The `train_data:`/`validation_data:` blocks are
+implemented, and `component_pool:` is implemented modulo the rework noted
+in the table below (until that lands, the `component_pool:` blocks here do
+not parse); everything else is the shape the follow-on PRs must parse.
+They exist to be critiqued now, before more code exists, and to let the
+critique drive the design — they are not runnable.
 
 | Config block | PR |
 |---|---|

--- a/fme/translate/examples/README.md
+++ b/fme/translate/examples/README.md
@@ -2,15 +2,16 @@
 
 Full example training configurations for the two target programs of the
 `fme/translate` PR series, written against the *intended* config surface
-through the whole series. Only the `component_pool:` block is implemented
-in PR 1 (the skeleton); everything else is the shape the follow-on PRs
-must parse. They exist to be critiqued now, before more code exists, and
-to let the critique drive the design — they are not runnable.
+through the whole series. The `component_pool:` and
+`train_data:`/`validation_data:` blocks are implemented; everything else
+is the shape the follow-on PRs must parse. They exist to be critiqued
+now, before more code exists, and to let the critique drive the design —
+they are not runnable.
 
 | Config block | PR |
 |---|---|
 | `component_pool:` (domains / transforms / backbones, freeze, checkpoint init) | 1 — modulo channels-on-transforms (domain load lists derived), int-declared latent blocks expanded in backbone `in_names`/`out_names`, and identity normalization |
-| `train_data:` / `validation_data:` stream lists (time-pairing derived from objective co-occurrence, not configured) | 2 |
+| `train_data:` / `validation_data:` stream lists (time-pairing derived from objective co-occurrence, not configured) | 2 — implemented; the pairing groups come from the `objectives:` list, which PR 3 supplies |
 | `objectives:` (`translation`, `forward_prediction` over one-backbone component chains), `optimization:`, weighted-sum trainer | 3 |
 | `inference:` composites (one-backbone component chains, Stepper-compatible export) | 4 |
 | `latent_consistency` objective type, noise-conditioned encoder and latent-resampler registry entries | 6 |

--- a/fme/translate/examples/multi-resolution-latent.yaml
+++ b/fme/translate/examples/multi-resolution-latent.yaml
@@ -4,9 +4,10 @@
 # 4° latent share the same downsampling modules. The forward stepper lives in
 # the 4° latent.
 # Intended config surface for the fme/translate PR series; the
-# component_pool: and train_data:/validation_data: blocks are implemented.
-# See README.md in this directory for which PR lands each block.
-# Not runnable.
+# train_data:/validation_data: blocks are implemented, and component_pool:
+# modulo the PR-1 rework noted in README.md (until that lands, the
+# component_pool: block below does not parse). See README.md in this
+# directory for which PR lands each block. Not runnable.
 experiment_dir: train_output
 save_checkpoint: true
 validate_using_ema: true

--- a/fme/translate/examples/multi-resolution-latent.yaml
+++ b/fme/translate/examples/multi-resolution-latent.yaml
@@ -3,9 +3,10 @@
 # resamplers move between latent resolutions, so the 1° and 2° paths into the
 # 4° latent share the same downsampling modules. The forward stepper lives in
 # the 4° latent.
-# Intended config surface for the fme/translate PR series; only the
-# component_pool: block is implemented in PR 1. See README.md in this
-# directory for which PR lands each block. Not runnable.
+# Intended config surface for the fme/translate PR series; the
+# component_pool: and train_data:/validation_data: blocks are implemented.
+# See README.md in this directory for which PR lands each block.
+# Not runnable.
 experiment_dir: train_output
 save_checkpoint: true
 validate_using_ema: true

--- a/fme/translate/examples/transfer-learning.yaml
+++ b/fme/translate/examples/transfer-learning.yaml
@@ -5,9 +5,10 @@
 # the translators are same-grid (a resolution-changing registry entry drops
 # in if the ERA5 side were 1°).
 # Intended config surface for the fme/translate PR series; the
-# component_pool: and train_data:/validation_data: blocks are implemented.
-# See README.md in this directory for which PR lands each block.
-# Not runnable.
+# train_data:/validation_data: blocks are implemented, and component_pool:
+# modulo the PR-1 rework noted in README.md (until that lands, the
+# component_pool: block below does not parse). See README.md in this
+# directory for which PR lands each block. Not runnable.
 experiment_dir: train_output
 save_checkpoint: true
 validate_using_ema: true

--- a/fme/translate/examples/transfer-learning.yaml
+++ b/fme/translate/examples/transfer-learning.yaml
@@ -4,9 +4,10 @@
 # checkpoint. Cycle consistency in both directions. Both datasets at 4°, so
 # the translators are same-grid (a resolution-changing registry entry drops
 # in if the ERA5 side were 1°).
-# Intended config surface for the fme/translate PR series; only the
-# component_pool: block is implemented in PR 1. See README.md in this
-# directory for which PR lands each block. Not runnable.
+# Intended config surface for the fme/translate PR series; the
+# component_pool: and train_data:/validation_data: blocks are implemented.
+# See README.md in this directory for which PR lands each block.
+# Not runnable.
 experiment_dir: train_output
 save_checkpoint: true
 validate_using_ema: true


### PR DESCRIPTION
PR 2 of the `fme/translate` series, targeting the long-lived base branch
`feature/translate-skeleton` (PR #1360) rather than `main`.

Translate training reads several named data streams at once — the same state at
1°/2°/4°, or ERA5 alongside SHiELD. Some of those streams must be sampled at the
same valid times (a translation objective comparing 1° and 2° fields of one state
is meaningless if the two are drawn from different times) and some must not be
(the transfer-learning program's two streams are unpaired distributions). This
adds `fme/translate/data/`: named streams, that pairing, and the multi-stream
`GriddedDataABC` implementation training will consume.

Whether two streams are sampled together is **derived, never configured**. Each
objective declares what it needs from each stream it consumes; every objective
ties its streams together, and the connected components of the resulting graph
are the *pairing groups*. Streams in a group share a time index; groups are
sampled independently. Grouping is transitive, so objectives over (a, b) and
(b, c) put all three on one index. A `sampling:` knob in the config could
contradict the objectives; a derivation cannot.

The requirements type is the seam PR 3 (objectives) will produce: it constructs
one `ObjectiveDataRequirements` per objective and calls
`TranslateDataRequirements.from_objectives`, which merges per-stream variable
names as an ordered union and per-stream window length as the *pointwise maximum*
of the objectives' `IntSchedule`s (ace loads a window of the scheduled length and
each objective samples a prefix of it, so loading the longest window any objective
asks for serves them all). Nothing in the seam depends on the component pool: the
loader takes variable names from the requirements, not from the pool's domain
channel lists.

Alignment within a group is validated when the group is built, since pairing by
index is otherwise silently wrong: the streams must share a timestep, and their
sample start times must match index by index, with the first offending index and
its two times named in the error. A group's length is the minimum over its
streams, because objectives asking for different window lengths leave different
numbers of valid start times.

`n_samples`/`n_batches`/seeding semantics under unequal groups: `n_batches` is the
minimum over the groups (iteration stops with the shortest, so no group is
re-drawn mid-epoch), and `n_samples` is `n_batches * batch_size` — samples drawn
*per group*, not summed across groups, so it stays the count a per-batch metric
divides by. Each group's sampler is built with its own `seed_offset`; without
that, two equal-length groups receive the same permutation and are index-paired
in fact while claiming to be independent (a test fails if the offset is removed).

`TranslateGriddedData.dataset_info` is keyed by **domain**, not stream: that is
the pairing key `ComponentPoolConfig.build` consumes, and streams sharing a
domain are checked to describe compatible datasets via
`DatasetInfo.assert_compatible_with`, with their variable metadata and labels
unioned.

Changes:
- `fme.translate.data.requirements`: `StreamRequirements`,
  `ObjectiveDataRequirements`, and `TranslateDataRequirements.from_objectives` —
  the objective-to-data seam and its merge (name union, pointwise-max schedule,
  pairing groups).
- `fme.translate.data.config`: `StreamConfig` (`domain`, `dataset`, optional
  `name` defaulting to the domain via `stream_name`) and
  `TranslateDataLoaderConfig`, mirroring `fme.ace.data_loading.config.DataLoaderConfig`'s
  field names and validating in `__post_init__`.
- `fme.translate.data.batch_data`: `TranslateBatchData`, a
  `Mapping[str, BatchData]` generalizing `fme.coupled`'s two-component batch
  type, plus `TranslateCollateFn`.
- `fme.translate.data.dataset`: `PairedStreamDataset`, an N-stream
  `GenericDataset` that pairs by index and validates timestep and start-time
  alignment at build time.
- `fme.translate.data.dataloader`, `.gridded_data`, `.getters`:
  `TranslateDataLoader` (one per pairing group, all behavior from
  `GenericDataLoader`), `TranslateGriddedData` (zips the groups, publishes
  domain-keyed `dataset_info`), and `get_gridded_data(config, requirements, train)`.
- `fme.core.distributed.Distributed.get_sampler`: new `seed_offset` argument
  (default 0, existing callers unaffected) so several samplers over equal-length
  datasets can be shuffled independently rather than in lockstep. Added here
  rather than mutating the returned sampler so the spatial-parallel `num_replicas`
  and `rank` logic stays in one place.
- `fme/translate/examples/`: the README table and the two configs' headers now
  say which blocks parse — `train_data:`/`validation_data:` with this PR, and
  `component_pool:` only once PR 1's remaining rework (channels-on-transforms
  with derived domain load lists, int-declared latent blocks, identity
  normalization) lands, which is tracked separately and is why the loader takes
  variable names from the requirements seam rather than the pool config.

Design points worth a reviewer's attention:
- `PairedStreamDataset` is translate-local rather than a reuse of
  `fme.downscaling`'s `FineCoarsePairedDataset`, which is hard-wired to a
  fine/coarse pair and to single-timestep items (its `BatchItemDatasetAdapter`
  squeezes the time dimension away) and so cannot carry the time windows a
  forward-prediction objective needs. `fme.coupled.CoupledDataset` is the closer
  analogue but is likewise fixed at two named components. What is reused is the
  machinery under both: `GenericDataset`/`GenericDataLoader` supply subsetting,
  epoch propagation, shuffle control, `batch_size` and `n_samples`.
- Unequal but integer-ratio timesteps within a group (`fme.coupled`'s
  `n_steps_fast` index scaling) is a deliberate non-feature; the docstring names
  it as the path if an objective ever needs it.
- Batches are moved to the device but not spatially scattered, following
  `fme.coupled`: spatial model parallelism would need each stream scattered
  against its own grid, which no translate module supports yet. Data-parallel
  sharding is handled. `get_gridded_data` calls
  `Distributed.require_no_spatial_parallelism`, so a spatially-parallel run
  fails rather than handing every co-rank the whole global field.
- `DataRequirements.allow_missing_variables` is refused rather than ignored:
  `StreamConfig.get_dataset` does not plumb it to `DatasetABC.build`, so a
  requirements object carrying it would load every variable and report success.
- ace's `time_buffer` window-reuse options are not offered: they draw several
  output batches from one preloaded window, which would break the index pairing.
- A configured stream that no objective consumes is an error, not a silent
  unused load.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

