### PR TITLE
Avoid CUDA context creation in DataLoader workers

### DIFF
--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -106,7 +106,6 @@ class ModelTorchDistributed(DistributedBackend):
     ):
         spatial_size = h_size * w_size
         if _in_dataloader_worker():
-            # see _in_dataloader_worker; the (data, h, w) mesh is row-major
             self._rank, self._world_size = _rank_metadata_from_env()
             _check_world_size_divisible(self._world_size, spatial_size)
             self._data_size = self._world_size // spatial_size

--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -35,12 +35,24 @@ from ._gloo_patch import patch_gloo_alltoall
 from .base import DistributedBackend
 from .external.pnd_manager import DistributedManager
 from .non_distributed import DummyWrapper
-from .torch_distributed import _gather_irregular
+from .torch_distributed import (
+    _gather_irregular,
+    _in_dataloader_worker,
+    _rank_metadata_from_env,
+)
 
 logger = logging.getLogger(__name__)
 
 
 T = TypeVar("T")
+
+
+def _check_world_size_divisible(world_size: int, spatial_size: int) -> None:
+    if world_size % spatial_size != 0:
+        raise ValueError(
+            f"world_size must be divisible by h_size * w_size, "
+            f"got world_size={world_size} and h*w={spatial_size}"
+        )
 
 
 class _AutogradAllReduce(torch.autograd.Function):
@@ -92,18 +104,27 @@ class ModelTorchDistributed(DistributedBackend):
         w_size: int = 1,
         verbose: bool = False,
     ):
+        spatial_size = h_size * w_size
+        if _in_dataloader_worker():
+            # see _in_dataloader_worker for why workers skip process group and
+            # CUDA device initialization, which here also means skipping the
+            # DeviceMesh. The (data, h, w) mesh is row-major over global ranks,
+            # so the data-parallel index and size follow from arithmetic; the
+            # spatial groups, mesh and device id are left unset, so that using
+            # them raises rather than silently misbehaving without a mesh.
+            self._rank, self._world_size = _rank_metadata_from_env()
+            _check_world_size_divisible(self._world_size, spatial_size)
+            self._data_size = self._world_size // spatial_size
+            self._data_rank = self._rank // spatial_size
+            return
+
         # Initialize PhysicsNeMo DistributedManager.
         DistributedManager.initialize()
         self._dm = DistributedManager()
 
         # Build a 3-D (data, h, w) DeviceMesh; data=-1 auto-sizes the
         # data-parallel dimension to absorb all remaining ranks.
-        spatial_size = h_size * w_size
-        if self._dm.world_size % spatial_size != 0:
-            raise ValueError(
-                f"world_size must be divisible by h_size * w_size, "
-                f"got world_size={self._dm.world_size} and h*w={spatial_size}"
-            )
+        _check_world_size_divisible(self._dm.world_size, spatial_size)
         mesh = self._dm.initialize_mesh(
             mesh_shape=(-1, h_size, w_size),
             mesh_dim_names=("data", "h", "w"),

--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -106,12 +106,7 @@ class ModelTorchDistributed(DistributedBackend):
     ):
         spatial_size = h_size * w_size
         if _in_dataloader_worker():
-            # see _in_dataloader_worker for why workers skip process group and
-            # CUDA device initialization, which here also means skipping the
-            # DeviceMesh. The (data, h, w) mesh is row-major over global ranks,
-            # so the data-parallel index and size follow from arithmetic; the
-            # spatial groups, mesh and device id are left unset, so that using
-            # them raises rather than silently misbehaving without a mesh.
+            # see _in_dataloader_worker; the (data, h, w) mesh is row-major
             self._rank, self._world_size = _rank_metadata_from_env()
             _check_world_size_divisible(self._world_size, spatial_size)
             self._data_size = self._world_size // spatial_size

