### PR TITLE
Bump to python=3.12 and torch=2.10

### DIFF
--- a/.github/workflows/beaker.yaml
+++ b/.github/workflows/beaker.yaml
@@ -24,7 +24,7 @@ jobs:
       BEAKER_CHECKPOINT_TEST_DATASET: elynn/ci-inference
       WANDB_PROJECT: ace-ci-tests
       WANDB_ENTITY: ai2cm
-      PYTHON_VERSION: "3.11"
+      PYTHON_VERSION: "3.12"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
           echo "CURRENT_WEEK=$(date +'%Y-%U')" >> $GITHUB_ENV
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install uv
           # can't use --system here because it doesn't work with --no-build-isolation and a healpix dependency
-          uv venv --python 3.11
+          uv venv --python 3.12
           uv pip install -c constraints.txt -e .[docs]
           uv pip install --no-build-isolation -c constraints.txt -e .[docs,healpix]
       - name: Build docs

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
           echo "CURRENT_WEEK=$(date +'%Y-%U')" >> $GITHUB_ENV
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install uv
           # can't use --system here because it doesn't work with --no-build-isolation and a healpix dependency
-          uv venv --python 3.11
+          uv venv --python 3.12
           uv pip install -c constraints.txt -e .[dev,graphcast]
           uv pip install --no-build-isolation -c constraints.txt -r requirements-healpix.txt
       - name: Run unit tests with code coverage
@@ -47,7 +47,7 @@ jobs:
           echo "CURRENT_WEEK=$(date +'%Y-%U')" >> $GITHUB_ENV
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
@@ -72,7 +72,7 @@ jobs:
           echo "CURRENT_WEEK=$(date +'%Y-%U')" >> $GITHUB_ENV
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
@@ -87,7 +87,7 @@ jobs:
           sudo apt-get install -y make git build-essential
           python -m pip install uv
           # can't use --system here because it doesn't work with --no-build-isolation and a healpix dependency
-          if [ ! -d ".venv" ]; then uv venv --python 3.11; fi
+          if [ ! -d ".venv" ]; then uv venv --python 3.12; fi
           uv pip install -c constraints.txt -e .[dev,graphcast]
           uv pip install --no-build-isolation -c constraints.txt -r requirements-healpix.txt
       - name: Run CUDA check and pytest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build_nsight_image:
 
 # recommended to deactivate current conda environment before running this
 create_environment:
-	conda create -n $(ENVIRONMENT_NAME) python=3.11 $(CONDA_PACKAGES)
+	conda create -n $(ENVIRONMENT_NAME) python=3.12 $(CONDA_PACKAGES)
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) python -m pip install uv
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install -c constraints.txt -e .[dev,docs,graphcast]
 	conda run --no-capture-output -n $(ENVIRONMENT_NAME) uv pip install --no-build-isolation -c constraints.txt -r requirements-healpix.txt

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,14 @@ enter_docker_image: build_docker_image
 launch_beaker_session:
 	./launch-beaker-session.sh $(USERNAME)/$(IMAGE)-$(VERSION)
 
+# FLAVOR=devel gets the base image variant that ships nvcc, needed to build the
+# CUDA extensions
 build_deps_only_image:
-	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile -t $(IMAGE)-deps-only:$(VERSION) --target deps-only .
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile --build-arg FLAVOR=devel -t $(IMAGE)-deps-only:$(VERSION) --target deps-only .
 	beaker image create $(IMAGE)-deps-only:$(VERSION) --name $(IMAGE)-deps-only-$(VERSION) --workspace ai2/ace-ci-tests
 
 build_nsight_image:
-	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile -t $(IMAGE)-nsight:$(VERSION) --target nsight .
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile --build-arg FLAVOR=devel -t $(IMAGE)-nsight:$(VERSION) --target nsight .
 	beaker image create $(IMAGE)-nsight:$(VERSION) --name $(IMAGE)-nsight-$(VERSION) --workspace ai2/ace
 
 # recommended to deactivate current conda environment before running this

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,12 @@ enter_docker_image: build_docker_image
 launch_beaker_session:
 	./launch-beaker-session.sh $(USERNAME)/$(IMAGE)-$(VERSION)
 
-# FLAVOR=devel gets the base image variant that ships nvcc, needed to build the
-# CUDA extensions
 build_deps_only_image:
