### PR TITLE
Consistent branch rules between agents and contributing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,15 +68,7 @@ Before starting, plan out how the changes will be made in one or more atomic com
 Commits should leave the codebase in a consistent state, and should not add unused features that can't be reviewed in isolation.
 They should also include tests for any new functionality, and should not break existing tests.
 
-When making new branches, use the naming convention:
-`<type>/<short-description>`, where `<type>` is one of:
-- feature: Any new functionality (most common branch type).
-- refactor: No changes to features or configs, just code restructuring.
-- fix: Bug fixes.
-- exp: Branch used for running experiments, likely will not be merged to main.
-- config: Changes to configurations under config/.
-- scripts: Changes isolated to a single directory under scripts/.
-- docs: Documentation changes only.
+For branch naming conventions, see the "Internal Development" section of CONTRIBUTING.md.
 
 ### Naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,11 @@ development guidelines.
 When making new branches, use the naming convention:
 `<type>/<short-description>`, where `<type>` is one of:
 - feature: Any new functionality in the repository including workflows and scripts but not including configurations. Should be the "default" type if it's unclear which to use.
-- refactor: No changes to features, just code restructuring or simplification.
+- refactor: No changes to features or configurations, just code restructuring or simplification.
 - fix: Bug fixes.
 - exp: Branch used for running experiments that is likely not intended to merge with mainline code. Functionality changes in these branches should first be PR'd using a feature branch.
-- config: Changes to baseline and experimental configurations under config/.
-- scripts: Changes isolated to a single script under scripts/ and subject to less rigorous review than changes to core code.
+- config: Changes to baseline and experimental configurations under configs/.
+- scripts: Changes isolated to a single script or a single directory under scripts/, and subject to less rigorous review than changes to core code.
 - docs: Documentation changes only.
 
 ## Code Guidelines


### PR DESCRIPTION
Small PR that dedups the branch name rules between AGENTS and CONTRIBUTING.md, hopefully without forcing agents to read much extra into context.
