### PR TITLE
Avoid CUDA context creation in DataLoader workers

### DIFF
--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -3,9 +3,10 @@ import os
 import pytest
 import torch
 import torch.multiprocessing as mp
+import torch.utils.data
 
 from fme import get_device
-from fme.core.distributed import Distributed
+from fme.core.distributed import Distributed, torch_distributed
 from fme.core.distributed.torch_distributed import (
     _gather_irregular,
     _pad_tensor_at_end,
@@ -147,3 +148,36 @@ def test_gather_irregular():
     assert all(
         shape == gathered_nonscalar_shapes[0] for shape in gathered_nonscalar_shapes
     )
+
+
+def test_dataloader_worker_skips_cuda_and_process_group_init(monkeypatch):
+    """A DataLoader worker gets usable rank metadata without initializing CUDA.
+
+    Each CUDA context costs hundreds of MiB of GPU memory, and workers have no
+    use for one, so a worker must not set the CUDA device or join the process
+    group.
+    """
+    monkeypatch.setattr(torch_distributed, "using_gpu", lambda: True)
+    monkeypatch.setattr(torch_distributed, "using_srun", lambda: False)
+    monkeypatch.setattr(
+        torch.utils.data, "get_worker_info", lambda: object(), raising=False
+    )
+
+    def fail(*args, **kwargs):
+        raise AssertionError("must not be called in a DataLoader worker")
+
+    monkeypatch.setattr(torch.distributed, "init_process_group", fail)
+    monkeypatch.setattr(torch.cuda, "set_device", fail)
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    monkeypatch.setenv("LOCAL_RANK", "3")
+
+    dist = torch_distributed.TorchDistributed()
+
+    assert dist.rank == 3
+    assert dist.total_ranks == 8
+    assert dist._device_id == 3
+
+
+def test_not_in_dataloader_worker_in_main_process():
+    assert not torch_distributed._in_dataloader_worker()

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 
 import torch.distributed
 import torch.nn as nn
+import torch.utils.data
 import torch_harmonics as th
 from torch.nn import SyncBatchNorm
 from torch.nn.functional import pad
@@ -23,10 +24,42 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _in_dataloader_worker() -> bool:
+    """Whether this process is a torch DataLoader worker.
+
+    Workers only need rank and world size, which they use to decide which
+    samples belong to their rank. They never run collectives or touch GPU
+    tensors, so joining the process group and setting the CUDA device would
+    only create an idle ~520 MiB CUDA context per worker. With several
+    persistent worker pools per rank that costs GiB of GPU memory that the
+    training step could otherwise use.
+    """
+    return torch.utils.data.get_worker_info() is not None
+
+
+def _rank_metadata_from_env() -> tuple[int, int, int]:
+    """Return ``(rank, world_size, local_rank)`` from the launcher's env vars."""
+    if using_srun():
+        # the srun setting assumes one GPU per process, so local rank is always 0
+        return int(os.environ["SLURM_PROCID"]), int(os.environ["SLURM_NTASKS"]), 0
+    return (
+        int(os.environ["RANK"]),
+        int(os.environ["WORLD_SIZE"]),
+        int(os.environ["LOCAL_RANK"]),
+    )
+
+
 class TorchDistributed(DistributedBackend):
     """A non-distributed backend implementation."""
 
     def __init__(self):
+        if _in_dataloader_worker() and self.is_available():
+            # see _in_dataloader_worker for why workers skip process group
+            # and CUDA device initialization
+            self._rank, self.world_size, local_rank = _rank_metadata_from_env()
+            if using_gpu():
+                self._device_id = local_rank
+            return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun
             if not torch.distributed.is_initialized():
                 if using_gpu():


### PR DESCRIPTION
Inference dataloaders run with a forkserver multiprocessing context and persistent workers, and their `worker_init_fn` enters a `Distributed` context so each worker can decide which samples belong to its rank. Constructing `TorchDistributed` called `torch.cuda.set_device`, which creates a CUDA context (~520 MiB) in every worker process. A training config with six inline inference loaders at `num_data_workers: 4` therefore leaves 24 idle CUDA contexts holding 12.2 GiB on each GPU, which is enough to turn an otherwise-fitting training step into `torch.OutOfMemoryError` during backward.

DataLoader workers only read `rank` and `world_size`, which `fme.ace.data_loading.inference.InferenceDataset` uses for sharding; they never run collectives and never place tensors on the GPU. Workers now take that metadata from the launcher's environment variables and skip both process group and CUDA device initialization. Objects pickled into the workers hold only CPU tensors, since `DatasetProperties.to_device` returns a new instance and is applied in `GriddedData`/`InferenceGriddedData` rather than on the dataset itself, so no CUDA context is re-created by unpickling.

This covers both `fme.ace.data_loading.getters._forkserver_worker_init_fn` and `fme.coupled.data_loading.getters._coupled_forkserver_worker_init_fn`, since the fix is in the backend they both build.

Changes:
- `fme.core.distributed.torch_distributed._in_dataloader_worker` and `_rank_metadata_from_env`: new helpers that detect a DataLoader worker and read rank, world size and local rank from the torchrun or srun environment variables
- `fme.core.distributed.torch_distributed.TorchDistributed.__init__`: in a DataLoader worker, populate rank metadata from the environment and return without calling `torch.distributed.init_process_group` or `torch.cuda.set_device`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