-	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile --build-arg FLAVOR=devel -t $(IMAGE)-deps-only:$(VERSION) --target deps-only .
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile -t $(IMAGE)-deps-only:$(VERSION) --target deps-only .
 	beaker image create $(IMAGE)-deps-only:$(VERSION) --name $(IMAGE)-deps-only-$(VERSION) --workspace ai2/ace-ci-tests
 
 build_nsight_image:
-	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile --build-arg FLAVOR=devel -t $(IMAGE)-nsight:$(VERSION) --target nsight .
+	DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 -f docker/Dockerfile -t $(IMAGE)-nsight:$(VERSION) --target nsight .
 	beaker image create $(IMAGE)-nsight:$(VERSION) --name $(IMAGE)-nsight-$(VERSION) --workspace ai2/ace
 
 # recommended to deactivate current conda environment before running this

--- a/configs/examples/perlmutter-conda/make-venv.sh
+++ b/configs/examples/perlmutter-conda/make-venv.sh
@@ -24,7 +24,7 @@ else
 
     echo "Creating environment at $ENVIRONMENT_PATH"
     module load python
-    conda create -p $ENVIRONMENT_PATH python=3.11 pip -y
+    conda create -p $ENVIRONMENT_PATH python=3.12 pip -y
     conda run --no-capture-output -p $ENVIRONMENT_PATH python -m pip install uv
     conda run --no-capture-output -p $ENVIRONMENT_PATH uv pip install -c constraints.txt .[dev,docs]
     rm -rf $SCRATCH/ace-slurm-env/temp/ace

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,3 @@
-torch==2.8.0  # version matches torch in Docker image
+torch==2.10.0  # version matches torch in Docker image
 xarray>=2025.01.2
 zarr>=3.0.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,10 @@
-FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime AS base
+# FLAVOR is `runtime` for the production image, and `devel` for the deps-only
+# image, which needs the nvcc shipped in the devel variant to build the CUDA
+# extensions. This tag provides Python 3.12 on Ubuntu 24.04; keep the torch
+# version in constraints.txt in sync with it.
+ARG PYTORCH_TAG=2.10.0-cuda12.8-cudnn9
+ARG FLAVOR=runtime
+FROM pytorch/pytorch:${PYTORCH_TAG}-${FLAVOR} AS base
 
 ENV FME_DIR=/full-model
 ENV DGLBACKEND=pytorch
@@ -13,11 +19,18 @@ RUN apt-get update -y && apt-get install -y \
 
 # Install gcloud- used for monthly netcdf data processing script
 # https://cloud.google.com/sdk/docs/install#deb
+# apt-key is gone in Ubuntu 24.04, so dearmor the key into the keyring directly.
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
-  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
+  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+  gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+  apt-get update -y && apt-get install google-cloud-cli -y
 
 ENV FORCE_CUDA_EXTENSION=1
+# The image's interpreter is the Ubuntu system Python, which carries the PEP 668
+# externally-managed marker. Installing into it is what we want in a container.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV UV_BREAK_SYSTEM_PACKAGES=1
 # install python deps
 RUN pip install uv
 COPY pyproject.toml /tmp/pyproject.toml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update -y && apt-get install -y \
 
 # Install gcloud- used for monthly netcdf data processing script
 # https://cloud.google.com/sdk/docs/install#deb
-# apt-key is gone in Ubuntu 24.04, so dearmor the key into the keyring directly.
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
   tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,3 @@
-# This tag provides Python 3.12 on Ubuntu 24.04; keep the torch version in
-# constraints.txt in sync with it.
 FROM pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime AS base
 
 ENV FME_DIR=/full-model
@@ -23,8 +21,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
   apt-get update -y && apt-get install google-cloud-cli -y
 
 ENV FORCE_CUDA_EXTENSION=1
-# The image's interpreter is the Ubuntu system Python, which carries the PEP 668
-# externally-managed marker. Installing into it is what we want in a container.
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ENV UV_BREAK_SYSTEM_PACKAGES=1
 # install python deps

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,6 @@
-# FLAVOR is `runtime` for the production image, and `devel` for the deps-only
-# image, which needs the nvcc shipped in the devel variant to build the CUDA
-# extensions. This tag provides Python 3.12 on Ubuntu 24.04; keep the torch
-# version in constraints.txt in sync with it.
-ARG PYTORCH_TAG=2.10.0-cuda12.8-cudnn9
-ARG FLAVOR=runtime
-FROM pytorch/pytorch:${PYTORCH_TAG}-${FLAVOR} AS base
+# This tag provides Python 3.12 on Ubuntu 24.04; keep the torch version in
+# constraints.txt in sync with it.
+FROM pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime AS base
 
 ENV FME_DIR=/full-model
 ENV DGLBACKEND=pytorch