--- a/fme/core/distributed/parallel_tests/test_dataloader_worker.py
+++ b/fme/core/distributed/parallel_tests/test_dataloader_worker.py
@@ -1,0 +1,49 @@
+"""
+Tests that the DataLoader worker code path reports the same sharding metadata
+as a fully initialized backend.
+
+A worker skips the process group, the CUDA device and (under spatial
+parallelism) the DeviceMesh, so it derives rank and data-parallel metadata from
+the launcher's environment variables and mesh arithmetic instead. Inference
+dataloaders use that metadata to decide which samples belong to their rank, so
+a mismatch with the real backend would silently drop or duplicate samples.
+
+These tests need a launcher to be meaningful and skip without one.
+"""
+
+import os
+
+import pytest
+import torch.utils.data
+
+from fme.core.device import using_srun
+from fme.core.distributed import Distributed
+from fme.core.distributed.model_torch_distributed import ModelTorchDistributed
+from fme.core.distributed.torch_distributed import TorchDistributed
+
+
+def _build_worker_backend(monkeypatch):
+    """Build the configured backend as a DataLoader worker would see it."""
+    monkeypatch.setattr(torch.utils.data, "get_worker_info", lambda: object())
+    if os.environ.get("FME_DISTRIBUTED_BACKEND") == "model":
+        return ModelTorchDistributed(
+            h_size=int(os.environ["FME_DISTRIBUTED_H"]),
+            w_size=int(os.environ["FME_DISTRIBUTED_W"]),
+        )
+    return TorchDistributed()
+
+
+@pytest.mark.parallel
+def test_worker_sharding_metadata_matches_backend(monkeypatch):
+    if "RANK" not in os.environ and not using_srun():
+        pytest.skip("requires torchrun or srun")
+    if os.environ.get("FME_DISTRIBUTED_BACKEND") == "none":
+        pytest.skip("requires a distributed backend")
+    dist = Distributed.get_instance()
+
+    worker = _build_worker_backend(monkeypatch)
+
+    assert worker.rank == dist.rank
+    assert worker.total_ranks == dist.world_size
+    assert worker.data_parallel_rank == dist.data_parallel_rank
+    assert worker.total_data_parallel_ranks == dist.total_data_parallel_ranks

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -177,6 +177,7 @@ def _forbid_cuda_and_process_group_init(monkeypatch):
 
     monkeypatch.setattr(torch.distributed, "init_process_group", fail)
     monkeypatch.setattr(torch.cuda, "set_device", fail)
+    # get_device() calls current_device(), which lazily initializes CUDA
     monkeypatch.setattr(torch.cuda, "current_device", fail)
 
 
@@ -187,6 +188,11 @@ def _pretend_dataloader_worker(monkeypatch):
 LAUNCHER_ENVS = [
     pytest.param(_set_torchrun_env, id="torchrun"),
     pytest.param(_set_srun_env, id="srun"),
+]
+
+LAUNCHER_ENVS_AND_DEVICE_IDS = [
+    pytest.param(_set_torchrun_env, 1, id="torchrun"),
+    pytest.param(_set_srun_env, 0, id="srun"),
 ]
 
 
