### PR TITLE
Carry corrector step diagnostics through coupled inference

### DIFF
--- a/fme/coupled/aggregator.py
+++ b/fme/coupled/aggregator.py
@@ -19,6 +19,7 @@ from fme.ace.aggregator.inference.main import (
     MeanMetricConfig,
     PowerSpectrumMetricConfig,
     SeasonalMetricConfig,
+    StepDiagnosticsMetricConfig,
     StepMeanMetricConfig,
     TimeMeanMetricConfig,
     VideoMetricConfig,
@@ -243,6 +244,12 @@ class InferenceEvaluatorAggregatorConfig:
             This should include both ocean and atmosphere variables.
         time_mean_reference_data: Path to reference time means to compare against.
             This should include both ocean and atmosphere variables.
+        step_diagnostics: Granularity of metrics computed from the step
+            diagnostics carried on prediction data (the corrector's
+            correction deltas), applied to both the ocean and atmosphere
+            aggregators; such metrics are logged only for a realm whose
+            component has a corrector, normalized with that realm's
+            normalizer.
     """
 
     log_histograms: bool = False
@@ -254,6 +261,9 @@ class InferenceEvaluatorAggregatorConfig:
     log_global_mean_norm_time_series: bool = True
     monthly_reference_data: str | None = None
     time_mean_reference_data: str | None = None
+    step_diagnostics: StepDiagnosticsMetricConfig = dataclasses.field(
+        default_factory=StepDiagnosticsMetricConfig
+    )
 
     def _build_metrics(
         self,
@@ -312,6 +322,7 @@ class InferenceEvaluatorAggregatorConfig:
         output_dir: str | None = None,
         ocean_channel_mean_names: Sequence[str] | None = None,
         atmosphere_channel_mean_names: Sequence[str] | None = None,
+        enable_time_series: bool = True,
     ) -> "InferenceEvaluatorAggregator":
         if n_timesteps_atmosphere > 2**15 and self.log_zonal_mean_images:
             # matplotlib raises an error if image size is too large, and we plot
@@ -352,6 +363,8 @@ class InferenceEvaluatorAggregatorConfig:
             ),
             channel_mean_names=ocean_channel_mean_names,
             save_diagnostics=save_diagnostics,
+            enable_time_series=enable_time_series,
+            step_diagnostics=self.step_diagnostics,
         )
         atmosphere_agg = build_inference_evaluator_aggregator(
             metrics=atmosphere_metrics,
@@ -369,6 +382,8 @@ class InferenceEvaluatorAggregatorConfig:
             ),
             channel_mean_names=atmosphere_channel_mean_names,
             save_diagnostics=save_diagnostics,
+            enable_time_series=enable_time_series,
+            step_diagnostics=self.step_diagnostics,
         )
 
         return InferenceEvaluatorAggregator(
@@ -552,11 +567,21 @@ class InferenceAggregatorConfig:
         log_global_mean_time_series: Whether to log global mean time series metrics.
         atmosphere_time_mean_reference_data: Path to atmosphere reference time means.
         ocean_time_mean_reference_data: Path to ocean reference time means.
+        step_diagnostics: Granularity of metrics computed from the step
+            diagnostics carried on prediction data (the corrector's
+            correction deltas), applied to both the ocean and atmosphere
+            aggregators. Such metrics require that realm's normalizer to be
+            supplied at build time: building with a non-default configuration
+            but no normalizer raises an error, while with the default
+            configuration the metrics are silently skipped.
     """
 
     log_global_mean_time_series: bool = True
     atmosphere_time_mean_reference_data: str | None = None
     ocean_time_mean_reference_data: str | None = None
+    step_diagnostics: StepDiagnosticsMetricConfig = dataclasses.field(
+        default_factory=StepDiagnosticsMetricConfig
+    )
 
     def build(
         self,
@@ -564,26 +589,32 @@ class InferenceAggregatorConfig:
         n_timesteps_ocean: int,
         n_timesteps_atmosphere: int,
         output_dir: str,
+        ocean_normalize: NormalizeFn | None = None,
+        atmosphere_normalize: NormalizeFn | None = None,
     ) -> "InferenceAggregator":
         ocean_ace_config = AceInferenceAggregatorConfig(
             time_mean_reference_data=self.ocean_time_mean_reference_data,
             log_global_mean_time_series=self.log_global_mean_time_series,
+            step_diagnostics=self.step_diagnostics,
         )
         atmosphere_ace_config = AceInferenceAggregatorConfig(
             time_mean_reference_data=self.atmosphere_time_mean_reference_data,
             log_global_mean_time_series=self.log_global_mean_time_series,
+            step_diagnostics=self.step_diagnostics,
         )
         ocean_agg = ocean_ace_config.build(
             dataset_info=dataset_info.ocean,
             n_timesteps=n_timesteps_ocean,
             output_dir=os.path.join(output_dir, "ocean"),
             save_diagnostics=True,
+            normalize=ocean_normalize,
         )
         atmosphere_agg = atmosphere_ace_config.build(
             dataset_info=dataset_info.atmosphere,
             n_timesteps=n_timesteps_atmosphere,
             output_dir=os.path.join(output_dir, "atmosphere"),
             save_diagnostics=True,
+            normalize=atmosphere_normalize,
         )
         return InferenceAggregator(
             ocean=ocean_agg,

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -2,10 +2,9 @@ import dataclasses
 from collections.abc import Callable, Sequence
 from typing import TypeVar
 
-import numpy as np
-
 from fme.ace.data_loading.batch_data import BatchData, PairedData, PrognosticState
 from fme.core.labels import LabelEncoding
+from fme.core.step.step_diagnostics import StepDiagnostics
 from fme.core.typing_ import TensorDict, TensorMapping
 from fme.coupled.data_loading.data_typing import CoupledDatasetItem
 from fme.coupled.requirements import CoupledPrognosticStateDataRequirements
@@ -154,6 +153,23 @@ class CoupledBatchData:
         self.atmosphere_data = self.atmosphere_data.pin_memory()
         return self
 
+    def with_step_diagnostics(
+        self,
+        ocean: StepDiagnostics | None,
+        atmosphere: StepDiagnostics | None,
+    ) -> "CoupledBatchData":
+        """Return a copy with each realm's BatchData carrying that realm's
+        step-diagnostics series. Each series must be aligned with its realm's
+        time axis, so attach only after any time-changing operations
+        (``BatchData`` raises on them once diagnostics are attached).
+        """
+        return CoupledBatchData(
+            ocean_data=dataclasses.replace(self.ocean_data, step_diagnostics=ocean),
+            atmosphere_data=dataclasses.replace(
+                self.atmosphere_data, step_diagnostics=atmosphere
+            ),
+        )
+
 
 @dataclasses.dataclass
 class CoupledPairedData:
@@ -171,30 +187,13 @@ class CoupledPairedData:
         prediction: CoupledBatchData,
         reference: CoupledBatchData,
     ) -> "CoupledPairedData":
-        if not np.all(
-            prediction.ocean_data.time.values == reference.ocean_data.time.values
-        ):
-            raise ValueError(
-                "Prediction and target ocean time coordinate must be the same."
-            )
-        if not np.all(
-            prediction.atmosphere_data.time.values
-            == reference.atmosphere_data.time.values
-        ):
-            raise ValueError(
-                "Prediction and target atmosphere time coordinate must be the same."
-            )
         return CoupledPairedData(
-            ocean_data=PairedData(
-                prediction=prediction.ocean_data.data,
-                reference=reference.ocean_data.data,
-                time=prediction.ocean_data.time,
-                labels=prediction.ocean_data.labels,
+            ocean_data=PairedData.from_batch_data(
+                prediction=prediction.ocean_data,
+                reference=reference.ocean_data,
             ),
-            atmosphere_data=PairedData(
-                prediction=prediction.atmosphere_data.data,
-                reference=reference.atmosphere_data.data,
-                time=prediction.atmosphere_data.time,
-                labels=prediction.atmosphere_data.labels,
+            atmosphere_data=PairedData.from_batch_data(
+                prediction=prediction.atmosphere_data,
+                reference=reference.atmosphere_data,
             ),
         )

--- a/fme/coupled/data_loading/test_batch_data.py
+++ b/fme/coupled/data_loading/test_batch_data.py
@@ -1,0 +1,156 @@
+import dataclasses
+
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from fme.ace.data_loading.batch_data import BatchData
+from fme.core.device import get_device
+from fme.core.step.step_diagnostics import StepDiagnostics
+from fme.coupled.data_loading.batch_data import CoupledBatchData, CoupledPairedData
+
+N_SAMPLES = 2
+IMG_SHAPE = (5, 5)
+
+
+def _get_batch_data(
+    names: list[str],
+    n_time: int,
+    n_samples: int = N_SAMPLES,
+    n_ensemble: int = 1,
+    time_offset: int = 0,
+) -> BatchData:
+    data = {
+        name: torch.rand(n_samples, n_time, *IMG_SHAPE, device=get_device())
+        for name in names
+    }
+    return BatchData.new_on_device(
+        data=data,
+        time=xr.DataArray(
+            np.full((n_samples, n_time), time_offset),
+            dims=["sample", "time"],
+        ),
+        n_ensemble=n_ensemble,
+    )
+
+
+def _get_step_diagnostics(name: str, n_time: int, value: float) -> StepDiagnostics:
+    return StepDiagnostics(
+        delta={
+            name: torch.full(
+                (N_SAMPLES, n_time, *IMG_SHAPE), value, device=get_device()
+            )
+        }
+    )
+
+
+def _get_coupled_batch_data(
+    n_time_ocean: int = 2,
+    n_time_atmosphere: int = 4,
+    ocean_diagnostics: StepDiagnostics | None = None,
+    atmosphere_diagnostics: StepDiagnostics | None = None,
+    n_ensemble: int = 1,
+    time_offset: int = 0,
+) -> CoupledBatchData:
+    ocean_data = _get_batch_data(
+        ["sst"], n_time_ocean, n_ensemble=n_ensemble, time_offset=time_offset
+    )
+    atmosphere_data = _get_batch_data(
+        ["a_prog"], n_time_atmosphere, n_ensemble=n_ensemble, time_offset=time_offset
+    )
+    return CoupledBatchData(
+        ocean_data=dataclasses.replace(ocean_data, step_diagnostics=ocean_diagnostics),
+        atmosphere_data=dataclasses.replace(
+            atmosphere_data, step_diagnostics=atmosphere_diagnostics
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "ocean_set, atmosphere_set",
+    [(True, False), (False, True), (True, True)],
+)
+def test_from_coupled_batch_data_forwards_step_diagnostics(
+    ocean_set: bool, atmosphere_set: bool
+):
+    ocean_diagnostics = (
+        _get_step_diagnostics("sst", n_time=2, value=1.5) if ocean_set else None
+    )
+    atmosphere_diagnostics = (
+        _get_step_diagnostics("a_prog", n_time=4, value=-0.5)
+        if atmosphere_set
+        else None
+    )
+    prediction = _get_coupled_batch_data(
+        ocean_diagnostics=ocean_diagnostics,
+        atmosphere_diagnostics=atmosphere_diagnostics,
+    )
+    reference = _get_coupled_batch_data()
+    paired = CoupledPairedData.from_coupled_batch_data(prediction, reference)
+    assert paired.ocean_data.step_diagnostics is ocean_diagnostics
+    assert paired.atmosphere_data.step_diagnostics is atmosphere_diagnostics
+
+
+def test_from_coupled_batch_data_forwards_n_ensemble():
+    prediction = _get_coupled_batch_data(n_ensemble=2)
+    reference = _get_coupled_batch_data(n_ensemble=2)
+    paired = CoupledPairedData.from_coupled_batch_data(prediction, reference)
+    assert paired.ocean_data.n_ensemble == 2
+    assert paired.atmosphere_data.n_ensemble == 2
+
+
+@pytest.mark.parametrize("mismatched_realm", ["ocean", "atmosphere"])
+def test_from_coupled_batch_data_rejects_mismatched_time(mismatched_realm: str):
+    prediction = _get_coupled_batch_data()
+    reference = _get_coupled_batch_data()
+    shifted = _get_coupled_batch_data(time_offset=1)
+    if mismatched_realm == "ocean":
+        reference = CoupledBatchData(
+            ocean_data=shifted.ocean_data,
+            atmosphere_data=reference.atmosphere_data,
+        )
+    else:
+        reference = CoupledBatchData(
+            ocean_data=reference.ocean_data,
+            atmosphere_data=shifted.atmosphere_data,
+        )
+    with pytest.raises(ValueError, match="time coordinate must be the same"):
+        CoupledPairedData.from_coupled_batch_data(prediction, reference)
+
+
+@pytest.mark.parametrize(
+    "ocean_set, atmosphere_set",
+    [(True, False), (False, True), (True, True), (False, False)],
+)
+def test_with_step_diagnostics_attaches_per_realm(
+    ocean_set: bool, atmosphere_set: bool
+):
+    batch = _get_coupled_batch_data()
+    ocean_diagnostics = (
+        _get_step_diagnostics("sst", n_time=2, value=1.5) if ocean_set else None
+    )
+    atmosphere_diagnostics = (
+        _get_step_diagnostics("a_prog", n_time=4, value=-0.5)
+        if atmosphere_set
+        else None
+    )
+    result = batch.with_step_diagnostics(
+        ocean=ocean_diagnostics, atmosphere=atmosphere_diagnostics
+    )
+    assert result.ocean_data.step_diagnostics is ocean_diagnostics
+    assert result.atmosphere_data.step_diagnostics is atmosphere_diagnostics
+    # the input batch is unmutated and the data is shared, not copied
+    assert batch.ocean_data.step_diagnostics is None
+    assert batch.atmosphere_data.step_diagnostics is None
+    assert result.ocean_data.data is batch.ocean_data.data
+    assert result.atmosphere_data.data is batch.atmosphere_data.data
+
+
+def test_with_step_diagnostics_validates_sample_dim():
+    batch = _get_coupled_batch_data()
+    bad_diagnostics = StepDiagnostics(
+        delta={"sst": torch.zeros(N_SAMPLES + 1, 2, *IMG_SHAPE, device=get_device())}
+    )
+    with pytest.raises(ValueError, match="leading dim"):
+        batch.with_step_diagnostics(ocean=bad_diagnostics, atmosphere=None)

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -289,6 +289,8 @@ def run_inference_from_config(config: InferenceConfig):
         n_timesteps_ocean=n_timesteps_ocean,
         n_timesteps_atmosphere=n_timesteps_atmosphere,
         output_dir=config.experiment_dir,
+        ocean_normalize=stepper.ocean.normalizer.normalize,
+        atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
     )
 
     writer = config.get_data_writer(data=data)

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -15,6 +15,7 @@ from fme.ace.stepper import StepperOverrideConfig
 from fme.ace.stepper.derived_forcings import DerivedForcingsConfig
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.logging_utils import LoggingConfig
+from fme.core.registry.corrector import CorrectorSelector
 from fme.core.testing import mock_wandb
 from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
 from fme.coupled.data_loading.inference import (
@@ -103,6 +104,18 @@ def test_load_stepper_config_ocean_prescribed_override_updates_forcing_window(
     assert "thetao_18" in ocean_reqs.names
 
 
+def seed_negative_values(data_path: str, name: str) -> None:
+    """Overwrite a variable on disk with the negation of its values (the mock
+    data is uniform in [0, 1), so the result is negative on-mask; NaN-masked
+    points stay NaN). A ``force_positive`` clamp only bites where the value is
+    already negative, so this makes such a corrector produce a nonzero delta.
+    """
+    with xr.open_dataset(data_path, decode_times=False, decode_timedelta=False) as ds:
+        ds = ds.load()
+    ds[name] = -ds[name]
+    ds.to_netcdf(data_path)
+
+
 def save_coupled_stepper(
     base_dir: pathlib.Path,
     ocean_in_names: list[str],
@@ -116,6 +129,8 @@ def save_coupled_stepper(
     save_standalone_component_checkpoints: bool = False,
     ocean_timedelta: str = "2D",
     atmosphere_timedelta: str = "1D",
+    ocean_corrector: CorrectorSelector | None = None,
+    atmosphere_corrector: CorrectorSelector | None = None,
 ) -> str | StandaloneComponentCheckpointsConfig:
     config = get_stepper_config(
         ocean_in_names=ocean_in_names,
@@ -127,6 +142,8 @@ def save_coupled_stepper(
         ocean_fraction_name=ocean_fraction_name,
         ocean_timedelta=ocean_timedelta,
         atmosphere_timedelta=atmosphere_timedelta,
+        ocean_corrector=ocean_corrector,
+        atmosphere_corrector=atmosphere_corrector,
     )
     if save_standalone_component_checkpoints:
         ocean_stepper = config.ocean.stepper.get_stepper(dataset_info.ocean)
@@ -298,6 +315,7 @@ def inference_helper(
             rmse_key = f"inference/mean/weighted_rmse/{var}"
             logs_with_rmse = [log for log in wandb_logs if rmse_key in log]
             assert len(logs_with_rmse) > 0, f"No RMSE logged for {var}"
+    return wandb_logs
 
 
 def _create_dataset_info_for_stepper(
@@ -544,3 +562,82 @@ def test_inference_backwards_compatibility(tmp_path: pathlib.Path):
         checkpoint_path=str(stepper_path),
         mock_data=mock_data,
     )
+
+
+def _run_evaluator_with_ocean_corrector(
+    tmp_path: pathlib.Path,
+    ocean_corrector: CorrectorSelector | None,
+):
+    ocean_in_names = ["o_prog", "sst", "mask_0", "a_diag"]
+    ocean_out_names = ["o_prog", "sst", "o_diag"]
+    atmos_in_names = ["a_prog", "surface_temperature", "ocean_fraction"]
+    atmos_out_names = ["a_prog", "surface_temperature", "a_diag"]
+    n_coupled_steps = 2
+    n_initial_conditions = 1
+    dataset_info, mock_data = _create_dataset_info_for_stepper(
+        ocean_in_names=ocean_in_names,
+        ocean_out_names=ocean_out_names,
+        atmos_in_names=atmos_in_names,
+        atmos_out_names=atmos_out_names,
+        n_coupled_steps=n_coupled_steps,
+        n_initial_conditions=n_initial_conditions,
+        data_dir=tmp_path / "stepper_data",
+    )
+    if ocean_corrector is not None:
+        seed_negative_values(
+            os.path.join(mock_data.ocean.data_dir, "data.nc"), "o_prog"
+        )
+    checkpoint_path = save_coupled_stepper(
+        tmp_path,
+        ocean_in_names=ocean_in_names,
+        ocean_out_names=ocean_out_names,
+        atmos_in_names=atmos_in_names,
+        atmos_out_names=atmos_out_names,
+        dataset_info=dataset_info,
+        ocean_timedelta=mock_data.ocean.timedelta,
+        atmosphere_timedelta=mock_data.atmosphere.timedelta,
+        ocean_corrector=ocean_corrector,
+    )
+    return inference_helper(
+        tmp_path=tmp_path,
+        ocean_in_names=ocean_in_names,
+        ocean_out_names=ocean_out_names,
+        atmos_in_names=atmos_in_names,
+        atmos_out_names=atmos_out_names,
+        n_coupled_steps=n_coupled_steps,
+        coupled_steps_in_memory=1,
+        n_initial_conditions=n_initial_conditions,
+        checkpoint_path=checkpoint_path,
+        mock_data=mock_data,
+    )
+
+
+@pytest.mark.medium_duration
+def test_evaluator_logs_correction_metrics_per_realm(tmp_path: pathlib.Path):
+    wandb_logs = _run_evaluator_with_ocean_corrector(
+        tmp_path,
+        ocean_corrector=CorrectorSelector(
+            "ocean_corrector", {"force_positive_names": ["o_prog"]}
+        ),
+    )
+    magnitude_key = "inference/time_mean_norm/correction_magnitude/o_prog"
+    logs_with_magnitude = [log for log in wandb_logs if magnitude_key in log]
+    assert len(logs_with_magnitude) > 0
+    # the negative-seeded data makes the force_positive clamp fire, so the
+    # logged correction magnitude is nonzero
+    for log in logs_with_magnitude:
+        assert log[magnitude_key] > 0.0
+    # the corrector-less atmosphere logs no correction metrics
+    all_keys = {key for log in wandb_logs for key in log}
+    correction_keys = {key for key in all_keys if "correction" in key}
+    assert correction_keys
+    assert all("o_prog" in key for key in correction_keys)
+
+
+@pytest.mark.medium_duration
+def test_evaluator_logs_no_correction_metrics_without_corrector(
+    tmp_path: pathlib.Path,
+):
+    wandb_logs = _run_evaluator_with_ocean_corrector(tmp_path, ocean_corrector=None)
+    all_keys = {key for log in wandb_logs for key in log}
+    assert not any("correction" in key for key in all_keys)

--- a/fme/coupled/inference/test_inference.py
+++ b/fme/coupled/inference/test_inference.py
@@ -13,6 +13,7 @@ from fme.ace.inference.data_writer.main import DataWriterConfig
 from fme.ace.inference.inference import ForcingDataLoaderConfig
 from fme.ace.stepper import StepperOverrideConfig
 from fme.core.logging_utils import LoggingConfig
+from fme.core.registry.corrector import CorrectorSelector
 from fme.core.testing import mock_wandb
 from fme.coupled.data_loading.inference import CoupledForcingDataLoaderConfig
 from fme.coupled.data_loading.test_data_loader import create_coupled_data_on_disk
@@ -31,6 +32,7 @@ from fme.coupled.inference.inference import (
 from fme.coupled.inference.test_evaluator import (
     _create_dataset_info_for_stepper,
     save_coupled_stepper,
+    seed_negative_values,
 )
 from fme.coupled.test_stepper import CoupledDatasetInfoBuilder
 
@@ -46,6 +48,10 @@ def _setup(
     n_initial_conditions: int,
     empty_ocean_forcing: bool = False,
     atmosphere_times_offset: int = 0,
+    ocean_corrector: CorrectorSelector | None = None,
+    seed_negative_ocean_variable: str | None = None,
+    ocean_save_step_diagnostics: bool = False,
+    atmosphere_save_step_diagnostics: bool = False,
 ):
     all_ocean_names = set(ocean_in_names + ocean_out_names)
     all_atmos_names = set(atmos_in_names + atmos_out_names)
@@ -72,6 +78,11 @@ def _setup(
         n_levels_atmosphere=1,
         atmosphere_start_time_offset_from_ocean=atmosphere_times_offset,
     )
+    if seed_negative_ocean_variable is not None:
+        seed_negative_values(
+            os.path.join(mock_data.ocean.data_dir, "data.nc"),
+            seed_negative_ocean_variable,
+        )
     dataset_info = CoupledDatasetInfoBuilder(
         vcoord=mock_data.vcoord,
         hcoord=mock_data.hcoord,
@@ -90,6 +101,7 @@ def _setup(
         save_standalone_component_checkpoints=True,
         ocean_timedelta=mock_data.ocean.timedelta,
         atmosphere_timedelta=mock_data.atmosphere.timedelta,
+        ocean_corrector=ocean_corrector,
     )
     if empty_ocean_forcing:
         atmos_forcing_config = mock_data.dataset_config.atmosphere
@@ -130,10 +142,12 @@ def _setup(
             ocean=DataWriterConfig(
                 save_prediction_files=True,
                 save_monthly_files=True,
+                save_step_diagnostics=ocean_save_step_diagnostics,
             ),
             atmosphere=DataWriterConfig(
                 save_prediction_files=True,
                 save_monthly_files=True,
+                save_step_diagnostics=atmosphere_save_step_diagnostics,
             ),
         ),
         coupled_steps_in_memory=coupled_steps_in_memory,
@@ -341,3 +355,80 @@ def test_inference_with_empty_ocean_forcing(
     with mock_wandb() as wandb:
         wandb.configure(log_to_wandb=True)
         main(yaml_config=str(config_filename))
+
+
+def _setup_with_ocean_corrector(
+    tmp_path: pathlib.Path,
+    n_coupled_steps: int,
+    ocean_save_step_diagnostics: bool,
+    atmosphere_save_step_diagnostics: bool,
+):
+    ocean_in_names = ["o_prog", "sst", "mask_0", "a_diag"]
+    ocean_out_names = ["o_prog", "sst", "o_diag"]
+    atmos_in_names = ["a_prog", "surface_temperature", "forcing_var", "ocean_fraction"]
+    atmos_out_names = ["a_prog", "surface_temperature", "a_diag"]
+    return _setup(
+        ocean_in_names=ocean_in_names,
+        ocean_out_names=ocean_out_names,
+        atmos_in_names=atmos_in_names,
+        atmos_out_names=atmos_out_names,
+        tmp_path=tmp_path,
+        n_coupled_steps=n_coupled_steps,
+        coupled_steps_in_memory=1,
+        n_initial_conditions=1,
+        ocean_corrector=CorrectorSelector(
+            "ocean_corrector", {"force_positive_names": ["o_prog"]}
+        ),
+        seed_negative_ocean_variable="o_prog",
+        ocean_save_step_diagnostics=ocean_save_step_diagnostics,
+        atmosphere_save_step_diagnostics=atmosphere_save_step_diagnostics,
+    )
+
+
+def _run_inference(tmp_path: pathlib.Path, config: InferenceConfig) -> None:
+    config_filename = tmp_path / "config.yaml"
+    with open(config_filename, "w") as f:
+        yaml.dump(dataclasses.asdict(config), f)
+    with mock_wandb() as wandb:
+        wandb.configure(log_to_wandb=True)
+        main(yaml_config=str(config_filename))
+
+
+@pytest.mark.medium_duration
+def test_inference_writes_step_diagnostics_per_realm(tmp_path: pathlib.Path):
+    n_coupled_steps = 2
+    config, _, _ = _setup_with_ocean_corrector(
+        tmp_path,
+        n_coupled_steps=n_coupled_steps,
+        ocean_save_step_diagnostics=True,
+        atmosphere_save_step_diagnostics=True,
+    )
+    _run_inference(tmp_path, config)
+    deltas_path = tmp_path / "ocean" / "step_diagnostics" / "correction_deltas.nc"
+    assert deltas_path.exists()
+    ds = xr.open_dataset(deltas_path, decode_timedelta=False)
+    # the force_positive corrector declares only the force-positive variable,
+    # on the ocean's own time axis
+    assert set(ds.data_vars) == {"o_prog"}
+    assert ds["o_prog"].sizes["time"] == n_coupled_steps
+    # the negative-seeded data makes the clamp fire, so a nonzero delta
+    # reaches the writer
+    assert np.nansum(np.abs(ds["o_prog"].values)) > 0
+    # the corrector-less atmosphere writes nothing even with its flag on
+    atmos_deltas_path = (
+        tmp_path / "atmosphere" / "step_diagnostics" / "correction_deltas.nc"
+    )
+    assert not atmos_deltas_path.exists()
+
+
+@pytest.mark.medium_duration
+def test_inference_no_step_diagnostics_by_default(tmp_path: pathlib.Path):
+    config, _, _ = _setup_with_ocean_corrector(
+        tmp_path,
+        n_coupled_steps=2,
+        ocean_save_step_diagnostics=False,
+        atmosphere_save_step_diagnostics=False,
+    )
+    _run_inference(tmp_path, config)
+    assert not (tmp_path / "ocean" / "step_diagnostics").exists()
+    assert not (tmp_path / "atmosphere" / "step_diagnostics").exists()

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -36,6 +36,7 @@ from fme.ace.stepper.single_module import (
     load_weights_and_history as load_uncoupled_weights_and_history,
 )
 from fme.ace.stepper.time_length_probabilities import TimeLengthProbabilities
+from fme.core.corrector.output import CorrectorDiagnostics
 from fme.core.dataset_info import DatasetInfo
 from fme.core.distributed import Distributed
 from fme.core.generics.inference import PredictFunction
@@ -846,11 +847,17 @@ class ComponentStepPrediction:
         data: TensorDict,
         step: int,
         stepper_state: StepperState | None,
+        corrector_diagnostics: CorrectorDiagnostics,
     ):
+        # corrector_diagnostics is required, not defaulted: this class is the
+        # seam where the component StepOutput's diagnostics would otherwise be
+        # dropped, so a new construction site must say what it carries rather
+        # than silently defaulting to empty.
         self._realm: Literal["ocean", "atmosphere"] = realm
         self._data = data
         self._step = step
         self._stepper_state = stepper_state
+        self._corrector_diagnostics = corrector_diagnostics
 
     @property
     def realm(self) -> Literal["ocean", "atmosphere"]:
@@ -867,6 +874,25 @@ class ComponentStepPrediction:
     @property
     def stepper_state(self) -> StepperState | None:
         return self._stepper_state
+
+    @property
+    def corrector_diagnostics(self) -> CorrectorDiagnostics:
+        return self._corrector_diagnostics
+
+
+def _realm_step_outputs(
+    output_list: list[ComponentStepPrediction],
+    realm: Literal["ocean", "atmosphere"],
+) -> list[StepOutput]:
+    return [
+        StepOutput(
+            output=x.data,
+            stepper_state=x.stepper_state,
+            corrector_diagnostics=x.corrector_diagnostics,
+        )
+        for x in output_list
+        if x.realm == realm
+    ]
 
 
 class CoupledStepper:
@@ -1220,6 +1246,7 @@ class CoupledStepper:
                     data=atmos_step,
                     step=atmos_step_num,
                     stepper_state=atmos_stepper_state,
+                    corrector_diagnostics=atmos_result.corrector_diagnostics,
                 )
                 atmos_step = optimizer.detach_if_using_gradient_accumulation(atmos_step)
                 atmos_steps.append(atmos_step)
@@ -1262,6 +1289,7 @@ class CoupledStepper:
                 data=ocean_step,
                 step=i_outer,
                 stepper_state=ocean_result.stepper_state,
+                corrector_diagnostics=ocean_result.corrector_diagnostics,
             )
 
             # prepare ic states for next coupled step
@@ -1297,22 +1325,14 @@ class CoupledStepper:
         forcing_data: CoupledBatchData,
     ) -> CoupledBatchData:
         atmos_data = process_prediction_generator_list(
-            [
-                StepOutput(output=x.data, stepper_state=x.stepper_state)
-                for x in output_list
-                if x.realm == "atmosphere"
-            ],
+            _realm_step_outputs(output_list, "atmosphere"),
             time=forcing_data.atmosphere_data.time[:, self.atmosphere.n_ic_timesteps :],
             horizontal_dims=forcing_data.atmosphere_data.horizontal_dims,
             labels=forcing_data.atmosphere_data.labels,
             n_ensemble=forcing_data.atmosphere_data.n_ensemble,
         )
         ocean_data = process_prediction_generator_list(
-            [
-                StepOutput(output=x.data, stepper_state=x.stepper_state)
-                for x in output_list
-                if x.realm == "ocean"
-            ],
+            _realm_step_outputs(output_list, "ocean"),
             time=forcing_data.ocean_data.time[:, self.ocean.n_ic_timesteps :],
             horizontal_dims=forcing_data.ocean_data.horizontal_dims,
             labels=forcing_data.ocean_data.labels,
@@ -1325,7 +1345,7 @@ class CoupledStepper:
         initial_condition: CoupledPrognosticState,
         forcing: CoupledBatchData,
         compute_derived_variables: bool = False,
-    ):
+    ) -> tuple[CoupledBatchData, CoupledPrognosticState]:
         timer = GlobalTimer.get_instance()
         output_list = list(
             self.get_prediction_generator(
@@ -1347,7 +1367,29 @@ class CoupledStepper:
                         n_ic_timesteps_atmosphere=self.atmosphere.n_ic_timesteps,
                     )
                 )
-        return gen_data
+        prognostic_state = CoupledPrognosticState(
+            ocean_data=gen_data.ocean_data.get_end(
+                self.ocean.prognostic_names,
+                self.n_ic_timesteps,
+            ),
+            atmosphere_data=gen_data.atmosphere_data.get_end(
+                self.atmosphere.prognostic_names,
+                self.atmosphere.n_ic_timesteps,
+            ),
+        )
+        # Attach the stacked per-step diagnostics last: every time-touching
+        # BatchData method (including get_end above) raises on a
+        # diagnostics-bearing batch, and here each realm's series is aligned
+        # with that realm's prediction time axis.
+        gen_data = gen_data.with_step_diagnostics(
+            ocean=StepOutput.stack_diagnostics(
+                _realm_step_outputs(output_list, "ocean")
+            ),
+            atmosphere=StepOutput.stack_diagnostics(
+                _realm_step_outputs(output_list, "atmosphere")
+            ),
+        )
+        return gen_data, prognostic_state
 
     def predict_paired(
         self,
@@ -1358,7 +1400,9 @@ class CoupledStepper:
         """
         Predict multiple steps forward given initial condition and reference data.
         """
-        gen_data = self._predict(initial_condition, forcing, compute_derived_variables)
+        gen_data, prognostic_state = self._predict(
+            initial_condition, forcing, compute_derived_variables
+        )
         atmos_forward_data = self.atmosphere.get_forward_data(
             forcing.atmosphere_data, compute_derived_variables=compute_derived_variables
         )
@@ -1373,16 +1417,7 @@ class CoupledStepper:
                     atmosphere_data=atmos_forward_data,
                 ),
             ),
-            CoupledPrognosticState(
-                ocean_data=gen_data.ocean_data.get_end(
-                    self.ocean.prognostic_names,
-                    self.n_ic_timesteps,
-                ),
-                atmosphere_data=gen_data.atmosphere_data.get_end(
-                    self.atmosphere.prognostic_names,
-                    self.atmosphere.n_ic_timesteps,
-                ),
-            ),
+            prognostic_state,
         )
 
     def predict(
@@ -1391,22 +1426,7 @@ class CoupledStepper:
         forcing: CoupledBatchData,
         compute_derived_variables: bool = False,
     ) -> tuple[CoupledBatchData, CoupledPrognosticState]:
-        gen_data = self._predict(initial_condition, forcing, compute_derived_variables)
-        return (
-            CoupledBatchData(
-                ocean_data=gen_data.ocean_data, atmosphere_data=gen_data.atmosphere_data
-            ),
-            CoupledPrognosticState(
-                ocean_data=gen_data.ocean_data.get_end(
-                    self.ocean.prognostic_names,
-                    self.n_ic_timesteps,
-                ),
-                atmosphere_data=gen_data.atmosphere_data.get_end(
-                    self.atmosphere.prognostic_names,
-                    self.atmosphere.n_ic_timesteps,
-                ),
-            ),
-        )
+        return self._predict(initial_condition, forcing, compute_derived_variables)
 
     def update_training_history(self, training_job: TrainingJob) -> None:
         """

--- a/fme/coupled/test_aggregator.py
+++ b/fme/coupled/test_aggregator.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import xarray as xr
 
+from fme.ace.aggregator.inference.step_diagnostics import StepDiagnosticsMetricConfig
 from fme.ace.aggregator.inference.test_evaluator import get_zero_time
 from fme.ace.aggregator.one_step.main import (
     OneStepAggregatorConfig,
@@ -18,8 +19,10 @@ from fme.ace.testing import DimSizes, MonthlyReferenceData
 from fme.core.coordinates import DimSize, LatLonCoordinates
 from fme.core.dataset_info import DatasetInfo
 from fme.core.device import get_device
+from fme.core.step.step_diagnostics import StepDiagnostics
 from fme.core.typing_ import EnsembleTensorDict
 from fme.coupled.aggregator import (
+    InferenceAggregatorConfig,
     InferenceEvaluatorAggregatorConfig,
     OneStepAggregator,
     _combine_logs,
@@ -389,3 +392,198 @@ def test_one_step_aggregator_config_reaches_both_sub_aggregators():
     # sanity check: the disabled keys are exactly the ones present by default
     default_logs = _one_step_summary_logs(config=None)
     assert any(key.startswith("val/snapshot/") for key in default_logs)
+
+
+def _make_correction_paired_data(
+    nx: int,
+    ny: int,
+    n_time: int,
+    ocean_delta: float | None,
+    atmosphere_delta: float | None,
+    n_sample: int = 2,
+) -> CoupledPairedData:
+    time = xr.DataArray(
+        [
+            [
+                (cftime.DatetimeProlepticGregorian(2000, 1, 1) + i * TIMESTEP)
+                for i in range(n_time)
+            ]
+            for _ in range(n_sample)
+        ],
+        dims=["sample", "time"],
+    )
+
+    def _realm(name: str, delta: float | None) -> PairedData:
+        return PairedData.new_on_device(
+            prediction={
+                name: torch.randn(n_sample, n_time, ny, nx, device=get_device())
+            },
+            reference={
+                name: torch.randn(n_sample, n_time, ny, nx, device=get_device())
+            },
+            time=time,
+            step_diagnostics=(
+                StepDiagnostics(
+                    delta={
+                        name: torch.full(
+                            (n_sample, n_time, ny, nx),
+                            delta,
+                            device=get_device(),
+                        )
+                    }
+                )
+                if delta is not None
+                else None
+            ),
+        )
+
+    return CoupledPairedData(
+        ocean_data=_realm("ocean_var", ocean_delta),
+        atmosphere_data=_realm("atmos_var", atmosphere_delta),
+    )
+
+
+def _divide_by(std: float):
+    def normalize(tensors, apply_mean: bool = True):
+        return {k: v / std for k, v in tensors.items()}
+
+    return normalize
+
+
+def _build_evaluator_aggregator_for_correction(
+    ocean_std: float, atmosphere_std: float, n_time: int
+):
+    return InferenceEvaluatorAggregatorConfig().build(
+        dataset_info=_coupled_ds_info(2, 2),
+        n_timesteps_ocean=n_time,
+        n_timesteps_atmosphere=n_time,
+        initial_time=get_zero_time(shape=[2, 0], dims=["sample", "time"]),
+        ocean_normalize=_divide_by(ocean_std),
+        atmosphere_normalize=_divide_by(atmosphere_std),
+        save_diagnostics=False,
+    )
+
+
+def test_inference_evaluator_aggregator_logs_correction_metrics_per_realm():
+    n_time = 3
+    agg = _build_evaluator_aggregator_for_correction(
+        ocean_std=4.0, atmosphere_std=2.0, n_time=n_time
+    )
+    agg.record_batch(
+        _make_correction_paired_data(
+            2, 2, n_time, ocean_delta=2.0, atmosphere_delta=3.0
+        )
+    )
+    summary = agg.get_summary_logs()
+    # each realm's delta is normalized with that realm's std
+    assert summary["time_mean_norm/correction_magnitude/ocean_var"] == pytest.approx(
+        2.0 / 4.0
+    )
+    assert summary["time_mean_norm/correction_magnitude/atmos_var"] == pytest.approx(
+        3.0 / 2.0
+    )
+
+
+def test_inference_evaluator_aggregator_silent_without_step_diagnostics():
+    n_time = 3
+    agg = _build_evaluator_aggregator_for_correction(
+        ocean_std=4.0, atmosphere_std=2.0, n_time=n_time
+    )
+    agg.record_batch(
+        _make_correction_paired_data(
+            2, 2, n_time, ocean_delta=2.0, atmosphere_delta=None
+        )
+    )
+    summary = agg.get_summary_logs()
+    assert "time_mean_norm/correction_magnitude/ocean_var" in summary
+    assert not any("correction" in key and "atmos_var" in key for key in summary)
+
+
+@pytest.mark.parametrize(
+    "ocean_normalize, atmosphere_normalize",
+    [
+        (None, None),
+        (_divide_by(1.0), None),
+        (None, _divide_by(1.0)),
+    ],
+    ids=["neither", "ocean_only", "atmosphere_only"],
+)
+def test_inference_aggregator_correction_metrics_require_normalizer(
+    tmp_path, ocean_normalize, atmosphere_normalize
+):
+    # default configuration with missing normalizers builds silently
+    InferenceAggregatorConfig().build(
+        dataset_info=_coupled_ds_info(2, 2),
+        n_timesteps_ocean=3,
+        n_timesteps_atmosphere=3,
+        output_dir=str(tmp_path),
+        ocean_normalize=ocean_normalize,
+        atmosphere_normalize=atmosphere_normalize,
+    )
+    # an explicit non-default opt-in with a missing normalizer raises
+    config = InferenceAggregatorConfig(
+        step_diagnostics=StepDiagnosticsMetricConfig(correction_maps=True)
+    )
+    with pytest.raises(ValueError, match="normalizer"):
+        config.build(
+            dataset_info=_coupled_ds_info(2, 2),
+            n_timesteps_ocean=3,
+            n_timesteps_atmosphere=3,
+            output_dir=str(tmp_path),
+            ocean_normalize=ocean_normalize,
+            atmosphere_normalize=atmosphere_normalize,
+        )
+
+
+def test_inference_aggregator_builds_correction_metrics_with_normalizers(tmp_path):
+    n_time = 3
+    agg = InferenceAggregatorConfig().build(
+        dataset_info=_coupled_ds_info(2, 2),
+        n_timesteps_ocean=n_time,
+        n_timesteps_atmosphere=n_time,
+        output_dir=str(tmp_path),
+        ocean_normalize=_divide_by(4.0),
+        atmosphere_normalize=_divide_by(2.0),
+    )
+    agg.record_batch(
+        _make_correction_paired_data(
+            2, 2, n_time, ocean_delta=2.0, atmosphere_delta=3.0
+        )
+    )
+    summary = agg.get_summary_logs()
+    assert summary["time_mean_norm/correction_magnitude/ocean_var"] == pytest.approx(
+        2.0 / 4.0
+    )
+    assert summary["time_mean_norm/correction_magnitude/atmos_var"] == pytest.approx(
+        3.0 / 2.0
+    )
+    agg.flush_diagnostics()
+    # each realm's correction diagnostics land in that realm's subdirectory
+    assert (tmp_path / "ocean" / "mean_norm_correction_diagnostics.nc").exists()
+    assert (tmp_path / "atmosphere" / "mean_norm_correction_diagnostics.nc").exists()
+
+
+def test_inference_evaluator_aggregator_inline_validation_drops_correction_series():
+    # inline validation (fme/coupled/train/train_config.py) builds with
+    # enable_time_series=False: correction scalars stay, per-step series drop
+    n_time = 3
+    agg = InferenceEvaluatorAggregatorConfig().build(
+        dataset_info=_coupled_ds_info(2, 2),
+        n_timesteps_ocean=n_time,
+        n_timesteps_atmosphere=n_time,
+        initial_time=get_zero_time(shape=[2, 0], dims=["sample", "time"]),
+        ocean_normalize=_divide_by(4.0),
+        atmosphere_normalize=_divide_by(2.0),
+        save_diagnostics=False,
+        enable_time_series=False,
+    )
+    inference_logs = agg.record_batch(
+        _make_correction_paired_data(
+            2, 2, n_time, ocean_delta=2.0, atmosphere_delta=3.0
+        )
+    )
+    summary = agg.get_summary_logs()
+    assert "time_mean_norm/correction_magnitude/ocean_var" in summary
+    assert "time_mean_norm/correction_magnitude/atmos_var" in summary
+    series_keys = {key for log in inference_logs for key in log}
+    assert not any("correction" in key for key in series_keys)

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -20,6 +20,7 @@ from fme.core.coordinates import (
     NullVerticalCoordinate,
     VerticalCoordinate,
 )
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.dataset_info import DatasetInfo
 from fme.core.loss import StepLossConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
@@ -1210,6 +1211,8 @@ def get_stepper_config(
     ocean_prescribed_prognostic_names: list[str] | None = None,
     atmosphere_prescribed_prognostic_names: list[str] | None = None,
     atmosphere_input_dropout: VariableMaskingConfig | None = None,
+    ocean_corrector: CorrectorSelector | None = None,
+    atmosphere_corrector: CorrectorSelector | None = None,
 ):
     # CoupledStepper requires that both component datasets include prognostic
     # surface temperature variables and that the atmosphere data includes an
@@ -1234,6 +1237,14 @@ def get_stepper_config(
     ocean_prescribed = list(ocean_prescribed_prognostic_names or [])
     atmosphere_prescribed = list(atmosphere_prescribed_prognostic_names or [])
 
+    if ocean_corrector is None:
+        ocean_corrector = CorrectorSelector("ocean_corrector", {})
+    atmosphere_corrector_config: AtmosphereCorrectorConfig | CorrectorSelector
+    if atmosphere_corrector is None:
+        atmosphere_corrector_config = AtmosphereCorrectorConfig()
+    else:
+        atmosphere_corrector_config = atmosphere_corrector
+
     config = CoupledStepperConfig(
         atmosphere=ComponentConfig(
             timedelta=atmosphere_timedelta,
@@ -1254,6 +1265,7 @@ def get_stepper_config(
                                 ocean_fraction_name=ocean_fraction_name,
                             ),
                             input_dropout=atmosphere_input_dropout,
+                            corrector=atmosphere_corrector_config,
                         ),
                     ),
                 ),
@@ -1274,7 +1286,7 @@ def get_stepper_config(
                             normalization=trivial_network_and_loss_normalization(
                                 ocean_norm_names
                             ),
-                            corrector=CorrectorSelector("ocean_corrector", {}),
+                            corrector=ocean_corrector,
                         ),
                     ),
                 ),
@@ -2487,3 +2499,157 @@ def test_train_on_batch_evaluate_all_steps_with_stochastic_n_steps(
         assert {len(keys) for keys in atmos_key_sets} == {1, 4}
         for keys in atmos_key_sets:
             assert keys == {f"loss/atmosphere_step_{step}" for step in range(len(keys))}
+
+
+def _get_coupler_and_ic_for_step_diagnostics(
+    ocean_offset: float | None,
+    atmosphere_offset: float | None,
+    n_forward_times_ocean: int = 2,
+    n_forward_times_atmosphere: int = 4,
+    n_samples: int = 2,
+):
+    """Build a coupler and initial condition for step-diagnostics tests,
+    injecting a constant-offset corrector on each realm whose offset is
+    not None. The atmosphere corrector targets "a_prog" rather than the
+    prescribed surface-temperature variable, which the SST prescription
+    (running after the corrector) forbids.
+    """
+    from fme.core.corrector.registry import CorrectionSequence
+    from fme.core.corrector.test_registry import ConstantOffsetCorrection
+    from fme.core.step.single_module import SingleModuleStep
+
+    coupler, coupled_data, _, _ = get_stepper_and_batch(
+        ocean_in_names=["sst", "mask_0"],
+        ocean_out_names=["sst"],
+        atmosphere_in_names=["a_prog", "surface_temperature", "ocean_fraction"],
+        atmosphere_out_names=["a_prog", "surface_temperature"],
+        n_forward_times_ocean=n_forward_times_ocean,
+        n_forward_times_atmosphere=n_forward_times_atmosphere,
+        n_samples=n_samples,
+    )
+    if ocean_offset is not None:
+        assert isinstance(coupler.ocean._step_obj, SingleModuleStep)
+        coupler.ocean._step_obj._corrector = CorrectionSequence(
+            [ConstantOffsetCorrection("sst", ocean_offset)]
+        )
+    if atmosphere_offset is not None:
+        assert isinstance(coupler.atmosphere._step_obj, SingleModuleStep)
+        coupler.atmosphere._step_obj._corrector = CorrectionSequence(
+            [ConstantOffsetCorrection("a_prog", atmosphere_offset)]
+        )
+    data = coupled_data.data
+    ic = CoupledPrognosticState(
+        ocean_data=data.ocean_data.get_start(
+            coupler.ocean.prognostic_names, n_ic_timesteps=1
+        ),
+        atmosphere_data=data.atmosphere_data.get_start(
+            coupler.atmosphere.prognostic_names, n_ic_timesteps=1
+        ),
+    )
+    return coupler, data, ic
+
+
+@pytest.mark.parametrize("corrected_realm", ["ocean", "atmosphere"])
+def test_predict_paired_attaches_step_diagnostics_for_corrected_realm(
+    corrected_realm: str,
+):
+    offset = 1.5
+    coupler, data, ic = _get_coupler_and_ic_for_step_diagnostics(
+        ocean_offset=offset if corrected_realm == "ocean" else None,
+        atmosphere_offset=offset if corrected_realm == "atmosphere" else None,
+    )
+    paired_data, _ = coupler.predict_paired(initial_condition=ic, forcing=data)
+    if corrected_realm == "ocean":
+        corrected, silent = paired_data.ocean_data, paired_data.atmosphere_data
+        name, n_steps = "sst", 2
+    else:
+        corrected, silent = paired_data.atmosphere_data, paired_data.ocean_data
+        name, n_steps = "a_prog", 4
+    assert silent.step_diagnostics is None
+    assert corrected.step_diagnostics is not None
+    assert set(corrected.step_diagnostics.delta) == {name}
+    delta = corrected.step_diagnostics.delta[name]
+    # forward-step aligned with that realm's prediction series
+    assert delta.shape == corrected.prediction[name].shape
+    assert delta.shape[1] == n_steps
+    torch.testing.assert_close(delta, torch.full_like(delta, offset))
+
+
+def test_predict_paired_step_diagnostics_both_realms():
+    ocean_offset, atmosphere_offset = 1.5, -0.5
+    coupler, data, ic = _get_coupler_and_ic_for_step_diagnostics(
+        ocean_offset=ocean_offset,
+        atmosphere_offset=atmosphere_offset,
+    )
+    paired_data, _ = coupler.predict_paired(initial_condition=ic, forcing=data)
+    ocean_diagnostics = paired_data.ocean_data.step_diagnostics
+    atmos_diagnostics = paired_data.atmosphere_data.step_diagnostics
+    assert ocean_diagnostics is not None
+    assert atmos_diagnostics is not None
+    ocean_delta = ocean_diagnostics.delta["sst"]
+    atmos_delta = atmos_diagnostics.delta["a_prog"]
+    # each realm's own step count: outer ocean steps vs inner atmosphere steps
+    assert ocean_delta.shape[1] == 2
+    assert atmos_delta.shape[1] == 4
+    torch.testing.assert_close(ocean_delta, torch.full_like(ocean_delta, ocean_offset))
+    torch.testing.assert_close(
+        atmos_delta, torch.full_like(atmos_delta, atmosphere_offset)
+    )
+
+
+def test_predict_attaches_step_diagnostics():
+    # CoupledStepper.predict has no production call sites today (only
+    # predict_paired is used), but _predict now serves both and the attach
+    # ordering (after get_end) is easy to break.
+    offset = 2.0
+    coupler, data, ic = _get_coupler_and_ic_for_step_diagnostics(
+        ocean_offset=offset, atmosphere_offset=None
+    )
+    prediction, prognostic_state = coupler.predict(initial_condition=ic, forcing=data)
+    assert prediction.ocean_data.step_diagnostics is not None
+    delta = prediction.ocean_data.step_diagnostics.delta["sst"]
+    torch.testing.assert_close(delta, torch.full_like(delta, offset))
+    assert prediction.atmosphere_data.step_diagnostics is None
+    # the prognostic state is taken before the attach and stays usable
+    ocean_end = prognostic_state.ocean_data.as_batch_data()
+    assert ocean_end.n_timesteps == 1
+    assert set(ocean_end.data) == set(coupler.ocean.prognostic_names)
+
+
+def test_predict_paired_without_corrector_has_no_step_diagnostics():
+    coupler, data, ic = _get_coupler_and_ic_for_step_diagnostics(
+        ocean_offset=None, atmosphere_offset=None
+    )
+    paired_data, _ = coupler.predict_paired(initial_condition=ic, forcing=data)
+    assert paired_data.ocean_data.step_diagnostics is None
+    assert paired_data.atmosphere_data.step_diagnostics is None
+
+
+def test_predict_paired_step_diagnostics_zero_for_unchanged_variable():
+    # a corrector that declares a name but leaves it unchanged still yields a
+    # non-None series of exact zeros (declared-names semantics)
+    coupler, data, ic = _get_coupler_and_ic_for_step_diagnostics(
+        ocean_offset=0.0, atmosphere_offset=None
+    )
+    paired_data, _ = coupler.predict_paired(initial_condition=ic, forcing=data)
+    ocean_diagnostics = paired_data.ocean_data.step_diagnostics
+    assert ocean_diagnostics is not None
+    delta = ocean_diagnostics.delta["sst"]
+    torch.testing.assert_close(delta, torch.zeros_like(delta))
+
+
+def test_prediction_generator_yields_corrector_diagnostics():
+    ocean_offset, atmosphere_offset = 1.5, -0.5
+    coupler, data, ic = _get_coupler_and_ic_for_step_diagnostics(
+        ocean_offset=ocean_offset,
+        atmosphere_offset=atmosphere_offset,
+    )
+    predictions = list(coupler.get_prediction_generator(ic, data, NullOptimization()))
+    assert {x.realm for x in predictions} == {"ocean", "atmosphere"}
+    for prediction in predictions:
+        if prediction.realm == "ocean":
+            name, offset = "sst", ocean_offset
+        else:
+            name, offset = "a_prog", atmosphere_offset
+        delta = prediction.corrector_diagnostics.delta[name]
+        torch.testing.assert_close(delta, torch.full_like(delta, offset))

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -228,6 +228,11 @@ class InlineInferenceConfig:
                 atmosphere_normalize=stepper.atmosphere.normalizer.normalize,
                 save_diagnostics=save_per_epoch_diagnostics,
                 output_dir=os.path.join(output_dir, name),
+                # inline validation reuses the aggregator across batches whose
+                # windows do not tile one contiguous time series, so per-step
+                # series aggregators must not be built (as in
+                # fme/ace/train/train_config.py)
+                enable_time_series=False,
             )
 
         return factory

--- a/pr-plan.md
+++ b/pr-plan.md
@@ -1,0 +1,321 @@
+# Carry corrector step diagnostics through coupled inference
+
+Threads each component stepper's per-step correction `delta` through `CoupledStepper` onto
+that realm's prediction data, and surfaces the existing step-diagnostics writer and
+correction-metrics aggregator per realm in the coupled inference configs. No new
+coupled-specific diagnostics container: the `fme.ace` components are reused once per realm.
+
+---
+
+## `fme/coupled/stepper.py` (modified)
+
+```python
+class ComponentStepPrediction:
+    def __init__(
+        self,
+        realm: Literal["ocean", "atmosphere"],
+        data: TensorDict,
+        step: int,
+        stepper_state: StepperState | None,
+        corrector_diagnostics: CorrectorDiagnostics,  # NEW
+    ):
+        ...
+
+    # Required, not defaulted: this class is the seam where the component
+    # StepOutput's diagnostics are currently dropped, so a new yield site must be
+    # forced to say what it carries rather than silently defaulting to empty.
+
+    @property
+    def corrector_diagnostics(self) -> CorrectorDiagnostics:  # NEW
+        ...
+```
+
+```python
+class CoupledStepper:
+    def get_prediction_generator(
+        self,
+        initial_condition: CoupledPrognosticState,
+        forcing_data: CoupledBatchData,
+        optimizer: OptimizationABC,
+    ) -> Generator[ComponentStepPrediction, None, None]:
+        # CHANGED — both yield sites (the inner atmosphere loop and the outer
+        # ocean step) pass the component StepOutput's corrector_diagnostics
+        ...
+
+    def _process_prediction_generator_list(
+        self,
+        output_list: list[ComponentStepPrediction],
+        forcing_data: CoupledBatchData,
+    ) -> CoupledBatchData:
+        # CHANGED — the per-realm StepOutput reconstruction carries
+        # corrector_diagnostics instead of defaulting it to empty. Attaches
+        # nothing: the returned batch still passes through time-changing ops.
+        ...
+
+    def _predict(
+        self,
+        initial_condition: CoupledPrognosticState,
+        forcing: CoupledBatchData,
+        compute_derived_variables: bool = False,
+    ) -> tuple[CoupledBatchData, CoupledPrognosticState]:
+        # CHANGED — also returns the end state (was: prediction only), so the
+        # stacked per-realm diagnostics can be attached after get_end.
+        # Rejected: attaching in predict() and predict_paired() separately, which
+        # duplicates the attach and its ordering constraint at two call sites.
+        ...
+
+    def predict(
+        self,
+        initial_condition: CoupledPrognosticState,
+        forcing: CoupledBatchData,
+        compute_derived_variables: bool = False,
+    ) -> tuple[CoupledBatchData, CoupledPrognosticState]:
+        # CHANGED — returns _predict's tuple; the duplicated get_end block moves
+        # into _predict
+        ...
+
+    def predict_paired(
+        self,
+        initial_condition: CoupledPrognosticState,
+        forcing: CoupledBatchData,
+        compute_derived_variables: bool = False,
+    ) -> tuple[CoupledPairedData, CoupledPrognosticState]:
+        # CHANGED — consumes _predict's tuple
+        ...
+```
+
+### Critical detail — where the diagnostics attach, and why
+
+- Each realm's stacked series comes from `StepOutput.stack_diagnostics` over that realm's
+  own `ComponentStepPrediction`s, so it is `None` when that realm's stepper has no
+  corrector or its corrector modified nothing — matching single-component inference.
+- `BatchData` rejects a diagnostics-bearing batch in every time-changing method
+  (`prepend`, `compute_derived_variables`, `remove_initial_condition`, `get_end`, …).
+  Attachment must therefore be the last thing `_predict` does: after the
+  prepend / compute-derived / remove-initial-condition dance **and** after the end states
+  are taken. This mirrors the attach position in single-component `Stepper.predict`.
+- Per-realm time axes differ (several atmosphere steps per ocean step). Each realm's series
+  is stacked from that realm's own steps and is aligned with that realm's prediction time
+  axis by construction, so no cross-realm time handling is required.
+
+## `fme/coupled/data_loading/batch_data.py` (modified)
+
+```python
+@dataclasses.dataclass
+class CoupledPairedData:
+    @classmethod
+    def from_coupled_batch_data(
+        cls,
+        prediction: CoupledBatchData,
+        reference: CoupledBatchData,
+    ) -> "CoupledPairedData":
+        # CHANGED — forward each realm's prediction step_diagnostics onto that
+        # realm's PairedData, so it reaches the per-realm writers and aggregators
+        ...
+```
+
+## `fme/coupled/aggregator.py` (modified)
+
+```python
+@dataclasses.dataclass
+class InferenceEvaluatorAggregatorConfig:
+    # NEW — one field applied to both realms, matching how this config already
+    # applies log_histograms / log_video / log_zonal_mean_images to both.
+    # Rejected: ocean_/atmosphere_-prefixed fields, which double the surface for a
+    # granularity choice that is not realm-specific; per-realm *availability*
+    # still resolves separately, from each realm's own normalizer.
+    step_diagnostics: StepDiagnosticsMetricConfig = dataclasses.field(
+        default_factory=StepDiagnosticsMetricConfig
+    )
+
+    def build(
+        self,
+        dataset_info: CoupledDatasetInfo,
+        n_timesteps_ocean: int,
+        n_timesteps_atmosphere: int,
+        initial_time: xr.DataArray,
+        ocean_normalize: NormalizeFn,
+        atmosphere_normalize: NormalizeFn,
+        save_diagnostics: bool = True,
+        output_dir: str | None = None,
+        ocean_channel_mean_names: Sequence[str] | None = None,
+        atmosphere_channel_mean_names: Sequence[str] | None = None,
+    ) -> "InferenceEvaluatorAggregator":
+        # CHANGED — pass step_diagnostics into both per-realm
+        # build_inference_evaluator_aggregator calls, each with that realm's
+        # normalizer and output subdirectory
+        ...
+
+
+@dataclasses.dataclass
+class InferenceAggregatorConfig:
+    step_diagnostics: StepDiagnosticsMetricConfig = dataclasses.field(  # NEW
+        default_factory=StepDiagnosticsMetricConfig
+    )
+
+    def build(
+        self,
+        dataset_info: CoupledDatasetInfo,
+        n_timesteps_ocean: int,
+        n_timesteps_atmosphere: int,
+        output_dir: str,
+        ocean_normalize: NormalizeFn | None = None,  # NEW
+        atmosphere_normalize: NormalizeFn | None = None,  # NEW
+    ) -> "InferenceAggregator":
+        # CHANGED — set step_diagnostics on each realm's ace config and pass that
+        # realm's normalizer through. Optional-with-None default mirrors the ace
+        # InferenceAggregatorConfig.build signature: with the default config and
+        # no normalizer the correction metrics are silently skipped; an explicit
+        # non-default configuration without a normalizer raises.
+        ...
+```
+
+## `fme/coupled/inference/inference.py` (modified)
+
+```python
+def run_inference_from_config(config: InferenceConfig):
+    aggregator = aggregator_config.build(
+        ...,
+        ocean_normalize=stepper.ocean.normalizer.normalize,  # NEW
+        atmosphere_normalize=stepper.atmosphere.normalizer.normalize,  # NEW
+    )  # CHANGED
+```
+
+## `fme/coupled/inference/data_writer.py` (unchanged — verified, not modified)
+
+`CoupledDataWriterConfig` already holds one `DataWriterConfig` per realm and builds into the
+`ocean/` and `atmosphere/` subdirectories, and `CoupledPairedDataWriter.append_batch`
+forwards each realm's `PairedData` to that realm's `PairedDataWriter`, which writes
+`step_diagnostics/correction_deltas.nc` when the batch carries diagnostics. Once the
+carriage above lands, `save_step_diagnostics: true` on a realm's writer config works
+end-to-end with no new writer surface; the end-to-end test below pins that.
+
+The coupled evaluator's inline-validation path needs no change either: coupled training
+already builds the evaluator aggregator with both realms' normalizers, so the new
+`step_diagnostics` field reaches it through the same config.
+
+---
+
+## Tests
+
+## `fme/coupled/test_stepper.py` (modified)
+
+```python
+# Build on get_stepper_and_batch and the existing test_predict_paired setup;
+# inject CorrectionSequence([ConstantOffsetCorrection(...)]) onto a component
+# stepper's step object, as the single-component stepper tests do.
+
+def test_predict_paired_attaches_step_diagnostics_for_corrected_realm():
+    # GOAL: with a constant-offset corrector on exactly one realm, that realm's
+    # PairedData carries step_diagnostics whose delta equals the offset at every
+    # forward step and is shaped like that realm's prediction series; the other
+    # realm's step_diagnostics is None.
+    # PARAMETERIZE: corrected realm in {ocean, atmosphere} — this also covers the
+    # differing per-realm step counts (outer ocean steps vs inner atmosphere steps).
+    ...
+
+def test_predict_paired_step_diagnostics_both_realms():
+    # GOAL: correctors on both components yield independent per-realm delta series,
+    # each with that realm's own step count and offset value.
+    ...
+
+def test_predict_paired_prediction_values_unchanged_by_carriage():
+    # GOAL: regression guard — with a corrector installed, prediction values and
+    # the returned prognostic state are identical whether or not the diagnostics
+    # are carried, including with compute_derived_variables=True (the prepend /
+    # compute-derived / remove-initial-condition path).
+    ...
+
+def test_predict_attaches_step_diagnostics():
+    # GOAL: the non-paired predict path attaches the same per-realm series and
+    # still returns a usable end state (the attach happens after get_end).
+    ...
+
+def test_predict_paired_without_corrector_has_no_step_diagnostics():
+    # GOAL: both realms' step_diagnostics are None when no component has a
+    # corrector.
+    ...
+
+def test_prediction_generator_yields_corrector_diagnostics():
+    # GOAL: each ComponentStepPrediction carries its component step's
+    # corrector_diagnostics, for both the inner atmosphere and outer ocean yields.
+    ...
+```
+
+## `fme/coupled/data_loading/test_batch_data.py` (new)
+
+```python
+def test_from_coupled_batch_data_forwards_step_diagnostics():
+    # GOAL: each realm's prediction step_diagnostics lands on that realm's
+    # PairedData, and None passes through as None.
+    # PARAMETERIZE: (ocean, atmosphere) diagnostics presence in
+    # {(set, None), (None, set), (set, set)}.
+    ...
+```
+
+## `fme/coupled/test_aggregator.py` (modified)
+
+```python
+def test_inference_evaluator_aggregator_logs_correction_metrics_per_realm():
+    # GOAL: recording a CoupledPairedData carrying a known constant delta on both
+    # realms produces the correction scalars for each realm under that realm's
+    # label prefix, with the exact expected normalized value (delta / std of that
+    # realm's normalizer).
+    ...
+
+def test_inference_evaluator_aggregator_silent_without_step_diagnostics():
+    # GOAL: no correction keys are logged for a realm whose step_diagnostics is
+    # None; the other realm's are unaffected.
+    ...
+
+def test_inference_aggregator_correction_metrics_require_normalizer():
+    # GOAL: the no-target coupled config builds silently (no correction metrics)
+    # with default step_diagnostics and no normalizer, and raises when
+    # step_diagnostics is explicitly non-default and no normalizer is supplied.
+    # PARAMETERIZE: normalizer supplied for neither / only one realm.
+    ...
+
+def test_inference_aggregator_builds_correction_metrics_with_normalizers():
+    # GOAL: with both normalizers supplied, each realm's aggregator records
+    # correction metrics into its own output subdirectory.
+    ...
+```
+
+## `fme/coupled/inference/test_inference.py` (modified)
+
+```python
+# Extend the existing end-to-end coupled inference test setup.
+
+def test_inference_writes_step_diagnostics_per_realm(tmp_path):
+    # GOAL: a run whose ocean stepper has a config-declared corrector and
+    # save_step_diagnostics=True on the ocean writer writes
+    # ocean/step_diagnostics/correction_deltas.nc with the corrected variables on
+    # the ocean time axis, and writes no such file under atmosphere/.
+    ...
+
+def test_inference_no_step_diagnostics_by_default(tmp_path):
+    # GOAL: default configuration writes no step_diagnostics directory under
+    # either realm.
+    ...
+```
+
+## `fme/coupled/inference/test_evaluator.py` (modified)
+
+```python
+def test_evaluator_logs_correction_metrics_per_realm(tmp_path):
+    # GOAL: an evaluator run with a corrector-equipped component logs that realm's
+    # correction scalars, and a run with no corrector logs none — the defaults-
+    # preserved check for existing coupled evaluator runs.
+    ...
+```
+
+---
+
+## Open Questions
+
+- The correction-metrics granularity is one `step_diagnostics` field applied to both realms.
+  Worth per-realm fields instead if enabling `correction_maps` for only the ocean is a real
+  use case?
+- `InferenceAggregatorConfig.build` takes the two normalizers as optional keyword arguments
+  to match the single-component signature and keep existing call sites working. Making them
+  required would force every caller to opt in explicitly — preferable?

--- a/pr-plan.md
+++ b/pr-plan.md
@@ -35,6 +35,10 @@ correction-metrics aggregator per realm in the coupled inference configs.
   `fme/ace/aggregator/inference/step_diagnostics.py` hard-codes `dims = ("lat", "lon")`, so a
   realm whose horizontal dims differ would break. Splitting the field later is a
   config-breaking change; accepted, because the split has no use today.
+- **No new writer config surface.** The existing per-realm
+  `DataWriterConfig.save_step_diagnostics` is the whole writer interface; turning the files
+  on for both realms is two YAML edits in two places. Decided: acceptable — no coupled-level
+  convenience flag.
 - **The two normalizer arguments mirror the `fme.ace` signature they wrap.**
   `fme/ace/aggregator/inference/main.py`'s `InferenceAggregatorConfig.build` takes
   `normalize: NormalizeFn | None = None`, so the coupled version takes one optional
@@ -218,6 +222,16 @@ class CoupledPairedData:
         # prediction.n_ensemble (silently defaulting to 1) where the ace helper
         # forwards it. Called out because it is a behavior change beyond diagnostics
         # carriage — see the test for it below.
+        #
+        # Verified inert today: no coupled predict_paired call site passes a batch
+        # with n_ensemble > 1. Coupled ensemble inference (n_ensemble_per_ic)
+        # broadcasts only the initial condition, so the forcing windows — whose
+        # n_ensemble the prediction inherits in _process_prediction_generator_list —
+        # keep n_ensemble=1; the n_ensemble=2 CRPS broadcast happens only inside
+        # CoupledTrainStepper.train_on_batch, which is also the path validation
+        # loss takes (fme/core/generics/validation.py) and never reaches
+        # predict_paired. So the byte-for-byte defaults claim holds; the fix
+        # matters only for a future ensemble-aware coupled predict path.
         ...
 ```
 
@@ -365,16 +379,6 @@ def test_predict_paired_step_diagnostics_both_realms():
     # each with that realm's own step count and offset value.
     ...
 
-def test_predict_paired_regression_against_baseline():
-    # GOAL: regression guard on the values, since carriage is unconditional and
-    # there is no runtime toggle to A/B against. Pin prediction values and the
-    # returned prognostic state with validate_tensor_dict
-    # (fme/core/testing/regression.py) against a committed .pt baseline, with a
-    # corrector installed and compute_derived_variables=True, so the prepend /
-    # compute-derived / remove-initial-condition path is exercised.
-    # The baseline is generated on main, before the carriage lands.
-    ...
-
 def test_predict_attaches_step_diagnostics():
     # GOAL: the non-paired predict path attaches the same per-realm series and
     # still returns a usable prognostic state (the attach happens after get_end).
@@ -400,6 +404,10 @@ def test_prediction_generator_yields_corrector_diagnostics():
     # corrector_diagnostics, for both the inner atmosphere and outer ocean yields.
     ...
 ```
+
+Deliberately no `.pt` values-regression baseline: the carriage adds a new field and changes
+no prediction arithmetic, and the `_predict` / `get_end` refactor is exercised by every
+existing `predict` / `predict_paired` test plus the exact-value diagnostics tests above.
 
 ### `fme/coupled/data_loading/test_batch_data.py` (new)
 
@@ -467,9 +475,11 @@ is real setup work, not an "extend the existing test" one-liner. `test_inference
 The ocean-side corrector should be `OceanCorrectorConfig(force_positive_names=[...])`: it is
 the only ocean corrector option that works on the synthetic single-level test data (the
 sea-ice, surface-energy-flux, and ocean-heat-content corrections all need extra fields).
-Because a `force_positive` clamp only bites where the value is already negative, the test
-data must be seeded to make the clamp fire, or the assertion has to accept the all-zero
-series from the semantics above — pick one explicitly when writing the test.
+Because a `force_positive` clamp only bites where the value is already negative, seed the
+test data with negative values in the force-positive variable so the clamp fires and the
+end-to-end assertions see a nonzero delta reach the writer and aggregator. (The all-zero
+semantics is already pinned by the unit-level zeros test above; do not fall back to
+asserting the zero series here.)
 
 ### `fme/coupled/inference/test_inference.py` (modified)
 
@@ -500,13 +510,3 @@ def test_evaluator_logs_no_correction_metrics_without_corrector(tmp_path):
     # key set contains no correction keys at all.
     ...
 ```
-
----
-
-## Open questions
-
-- **Should the writer flag be surfaced any differently?** This PR adds no writer config
-  surface, relying on the existing per-realm `DataWriterConfig.save_step_diagnostics`. That
-  means turning the files on for both realms is two YAML edits in two places. Acceptable, or
-  worth a coupled-level convenience flag? (Not the same granularity question as the
-  aggregator config above — this one asks for *less* per-realm surface, not more.)

--- a/pr-plan.md
+++ b/pr-plan.md
@@ -1,9 +1,45 @@
 # Carry corrector step diagnostics through coupled inference
 
-Threads each component stepper's per-step correction `delta` through `CoupledStepper` onto
-that realm's prediction data, and surfaces the existing step-diagnostics writer and
-correction-metrics aggregator per realm in the coupled inference configs. No new
-coupled-specific diagnostics container: the `fme.ace` components are reused once per realm.
+## Why
+
+Single-component inference can already answer "what is the corrector actually doing?" — it
+writes the per-step correction `delta` to `step_diagnostics/correction_deltas.nc` and logs
+normalized correction magnitudes. Coupled inference cannot: `CoupledStepper` drops each
+component stepper's `StepOutput.corrector_diagnostics` at the component-step seam, so a
+coupled run with a corrector on either realm is silent.
+
+That matters when diagnosing a coupled run that drifts: the corrector is one of the few
+places where the emulator's output is overwritten by something other than the network, and
+today there is no way to tell whether it is nudging gently or holding the state up. This PR
+makes the coupled path report what the single-component path already reports, per realm.
+
+## What changes
+
+Thread each component stepper's per-step correction `delta` through `CoupledStepper` onto
+that realm's prediction data, then surface the existing `fme.ace` step-diagnostics writer and
+correction-metrics aggregator per realm in the coupled inference configs.
+
+## Design choices
+
+- **Reuse the `fme.ace` components once per realm** rather than adding a coupled-specific
+  diagnostics container. `StepDiagnostics`, `StepDiagnosticsWriter`, and
+  `StepDiagnosticsAggregator` are realm-agnostic; a coupled run is two realms each with
+  their own normalizer, time axis, and output subdirectory, which is exactly what building
+  the ace components twice gives. The coupled layer adds carriage and config plumbing only.
+- **One `step_diagnostics` config field applied to both realms**, not
+  `ocean_`/`atmosphere_`-prefixed pairs. This matches how `InferenceEvaluatorAggregatorConfig`
+  already applies `log_histograms`, `log_video`, and `log_zonal_mean_images` to both realms.
+  Per-realm granularity is deliberately deferred: the only case that would want it is
+  enabling `correction_maps` for one realm only, and `correction_maps` is not usable
+  per-realm as things stand — `CorrectionDeltaTimeMeanAggregator.get_dataset` in
+  `fme/ace/aggregator/inference/step_diagnostics.py` hard-codes `dims = ("lat", "lon")`, so a
+  realm whose horizontal dims differ would break. Splitting the field later is a
+  config-breaking change; accepted, because the split has no use today.
+- **The two normalizer arguments mirror the `fme.ace` signature they wrap.**
+  `fme/ace/aggregator/inference/main.py`'s `InferenceAggregatorConfig.build` takes
+  `normalize: NormalizeFn | None = None`, so the coupled version takes one optional
+  normalizer per realm rather than making them required. The availability rule that makes
+  optional safe already lives in `StepDiagnosticsMetricConfig.build`, not in the caller.
 
 ---
 
@@ -48,8 +84,13 @@ class CoupledStepper:
         forcing_data: CoupledBatchData,
     ) -> CoupledBatchData:
         # CHANGED — the per-realm StepOutput reconstruction carries
-        # corrector_diagnostics instead of defaulting it to empty. Attaches
-        # nothing: the returned batch still passes through time-changing ops.
+        # corrector_diagnostics instead of defaulting it to empty, so the stacked
+        # series can be built from it later.
+        #
+        # Still attaches nothing to the returned CoupledBatchData: that batch is
+        # about to pass through prepend / compute_derived_variables /
+        # remove_initial_condition, all of which raise on a diagnostics-bearing
+        # batch. See "Where the diagnostics attach" below.
         ...
 
     def _predict(
@@ -58,8 +99,11 @@ class CoupledStepper:
         forcing: CoupledBatchData,
         compute_derived_variables: bool = False,
     ) -> tuple[CoupledBatchData, CoupledPrognosticState]:
-        # CHANGED — also returns the end state (was: prediction only), so the
-        # stacked per-realm diagnostics can be attached after get_end.
+        # CHANGED — also returns the prognostic state (was: prediction only), so
+        # the get_end block that predict and predict_paired each duplicated moves
+        # in here, and the stacked per-realm diagnostics can be attached after it
+        # via CoupledBatchData.with_step_diagnostics.
+        #
         # Rejected: attaching in predict() and predict_paired() separately, which
         # duplicates the attach and its ordering constraint at two call sites.
         ...
@@ -70,8 +114,8 @@ class CoupledStepper:
         forcing: CoupledBatchData,
         compute_derived_variables: bool = False,
     ) -> tuple[CoupledBatchData, CoupledPrognosticState]:
-        # CHANGED — returns _predict's tuple; the duplicated get_end block moves
-        # into _predict
+        # CHANGED — returns _predict's tuple directly; its get_end block and its
+        # redundant CoupledBatchData rebuild both go away
         ...
 
     def predict_paired(
@@ -80,27 +124,84 @@ class CoupledStepper:
         forcing: CoupledBatchData,
         compute_derived_variables: bool = False,
     ) -> tuple[CoupledPairedData, CoupledPrognosticState]:
-        # CHANGED — consumes _predict's tuple
+        # CHANGED — consumes _predict's tuple; its get_end block goes away
         ...
 ```
 
-### Critical detail — where the diagnostics attach, and why
+### Where the diagnostics attach, and why
 
-- Each realm's stacked series comes from `StepOutput.stack_diagnostics` over that realm's
-  own `ComponentStepPrediction`s, so it is `None` when that realm's stepper has no
-  corrector or its corrector modified nothing — matching single-component inference.
+- Each realm's stacked series comes from `StepOutput.stack_diagnostics` over that realm's own
+  `ComponentStepPrediction`s, so it is `None` exactly when that realm's stepper has no
+  corrector — matching single-component inference. See "What counts as silence" below for
+  the corrector-that-changed-nothing case, which is *not* silent.
 - `BatchData` rejects a diagnostics-bearing batch in every time-changing method
-  (`prepend`, `compute_derived_variables`, `remove_initial_condition`, `get_end`, …).
-  Attachment must therefore be the last thing `_predict` does: after the
-  prepend / compute-derived / remove-initial-condition dance **and** after the end states
-  are taken. This mirrors the attach position in single-component `Stepper.predict`.
+  (`prepend`, `compute_derived_variables`, `remove_initial_condition`, `get_end`,
+  `select_time_slice`, `subset_names`, `get_start`, `scatter_spatial`) via
+  `BatchData._raise_if_step_diagnostics`. Attachment must therefore be the last thing
+  `_predict` does: after the prepend / compute-derived / remove-initial-condition dance
+  **and** after the prognostic state is taken. This mirrors the attach position in
+  `fme/ace/stepper/single_module.py`, where `Stepper.predict` rebuilds its `BatchData` with
+  `step_diagnostics` only after `get_end`.
 - Per-realm time axes differ (several atmosphere steps per ocean step). Each realm's series
   is stacked from that realm's own steps and is aligned with that realm's prediction time
   axis by construction, so no cross-realm time handling is required.
 
+### What counts as silence
+
+`build_corrector_diagnostics` in `fme/core/corrector/output.py` keys `delta` by the names the
+corrector *declares* it writes, not by names whose values actually changed. Consequences the
+tests below pin:
+
+- A realm with **no corrector** produces `step_diagnostics is None` — no file, no metrics.
+- A realm with a corrector that declares names but leaves them **numerically unchanged**
+  produces a non-`None` series of exact zeros: the file *is* written and the scalars *are*
+  logged as `0.0`. This is the ace behavior; the coupled path inherits it rather than adding
+  a coupled-only "drop all-zero deltas" rule.
+- Names in a component's `prescribed_prognostic_names` are dropped from `delta` by
+  `fme/core/step/single_module.py`, because a prescribed overwrite replaces the corrected
+  value and the delta would no longer be exact. Coupled inference supports per-component
+  `ocean_prescribed_prognostic_names` / `atmosphere_prescribed_prognostic_names`, so the
+  written variable set is override-dependent. Not new behavior, but worth knowing when
+  reading a coupled `correction_deltas.nc`.
+
+### Constraint on a corrector for the atmosphere realm
+
+`fme/core/step/single_module.py` raises
+
+```
+post-corrector adjustment names overlap the corrector's modified names: [...]
+```
+
+when the `OceanConfig`-prescribed `surface_temperature_name` appears in the corrector's
+delta, because the SST prescription runs *after* the corrector and would break
+`delta = output - input_snapshot`. A coupled atmosphere stepper is required to have an
+`OceanConfig` (`CoupledStepperConfig._validate_component_configs` raises without one), so an
+atmosphere corrector in a coupled run can never touch the prescribed surface-temperature
+variable. This is pre-existing and unchanged; it constrains the test setup below (the
+atmosphere-side corrector must target some other variable) and is not otherwise worked
+around.
+
 ## `fme/coupled/data_loading/batch_data.py` (modified)
 
 ```python
+@dataclasses.dataclass
+class CoupledBatchData:
+    def with_step_diagnostics(  # NEW
+        self,
+        ocean: StepDiagnostics | None,
+        atmosphere: StepDiagnostics | None,
+    ) -> "CoupledBatchData":
+        # Returns a copy with each realm's BatchData carrying that realm's series,
+        # via dataclasses.replace on each BatchData (so BatchData.__post_init__
+        # re-validates the diagnostics' sample dim against the batch).
+        #
+        # Why a method here rather than open-coding it in _predict, as ace does in
+        # Stepper.predict: coupled would need the rebuild twice in one expression,
+        # and this keeps the ordering constraint documented next to the field it
+        # constrains. It is the only new API surface in this PR.
+        ...
+
+
 @dataclasses.dataclass
 class CoupledPairedData:
     @classmethod
@@ -109,22 +210,27 @@ class CoupledPairedData:
         prediction: CoupledBatchData,
         reference: CoupledBatchData,
     ) -> "CoupledPairedData":
-        # CHANGED — forward each realm's prediction step_diagnostics onto that
-        # realm's PairedData, so it reaches the per-realm writers and aggregators
+        # CHANGED — delegate each realm to PairedData.from_batch_data instead of
+        # hand-copying fields. That helper already does the time-equality check and
+        # forwards step_diagnostics, so the carriage comes for free.
+        #
+        # Drive-by fix this delegation includes: the hand-rolled version dropped
+        # prediction.n_ensemble (silently defaulting to 1) where the ace helper
+        # forwards it. Called out because it is a behavior change beyond diagnostics
+        # carriage — see the test for it below.
         ...
 ```
 
 ## `fme/coupled/aggregator.py` (modified)
 
+Both new fields need a `Parameters:` entry in their config's class docstring — these two
+docstrings document every field today, and the generated config documentation is built from
+them.
+
 ```python
 @dataclasses.dataclass
 class InferenceEvaluatorAggregatorConfig:
-    # NEW — one field applied to both realms, matching how this config already
-    # applies log_histograms / log_video / log_zonal_mean_images to both.
-    # Rejected: ocean_/atmosphere_-prefixed fields, which double the surface for a
-    # granularity choice that is not realm-specific; per-realm *availability*
-    # still resolves separately, from each realm's own normalizer.
-    step_diagnostics: StepDiagnosticsMetricConfig = dataclasses.field(
+    step_diagnostics: StepDiagnosticsMetricConfig = dataclasses.field(  # NEW
         default_factory=StepDiagnosticsMetricConfig
     )
 
@@ -143,7 +249,9 @@ class InferenceEvaluatorAggregatorConfig:
     ) -> "InferenceEvaluatorAggregator":
         # CHANGED — pass step_diagnostics into both per-realm
         # build_inference_evaluator_aggregator calls, each with that realm's
-        # normalizer and output subdirectory
+        # normalizer and output subdirectory. Both normalizers are already
+        # required here, so correction-metric availability cannot differ between
+        # realms on this path.
         ...
 
 
@@ -163,10 +271,16 @@ class InferenceAggregatorConfig:
         atmosphere_normalize: NormalizeFn | None = None,  # NEW
     ) -> "InferenceAggregator":
         # CHANGED — set step_diagnostics on each realm's ace config and pass that
-        # realm's normalizer through. Optional-with-None default mirrors the ace
-        # InferenceAggregatorConfig.build signature: with the default config and
-        # no normalizer the correction metrics are silently skipped; an explicit
-        # non-default configuration without a normalizer raises.
+        # realm's normalizer through.
+        #
+        # Optional-with-None mirrors fme/ace/aggregator/inference/main.py's
+        # InferenceAggregatorConfig.build(normalize=None), which is the config this
+        # one wraps twice. The availability rule lives in
+        # StepDiagnosticsMetricConfig.build and needs no help here: default config
+        # with no normalizer is silently skipped, and an explicit non-default
+        # configuration with no normalizer raises. This is the only path where a
+        # normalizer can be absent, so it is the only path where the two realms can
+        # resolve availability differently.
         ...
 ```
 
@@ -181,30 +295,62 @@ def run_inference_from_config(config: InferenceConfig):
     )  # CHANGED
 ```
 
-## `fme/coupled/inference/data_writer.py` (unchanged — verified, not modified)
+This is the only production call site of the coupled `InferenceAggregatorConfig.build`, and
+this PR updates it, so the optional defaults above exist for ace-signature parity, not to
+avoid touching callers.
 
-`CoupledDataWriterConfig` already holds one `DataWriterConfig` per realm and builds into the
-`ocean/` and `atmosphere/` subdirectories, and `CoupledPairedDataWriter.append_batch`
-forwards each realm's `PairedData` to that realm's `PairedDataWriter`, which writes
-`step_diagnostics/correction_deltas.nc` when the batch carries diagnostics. Once the
-carriage above lands, `save_step_diagnostics: true` on a realm's writer config works
-end-to-end with no new writer surface; the end-to-end test below pins that.
+---
 
-The coupled evaluator's inline-validation path needs no change either: coupled training
-already builds the evaluator aggregator with both realms' normalizers, so the new
-`step_diagnostics` field reaches it through the same config.
+## Defaults, and what existing runs start doing
+
+`StepDiagnosticsMetricConfig.correction_scalars` defaults to `True` (`correction_maps`
+defaults to `False`), and coupled training already supplies both realms' normalizers to
+`InferenceEvaluatorAggregatorConfig.build` in `fme/coupled/train/train_config.py`. So:
+
+| Run shape | What changes |
+| --- | --- |
+| No corrector on either realm | Nothing. No new files, no new log keys, unchanged rollout values. |
+| Corrector on a realm | That realm gains `time_mean_norm/correction_magnitude/*` and, where per-step time series are enabled, `mean_norm/weighted_correction_*` log keys. Rollout values unchanged. |
+| Corrector on a realm, `save_step_diagnostics: true` on that realm's writer config | Additionally writes `<realm>/step_diagnostics/correction_deltas.nc`. Off by default. |
+
+This applies to coupled inference, the coupled evaluator, and coupled inline validation
+during training, since all three build through the same two configs. No writer config
+surface is added. The corrector-free row is pinned by
+`test_evaluator_logs_no_correction_metrics_without_corrector` below.
+
+## Not changed (verified, no edits needed)
+
+- **`fme/coupled/inference/data_writer.py`.** `CoupledDataWriterConfig` already holds one
+  `DataWriterConfig` per realm and builds into the `ocean/` and `atmosphere/`
+  subdirectories, and `CoupledPairedDataWriter.append_batch` forwards each realm's
+  `PairedData` to that realm's `PairedDataWriter`, which writes
+  `step_diagnostics/correction_deltas.nc` when the batch carries diagnostics. Once the
+  carriage lands, `save_step_diagnostics: true` works end-to-end with no new writer surface;
+  the end-to-end test pins that.
+- **The coupled training path.** `CoupledTrainStepper._accumulate_step_loss` rebuilds each
+  `ComponentStepPrediction` into `ComponentEnsembleStepPrediction`, which has no diagnostics
+  field, so `train_on_batch` still drops them. Deliberate, and consistent with
+  single-component training, where `TrainOutput` carries no diagnostics either. Making
+  `corrector_diagnostics` a required constructor argument means a future ensemble-side
+  carriage has to make that choice explicitly rather than inherit an empty default.
+- **`InferenceAggregator.log_time_series`** in `fme/coupled/aggregator.py` consults only the
+  ocean aggregator. Wiring normalizers in flips it to unconditionally `True`. Nothing in
+  `fme/` reads the property, so this is inert — noted because it is a behavior change the
+  diff does not otherwise show.
 
 ---
 
 ## Tests
 
-## `fme/coupled/test_stepper.py` (modified)
+### `fme/coupled/test_stepper.py` (modified)
+
+Build on `get_stepper_and_batch` (`fme/coupled/test_stepper.py:1289`) and the existing
+`test_predict_paired` (`fme/coupled/test_stepper.py:1739`) setup; inject
+`CorrectionSequence([ConstantOffsetCorrection(...)])` onto a component stepper's step object,
+as `fme/ace/stepper/test_single_module.py` does. The injected corrector must not target the
+atmosphere's prescribed surface-temperature variable (see the constraint above).
 
 ```python
-# Build on get_stepper_and_batch and the existing test_predict_paired setup;
-# inject CorrectionSequence([ConstantOffsetCorrection(...)]) onto a component
-# stepper's step object, as the single-component stepper tests do.
-
 def test_predict_paired_attaches_step_diagnostics_for_corrected_realm():
     # GOAL: with a constant-offset corrector on exactly one realm, that realm's
     # PairedData carries step_diagnostics whose delta equals the offset at every
@@ -219,21 +365,34 @@ def test_predict_paired_step_diagnostics_both_realms():
     # each with that realm's own step count and offset value.
     ...
 
-def test_predict_paired_prediction_values_unchanged_by_carriage():
-    # GOAL: regression guard — with a corrector installed, prediction values and
-    # the returned prognostic state are identical whether or not the diagnostics
-    # are carried, including with compute_derived_variables=True (the prepend /
-    # compute-derived / remove-initial-condition path).
+def test_predict_paired_regression_against_baseline():
+    # GOAL: regression guard on the values, since carriage is unconditional and
+    # there is no runtime toggle to A/B against. Pin prediction values and the
+    # returned prognostic state with validate_tensor_dict
+    # (fme/core/testing/regression.py) against a committed .pt baseline, with a
+    # corrector installed and compute_derived_variables=True, so the prepend /
+    # compute-derived / remove-initial-condition path is exercised.
+    # The baseline is generated on main, before the carriage lands.
     ...
 
 def test_predict_attaches_step_diagnostics():
     # GOAL: the non-paired predict path attaches the same per-realm series and
-    # still returns a usable end state (the attach happens after get_end).
+    # still returns a usable prognostic state (the attach happens after get_end).
+    # NOTE: CoupledStepper.predict has no production call sites today — only
+    # predict_paired is used, by coupled inference and the coupled evaluator. This
+    # is coverage for an otherwise test-only path, kept because _predict now serves
+    # both and the attach ordering is easy to break.
     ...
 
 def test_predict_paired_without_corrector_has_no_step_diagnostics():
     # GOAL: both realms' step_diagnostics are None when no component has a
     # corrector.
+    ...
+
+def test_predict_paired_step_diagnostics_zero_for_unchanged_variable():
+    # GOAL: a corrector that declares a name but leaves it unchanged still produces
+    # a non-None series of exact zeros — pins the declared-names semantics that the
+    # writer and aggregator tests below depend on.
     ...
 
 def test_prediction_generator_yields_corrector_diagnostics():
@@ -242,7 +401,7 @@ def test_prediction_generator_yields_corrector_diagnostics():
     ...
 ```
 
-## `fme/coupled/data_loading/test_batch_data.py` (new)
+### `fme/coupled/data_loading/test_batch_data.py` (new)
 
 ```python
 def test_from_coupled_batch_data_forwards_step_diagnostics():
@@ -251,9 +410,24 @@ def test_from_coupled_batch_data_forwards_step_diagnostics():
     # PARAMETERIZE: (ocean, atmosphere) diagnostics presence in
     # {(set, None), (None, set), (set, set)}.
     ...
+
+def test_from_coupled_batch_data_forwards_n_ensemble():
+    # GOAL: pins the drive-by fix — n_ensemble reaches each realm's PairedData
+    # instead of defaulting to 1.
+    ...
+
+def test_from_coupled_batch_data_rejects_mismatched_time():
+    # GOAL: the time-equality check survives delegating to
+    # PairedData.from_batch_data, for each realm independently.
+    ...
+
+def test_with_step_diagnostics_attaches_per_realm():
+    # GOAL: attaches each realm's series independently, passes None through, and
+    # leaves the input CoupledBatchData unmutated.
+    ...
 ```
 
-## `fme/coupled/test_aggregator.py` (modified)
+### `fme/coupled/test_aggregator.py` (modified)
 
 ```python
 def test_inference_evaluator_aggregator_logs_correction_metrics_per_realm():
@@ -281,11 +455,25 @@ def test_inference_aggregator_builds_correction_metrics_with_normalizers():
     ...
 ```
 
-## `fme/coupled/inference/test_inference.py` (modified)
+### Test-setup work the end-to-end tests need first
+
+The coupled inference and evaluator tests build their checkpoint through
+`save_coupled_stepper` (`fme/coupled/inference/test_evaluator.py:106`), which delegates to
+`get_stepper_config` (`fme/coupled/test_stepper.py:1197`). Neither exposes a corrector today,
+so both need a new optional per-component corrector-config argument threaded through — this
+is real setup work, not an "extend the existing test" one-liner. `test_inference.py` imports
+`save_coupled_stepper` from `test_evaluator.py`, so one threading change serves both files.
+
+The ocean-side corrector should be `OceanCorrectorConfig(force_positive_names=[...])`: it is
+the only ocean corrector option that works on the synthetic single-level test data (the
+sea-ice, surface-energy-flux, and ocean-heat-content corrections all need extra fields).
+Because a `force_positive` clamp only bites where the value is already negative, the test
+data must be seeded to make the clamp fire, or the assertion has to accept the all-zero
+series from the semantics above — pick one explicitly when writing the test.
+
+### `fme/coupled/inference/test_inference.py` (modified)
 
 ```python
-# Extend the existing end-to-end coupled inference test setup.
-
 def test_inference_writes_step_diagnostics_per_realm(tmp_path):
     # GOAL: a run whose ocean stepper has a config-declared corrector and
     # save_step_diagnostics=True on the ocean writer writes
@@ -299,23 +487,26 @@ def test_inference_no_step_diagnostics_by_default(tmp_path):
     ...
 ```
 
-## `fme/coupled/inference/test_evaluator.py` (modified)
+### `fme/coupled/inference/test_evaluator.py` (modified)
 
 ```python
 def test_evaluator_logs_correction_metrics_per_realm(tmp_path):
     # GOAL: an evaluator run with a corrector-equipped component logs that realm's
-    # correction scalars, and a run with no corrector logs none — the defaults-
-    # preserved check for existing coupled evaluator runs.
+    # correction scalars under that realm's prefix.
+    ...
+
+def test_evaluator_logs_no_correction_metrics_without_corrector(tmp_path):
+    # GOAL: the defaults-preserved check — a corrector-free evaluator run's logged
+    # key set contains no correction keys at all.
     ...
 ```
 
 ---
 
-## Open Questions
+## Open questions
 
-- The correction-metrics granularity is one `step_diagnostics` field applied to both realms.
-  Worth per-realm fields instead if enabling `correction_maps` for only the ocean is a real
-  use case?
-- `InferenceAggregatorConfig.build` takes the two normalizers as optional keyword arguments
-  to match the single-component signature and keep existing call sites working. Making them
-  required would force every caller to opt in explicitly — preferable?
+- **Should the writer flag be surfaced any differently?** This PR adds no writer config
+  surface, relying on the existing per-realm `DataWriterConfig.save_step_diagnostics`. That
+  means turning the files on for both realms is two YAML edits in two places. Acceptable, or
+  worth a coupled-level convenience flag? (Not the same granularity question as the
+  aggregator config above — this one asks for *less* per-realm surface, not more.)


### PR DESCRIPTION
Coupled inference now surfaces the same corrector diagnostics that single-component inference does, per realm. Each component stepper's per-step correction delta is carried through `CoupledStepper` onto that realm's prediction data, so a coupled run whose ocean and/or atmosphere stepper has a corrector writes `<realm>/step_diagnostics/correction_deltas.nc` when that realm's writer config enables it, and logs the correction metrics normalized with that realm's stepper normalizer. A realm whose stepper has no corrector stays silent; a corrector that declares variables but leaves them unchanged reports a zeros series, matching the single-component behavior. The existing `fme.ace` step-diagnostics writer and correction-metrics aggregator are reused once per realm rather than reimplemented, so there is no coupled-specific diagnostics container.

Defaults preserve current coupled behavior: no new files, unchanged rollout values, and no writer config surface added. Correction metric scalars are on by default, so a corrector-equipped coupled run gains those logged scalars — in coupled inference, the coupled evaluator, and coupled inline validation, which all build through the same two configs — and nothing else changes.

Changes:
- `fme.coupled.stepper.ComponentStepPrediction` carries the component step's corrector diagnostics, threaded from both the inner atmosphere and the outer ocean yield sites.
- `fme.coupled.stepper.CoupledStepper._predict` returns the prognostic state alongside the prediction and attaches each realm's stacked series after the derived-variable windowing, which is the only point where the series and the data are time-aligned. The `get_end` block that `predict` and `predict_paired` each duplicated moves into it.
- `fme.coupled.data_loading.batch_data.CoupledBatchData.with_step_diagnostics` attaches a per-realm series, re-validating each series against its batch.
- `fme.coupled.data_loading.batch_data.CoupledPairedData.from_coupled_batch_data` delegates each realm to `PairedData.from_batch_data` instead of hand-copying fields, which forwards `step_diagnostics` and fixes a pre-existing silent drop of `n_ensemble` to its default of 1.
- `fme.coupled.aggregator.InferenceEvaluatorAggregatorConfig` and `fme.coupled.aggregator.InferenceAggregatorConfig` gain a `step_diagnostics` field applied to both realms; the latter's `build` gains optional `ocean_normalize` / `atmosphere_normalize` arguments, mirroring the `fme.ace` `InferenceAggregatorConfig.build` signature it wraps once per realm. Coupled inference supplies both from each component stepper's normalizer.
- `fme.coupled.aggregator.InferenceEvaluatorAggregatorConfig.build` gains an `enable_time_series` argument, and coupled inline validation passes `False` — mirroring the `fme.ace` training path — so the correction per-step series (whose contiguous-window time bookkeeping inline validation violates) is never built there, while the time-mean correction scalars remain.

`pr-plan.md` at the repo root is the API roadmap for the change, including the constraint that an atmosphere corrector cannot touch the `OceanConfig`-prescribed surface temperature variable, and the test-setup threading the end-to-end tests need.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