--- a/docker/install_apex_groupnorm.sh
+++ b/docker/install_apex_groupnorm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install NVIDIA Apex GroupNorm
-# Tested on: Python 3.11, PyTorch 2.8.0, CUDA 12.8, Ubuntu 22.04
+# Tested on: Python 3.12, PyTorch 2.10.0, CUDA 12.8, Ubuntu 24.04
 #
 # This script includes a fix for the missing <tuple> include in the Apex v2 code
 # which causes compilation errors with CUDA 12.8 + GCC 11.
@@ -31,7 +31,7 @@ sed -i '1a #include <tuple>' apex/contrib/csrc/group_norm_v2/gn_cuda_host_templa
 # Step 2: Build and install
 echo ""
 echo "[2/2] Building Apex with GroupNorm extension only..."
-CPLUS_INCLUDE_PATH=/opt/conda/targets/x86_64-linux/include:$CPLUS_INCLUDE_PATH \
+CPLUS_INCLUDE_PATH=${CUDA_HOME:-/usr/local/cuda}/targets/x86_64-linux/include:$CPLUS_INCLUDE_PATH \
     APEX_GROUP_NORM=1 \
     pip install -v --no-build-isolation --no-cache-dir ./
 

--- a/docker/install_cuda_extensions.sh
+++ b/docker/install_cuda_extensions.sh
@@ -1,22 +1,76 @@
 #!/bin/bash
 # Install CUDA extensions for torch-harmonics and Apex GroupNorm.
 #
-# Requires nvcc, which the `devel` flavor of the PyTorch base image provides
-# (see FLAVOR in docker/Dockerfile).
+# The PyTorch runtime base image is built on plain Ubuntu and gets CUDA from pip
+# wheels, so it has no nvcc. This installs the CUDA toolkit from NVIDIA's apt
+# repository, builds the extensions against it, then purges it again so only the
+# built extensions are left behind.
+#
+# Must be run as a single Docker RUN step, otherwise the toolkit is captured in
+# an image layer and purging it later does not reclaim the space.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Keep in sync with the CUDA version of the base image in docker/Dockerfile.
+CUDA_APT_SUFFIX=12-8
+CUDA_INSTALL_DIR=/usr/local/cuda-12.8
+
 echo "=== Installing CUDA extensions ==="
 
+# Step 1: Install CUDA toolkit via apt
+echo ""
+echo "[1/3] Installing CUDA toolkit (nvcc) via apt..."
+# Record the installed packages first, so that step 3 purges exactly what was
+# added here, down to the keyring that registers NVIDIA's apt repository. The
+# base image installs no CUDA apt packages, but diffing also keeps the purge
+# from reaching anything that was already present.
+PACKAGES_BEFORE=$(mktemp)
+PACKAGES_ADDED=$(mktemp)
+dpkg-query -W -f='${Package}\n' | sort > "${PACKAGES_BEFORE}"
+
+KEYRING_DIR=$(mktemp -d)
+curl -fsSL -o "${KEYRING_DIR}/cuda-keyring.deb" \
+    "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb"
+dpkg -i "${KEYRING_DIR}/cuda-keyring.deb"
+rm -rf "${KEYRING_DIR}"
+apt-get update -y
+
+apt-get install -y --no-install-recommends "cuda-toolkit-${CUDA_APT_SUFFIX}"
+
+dpkg-query -W -f='${Package}\n' | sort | comm -13 "${PACKAGES_BEFORE}" - \
+    > "${PACKAGES_ADDED}"
+
+export CUDA_HOME="${CUDA_INSTALL_DIR}"
+export PATH="${CUDA_HOME}/bin:${PATH}"
+
 if ! command -v nvcc > /dev/null; then
-    echo "nvcc not found; build the image with --build-arg FLAVOR=devel" >&2
+    echo "nvcc not found on PATH after installing the CUDA toolkit" >&2
     exit 1
 fi
+nvcc --version
 
+# Step 2: Build CUDA extensions
+echo ""
+echo "[2/3] Building CUDA extensions..."
 "$SCRIPT_DIR/install_torch_harmonics_cuda.sh"
 "$SCRIPT_DIR/install_apex_groupnorm.sh"