@@ -238,9 +244,11 @@ def test_spatial_parallel_dataloader_worker_skips_cuda_and_process_group_init(
     assert dist.total_data_parallel_ranks == 4
 
 
-@pytest.mark.parametrize("set_launcher_env", LAUNCHER_ENVS)
+@pytest.mark.parametrize(
+    "set_launcher_env,expected_device_id", LAUNCHER_ENVS_AND_DEVICE_IDS
+)
 def test_dataloader_worker_guard_does_not_affect_main_process(
-    monkeypatch, set_launcher_env
+    monkeypatch, set_launcher_env, expected_device_id
 ):
     """Outside a worker the CUDA device is still set, as training requires."""
     set_launcher_env(monkeypatch, rank=3, world_size=8, local_rank=1)
@@ -256,4 +264,14 @@ def test_dataloader_worker_guard_does_not_affect_main_process(
 
     assert dist.rank == 3
     assert dist.total_ranks == 8
-    assert set_devices == [dist._device_id]
+    assert set_devices == [expected_device_id]
+
+
+def test_dataloader_worker_without_launcher_env_raises(monkeypatch):
+    """A worker with no launcher environment reports why, not a KeyError."""
+    monkeypatch.delenv("FME_USE_SRUN", raising=False)
+    monkeypatch.delenv("RANK", raising=False)
+    _pretend_dataloader_worker(monkeypatch)
+
+    with pytest.raises(ValueError, match="without torchrun or srun"):
+        torch_distributed.TorchDistributed()

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -3,9 +3,10 @@ import os
 import pytest
 import torch
 import torch.multiprocessing as mp
+import torch.utils.data
 
 from fme import get_device
-from fme.core.distributed import Distributed
+from fme.core.distributed import Distributed, torch_distributed
 from fme.core.distributed.torch_distributed import (
     _gather_irregular,
     _pad_tensor_at_end,
@@ -147,3 +148,36 @@ def test_gather_irregular():
     assert all(
         shape == gathered_nonscalar_shapes[0] for shape in gathered_nonscalar_shapes
     )
+
+
+def test_dataloader_worker_skips_cuda_and_process_group_init(monkeypatch):
+    """A DataLoader worker gets usable rank metadata without initializing CUDA.
+
+    Each CUDA context costs hundreds of MiB of GPU memory, and workers have no
+    use for one, so a worker must not set the CUDA device or join the process
+    group.
+    """
+    monkeypatch.setattr(torch_distributed, "using_gpu", lambda: True)
+    monkeypatch.setattr(torch_distributed, "using_srun", lambda: False)
+    monkeypatch.setattr(
+        torch.utils.data, "get_worker_info", lambda: object(), raising=False
+    )
+
+    def fail(*args, **kwargs):
+        raise AssertionError("must not be called in a DataLoader worker")
+
+    monkeypatch.setattr(torch.distributed, "init_process_group", fail)
+    monkeypatch.setattr(torch.cuda, "set_device", fail)
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    monkeypatch.setenv("LOCAL_RANK", "3")
+
+    dist = torch_distributed.TorchDistributed()
+
+    assert dist.rank == 3
+    assert dist.total_ranks == 8
+    assert dist._device_id == 3
+
+
+def test_not_in_dataloader_worker_in_main_process():
+    assert not torch_distributed._in_dataloader_worker()

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -177,7 +177,6 @@ def _forbid_cuda_and_process_group_init(monkeypatch):
 
     monkeypatch.setattr(torch.distributed, "init_process_group", fail)
     monkeypatch.setattr(torch.cuda, "set_device", fail)
-    # get_device() calls current_device(), which lazily initializes CUDA
     monkeypatch.setattr(torch.cuda, "current_device", fail)
 
 

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -7,6 +7,8 @@ import torch.utils.data
 
 from fme import get_device
 from fme.core.distributed import Distributed, torch_distributed
+from fme.core.distributed.external.pnd_manager import DistributedManager
+from fme.core.distributed.model_torch_distributed import ModelTorchDistributed
 from fme.core.distributed.torch_distributed import (
     _gather_irregular,
     _pad_tensor_at_end,
@@ -150,34 +152,109 @@ def test_gather_irregular():
     )
 
 
-def test_dataloader_worker_skips_cuda_and_process_group_init(monkeypatch):
-    """A DataLoader worker gets usable rank metadata without initializing CUDA.
+def _set_torchrun_env(monkeypatch, rank: int, world_size: int, local_rank: int):
+    monkeypatch.delenv("FME_USE_SRUN", raising=False)
+    monkeypatch.setenv("RANK", str(rank))
+    monkeypatch.setenv("WORLD_SIZE", str(world_size))
+    monkeypatch.setenv("LOCAL_RANK", str(local_rank))
 
-    Each CUDA context costs hundreds of MiB of GPU memory, and workers have no
-    use for one, so a worker must not set the CUDA device or join the process
-    group.
-    """
-    monkeypatch.setattr(torch_distributed, "using_gpu", lambda: True)
-    monkeypatch.setattr(torch_distributed, "using_srun", lambda: False)
-    monkeypatch.setattr(
-        torch.utils.data, "get_worker_info", lambda: object(), raising=False
+
+def _set_srun_env(monkeypatch, rank: int, world_size: int, local_rank: int):
+    monkeypatch.setenv("FME_USE_SRUN", "1")
+    monkeypatch.setenv("SLURM_PROCID", str(rank))
+    monkeypatch.setenv("SLURM_NTASKS", str(world_size))
+    monkeypatch.setenv("SLURM_LOCALID", str(local_rank))
+    monkeypatch.setenv(
+        "SRUN_DIST_FILE_PATH", "/tmp/unused-init-process-group-is-stubbed"
     )
+
+
+def _forbid_cuda_and_process_group_init(monkeypatch):
+    """Make every CUDA and process group entry point a worker must avoid fail."""
 
     def fail(*args, **kwargs):
         raise AssertionError("must not be called in a DataLoader worker")
 
     monkeypatch.setattr(torch.distributed, "init_process_group", fail)
     monkeypatch.setattr(torch.cuda, "set_device", fail)
-    monkeypatch.setenv("RANK", "3")
-    monkeypatch.setenv("WORLD_SIZE", "8")
-    monkeypatch.setenv("LOCAL_RANK", "3")
+    # get_device() calls current_device(), which lazily initializes CUDA
+    monkeypatch.setattr(torch.cuda, "current_device", fail)
+
+
+def _pretend_dataloader_worker(monkeypatch):
+    monkeypatch.setattr(torch.utils.data, "get_worker_info", lambda: object())
+
+
+LAUNCHER_ENVS = [
+    pytest.param(_set_torchrun_env, id="torchrun"),
+    pytest.param(_set_srun_env, id="srun"),
+]
+
+
+@pytest.mark.parametrize("set_launcher_env", LAUNCHER_ENVS)
+def test_dataloader_worker_skips_cuda_and_process_group_init(
+    monkeypatch, set_launcher_env
+):
+    """A DataLoader worker gets usable rank metadata without initializing CUDA.
+
+    Each CUDA context costs hundreds of MiB of GPU memory, and workers have no
+    use for one, so a worker must not set the CUDA device or join the process
+    group.
+    """
+    set_launcher_env(monkeypatch, rank=3, world_size=8, local_rank=1)
+    _pretend_dataloader_worker(monkeypatch)
+    _forbid_cuda_and_process_group_init(monkeypatch)
 
     dist = torch_distributed.TorchDistributed()
 
     assert dist.rank == 3
     assert dist.total_ranks == 8
-    assert dist._device_id == 3
 
 
-def test_not_in_dataloader_worker_in_main_process():
-    assert not torch_distributed._in_dataloader_worker()
+@pytest.mark.parametrize("set_launcher_env", LAUNCHER_ENVS)
+def test_spatial_parallel_dataloader_worker_skips_cuda_and_process_group_init(
+    monkeypatch, set_launcher_env
+):
+    """A worker under spatial parallelism also gets metadata CUDA-free.
+
+    The data-parallel index and size are derived from the row-major
+    (data, h, w) mesh layout rather than from the DeviceMesh, which cannot be
+    built without the process group the worker skips.
+    """
+    set_launcher_env(monkeypatch, rank=3, world_size=8, local_rank=1)
+    _pretend_dataloader_worker(monkeypatch)
+    _forbid_cuda_and_process_group_init(monkeypatch)
+
+    def fail_initialize():
+        raise AssertionError("must not be called in a DataLoader worker")
+
+    monkeypatch.setattr(DistributedManager, "initialize", fail_initialize)
+
+    dist = ModelTorchDistributed(h_size=2, w_size=1)
+
+    assert dist.rank == 3
+    assert dist.total_ranks == 8
+    # rank 3 is the second (h, w) group of the second data-parallel slice
+    assert dist.data_parallel_rank == 1
+    assert dist.total_data_parallel_ranks == 4
+
+
+@pytest.mark.parametrize("set_launcher_env", LAUNCHER_ENVS)
+def test_dataloader_worker_guard_does_not_affect_main_process(
+    monkeypatch, set_launcher_env
+):
+    """Outside a worker the CUDA device is still set, as training requires."""
+    set_launcher_env(monkeypatch, rank=3, world_size=8, local_rank=1)
+    monkeypatch.setattr(torch_distributed, "using_gpu", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 8)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 3)
+    monkeypatch.setattr(torch.distributed, "init_process_group", lambda **kwargs: None)
+    set_devices: list[int] = []
+    monkeypatch.setattr(torch.cuda, "set_device", set_devices.append)
+
+    dist = torch_distributed.TorchDistributed()
+
+    assert dist.rank == 3
+    assert dist.total_ranks == 8
+    assert set_devices == [dist._device_id]

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -27,38 +27,33 @@ T = TypeVar("T")
 def _in_dataloader_worker() -> bool:
     """Whether this process is a torch DataLoader worker.
 
-    Workers only need rank and world size, which they use to decide which
-    samples belong to their rank. They never run collectives or touch GPU
-    tensors, so joining the process group and setting the CUDA device would
-    only create an idle ~520 MiB CUDA context per worker. With several
-    persistent worker pools per rank that costs GiB of GPU memory that the
-    training step could otherwise use.
+    Workers only need sharding metadata, which they use to decide which samples
+    belong to their rank. They never run collectives or touch GPU tensors, so
+    joining the process group and setting the CUDA device would only create an
+    idle ~520 MiB CUDA context per worker. With several persistent worker pools
+    per rank that costs GiB of GPU memory that the training step could
+    otherwise use.
     """
     return torch.utils.data.get_worker_info() is not None
 
 
-def _rank_metadata_from_env() -> tuple[int, int, int]:
-    """Return ``(rank, world_size, local_rank)`` from the launcher's env vars."""
+def _rank_metadata_from_env() -> tuple[int, int]:
+    """Return ``(rank, world_size)`` from the launcher's environment variables."""
     if using_srun():
-        # the srun setting assumes one GPU per process, so local rank is always 0
-        return int(os.environ["SLURM_PROCID"]), int(os.environ["SLURM_NTASKS"]), 0
-    return (
-        int(os.environ["RANK"]),
-        int(os.environ["WORLD_SIZE"]),
-        int(os.environ["LOCAL_RANK"]),
-    )
+        return int(os.environ["SLURM_PROCID"]), int(os.environ["SLURM_NTASKS"])
+    return int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
 
 
 class TorchDistributed(DistributedBackend):
     """A non-distributed backend implementation."""
 
     def __init__(self):
-        if _in_dataloader_worker() and self.is_available():
-            # see _in_dataloader_worker for why workers skip process group
-            # and CUDA device initialization
-            self._rank, self.world_size, local_rank = _rank_metadata_from_env()
-            if using_gpu():
-                self._device_id = local_rank
+        if _in_dataloader_worker():
+            # see _in_dataloader_worker for why workers skip process group and
+            # CUDA device initialization. _device_id is deliberately left
+            # unset, so that using it raises instead of silently reporting a
+            # device this process never selected.
+            self._rank, self.world_size = _rank_metadata_from_env()
             return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun
             if not torch.distributed.is_initialized():

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 
 import torch.distributed
 import torch.nn as nn
+import torch.utils.data
 import torch_harmonics as th
 from torch.nn import SyncBatchNorm
 from torch.nn.functional import pad
@@ -23,10 +24,42 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _in_dataloader_worker() -> bool:
+    """Whether this process is a torch DataLoader worker.
+
+    Workers only need rank and world size, which they use to decide which
+    samples belong to their rank. They never run collectives or touch GPU
+    tensors, so joining the process group and setting the CUDA device would
+    only create an idle ~520 MiB CUDA context per worker. With several
+    persistent worker pools per rank that costs GiB of GPU memory that the
+    training step could otherwise use.
+    """
+    return torch.utils.data.get_worker_info() is not None
+
+
+def _rank_metadata_from_env() -> tuple[int, int, int]:
+    """Return ``(rank, world_size, local_rank)`` from the launcher's env vars."""
+    if using_srun():
+        # the srun setting assumes one GPU per process, so local rank is always 0
+        return int(os.environ["SLURM_PROCID"]), int(os.environ["SLURM_NTASKS"]), 0
+    return (
+        int(os.environ["RANK"]),
+        int(os.environ["WORLD_SIZE"]),
+        int(os.environ["LOCAL_RANK"]),
+    )
+
+
 class TorchDistributed(DistributedBackend):
     """A non-distributed backend implementation."""
 
     def __init__(self):
+        if _in_dataloader_worker() and self.is_available():
+            # see _in_dataloader_worker for why workers skip process group
+            # and CUDA device initialization
+            self._rank, self.world_size, local_rank = _rank_metadata_from_env()
+            if using_gpu():
+                self._device_id = local_rank
+            return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun
             if not torch.distributed.is_initialized():
                 if using_gpu():

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -49,7 +49,6 @@ class TorchDistributed(DistributedBackend):
 
     def __init__(self):
         if _in_dataloader_worker():
-            # see _in_dataloader_worker; _device_id is deliberately left unset
             self._rank, self.world_size = _rank_metadata_from_env()
             return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -41,6 +41,8 @@ def _rank_metadata_from_env() -> tuple[int, int]:
     """Return ``(rank, world_size)`` from the launcher's environment variables."""
     if using_srun():
         return int(os.environ["SLURM_PROCID"]), int(os.environ["SLURM_NTASKS"])
+    if "RANK" not in os.environ:
+        raise ValueError("Distributed backend initialized without torchrun or srun.")
     return int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
 
 

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -49,10 +49,7 @@ class TorchDistributed(DistributedBackend):
 
     def __init__(self):
         if _in_dataloader_worker():
-            # see _in_dataloader_worker for why workers skip process group and
-            # CUDA device initialization. _device_id is deliberately left
-            # unset, so that using it raises instead of silently reporting a
-            # device this process never selected.
+            # see _in_dataloader_worker; _device_id is deliberately left unset
             self._rank, self.world_size = _rank_metadata_from_env()
             return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun


### PR DESCRIPTION
Inference dataloaders run with a forkserver context and persistent workers, and their `worker_init_fn` enters a `Distributed` context so each worker knows which samples belong to its rank. Constructing the backend called `torch.cuda.set_device`, creating a ~520 MiB CUDA context in every worker. A training config with six inline inference loaders at `num_data_workers: 4` therefore left 24 idle contexts holding 12.2 GiB on each GPU, enough to turn an otherwise-fitting training step into `torch.OutOfMemoryError` during backward.

Workers only read sharding metadata — `data_parallel_rank` and `total_data_parallel_ranks` in `fme.ace.data_loading.inference.InferenceDataset`, `rank` and `world_size` in the coupled equivalent. They never run collectives and never place tensors on the GPU. They now take that metadata from the launcher's environment variables and skip both process group and CUDA device initialization. Objects pickled into workers hold only CPU tensors, since `DatasetProperties.to_device` returns a new instance and is applied in `GriddedData`/`InferenceGriddedData` rather than on the dataset, so unpickling re-creates no context.

Workers were also joining the process group. That was harmless — torchrun's agent hosts the TCPStore so every rank connects as a client, `_store_based_barrier` is already satisfied when a worker increments the counter, and NCCL communicator creation is lazy without a `device_id`. The CUDA context was the whole cost.

Both `TorchDistributed` and `ModelTorchDistributed` are reachable from a worker, so both are fixed, which covers `fme.ace.data_loading.getters._forkserver_worker_init_fn` and `fme.coupled.data_loading.getters._coupled_forkserver_worker_init_fn`. Under spatial parallelism a worker cannot build the DeviceMesh that normally supplies data-parallel rank and size, so it derives them from the row-major `(data, h, w)` mesh layout; a parallel test checks that arithmetic against a real mesh. Attributes a worker cannot populate — the device id, the spatial process groups, the mesh — are left unset, so using one raises rather than reporting a value that disagrees with the process's actual state.

Changes:
- `fme.core.distributed.torch_distributed._in_dataloader_worker` and `_rank_metadata_from_env`: new helpers that detect a DataLoader worker and read rank and world size from the torchrun or srun environment variables, raising the same "initialized without torchrun or srun" `ValueError` as the non-worker path when neither launcher is detected
- `fme.core.distributed.torch_distributed.TorchDistributed.__init__`: in a worker, populate rank metadata from the environment and return without calling `torch.distributed.init_process_group` or `torch.cuda.set_device`
- `fme.core.distributed.model_torch_distributed.ModelTorchDistributed.__init__`: same guard, additionally skipping `DistributedManager.initialize` and the DeviceMesh, and deriving data-parallel rank and size arithmetically
- `fme.core.distributed.model_torch_distributed._check_world_size_divisible`: new helper, shared by the worker and mesh paths

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