+
+# Step 3: Remove CUDA build tools to save space
+echo ""
+echo "[3/3] Removing CUDA build tools..."
+xargs -r apt-get purge -y < "${PACKAGES_ADDED}"
+rm -f "${PACKAGES_BEFORE}" "${PACKAGES_ADDED}"
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+# dpkg only removes the files it installed, so drop anything the builds left in
+# the toolkit directory. The /usr/local/cuda symlink is an update-alternatives
+# link that the toolkit's postrm removes, but clean it up if it is left dangling.
+rm -rf "${CUDA_INSTALL_DIR}"
+if [ -L /usr/local/cuda ] && [ ! -e /usr/local/cuda ]; then
+    rm -f /usr/local/cuda
+fi
 
 echo ""
 echo "=== CUDA extensions installation complete ==="

--- a/docker/install_cuda_extensions.sh
+++ b/docker/install_cuda_extensions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Install CUDA extensions for torch-harmonics and Apex GroupNorm.
 #
-# Installs the CUDA toolkit once, runs both build scripts, then removes
-# the toolkit to save image space.
+# Requires nvcc, which the `devel` flavor of the PyTorch base image provides
+# (see FLAVOR in docker/Dockerfile).
 
 set -e
 
@@ -10,22 +10,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "=== Installing CUDA extensions ==="
 
-# Step 1: Install CUDA toolkit via conda
-echo ""
-echo "[1/3] Installing CUDA toolkit (nvcc) via conda..."
-conda install -y -c nvidia cuda-nvcc=12.8 cuda-toolkit=12.8
+if ! command -v nvcc > /dev/null; then
+    echo "nvcc not found; build the image with --build-arg FLAVOR=devel" >&2
+    exit 1
+fi
 
-# Step 2: Build CUDA extensions
-echo ""
-echo "[2/3] Building CUDA extensions..."
 "$SCRIPT_DIR/install_torch_harmonics_cuda.sh"
 "$SCRIPT_DIR/install_apex_groupnorm.sh"
-
-# Step 3: Remove CUDA build tools to save space
-echo ""
-echo "[3/3] Removing CUDA build tools..."
-conda remove -y cuda-nvcc cuda-toolkit --force
-conda clean -afy
 
 echo ""
 echo "=== CUDA extensions installation complete ==="

--- a/docker/install_torch_harmonics_cuda.sh
+++ b/docker/install_torch_harmonics_cuda.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Reinstall torch-harmonics with optimized CUDA kernels
-# Tested on: Python 3.11, PyTorch 2.8.0, CUDA 12.8, Ubuntu 22.04
+# Tested on: Python 3.12, PyTorch 2.10.0, CUDA 12.8, Ubuntu 24.04
 #
 # The default pip install of torch-harmonics does not compile custom CUDA
 # extensions because the runtime Docker image lacks nvcc. This script
@@ -15,7 +15,7 @@ echo ""
 echo "Building torch-harmonics with CUDA extensions..."
 FORCE_CUDA_EXTENSION=1 \
     TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0 10.0+PTX" \
-    CPLUS_INCLUDE_PATH=/opt/conda/targets/x86_64-linux/include:$CPLUS_INCLUDE_PATH \
+    CPLUS_INCLUDE_PATH=${CUDA_HOME:-/usr/local/cuda}/targets/x86_64-linux/include:$CPLUS_INCLUDE_PATH \
     pip install --no-build-isolation --no-cache-dir --no-deps --force-reinstall torch-harmonics==0.8.0
 
 echo ""

--- a/docs/builder.rst
+++ b/docs/builder.rst
@@ -101,7 +101,7 @@ The result is a user-configurable instance we can use to optimize model weights.
     Adam (
     Parameter Group 0
         amsgrad: False
-        betas: [0.9, 0.999]
+        betas: (0.9, 0.999)
         capturable: False
         decoupled_weight_decay: False
         differentiable: False

--- a/latest_deps_only_image.txt
+++ b/latest_deps_only_image.txt
@@ -1,1 +1,1 @@
-elynn/fme-deps-only-769435616
+oliverwm/fme-deps-only-c9fb617a4

--- a/latest_deps_only_image.txt
+++ b/latest_deps_only_image.txt
@@ -1,1 +1,1 @@
-oliverwm/fme-deps-only-c9fb617a4
+oliverwm/fme-deps-only-c82095065


### PR DESCRIPTION
Bump to python=3.12 and torch=2.10 in our shared `fme` conda environment, docker image and CI testing environments. This PR does not change the dependencies or minimum required version of `fme` package. Bumping to python=3.12 will let us use the latest version of zarr-python.

Changes:
- update `Makefile`, CI workflows, constraints.txt and Dockerfile and related scripts to get python=3.12

- [x] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated