### PR TITLE
Agree a batch boundary across ranks so a preempted job leaves the training loop together

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -190,15 +190,22 @@ def reset_global_timer():
 
 @pytest.fixture(autouse=True)
 def reset_post_shutdown_callbacks():
-    # the registry is process-global and nothing clears it between tests -- the
-    # session-scoped context above installs no handler, so its usual
+    # both registries are process-global and nothing clears them between tests --
+    # the session-scoped context above installs no handler, so its usual
     # clear-on-exit never runs either. Without this, every Trainer built by an
-    # earlier test would still be called on a signal raised by a later one
-    from fme.core.distributed.shutdown import clear_post_shutdown_callbacks
+    # earlier test would still be called on a signal raised by a later one, and a
+    # deferral left behind by a failed test would make a later test's signal
+    # deferred to a scope nobody polls
+    from fme.core.distributed.shutdown import (
+        clear_pending_stop,
+        clear_post_shutdown_callbacks,
+    )
 
     clear_post_shutdown_callbacks()
+    clear_pending_stop()
     yield
     clear_post_shutdown_callbacks()
+    clear_pending_stop()
 
 
 @pytest.fixture(autouse=True)

--- a/fme/core/distributed/__init__.py
+++ b/fme/core/distributed/__init__.py
@@ -1,3 +1,10 @@
+from .cooperative_stop import cooperative_stop
 from .distributed import Distributed
+from .shutdown import add_post_shutdown_callback
 
-__all__ = ["Distributed"]
+# `add_post_shutdown_callback` is exported alongside the other two because an
+# adopter that wants work to run after the teardown -- writing a restart
+# checkpoint, say -- should not have to reach into
+# `fme.core.distributed.shutdown` for it. Those three names are the whole
+# adopter-facing surface of the cooperative stop.
+__all__ = ["Distributed", "add_post_shutdown_callback", "cooperative_stop"]

--- a/fme/core/distributed/base.py
+++ b/fme/core/distributed/base.py
@@ -6,6 +6,8 @@ from typing import TypeVar
 import torch
 import torch.nn as nn
 
+from .stop_agreement import StopAgreement
+
 T = TypeVar("T")
 
 
@@ -57,6 +59,33 @@ class DistributedBackend(ABC):
 
     @abstractmethod
     def reduce_max(self, tensor: torch.Tensor) -> torch.Tensor | None: ...
+
+    @abstractmethod
+    def stop_agreement(self) -> StopAgreement:
+        """The group ranks use to agree on leaving a loop together.
+
+        It must be **world-wide**, which is why it is not `reduce_max`: that is
+        data-parallel-only under a spatially-parallel backend, while the teardown
+        is world-wide, so reusing it would let a stop originating on a spatial
+        co-rank never reach its data-parallel peers.
+
+        Created with the backend and **not** destroyed with it. ``shutdown()`` is
+        a no-op on a gloo group and its destructor is unbounded, so the group is
+        held for the life of the process and disposed of by the process's exit.
+        """
+        ...
+
+    @abstractmethod
+    def abort(self) -> None:
+        """Abort this rank's communicators, for the teardown watchdog.
+
+        Called only when the collective teardown has overrun its deadline, in
+        place of dropping the communicators by a hard exit. It targets the
+        **default** group and never the agreement group: gloo's ``abort()`` is an
+        empty default, so this is NCCL-only in effect, and aborting the agreement
+        group would achieve nothing while the design needs it kept anyway.
+        """
+        ...
 
     @abstractmethod
     def gather(

--- a/fme/core/distributed/cooperative_stop.py
+++ b/fme/core/distributed/cooperative_stop.py
@@ -22,6 +22,25 @@ The whole adopter-facing surface is one context manager::
 Leaving the context on a stop performs the same teardown the signal handler would
 have performed -- the backend release, the post-shutdown callbacks, the exit code
 -- entered from the loop's boundary rather than from wherever the signal landed.
+**Every** path that leaves the loop ends that way: a stop read out of an exchange,
+a stop given up on, and an exception. A rank that broke out of the loop and carried
+on into another collective, whose peers had already left, is the fault this module
+exists to prevent.
+
+**What is covered is the one loop that adopts this, and nothing else.** A signal
+arriving during the validation pass, during inline inference, or inside
+``run_lr_tuning_trial`` is acted on where it lands, exactly as before this module
+existed -- and those paths issue aggregator reductions of their own, so a rank
+signalled there still tears the backend down from wherever it was. Widening the
+cover means wrapping those loops too; nothing here does it for them.
+
+**It costs a blocking host-side collective on every iteration** of the loop it
+wraps, over a world-wide gloo group, and there is no switch to turn it off. One
+exchange measured 630 us at 8 gloo ranks -- on an idle workstation, over loopback,
+with no figure above 8 ranks and nothing asserting it, so treat that as a lower
+bound of unknown looseness rather than a cost. It also removes the run-ahead
+today's async NCCL gradient all-reduce allows, capping a rank's host-side lead at
+one iteration.
 
 **Every deadline the design chooses lives here**, with the one module that
 consumes them, rather than split across the two below it in the layering.
@@ -38,32 +57,66 @@ from collections.abc import Iterator
 
 from .distributed import Distributed
 from .shutdown import PendingStop, StopReason, defer_termination, write_marker
-from .stop_agreement import GROUP_TIMEOUT, StopAgreement, is_deadline_expiry
+from .stop_agreement import (
+    StopAgreement,
+    default_group_timeout,
+    is_deadline_expiry,
+    timeout_contract_verified,
+)
 
 logger = logging.getLogger(__name__)
 
 # Seconds a rank with a local event of its own -- a signal it recorded, or an
 # exception it is raising -- will spend waiting for peers that may never arrive.
-# Derived by subtraction: the scheduler's grace period is 30-36s from SIGTERM and
-# `DEFAULT_TEARDOWN_TIMEOUT` claims 20s of it, so this is what is left.
-DEFAULT_STOP_AGREEMENT_BUDGET: float = 10.0
+#
+# Sized against the elastic agent's window, which is what the design is spending:
+# torchrun gives the ranks 30s between SIGTERM and SIGKILL (see
+# `DEFAULT_TEARDOWN_TIMEOUT`), this claims 5s of it and the teardown 20s, leaving
+# the post-shutdown callbacks -- the restart checkpoint, the reason the callbacks
+# exist -- the remaining 5s, a sixth of the window. Giving a rank longer to wait
+# for peers means taking it from the checkpoint, since the teardown timeout is
+# fixed.
+DEFAULT_STOP_AGREEMENT_BUDGET: float = 5.0
 
-# Floors every deadline a rank with a budget passes, and closes two traps at
-# once. torch reads a zero-length timeout as *no* timeout, and the pybind chrono
-# caster truncates a `timedelta` to integral milliseconds -- so a rank reaching a
-# boundary with 0.4ms of budget left would otherwise wait the group's 30 minutes.
-# The size is a decision, not a round number: it is the whole time an already-late
-# rank gives its peers to answer, and a measured exchange is 630us at 8 ranks, so
-# it clears both the truncation boundary and the 404ms spread with which the
-# elastic agent delivers SIGTERM across ranks.
-_MIN_DEADLINE: float = 1.0
+# Floors every deadline a rank with a budget passes, and closes three traps.
+#
+# Two are torch's, and 1.0 would close them: a zero-length timeout is read as *no*
+# timeout, and the pybind chrono caster truncates a `timedelta` to integral
+# milliseconds, so a rank reaching a boundary with 0.4ms of budget left would
+# otherwise wait the group's own timeout. Any floor above a millisecond does that,
+# and comfortably clears the 404ms spread with which the elastic agent delivers
+# SIGTERM across ranks.
+#
+# The third trap is the sizing, and it is why this is 3s rather than 1s. The floor
+# is the whole time a rank with a spent budget gives its peers to answer -- most
+# sharply a rank *originating* an exception, whose peers have no local event of
+# their own and so do not know to hurry. Those peers are mid-iteration: they reach
+# the boundary only at the end of the batch they are already in, so the floor has to
+# exceed a batch. The one figure measured from production runs is ~0.28s/batch,
+# which 1s clears by only 3.5x -- and batch time is configuration-dependent, since
+# `use_gradient_accumulation` multiplies the reductions per batch by a stochastic
+# `n_loss_steps`. 3s is an order of magnitude over the measured figure while staying
+# under `DEFAULT_STOP_AGREEMENT_BUDGET`, so the budget, not the floor, is still what
+# bounds a rank that arrives on time. What it does not clear is a peer inside a
+# multi-second checkpoint write; that peer is given up on, and on the signal path
+# the loop now skips that write for exactly this reason.
+_MIN_DEADLINE: float = 3.0
 
-# What a rank with no local event of its own passes. Derived from the group's own
-# timeout rather than restated, so it cannot drift from it. Such a rank has no
-# reason to hurry and no standing to declare a peer dead, and a deadline equal to
-# the one the gradient all-reduce already carries cannot fire on a job that is not
-# already dead -- which is the whole of the false-positive argument.
-NO_LOCAL_EVENT_DEADLINE: float = GROUP_TIMEOUT.total_seconds()
+
+def no_local_event_deadline() -> float:
+    """Seconds a rank with no local event of its own passes.
+
+    Such a rank has no reason to hurry and no standing to declare a peer dead, so
+    it passes the deadline the gradient all-reduce already carries: a deadline
+    equal to that cannot fire on a job that is not already dead, which is the whole
+    of the false-positive argument.
+
+    That figure is read off the default group rather than restated here, because
+    the two backends configure it differently -- see `default_group_timeout`. It is
+    also what a rank with a local event falls back to on a torch release whose
+    timeout behaviours were never checked; see `timeout_contract_verified`.
+    """
+    return default_group_timeout()
 
 
 class PeerStopRequested(RuntimeError):
@@ -95,6 +148,34 @@ class CooperativeStop:
         # set by `close`, read by `_local_reason`; never a peer's reason
         self._originating = StopReason.NONE
         self._next_index = first_index
+        # The index of the exchange this object is in or last made, for the
+        # abandonment marker. `None` until the first one, so that a give-up in the
+        # loop-entry exchange is not reported against a batch index that does not
+        # exist.
+        self._exchange_index: int | None = None
+        # Both read once here rather than per boundary. The first is a torch
+        # version check and the second walks torch's group bookkeeping, and neither
+        # can change inside one loop -- while `agreed` runs tens of thousands of
+        # times per epoch.
+        self._bounded = timeout_contract_verified()
+        self._no_local_event_deadline = no_local_event_deadline()
+        # `agreement-bound` is written once per rank per loop, at the first
+        # boundary a rank passes with a local event of its own
+        self._reported_bound = False
+
+    @property
+    def pending(self) -> PendingStop:
+        """The deferral's record of a stop this rank has recorded but not acted on.
+
+        Exposed for two things the loop cannot otherwise do. It can **skip work**
+        once a stop is pending -- a multi-GB periodic checkpoint write above all,
+        which would otherwise delay the agreed stop by the whole write, and which
+        is redundant with the restart checkpoint about to be taken at the very
+        boundary the ranks are agreeing on. And it makes `PendingStop.request`
+        reachable, so a caller can stop for a reason of its own -- a wall-clock
+        budget, say -- from the surface it actually holds.
+        """
+        return self._pending
 
     def _local_reason(self) -> StopReason:
         """Why *this* rank is leaving, if it is. Never a peer's reason.
@@ -111,11 +192,14 @@ class CooperativeStop:
             return StopReason.SIGNAL
         return self._originating
 
-    def _deadline(self, index: int) -> float:
+    def _deadline(self) -> float:
         """The deadline for one exchange, under the one rule that matters.
 
-        A rank with no local event of its own passes the group's 30 minutes; a
-        rank with one passes what is left of its budget, floored.
+        A rank with no local event of its own passes the deadline the gradient
+        all-reduce already carries; a rank with one passes what is left of its
+        budget, floored -- unless the installed torch is one whose timeout
+        behaviours were never read, in which case it passes the same unbounded
+        figure a healthy rank does, and says so.
 
         A spent budget is not an abandonment and does not cause one. The budget
         bounds how long this rank waits for peers, not how long it may take to
@@ -126,10 +210,58 @@ class CooperativeStop:
         """
         remaining = self._pending.seconds_remaining()
         if remaining is None:
-            return NO_LOCAL_EVENT_DEADLINE
-        if remaining <= 0.0:
+            return self._no_local_event_deadline
+        if not self._bounded:
+            self._report_bound("group-timeout", self._no_local_event_deadline)
+            return self._no_local_event_deadline
+        deadline = max(remaining, _MIN_DEADLINE)
+        self._report_bound("budget", deadline)
+        return deadline
+
+    def _report_bound(self, bound: str, deadline: float) -> None:
+        """Record which bound is in force, once per loop, on the rank it binds.
+
+        Without this the degraded path is indistinguishable from the bounded one in
+        a container log: both produce the same ``stop-agreed`` line, and the reader
+        of a rank that sat for the default group's whole timeout has no way to tell
+        whether the design's short bound was in force and failed or was never
+        available at all. Only ranks with a local event of their own emit it, so a
+        healthy loop is silent.
+        """
+        if self._reported_bound:
+            return
+        self._reported_bound = True
+        write_marker(
+            "agreement-bound",
+            batch=self._exchange_label(),
+            bound=bound,
+            seconds=f"{deadline:.1f}",
+        )
+
+    def _exchange_label(self) -> str:
+        """Which exchange a marker is about, for the two that are not per boundary.
+
+        A string, because the loop-entry exchange contributes a loop *length* rather
+        than a batch index and so has no batch to name. Reading one past the last
+        index and subtracting, which is what an earlier version did, reported
+        ``batch=-1`` for exactly that case.
+        """
+        if self._exchange_index is None:
+            return "loop-entry"
+        return str(self._exchange_index)
+
+    def _boundary_deadline(self, index: int) -> float:
+        """`_deadline`, plus the marker a spent budget owes at a batch boundary.
+
+        Separate from `_deadline` because the marker's ``batch=`` field has to be a
+        batch index, and `assert_equal_loop_length`'s exchange has a loop *length*
+        to contribute instead -- so calling this from there would label a length as
+        a batch.
+        """
+        remaining = self._pending.seconds_remaining()
+        if remaining is not None and remaining <= 0.0:
             write_marker("agreement-expired", batch=str(index))
-        return max(remaining, _MIN_DEADLINE)
+        return self._deadline()
 
     def _report(self, reason: StopReason, high: int, low: int) -> None:
         """Emit what one completed exchange revealed.
@@ -157,8 +289,8 @@ class CooperativeStop:
         paths, so this is insurance against that construction changing rather
         than a live exposure. If it ever did change, the boundary exchanges could
         not detect it: the short rank would leave the loop and exchange nothing,
-        and the long rank would sit alone in one more exchange, with the group's
-        30 minutes on it and no peer to compare indices against.
+        and the long rank would sit alone in one more exchange, carrying
+        `no_local_event_deadline` and with no peer to compare indices against.
 
         Every rank reads the same reduced values, so every rank raises or none
         does -- which is why this is a raise rather than the diagnostic the
@@ -169,7 +301,7 @@ class CooperativeStop:
             UnequalLoopLength: On every rank, if the lengths differ.
         """
         _, high, low = self._agreement.exchange(
-            StopReason.NONE.value, length, self._deadline(length)
+            StopReason.NONE.value, length, self._deadline()
         )
         if high != low:
             raise UnequalLoopLength(
@@ -202,7 +334,8 @@ class CooperativeStop:
         # abandonment marker after a *failed* exchange still has to name the index
         # this rank was working on. On the ordinary path it makes no difference.
         self._next_index = index + 1
-        timeout = self._deadline(index)
+        self._exchange_index = index
+        timeout = self._boundary_deadline(index)
         try:
             reduced, high, low = self._agreement.exchange(
                 self._local_reason().value, index, timeout
@@ -217,6 +350,14 @@ class CooperativeStop:
                 # peers behind.
                 raise
             write_marker("agreement-timeout", batch=str(index), err=repr(str(err)))
+            # Not optional, and the one thing that keeps this branch from
+            # reintroducing the fault. A rank that gave up with no local event of
+            # its own has nothing else on the `PendingStop` for
+            # `defer_termination`'s dispatch to find, so without this it would
+            # leave the loop, tear nothing down, and walk into the next collective
+            # -- whose peers have gone -- holding an abandoned gloo group, to be
+            # SIGKILLed there with its communicators open.
+            self._pending.note_peer_stop()
             return True
         reason = StopReason(reduced)
         self._report(reason, high, low)
@@ -250,22 +391,23 @@ class CooperativeStop:
         """Whether an exchange was given up on, so the group is left behind."""
         return self._agreement.abandoned
 
-    def close(self, reason: StopReason, index: int) -> None:
-        """The exit exchange, under the one rule that governs when there is one.
+    def abandoned_at(self) -> str:
+        """Which exchange was given up on, for the abandonment marker."""
+        return self._exchange_label()
+
+    def close(self, index: int) -> None:
+        """The exit exchange, for a rank leaving the loop on an exception.
 
         It exchanges **if and only if this rank is originating a stop its peers
-        cannot yet have read out of an exchange** -- exactly ``reason is
-        EXCEPTION and not self._agreed``. A rank leaving because it *observed* a
-        stop has `_agreed` set, so the stop is already common knowledge and a
-        further exchange would be unmatched by the rank that has already left; a
-        rank leaving on a clean end of epoch is excluded by the first clause. A
-        rank originating an exception-driven stop is the one case its peers cannot
-        learn of any other way.
+        cannot yet have read out of an exchange** -- exactly ``not self._agreed``.
+        A rank leaving because it *observed* a stop has `_agreed` set, so the stop
+        is already common knowledge and a further exchange would be unmatched by
+        the rank that has already left. A rank originating an exception-driven stop
+        is the one case its peers cannot learn of any other way, and a rank leaving
+        on a clean end of epoch does not call this at all -- there is nothing for
+        its peers to learn and they are all arriving at the same place anyway.
 
         Args:
-            reason: ``EXCEPTION`` if this rank is unwinding, ``NONE`` otherwise --
-                including on this rank's own signal, because this branch also
-                fires on a clean end of epoch where no signal exists.
             index: The index this rank *would* have reached, i.e. `next_index`.
                 A parameter rather than something read off this object, because
                 the only value that matches the peers is that one.
@@ -276,15 +418,16 @@ class CooperativeStop:
         and defeat the whole point of leaving the traceback intact.
         """
         # before `_local_reason` is read to build the payload below
-        self._originating = reason
-        if reason is not StopReason.EXCEPTION or self._agreed:
+        self._originating = StopReason.EXCEPTION
+        if self._agreed:
             return
+        self._exchange_index = index
         # before the exchange it bounds: the raise is a local event on this rank,
         # which is what entitles it to a short deadline
         self._pending.arm_budget()
         try:
             reduced, high, low = self._agreement.exchange(
-                self._local_reason().value, index, self._deadline(index)
+                self._local_reason().value, index, self._boundary_deadline(index)
             )
         except BaseException:
             logger.exception(
@@ -319,17 +462,15 @@ def _cooperative_scope(
         except BaseException:
             # `next_index()`, not this rank's own counter: it never finished the
             # body, so its counter is one behind its peers'
-            stop.close(StopReason.EXCEPTION, stop.next_index())
+            stop.close(stop.next_index())
             raise  # the caller's `defer_termination` tears the backend down
-        else:
-            stop.close(StopReason.NONE, stop.next_index())  # never exchanges
     finally:
         if stop.abandoned:
             # The group is left behind rather than reclaimed, and
             # `destroy_process_group` is silent about it, so this line is the only
             # record. Emitted here because it must precede the teardown, which
             # `defer_termination`'s own `finally` performs next.
-            write_marker("agreement-abandoned", batch=str(stop.next_index() - 1))
+            write_marker("agreement-abandoned", batch=stop.abandoned_at())
 
 
 @contextlib.contextmanager
@@ -353,7 +494,9 @@ def cooperative_stop(
             every rank if it is not. ``None`` skips that exchange.
 
     Yields:
-        The object the loop body polls once per boundary.
+        The object the loop body polls once per boundary. Its `pending` property
+        is the deferral's own record, so the loop can also skip work once a stop
+        is pending rather than only stopping at the next boundary.
     """
     dist = Distributed.get_instance()
     # `defer_termination` is the *outer* context, so its `finally` -- which

--- a/fme/core/distributed/cooperative_stop.py
+++ b/fme/core/distributed/cooperative_stop.py
@@ -59,11 +59,13 @@ this design relies on elsewhere and is not one it relies on here.
 wraps, over a world-wide gloo group, and there is no switch to turn it off. That is
 a deliberate omission rather than an oversight: a supported configuration in which
 the mechanism is disabled is a supported configuration in which the fabric fault
-returns, and adding one remains open to the maintainer. One exchange measured
-630 us at 8 gloo ranks -- on an idle workstation, over loopback, with no figure
-above 8 ranks and nothing asserting it, so treat that as a lower bound of unknown
-looseness rather than a cost. It also removes the run-ahead today's async NCCL
-gradient all-reduce allows, capping a rank's host-side lead at one iteration.
+returns, and adding one remains open to the maintainer -- it is called out as a
+pre-merge decision at the top of the pull request's description rather than left
+here to be found. One exchange measured 630 us at 8 gloo ranks -- on an idle
+workstation, over loopback, with no figure above 8 ranks and nothing asserting it,
+so treat that as a lower bound of unknown looseness rather than a cost. It also
+removes the run-ahead today's async NCCL gradient all-reduce allows, capping a
+rank's host-side lead at one iteration.
 
 **Every deadline the design chooses lives here**, with the one module that
 consumes them, rather than split across the two below it in the layering.
@@ -72,12 +74,25 @@ consumes them, rather than split across the two below it in the layering.
 exits hard.** An exchange that is given up on leaves work in the gloo work queue
 for good, and no call reclaims the group in bounded time -- including interpreter
 finalization, which joins the worker thread that holds it and so waits for the
-wedged peer's socket to close (measured 119.3s against a peer parked 120s on torch
-2.7.1, versus 0.05s with ``os._exit``). So the scope asks the deferral for
-`PendingStop.require_hard_exit`, and the teardown ends in ``os._exit`` once the
-backend is released and the callbacks have run. A caller that means to stop
-cooperatively, time out, and then carry on in the same process is outside what this
-design can bound.
+wedged peer's socket to close; `PendingStop.require_hard_exit` carries the
+measurement. So the scope asks the deferral for that hard exit, and the teardown
+ends in ``os._exit`` once the backend is released and the callbacks have run. A
+caller that means to stop cooperatively, time out, and then carry on in the same
+process is outside what this design can bound.
+
+**Every evidence line this module writes is listed in one place**, in
+`fme.core.distributed.shutdown`'s module docstring, which is where `write_marker`
+lives: the event names, what each means, and what a reader does with it.
+
+**The public name `cooperative_stop` shadows this module**, and that is a known
+wart rather than a considered choice. ``from fme.core.distributed import
+cooperative_stop`` binds the re-exported *function*, so a test that wants to patch
+a module attribute has to reach the module through `importlib.import_module` --
+setting the attribute on the function silently patches nothing, which has cost time
+twice on this branch and is why
+`fme/core/distributed/test_cooperative_stop_exit.py` carries a comment about it at
+its own patch site. Renaming one of the two is the maintainer's option; it was left
+alone because a public-name change is a wider edit than the trap justifies.
 """
 
 import contextlib
@@ -94,13 +109,6 @@ from .stop_agreement import (
 )
 
 logger = logging.getLogger(__name__)
-
-# `index-mismatch` is written once per process rather than once per boundary. The
-# condition it reports -- ranks at different iteration indices -- does not un-happen,
-# and the run it exists to diagnose is one where every rank would otherwise emit one
-# line per batch: tens of thousands of stderr lines per rank on the very run whose
-# log a reader is trying to get through.
-_reported_index_mismatch: bool = False
 
 # Seconds a rank with a local event of its own -- a signal it recorded, or an
 # exception it is raising -- will spend waiting for peers that may never arrive.
@@ -136,6 +144,27 @@ _reported_index_mismatch: bool = False
 # under a second, and a rank whose peers are already waiting returns from the
 # exchange in microseconds. Giving a rank longer to wait for peers means taking it
 # from the checkpoint, since the teardown timeout is fixed.
+#
+# **This arithmetic is derived, not measured.** No test waits out a real budget or a
+# real 20s teardown: the autouse SIGALRM in `conftest.py` is 90s at the longest and
+# 3s under ``--very-fast``, so every driver injects small timeouts instead, and the
+# window being described here is longer than the alarm that would have to bound a
+# test of it. Treat the split as a design intent that CI does not check.
+#
+# **The strongest objection to the split, recorded as an open decision for the
+# maintainer**: the ceiling could be cut to about 5s and the remaining 20s given to
+# the checkpoint instead. The reviewer's argument is that a write already in flight
+# when the signal lands is exactly the case this test is built around --
+# `test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again`, in
+# `fme/core/generics/test_trainer.py` -- and a multi-GB ACE checkpoint takes
+# comfortably more than 7s, so T >= 7 is the *expected* case for a preemption
+# landing inside a periodic write, and the restart checkpoint that
+# `add_post_shutdown_callback` exists for is lost there by construction. What would
+# make a smaller ceiling safe is that `_ABORT_BACKSTOP` already bounds a hung
+# teardown at `teardown_timeout` + 5, so the teardown cannot overrun a short ceiling
+# by more than that. `DEFAULT_TEARDOWN_TIMEOUT` is left at 20.0 here because
+# re-cutting the split is a decision about what the design promises rather than a
+# fix, and it is called out as a pre-merge decision in the pull request description.
 DEFAULT_STOP_AGREEMENT_BUDGET: float = 5.0
 
 # Floors every deadline a rank with a budget passes, and closes three traps.
@@ -235,6 +264,16 @@ class CooperativeStop:
         # `agreement-bound` is written once per rank per loop, at the first
         # boundary a rank passes with a local event of its own
         self._reported_bound = False
+        # `index-mismatch` is written once per *scope* rather than once per boundary
+        # or once per process. Once per boundary would put tens of thousands of
+        # stderr lines per rank on the very run whose log a reader is trying to get
+        # through, since the condition it reports does not un-happen inside one loop.
+        # Once per process was the previous choice and was worse: a fresh
+        # desynchronisation at epoch 50 of a multi-day run would be silent because
+        # epoch 1 had already reported one, and this check is the design's only
+        # self-verification. Per scope gives the same protection against flooding
+        # without going quiet for the rest of the run.
+        self._reported_index_mismatch = False
 
     @property
     def pending(self) -> PendingStop:
@@ -257,9 +296,25 @@ class CooperativeStop:
         `close`'s assignment, because `agreed` is called from the loop body where
         a rank cannot yet know it is about to raise.
 
-        A rank that recorded a signal reports ``SIGNAL`` even while raising: a
-        preemption is what happened to it, and `defer_termination` gives a
-        recorded signal the same precedence when it picks an exit code.
+        **A recorded signal wins over an exception, deliberately, and this makes
+        ``EXCEPTION`` unreachable on the common path.** A rank that was signalled
+        *and* is raising contributes ``SIGNAL``, because when both are present the
+        signal is the root cause: the scheduler signals the whole process group, so
+        the exception a rank is carrying is usually a consequence of a peer having
+        already left -- a ``Connection closed by peer``, most often. The
+        consequence, spelled out because it is not obvious and nothing else says it:
+        the peers of a signalled-and-crashing rank read ``SIGNAL``, so they take
+        `PendingStop.note_peer_stop` and exit ``128 + SIGTERM`` as a clean
+        preemption, `PeerStopRequested` never fires, and no
+        ``stop-agreed reason=EXCEPTION`` line appears anywhere. That is intended.
+        The raising rank itself still exits 1 -- see the ``raising`` branch of
+        `defer_termination`, which preserves the exception's exit code so the
+        traceback is not traded away -- and torchrun surfaces that 1, so the job is
+        visibly failed rather than reported as a clean stop.
+
+        ``EXCEPTION`` therefore reaches a peer only where the raising rank was
+        *not* signalled: an in-process failure such as a NaN in the loss, which is
+        the case the exception rider was built for.
         """
         if self._pending.requested:
             return StopReason.SIGNAL
@@ -279,11 +334,18 @@ class CooperativeStop:
         reach the boundary -- and the usual reason it ran out is that this rank is
         the *late* one, walking out of a multi-second checkpoint write, in which
         case its peers are already blocked in the exchange below and it returns in
-        microseconds.
+        microseconds. It does owe an ``agreement-expired`` line, which is written
+        here rather than in a separate wrapper: an earlier version split the two on
+        the stated grounds that the marker's ``batch=`` field had to be a batch
+        index, and that was never the reason -- `_exchange_label` already names the
+        loop-entry exchange, whose contribution is a loop length rather than an
+        index.
         """
         remaining = self._pending.seconds_remaining()
         if remaining is None:
             return self._no_local_event_deadline
+        if remaining <= 0.0:
+            write_marker("agreement-expired", batch=self._exchange_label())
         if not self._bounded:
             self._report_bound("group-timeout", self._no_local_event_deadline)
             return self._no_local_event_deadline
@@ -323,19 +385,6 @@ class CooperativeStop:
             return "loop-entry"
         return str(self._exchange_index)
 
-    def _boundary_deadline(self, index: int) -> float:
-        """`_deadline`, plus the marker a spent budget owes at a batch boundary.
-
-        Separate from `_deadline` because the marker's ``batch=`` field has to be a
-        batch index, and `assert_equal_loop_length`'s exchange has a loop *length*
-        to contribute instead -- so calling this from there would label a length as
-        a batch.
-        """
-        remaining = self._pending.seconds_remaining()
-        if remaining is not None and remaining <= 0.0:
-            write_marker("agreement-expired", batch=str(index))
-        return self._deadline()
-
     def _report(self, reason: StopReason, high: int, low: int) -> None:
         """Emit what one completed exchange revealed.
 
@@ -343,12 +392,11 @@ class CooperativeStop:
         from a claim the log repeats into a fact the mechanism checked. It is
         **diagnostic only**: a desynchronised run is going to hang anyway, and a
         new mechanism unilaterally terminating healthy-looking jobs on a
-        self-diagnosis is a worse failure mode than the one it reports. It is also
-        reported once per process; see `_reported_index_mismatch`.
+        self-diagnosis is a worse failure mode than the one it reports. It is
+        reported once per scope; see where the flag is declared.
         """
-        global _reported_index_mismatch
-        if high != low and not _reported_index_mismatch:
-            _reported_index_mismatch = True
+        if high != low and not self._reported_index_mismatch:
+            self._reported_index_mismatch = True
             write_marker("index-mismatch", min=str(low), max=str(high))
         if reason is not StopReason.NONE:
             write_marker(
@@ -372,6 +420,24 @@ class CooperativeStop:
         does -- which is why this is a raise rather than the diagnostic the
         ±index check is. An unequal loop length is a precondition failure detected
         before any work is done, where continuing is a guaranteed hang.
+
+        **The two checks are treated oppositely on purpose, and the difference is
+        what a stop is made of.** An index mismatch is diagnostic because the ranks
+        still *agree on whether to stop*: the reduced reason is common to all of
+        them, so the mechanism is working and only its bookkeeping disagrees, and
+        `_report` explains why unilaterally killing a job over a self-diagnosis is
+        worse than reporting it. Unequal loop lengths break the agreement itself --
+        some rank leaves the loop while its peers are still exchanging, so those
+        peers wedge in an exchange nobody will join, which is the exact failure this
+        module exists to prevent. Proceeding is therefore not safe, and a job that
+        would hang is better ended with a message naming the cause.
+
+        If it ever fires on an asymmetry that is genuinely benign -- a deliberately
+        ragged sampler, say -- the fix is not to soften this into a warning, because
+        the wedge is real either way. It is to give the short rank something to
+        contribute at the boundaries its peers still reach, so the ranks keep
+        exchanging the same number of times: pad the short loop, or drop this
+        exchange and have every rank iterate a common length.
 
         This exchange needs `agreed`'s give-up handling and not only its own
         assertion, because a signal can land between `defer_termination` yielding
@@ -444,7 +510,7 @@ class CooperativeStop:
         # this rank was working on. On the ordinary path it makes no difference.
         self._next_index = index + 1
         self._exchange_index = index
-        timeout = self._boundary_deadline(index)
+        timeout = self._deadline()
         try:
             reduced, high, low = self._agreement.exchange(
                 self._local_reason().value, index, timeout
@@ -470,6 +536,26 @@ class CooperativeStop:
             # leave the loop, tear nothing down, and walk into the next collective
             # -- whose peers have gone -- holding an abandoned gloo group, to be
             # SIGKILLed there with its communicators open.
+            #
+            # **Residual, not a defect: this reports `128 + SIGTERM` even where no
+            # preemption happened.** "My peer stopped reaching the boundary" and "my
+            # peer was preempted" are different facts, and only the second is
+            # retryable -- so on a genuine hang (a deadlock, a stuck loader, a NCCL
+            # hang) the first rank to give up hands the launcher a retryable code and
+            # the hang becomes a silent automatic retry. It is left that way because
+            # the common case decides: a preemption in which this rank never received
+            # its own signal is far commoner than a hang, and exiting
+            # non-retryably would convert a retryable preemption into a hard failure,
+            # which loses a job that was going to be restarted anyway.
+            #
+            # A reader tells the two apart from the markers, not the exit code. This
+            # rank writes `agreement-timeout` and then `agreement-abandoned` and no
+            # `stop-agreed` line of its own, which is what distinguishes a give-up
+            # from a peer stop it actually read out of an exchange. Whether that
+            # give-up was a preemption or a hang is then told by whether
+            # `signal-deferred` appears anywhere in the job's log: a preemption
+            # reaches some rank even when it did not reach this one, while a hang
+            # reaches none.
             self._pending.note_peer_stop()
             return True
         reason = StopReason(reduced)
@@ -548,7 +634,7 @@ class CooperativeStop:
         self._pending.arm_budget()
         try:
             reduced, high, low = self._agreement.exchange(
-                self._local_reason().value, index, self._boundary_deadline(index)
+                self._local_reason().value, index, self._deadline()
             )
         except BaseException:
             # the operation stays in gloo's work queue, so this scope owes the
@@ -615,14 +701,12 @@ def _cooperative_scope(
             # And the process may not be left to finalize: the gloo destructor
             # joins the worker thread that still holds the abandoned operation, so
             # `sys.exit` waits for the wedged peer to die. This is the whole of the
-            # design's bound after an abandoned exchange.
-            #
-            # One path does not honour it, and it is the exception rider: a rank
-            # unwinding on an exception is torn down with `exit_process=False` so
-            # that its traceback survives, so it returns rather than exiting and may
-            # then sit in finalization until its peer dies. The traceback is worth
-            # more than the promptness there, and by that point the backend is
-            # released and the callbacks have run, so what is lost is only the time.
+            # design's bound after an abandoned exchange, and **every** path out of
+            # `defer_termination`'s dispatch honours it, the exception rider
+            # included: that branch prints the traceback itself and then hard-exits
+            # with the exception's code, rather than returning and being SIGKILLed in
+            # finalization -- which would hand the launcher a signal death and hold
+            # this rank's GPU allocation until its wedged peer died.
             pending.require_hard_exit()
 
 

--- a/fme/core/distributed/cooperative_stop.py
+++ b/fme/core/distributed/cooperative_stop.py
@@ -1,0 +1,370 @@
+"""Leave a batch loop at the same iteration on every rank.
+
+This is the loop-facing seam, and it joins the two halves below it: the
+*deferral* in `fme.core.distributed.shutdown`, which makes a termination signal
+record intent rather than tear the backend down, and the *agreement* in
+`fme.core.distributed.stop_agreement`, which is how ranks find out about each
+other's intent in bounded time. Neither half knows about the other; this module
+is the only place that needs both, and it is deliberately the smallest of the
+three.
+
+The whole adopter-facing surface is one context manager::
+
+    from fme.core.distributed import Distributed, cooperative_stop
+
+    with Distributed.context():
+        with cooperative_stop() as stop:
+            for index, batch in enumerate(loader):
+                train_on_batch(batch)          # contains the gradient all-reduce
+                if stop.agreed(index):
+                    break
+
+Leaving the context on a stop performs the same teardown the signal handler would
+have performed -- the backend release, the post-shutdown callbacks, the exit code
+-- entered from the loop's boundary rather than from wherever the signal landed.
+
+**Every deadline the design chooses lives here**, with the one module that
+consumes them, rather than split across the two below it in the layering.
+
+**The mechanism requires the process to exit.** An exchange that is given up on
+leaves work in the gloo work queue for good, and no call reclaims the group in
+bounded time. A caller that means to stop cooperatively, time out, and then carry
+on in the same process is outside what this design can bound.
+"""
+
+import contextlib
+import logging
+from collections.abc import Iterator
+
+from .distributed import Distributed
+from .shutdown import PendingStop, StopReason, defer_termination, write_marker
+from .stop_agreement import GROUP_TIMEOUT, StopAgreement, is_deadline_expiry
+
+logger = logging.getLogger(__name__)
+
+# Seconds a rank with a local event of its own -- a signal it recorded, or an
+# exception it is raising -- will spend waiting for peers that may never arrive.
+# Derived by subtraction: the scheduler's grace period is 30-36s from SIGTERM and
+# `DEFAULT_TEARDOWN_TIMEOUT` claims 20s of it, so this is what is left.
+DEFAULT_STOP_AGREEMENT_BUDGET: float = 10.0
+
+# Floors every deadline a rank with a budget passes, and closes two traps at
+# once. torch reads a zero-length timeout as *no* timeout, and the pybind chrono
+# caster truncates a `timedelta` to integral milliseconds -- so a rank reaching a
+# boundary with 0.4ms of budget left would otherwise wait the group's 30 minutes.
+# The size is a decision, not a round number: it is the whole time an already-late
+# rank gives its peers to answer, and a measured exchange is 630us at 8 ranks, so
+# it clears both the truncation boundary and the 404ms spread with which the
+# elastic agent delivers SIGTERM across ranks.
+_MIN_DEADLINE: float = 1.0
+
+# What a rank with no local event of its own passes. Derived from the group's own
+# timeout rather than restated, so it cannot drift from it. Such a rank has no
+# reason to hurry and no standing to declare a peer dead, and a deadline equal to
+# the one the gradient all-reduce already carries cannot fire on a job that is not
+# already dead -- which is the whole of the false-positive argument.
+NO_LOCAL_EVENT_DEADLINE: float = GROUP_TIMEOUT.total_seconds()
+
+
+class PeerStopRequested(RuntimeError):
+    """Raised on a rank whose peer is leaving the loop on an exception."""
+
+
+class UnequalLoopLength(RuntimeError):
+    """Raised on every rank when loop entry finds unequal loop lengths."""
+
+
+class CooperativeStop:
+    """The object a loop polls once per boundary.
+
+    Obtained from `cooperative_stop`, which is what wires it to a deferral and an
+    agreement group; constructing one directly is for tests that want to inject a
+    scripted agreement.
+    """
+
+    def __init__(
+        self,
+        pending: PendingStop,
+        agreement: StopAgreement,
+        first_index: int = 0,
+    ) -> None:
+        self._pending = pending
+        self._agreement = agreement
+        # a stop has been read out of, *or given up on*, an exchange
+        self._agreed = False
+        # set by `close`, read by `_local_reason`; never a peer's reason
+        self._originating = StopReason.NONE
+        self._next_index = first_index
+
+    def _local_reason(self) -> StopReason:
+        """Why *this* rank is leaving, if it is. Never a peer's reason.
+
+        It reads state rather than inferring it: ``EXCEPTION`` comes from
+        `close`'s assignment, because `agreed` is called from the loop body where
+        a rank cannot yet know it is about to raise.
+
+        A rank that recorded a signal reports ``SIGNAL`` even while raising: a
+        preemption is what happened to it, and `defer_termination` gives a
+        recorded signal the same precedence when it picks an exit code.
+        """
+        if self._pending.requested:
+            return StopReason.SIGNAL
+        return self._originating
+
+    def _deadline(self, index: int) -> float:
+        """The deadline for one exchange, under the one rule that matters.
+
+        A rank with no local event of its own passes the group's 30 minutes; a
+        rank with one passes what is left of its budget, floored.
+
+        A spent budget is not an abandonment and does not cause one. The budget
+        bounds how long this rank waits for peers, not how long it may take to
+        reach the boundary -- and the usual reason it ran out is that this rank is
+        the *late* one, walking out of a multi-second checkpoint write, in which
+        case its peers are already blocked in the exchange below and it returns in
+        microseconds.
+        """
+        remaining = self._pending.seconds_remaining()
+        if remaining is None:
+            return NO_LOCAL_EVENT_DEADLINE
+        if remaining <= 0.0:
+            write_marker("agreement-expired", batch=str(index))
+        return max(remaining, _MIN_DEADLINE)
+
+    def _report(self, reason: StopReason, high: int, low: int) -> None:
+        """Emit what one completed exchange revealed.
+
+        The symmetry check is what turns "every rank stopped at the same batch"
+        from a claim the log repeats into a fact the mechanism checked. It is
+        **diagnostic only**: a desynchronised run is going to hang anyway, and a
+        new mechanism unilaterally terminating healthy-looking jobs on a
+        self-diagnosis is a worse failure mode than the one it reports.
+        """
+        if high != low:
+            write_marker("index-mismatch", min=str(low), max=str(high))
+        if reason is not StopReason.NONE:
+            write_marker(
+                "stop-agreed",
+                batch=str(high),
+                world=str(self._agreement.world_size),
+                reason=reason.name,
+            )
+
+    def assert_equal_loop_length(self, length: int) -> None:
+        """One exchange at loop entry, asserting every rank's loop length agrees.
+
+        Equal per-rank batch counts hold by construction today, on both sampler
+        paths, so this is insurance against that construction changing rather
+        than a live exposure. If it ever did change, the boundary exchanges could
+        not detect it: the short rank would leave the loop and exchange nothing,
+        and the long rank would sit alone in one more exchange, with the group's
+        30 minutes on it and no peer to compare indices against.
+
+        Every rank reads the same reduced values, so every rank raises or none
+        does -- which is why this is a raise rather than the diagnostic the
+        ±index check is. An unequal loop length is a precondition failure detected
+        before any work is done, where continuing is a guaranteed hang.
+
+        Raises:
+            UnequalLoopLength: On every rank, if the lengths differ.
+        """
+        _, high, low = self._agreement.exchange(
+            StopReason.NONE.value, length, self._deadline(length)
+        )
+        if high != low:
+            raise UnequalLoopLength(
+                f"every rank must iterate the same number of batches, but this "
+                f"loop's length is {length} here while ranks reported lengths "
+                f"between {low} and {high}. Continuing would hang the first "
+                "collective the short rank never reaches."
+            )
+
+    def agreed(self, index: int) -> bool:
+        """One boundary exchange. Whether this rank should leave the loop now.
+
+        Args:
+            index: This rank's iteration index. Correctness rests on this being
+                called the same number of times on every rank, not on the value;
+                the value is carried so the evidence line and the symmetry
+                diagnostic have a number.
+
+        Returns:
+            Whether to leave the loop, which is true as soon as *any* rank's
+            reason reaches this one -- or as soon as this rank gives up waiting.
+
+        Raises:
+            PeerStopRequested: If a peer is leaving on an exception, so that this
+                rank unwinds rather than exiting as if it had been preempted.
+            RuntimeError: If a peer's process died, closing its socket. Masking
+                that as a graceful stop would hide the crash.
+        """
+        # Recorded before the exchange, not after it, because a `close` or an
+        # abandonment marker after a *failed* exchange still has to name the index
+        # this rank was working on. On the ordinary path it makes no difference.
+        self._next_index = index + 1
+        timeout = self._deadline(index)
+        try:
+            reduced, high, low = self._agreement.exchange(
+                self._local_reason().value, index, timeout
+            )
+        except RuntimeError as err:
+            # read out of, *or given up on*, an exchange: a rank that gave up here
+            # must not exchange again from `close` against peers already gone
+            self._agreed = True
+            if not is_deadline_expiry(err):
+                # A peer's process exited and closed its socket: a crash, not a
+                # wedge. Let it escape rather than reporting a rank that left its
+                # peers behind.
+                raise
+            write_marker("agreement-timeout", batch=str(index), err=repr(str(err)))
+            return True
+        reason = StopReason(reduced)
+        self._report(reason, high, low)
+        if reason is StopReason.NONE:
+            return False
+        self._agreed = True
+        if reason is StopReason.EXCEPTION:
+            raise PeerStopRequested(
+                f"a peer is leaving the loop on an exception at batch {high}"
+            )
+        # `note_peer_stop` rather than nothing, so that leaving the scope tears
+        # this rank down even if the signal was a peer's and never reached here
+        self._pending.note_peer_stop()
+        return True
+
+    def next_index(self) -> int:
+        """The index `close` must contribute in order to match its peers'.
+
+        One past the last index `agreed` was given. A rank raising inside the loop
+        body never reached the end of it, so its own counter still holds the
+        previous iteration's value while every peer that completed the body has
+        incremented -- contributing this rank's last-known index would fire
+        ``index-mismatch`` on exactly the path the exception rider covers. Before
+        the first `agreed` call this is the ``first_index`` it was constructed
+        with.
+        """
+        return self._next_index
+
+    @property
+    def abandoned(self) -> bool:
+        """Whether an exchange was given up on, so the group is left behind."""
+        return self._agreement.abandoned
+
+    def close(self, reason: StopReason, index: int) -> None:
+        """The exit exchange, under the one rule that governs when there is one.
+
+        It exchanges **if and only if this rank is originating a stop its peers
+        cannot yet have read out of an exchange** -- exactly ``reason is
+        EXCEPTION and not self._agreed``. A rank leaving because it *observed* a
+        stop has `_agreed` set, so the stop is already common knowledge and a
+        further exchange would be unmatched by the rank that has already left; a
+        rank leaving on a clean end of epoch is excluded by the first clause. A
+        rank originating an exception-driven stop is the one case its peers cannot
+        learn of any other way.
+
+        Args:
+            reason: ``EXCEPTION`` if this rank is unwinding, ``NONE`` otherwise --
+                including on this rank's own signal, because this branch also
+                fires on a clean end of epoch where no signal exists.
+            index: The index this rank *would* have reached, i.e. `next_index`.
+                A parameter rather than something read off this object, because
+                the only value that matches the peers is that one.
+
+        Never raises. On the mid-iteration path the exchange is *expected* to time
+        out, and this is called from ``except BaseException: close(...); raise`` --
+        so a raising `close` would replace the original exception with a timeout
+        and defeat the whole point of leaving the traceback intact.
+        """
+        # before `_local_reason` is read to build the payload below
+        self._originating = reason
+        if reason is not StopReason.EXCEPTION or self._agreed:
+            return
+        # before the exchange it bounds: the raise is a local event on this rank,
+        # which is what entitles it to a short deadline
+        self._pending.arm_budget()
+        try:
+            reduced, high, low = self._agreement.exchange(
+                self._local_reason().value, index, self._deadline(index)
+            )
+        except BaseException:
+            logger.exception(
+                "Failed to tell peers this rank is leaving the loop on an "
+                "exception; they may be left in a collective."
+            )
+            return
+        self._report(StopReason(reduced), high, low)
+
+
+@contextlib.contextmanager
+def _cooperative_scope(
+    pending: PendingStop,
+    agreement: StopAgreement,
+    first_index: int = 0,
+    loop_length: int | None = None,
+) -> Iterator[CooperativeStop]:
+    """Everything `cooperative_stop` does except opening the deferral.
+
+    Separate so that multi-rank tests can drive the real exit rules against an
+    agreement group of their own. They cannot go through `cooperative_stop`: it
+    reaches for the process-wide group, and a test that timed an exchange out on
+    that one would leave every later test in the session holding a gloo context
+    in an undefined state.
+    """
+    stop = CooperativeStop(pending, agreement, first_index=first_index)
+    try:
+        if loop_length is not None:
+            stop.assert_equal_loop_length(loop_length)
+        try:
+            yield stop
+        except BaseException:
+            # `next_index()`, not this rank's own counter: it never finished the
+            # body, so its counter is one behind its peers'
+            stop.close(StopReason.EXCEPTION, stop.next_index())
+            raise  # the caller's `defer_termination` tears the backend down
+        else:
+            stop.close(StopReason.NONE, stop.next_index())  # never exchanges
+    finally:
+        if stop.abandoned:
+            # The group is left behind rather than reclaimed, and
+            # `destroy_process_group` is silent about it, so this line is the only
+            # record. Emitted here because it must precede the teardown, which
+            # `defer_termination`'s own `finally` performs next.
+            write_marker("agreement-abandoned", batch=str(stop.next_index() - 1))
+
+
+@contextlib.contextmanager
+def cooperative_stop(
+    budget: float = DEFAULT_STOP_AGREEMENT_BUDGET,
+    first_index: int = 0,
+    loop_length: int | None = None,
+) -> Iterator[CooperativeStop]:
+    """Make the loop this wraps one every rank leaves at the same iteration.
+
+    Args:
+        budget: Seconds a rank with a local event of its own will wait for peers.
+            Absolute from that event, so a rank cannot accumulate a fresh budget
+            at each of several boundaries.
+        first_index: The index the loop's first iteration will pass to
+            `CooperativeStop.agreed`. It exists only so that a rank raising *in*
+            that first iteration contributes the index its peers will contribute;
+            a loop over ``enumerate(loader)`` wants the default.
+        loop_length: When given, loop entry performs one extra exchange asserting
+            that every rank's loop length is equal, raising `UnequalLoopLength` on
+            every rank if it is not. ``None`` skips that exchange.
+
+    Yields:
+        The object the loop body polls once per boundary.
+    """
+    dist = Distributed.get_instance()
+    # `defer_termination` is the *outer* context, so its `finally` -- which
+    # performs the teardown -- runs after `close` has finished exchanging.
+    # Nesting them the other way round would tear the backend down and then try
+    # to reduce on it.
+    with defer_termination(budget=budget) as pending:
+        with _cooperative_scope(
+            pending,
+            dist.stop_agreement(),
+            first_index=first_index,
+            loop_length=loop_length,
+        ) as stop:
+            yield stop

--- a/fme/core/distributed/cooperative_stop.py
+++ b/fme/core/distributed/cooperative_stop.py
@@ -22,33 +22,62 @@ The whole adopter-facing surface is one context manager::
 Leaving the context on a stop performs the same teardown the signal handler would
 have performed -- the backend release, the post-shutdown callbacks, the exit code
 -- entered from the loop's boundary rather than from wherever the signal landed.
-**Every** path that leaves the loop ends that way: a stop read out of an exchange,
-a stop given up on, and an exception. A rank that broke out of the loop and carried
-on into another collective, whose peers had already left, is the fault this module
+Every path that leaves the loop ends that way **where a handler is installed**: a
+stop read out of an exchange, a stop given up on, an unequal loop length given up
+on at entry, and an exception. A rank that broke out of the loop and carried on
+into another collective, whose peers had already left, is the fault this module
 exists to prevent.
+
+With no handler installed there is nothing registered to tear down, so leaving the
+loop on a stop simply returns -- see ``handle_termination_signals``, which is what
+publishes the teardown. A loop reached that way (the whole pytest session, and any
+caller using `PendingStop.request` without a handler) must therefore not treat the
+loop's end as a *completed* pass over its data; `Trainer.train_one_epoch` does not
+increment its epoch counter on a stop for exactly this reason.
 
 **What is covered is the one loop that adopts this, and nothing else.** A signal
 arriving during the validation pass, during inline inference, or inside
 ``run_lr_tuning_trial`` is acted on where it lands, exactly as before this module
 existed -- and those paths issue aggregator reductions of their own, so a rank
-signalled there still tears the backend down from wherever it was. Widening the
-cover means wrapping those loops too; nothing here does it for them.
+signalled there still tears the backend down from wherever it was. The one training
+loop that adopts this is `fme.core.generics.trainer.Trainer.train_one_epoch`;
+`fme/downscaling/train.py`'s `Trainer.train_one_epoch` is a second training loop
+that does not. Widening the cover means wrapping those loops too; nothing here does
+it for them.
+
+**One window inside the loop is uncovered.** A signal landing after the final
+``agreed()`` of an epoch has returned ``False`` finds the ``for`` already ending on
+``StopIteration``, so `defer_termination` acts on it unilaterally on the ranks it
+reached while ranks it did not reach carry on into the epoch tail -- the shuffle
+and the train-evaluation pass -- and strand there. The window is the epoch tail,
+which is where the already-accepted epoch-boundary regression lands too, and
+`note_peer_stop` exists precisely because a signal may not reach every rank, so
+"the elastic agent delivers SIGTERM to every rank within 404ms" is not an argument
+this design relies on elsewhere and is not one it relies on here.
 
 **It costs a blocking host-side collective on every iteration** of the loop it
-wraps, over a world-wide gloo group, and there is no switch to turn it off. One
-exchange measured 630 us at 8 gloo ranks -- on an idle workstation, over loopback,
-with no figure above 8 ranks and nothing asserting it, so treat that as a lower
-bound of unknown looseness rather than a cost. It also removes the run-ahead
-today's async NCCL gradient all-reduce allows, capping a rank's host-side lead at
-one iteration.
+wraps, over a world-wide gloo group, and there is no switch to turn it off. That is
+a deliberate omission rather than an oversight: a supported configuration in which
+the mechanism is disabled is a supported configuration in which the fabric fault
+returns, and adding one remains open to the maintainer. One exchange measured
+630 us at 8 gloo ranks -- on an idle workstation, over loopback, with no figure
+above 8 ranks and nothing asserting it, so treat that as a lower bound of unknown
+looseness rather than a cost. It also removes the run-ahead today's async NCCL
+gradient all-reduce allows, capping a rank's host-side lead at one iteration.
 
 **Every deadline the design chooses lives here**, with the one module that
 consumes them, rather than split across the two below it in the layering.
 
-**The mechanism requires the process to exit.** An exchange that is given up on
-leaves work in the gloo work queue for good, and no call reclaims the group in
-bounded time. A caller that means to stop cooperatively, time out, and then carry
-on in the same process is outside what this design can bound.
+**The mechanism requires the process to exit, and after an abandoned exchange it
+exits hard.** An exchange that is given up on leaves work in the gloo work queue
+for good, and no call reclaims the group in bounded time -- including interpreter
+finalization, which joins the worker thread that holds it and so waits for the
+wedged peer's socket to close (measured 119.3s against a peer parked 120s on torch
+2.7.1, versus 0.05s with ``os._exit``). So the scope asks the deferral for
+`PendingStop.require_hard_exit`, and the teardown ends in ``os._exit`` once the
+backend is released and the callbacks have run. A caller that means to stop
+cooperatively, time out, and then carry on in the same process is outside what this
+design can bound.
 """
 
 import contextlib
@@ -66,16 +95,47 @@ from .stop_agreement import (
 
 logger = logging.getLogger(__name__)
 
+# `index-mismatch` is written once per process rather than once per boundary. The
+# condition it reports -- ranks at different iteration indices -- does not un-happen,
+# and the run it exists to diagnose is one where every rank would otherwise emit one
+# line per batch: tens of thousands of stderr lines per rank on the very run whose
+# log a reader is trying to get through.
+_reported_index_mismatch: bool = False
+
 # Seconds a rank with a local event of its own -- a signal it recorded, or an
 # exception it is raising -- will spend waiting for peers that may never arrive.
 #
 # Sized against the elastic agent's window, which is what the design is spending:
 # torchrun gives the ranks 30s between SIGTERM and SIGKILL (see
-# `DEFAULT_TEARDOWN_TIMEOUT`), this claims 5s of it and the teardown 20s, leaving
-# the post-shutdown callbacks -- the restart checkpoint, the reason the callbacks
-# exist -- the remaining 5s, a sixth of the window. Giving a rank longer to wait
-# for peers means taking it from the checkpoint, since the teardown timeout is
-# fixed.
+# `DEFAULT_TEARDOWN_TIMEOUT`), the teardown claims 20s of it, and what is left is
+# for the post-shutdown callbacks -- the restart checkpoint, the reason the
+# callbacks exist.
+#
+# This budget alone does not decide the agreement's share, because `_MIN_DEADLINE`
+# floors every deadline. Write T for the seconds between a rank's local event and
+# the boundary it next reaches; its exchange then carries max(BUDGET - T,
+# _MIN_DEADLINE), so it is done agreeing by
+#
+#     max(BUDGET, T + _MIN_DEADLINE) = max(5, T + 3)
+#
+# and the callbacks begin with min(5, 7 - T) seconds of the 30s window left:
+#
+#   * T <= 2s -- the ordinary case, a rank at a boundary within a batch or two of
+#     the signal: the agreement spends 5s exactly as this figure claims, the
+#     teardown 20s, and the callbacks get the remaining 5s, a sixth of the window.
+#   * T > 2s: the floor overshoots the budget by T - 2 seconds, because a rank that
+#     arrives late still gives its peers a whole floor to answer in. A rank walking
+#     out of a 10s checkpoint write holds the agreement to t = 13s and leaves the
+#     teardown and the callbacks 17s of the window between them, not 25s.
+#   * T >= 7s: the callbacks begin at or after the SIGKILL in the worst case, and
+#     the restart checkpoint is lost. What keeps T small is that the loop skips a
+#     periodic checkpoint write once a stop is pending, so the one routine source
+#     of a multi-second T is a write already in flight when the signal landed.
+#
+# Both terms are ceilings, not reservations: the teardown normally returns in well
+# under a second, and a rank whose peers are already waiting returns from the
+# exchange in microseconds. Giving a rank longer to wait for peers means taking it
+# from the checkpoint, since the teardown timeout is fixed.
 DEFAULT_STOP_AGREEMENT_BUDGET: float = 5.0
 
 # Floors every deadline a rank with a budget passes, and closes three traps.
@@ -84,22 +144,29 @@ DEFAULT_STOP_AGREEMENT_BUDGET: float = 5.0
 # timeout, and the pybind chrono caster truncates a `timedelta` to integral
 # milliseconds, so a rank reaching a boundary with 0.4ms of budget left would
 # otherwise wait the group's own timeout. Any floor above a millisecond does that,
-# and comfortably clears the 404ms spread with which the elastic agent delivers
-# SIGTERM across ranks.
+# and comfortably clears the 404ms spread over which the elastic agent was observed
+# to deliver SIGTERM across ranks -- one observation on one configuration, so read it
+# as an order of magnitude rather than a bound.
 #
 # The third trap is the sizing, and it is why this is 3s rather than 1s. The floor
 # is the whole time a rank with a spent budget gives its peers to answer -- most
 # sharply a rank *originating* an exception, whose peers have no local event of
 # their own and so do not know to hurry. Those peers are mid-iteration: they reach
 # the boundary only at the end of the batch they are already in, so the floor has to
-# exceed a batch. The one figure measured from production runs is ~0.28s/batch,
-# which 1s clears by only 3.5x -- and batch time is configuration-dependent, since
-# `use_gradient_accumulation` multiplies the reductions per batch by a stochastic
-# `n_loss_steps`. 3s is an order of magnitude over the measured figure while staying
-# under `DEFAULT_STOP_AGREEMENT_BUDGET`, so the budget, not the floor, is still what
+# exceed a batch. The one figure observed from a production run is ~0.28s/batch, on
+# one configuration and with nothing asserting it, which 1s clears by only 3.5x --
+# and batch time is configuration-dependent, since `use_gradient_accumulation`
+# multiplies the reductions per batch by a stochastic `n_loss_steps`. 3s is an order
+# of magnitude over that observation while staying under
+# `DEFAULT_STOP_AGREEMENT_BUDGET`, so the budget, not the floor, is still what
 # bounds a rank that arrives on time. What it does not clear is a peer inside a
 # multi-second checkpoint write; that peer is given up on, and on the signal path
 # the loop now skips that write for exactly this reason.
+#
+# The floor is *not* bounded above by the budget, and that is the one cost of
+# choosing it: a rank arriving more than BUDGET - _MIN_DEADLINE = 2s after its own
+# local event spends longer agreeing than the budget names. The accounting at
+# `DEFAULT_STOP_AGREEMENT_BUDGET` includes that overshoot.
 _MIN_DEADLINE: float = 3.0
 
 
@@ -145,6 +212,12 @@ class CooperativeStop:
         self._agreement = agreement
         # a stop has been read out of, *or given up on*, an exchange
         self._agreed = False
+        # An exchange *this* object made was given up on. Not read off the
+        # agreement, whose flag lives on the process-wide group and so stays set
+        # for every later scope in the process -- which would make the
+        # `agreement-abandoned` line, whose whole value is being the only record of
+        # one event, appear on scopes that abandoned nothing.
+        self._abandoned = False
         # set by `close`, read by `_local_reason`; never a peer's reason
         self._originating = StopReason.NONE
         self._next_index = first_index
@@ -270,9 +343,12 @@ class CooperativeStop:
         from a claim the log repeats into a fact the mechanism checked. It is
         **diagnostic only**: a desynchronised run is going to hang anyway, and a
         new mechanism unilaterally terminating healthy-looking jobs on a
-        self-diagnosis is a worse failure mode than the one it reports.
+        self-diagnosis is a worse failure mode than the one it reports. It is also
+        reported once per process; see `_reported_index_mismatch`.
         """
-        if high != low:
+        global _reported_index_mismatch
+        if high != low and not _reported_index_mismatch:
+            _reported_index_mismatch = True
             write_marker("index-mismatch", min=str(low), max=str(high))
         if reason is not StopReason.NONE:
             write_marker(
@@ -282,7 +358,7 @@ class CooperativeStop:
                 reason=reason.name,
             )
 
-    def assert_equal_loop_length(self, length: int) -> None:
+    def assert_equal_loop_length(self, length: int) -> bool:
         """One exchange at loop entry, asserting every rank's loop length agrees.
 
         Equal per-rank batch counts hold by construction today, on both sampler
@@ -297,12 +373,44 @@ class CooperativeStop:
         ±index check is. An unequal loop length is a precondition failure detected
         before any work is done, where continuing is a guaranteed hang.
 
+        This exchange needs `agreed`'s give-up handling and not only its own
+        assertion, because a signal can land between `defer_termination` yielding
+        and here -- arming the budget, so this exchange carries
+        ``max(remaining, _MIN_DEADLINE)`` while unsignalled peers carry the default
+        group's own timeout. The window immediately before it respawns the epoch's
+        persistent DataLoader workers, which routinely costs seconds, so a peer more
+        than a few seconds from loop entry really does expire this deadline. Without
+        the handling below that expiry is a bare ``RuntimeError`` out of a
+        preemption: the job reports 1 with a traceback instead of ``128 + signum``.
+
+        Returns:
+            Whether a stop was given up on here, in which case the caller must
+            **not** run the loop -- its peers are not there, so the body's first
+            collective would strand this rank -- and must leave in the way
+            `_cooperative_scope` does.
+
         Raises:
             UnequalLoopLength: On every rank, if the lengths differ.
+            RuntimeError: If a peer's process died, closing its socket, exactly as
+                in `agreed`.
         """
-        _, high, low = self._agreement.exchange(
-            StopReason.NONE.value, length, self._deadline()
-        )
+        try:
+            _, high, low = self._agreement.exchange(
+                StopReason.NONE.value, length, self._deadline()
+            )
+        except RuntimeError as err:
+            # the same three steps as `agreed`'s give-up branch, for the same
+            # reasons: no further exchange, a record of why, and something on the
+            # `PendingStop` for `defer_termination`'s dispatch to find
+            self._agreed = True
+            self._abandoned = True
+            if not is_deadline_expiry(err):
+                raise
+            write_marker(
+                "agreement-timeout", batch=self._exchange_label(), err=str(err)
+            )
+            self._pending.note_peer_stop()
+            return True
         if high != low:
             raise UnequalLoopLength(
                 f"every rank must iterate the same number of batches, but this "
@@ -310,6 +418,7 @@ class CooperativeStop:
                 f"between {low} and {high}. Continuing would hang the first "
                 "collective the short rank never reaches."
             )
+        return False
 
     def agreed(self, index: int) -> bool:
         """One boundary exchange. Whether this rank should leave the loop now.
@@ -344,12 +453,16 @@ class CooperativeStop:
             # read out of, *or given up on*, an exchange: a rank that gave up here
             # must not exchange again from `close` against peers already gone
             self._agreed = True
+            self._abandoned = True
             if not is_deadline_expiry(err):
                 # A peer's process exited and closed its socket: a crash, not a
                 # wedge. Let it escape rather than reporting a rank that left its
                 # peers behind.
                 raise
-            write_marker("agreement-timeout", batch=str(index), err=repr(str(err)))
+            # `write_marker` encodes the message so that it cannot break the
+            # space-separated `key=value` contract, which a torch error message
+            # otherwise does on the first space it contains
+            write_marker("agreement-timeout", batch=str(index), err=str(err))
             # Not optional, and the one thing that keeps this branch from
             # reintroducing the fault. A rank that gave up with no local event of
             # its own has nothing else on the `PendingStop` for
@@ -388,8 +501,14 @@ class CooperativeStop:
 
     @property
     def abandoned(self) -> bool:
-        """Whether an exchange was given up on, so the group is left behind."""
-        return self._agreement.abandoned
+        """Whether *this scope* gave up on an exchange, so the group is left behind.
+
+        Per scope rather than per group, so that the ``agreement-abandoned`` line is
+        a record of one event. The agreement's own flag cannot answer this: it lives
+        on the process-wide group, so once any loop has abandoned an exchange it
+        stays set for the life of the process.
+        """
+        return self._abandoned
 
     def abandoned_at(self) -> str:
         """Which exchange was given up on, for the abandonment marker."""
@@ -412,10 +531,12 @@ class CooperativeStop:
                 A parameter rather than something read off this object, because
                 the only value that matches the peers is that one.
 
-        Never raises. On the mid-iteration path the exchange is *expected* to time
-        out, and this is called from ``except BaseException: close(...); raise`` --
-        so a raising `close` would replace the original exception with a timeout
-        and defeat the whole point of leaving the traceback intact.
+        Never raises, and everything after the ``_originating`` assignment is
+        guarded for that reason. On the mid-iteration path the exchange is
+        *expected* to time out, and this is called from
+        ``except BaseException: close(...); raise`` -- so a raising `close` would
+        replace the original exception with a timeout and defeat the whole point of
+        leaving the traceback intact.
         """
         # before `_local_reason` is read to build the payload below
         self._originating = StopReason.EXCEPTION
@@ -430,12 +551,23 @@ class CooperativeStop:
                 self._local_reason().value, index, self._boundary_deadline(index)
             )
         except BaseException:
+            # the operation stays in gloo's work queue, so this scope owes the
+            # abandonment line and the hard exit that goes with it
+            self._abandoned = True
             logger.exception(
                 "Failed to tell peers this rank is leaving the loop on an "
                 "exception; they may be left in a collective."
             )
             return
-        self._report(StopReason(reduced), high, low)
+        try:
+            self._report(StopReason(reduced), high, low)
+        except BaseException:
+            # `StopReason(reduced)` raises `ValueError` on a code the enum does not
+            # cover. Unreachable while it covers every value a `MAX` over it can
+            # produce -- but this method's no-raise guarantee is absolute, and
+            # leaving the conversion outside the guard made it the one statement
+            # that could replace the caller's exception with a `ValueError`.
+            logger.exception("Failed to report the exit exchange.")
 
 
 @contextlib.contextmanager
@@ -455,8 +587,17 @@ def _cooperative_scope(
     """
     stop = CooperativeStop(pending, agreement, first_index=first_index)
     try:
-        if loop_length is not None:
-            stop.assert_equal_loop_length(loop_length)
+        if loop_length is not None and stop.assert_equal_loop_length(loop_length):
+            # A give-up at loop entry: the loop body must not run, because its first
+            # collective would strand this rank against peers that are not there. A
+            # context manager cannot skip its own body, so leaving is the only
+            # option -- and `SystemExit` is the one that leaves without a traceback
+            # and without turning a preemption into a failed job. `defer_termination`
+            # treats it as an exit rather than as a propagating exception, so its
+            # dispatch tears the backend down, runs the callbacks and exits with the
+            # code below, which is `128 + signum` where a signal was recorded and the
+            # peer-stop convention otherwise.
+            raise SystemExit(pending.exit_code)
         try:
             yield stop
         except BaseException:
@@ -471,6 +612,18 @@ def _cooperative_scope(
             # record. Emitted here because it must precede the teardown, which
             # `defer_termination`'s own `finally` performs next.
             write_marker("agreement-abandoned", batch=stop.abandoned_at())
+            # And the process may not be left to finalize: the gloo destructor
+            # joins the worker thread that still holds the abandoned operation, so
+            # `sys.exit` waits for the wedged peer to die. This is the whole of the
+            # design's bound after an abandoned exchange.
+            #
+            # One path does not honour it, and it is the exception rider: a rank
+            # unwinding on an exception is torn down with `exit_process=False` so
+            # that its traceback survives, so it returns rather than exiting and may
+            # then sit in finalization until its peer dies. The traceback is worth
+            # more than the promptness there, and by that point the backend is
+            # released and the callbacks have run, so what is lost is only the time.
+            pending.require_hard_exit()
 
 
 @contextlib.contextmanager
@@ -497,6 +650,14 @@ def cooperative_stop(
         The object the loop body polls once per boundary. Its `pending` property
         is the deferral's own record, so the loop can also skip work once a stop
         is pending rather than only stopping at the next boundary.
+
+    Raises:
+        UnequalLoopLength: From loop entry, on every rank, when ``loop_length`` is
+            given and the lengths differ.
+        SystemExit: From loop entry, when the loop-entry exchange is given up on.
+            The loop body cannot run in that case, so this is how the scope leaves;
+            the teardown and the exit code are the deferral's, as they are for a
+            stop agreed at a boundary.
     """
     dist = Distributed.get_instance()
     # `defer_termination` is the *outer* context, so its `finally` -- which

--- a/fme/core/distributed/distributed.py
+++ b/fme/core/distributed/distributed.py
@@ -7,12 +7,13 @@ from typing import TypeVar
 import torch
 
 from fme.core import metrics
+from fme.core.device import in_dataloader_worker
 
 from .base import DistributedBackend
 from .model_torch_distributed import ModelTorchDistributed
 from .non_distributed import NonDistributed
 from .shutdown import handle_termination_signals
-from .stop_agreement import StopAgreement
+from .stop_agreement import SoloStopAgreement, StopAgreement
 from .torch_distributed import TorchDistributed
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,8 @@ class Distributed:
             self._distributed = NonDistributed()
         self._seed = 0
         self._force_non_distributed = force_non_distributed
+        # only ever set in a DataLoader worker; see `stop_agreement`
+        self._worker_stop_agreement: StopAgreement | None = None
 
     @classmethod
     @contextlib.contextmanager
@@ -523,7 +526,23 @@ class Distributed:
         Reached through `fme.core.distributed.cooperative_stop` rather than
         directly; it is on this facade so that the loop-facing layer needs
         nothing but the singleton every entrypoint already has.
+
+        A DataLoader worker gets `SoloStopAgreement`, whatever the backend holds.
+        The backends' own guard runs at *construction*, so it catches a spawn- or
+        forkserver-started worker and misses a fork-started one -- the default start
+        method -- which inherits the constructed backend and with it the parent's
+        real gloo group. Issuing a collective on that from a worker would be an
+        unmatched operation on a group its rank's real process is using.
+        `defer_termination` and `handle_termination_signals` each carry the same
+        guard for the same reason; this was the entry point relying on nobody
+        calling it.
         """
+        if in_dataloader_worker():
+            if self._worker_stop_agreement is None:
+                # one object for the life of the worker, as
+                # `DistributedBackend.stop_agreement` documents
+                self._worker_stop_agreement = SoloStopAgreement()
+            return self._worker_stop_agreement
         return self._distributed.stop_agreement()
 
     def abort(self) -> None:

--- a/fme/core/distributed/distributed.py
+++ b/fme/core/distributed/distributed.py
@@ -12,6 +12,7 @@ from .base import DistributedBackend
 from .model_torch_distributed import ModelTorchDistributed
 from .non_distributed import NonDistributed
 from .shutdown import handle_termination_signals
+from .stop_agreement import StopAgreement
 from .torch_distributed import TorchDistributed
 
 logger = logging.getLogger(__name__)
@@ -92,7 +93,11 @@ class Distributed:
         try:
             with contextlib.ExitStack() as stack:
                 if handle_signals:
-                    stack.enter_context(handle_termination_signals(instance.shutdown))
+                    stack.enter_context(
+                        handle_termination_signals(
+                            instance.shutdown, abort=instance.abort
+                        )
+                    )
                 yield
         except BaseException:
             # exit immediately to avoid hanging other ranks
@@ -511,6 +516,19 @@ class Distributed:
         buf = torch.zeros(global_shape, dtype=tensor.dtype, device=tensor.device)
         buf[(..., *slices)] = tensor
         return self.spatial_reduce_sum(buf)
+
+    def stop_agreement(self) -> StopAgreement:
+        """The group ranks use to agree on leaving a loop together.
+
+        Reached through `fme.core.distributed.cooperative_stop` rather than
+        directly; it is on this facade so that the loop-facing layer needs
+        nothing but the singleton every entrypoint already has.
+        """
+        return self._distributed.stop_agreement()
+
+    def abort(self) -> None:
+        """Abort this rank's communicators. For the teardown watchdog only."""
+        return self._distributed.abort()
 
     def shutdown(self):
         return self._distributed.shutdown()

--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -35,6 +35,7 @@ from ._gloo_patch import patch_gloo_alltoall
 from .base import DistributedBackend
 from .external.pnd_manager import DistributedManager
 from .non_distributed import DummyWrapper
+from .stop_agreement import SoloStopAgreement, StopAgreement, new_stop_agreement
 from .torch_distributed import _gather_irregular, _rank_metadata_from_env
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,11 @@ class ModelTorchDistributed(DistributedBackend):
             _check_world_size_divisible(self._world_size, spatial_size)
             self._data_size = self._world_size // spatial_size
             self._data_rank = self._rank // spatial_size
+            # a worker joins no group, so it can agree with nobody -- and must
+            # not, `new_group` being a collective its rank's real process is
+            # not making
+            self._stop_agreement: StopAgreement = SoloStopAgreement()
+            self._default_group: torch.distributed.ProcessGroup | None = None
             return
 
         # Initialize PhysicsNeMo DistributedManager.
@@ -131,6 +137,16 @@ class ModelTorchDistributed(DistributedBackend):
         self._rank = self._dm.rank
         self._local_rank = self._dm.local_rank
         self._world_size = self._dm.world_size
+
+        # The agreement group spans the **world**, not the "data" axis derived
+        # below: the teardown is world-wide -- `DistributedManager.cleanup()`
+        # destroys every group -- so a stop originating on a spatial co-rank has
+        # to reach its data-parallel peers, which anything on `self._data_group`
+        # would not. Created here, after `initialize_mesh` above, because
+        # `new_group` is a collective and every rank has to issue it in the same
+        # order relative to the mesh's own groups.
+        self._default_group = torch.distributed.distributed_c10d._get_default_group()
+        self._stop_agreement = new_stop_agreement(self._world_size)
 
         # Derive per-axis process groups and sizes from the mesh.
         self._data_group = self._dm.get_mesh_group(mesh["data"])
@@ -289,6 +305,16 @@ class ModelTorchDistributed(DistributedBackend):
             tensor, op=torch.distributed.ReduceOp.MAX, group=self._data_group
         )
         return tensor
+
+    def stop_agreement(self) -> StopAgreement:
+        return self._stop_agreement
+
+    def abort(self) -> None:
+        # the **default** group, captured at construction: gloo's `abort()` is an
+        # empty default, so this reaches the NCCL communicators and nothing else,
+        # and the agreement group is meant to be kept rather than aborted
+        if self._default_group is not None:
+            self._default_group.abort()
 
     def gather(
         self,

--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -36,7 +36,7 @@ from .base import DistributedBackend
 from .external.pnd_manager import DistributedManager
 from .non_distributed import DummyWrapper
 from .stop_agreement import SoloStopAgreement, StopAgreement, new_stop_agreement
-from .torch_distributed import _gather_irregular, _rank_metadata_from_env
+from .torch_distributed import _abort_group, _gather_irregular, _rank_metadata_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -313,8 +313,7 @@ class ModelTorchDistributed(DistributedBackend):
         # the **default** group, captured at construction: gloo's `abort()` is an
         # empty default, so this reaches the NCCL communicators and nothing else,
         # and the agreement group is meant to be kept rather than aborted
-        if self._default_group is not None:
-            self._default_group.abort()
+        _abort_group(self._default_group)
 
     def gather(
         self,

--- a/fme/core/distributed/model_torch_distributed.py
+++ b/fme/core/distributed/model_torch_distributed.py
@@ -146,7 +146,7 @@ class ModelTorchDistributed(DistributedBackend):
         # `new_group` is a collective and every rank has to issue it in the same
         # order relative to the mesh's own groups.
         self._default_group = torch.distributed.distributed_c10d._get_default_group()
-        self._stop_agreement = new_stop_agreement(self._world_size)
+        self._stop_agreement = new_stop_agreement(self._world_size, self._default_group)
 
         # Derive per-axis process groups and sizes from the mesh.
         self._data_group = self._dm.get_mesh_group(mesh["data"])

--- a/fme/core/distributed/non_distributed.py
+++ b/fme/core/distributed/non_distributed.py
@@ -8,6 +8,7 @@ from fme.core import metrics
 from fme.core.disco import DiscreteContinuousConvS2
 
 from .base import DistributedBackend
+from .stop_agreement import SoloStopAgreement, StopAgreement
 
 T = TypeVar("T")
 
@@ -67,6 +68,15 @@ class NonDistributed(DistributedBackend):
 
     def reduce_max(self, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
+
+    def stop_agreement(self) -> StopAgreement:
+        # one rank has nobody to agree with, and `SoloStopAgreement` returns the
+        # caller's own values, so no call site needs a `| None` check
+        return SoloStopAgreement()
+
+    def abort(self) -> None:
+        # no communicators to abort
+        return
 
     def gather(
         self, tensor: torch.Tensor, gather_list: list[torch.Tensor] | None = None

--- a/fme/core/distributed/non_distributed.py
+++ b/fme/core/distributed/non_distributed.py
@@ -32,6 +32,15 @@ class DummyWrapper(torch.nn.Module):
 class NonDistributed(DistributedBackend):
     """A non-distributed backend implementation."""
 
+    def __init__(self) -> None:
+        # one object for the life of the backend, because `stop_agreement`'s
+        # contract is that the object is created with the backend and not
+        # destroyed with it -- which the real backends implement and multi-rank
+        # tests assert. Harmless to return a fresh one here, but a contract stated
+        # one way and implemented two ways is how the harmless case stops being
+        # harmless.
+        self._stop_agreement = SoloStopAgreement()
+
     @property
     def rank(self) -> int:
         """Global rank of this process."""
@@ -72,7 +81,7 @@ class NonDistributed(DistributedBackend):
     def stop_agreement(self) -> StopAgreement:
         # one rank has nobody to agree with, and `SoloStopAgreement` returns the
         # caller's own values, so no call site needs a `| None` check
-        return SoloStopAgreement()
+        return self._stop_agreement
 
     def abort(self) -> None:
         # no communicators to abort

--- a/fme/core/distributed/parallel_tests/test_cooperative_stop.py
+++ b/fme/core/distributed/parallel_tests/test_cooperative_stop.py
@@ -48,6 +48,7 @@ from fme.core.distributed.stop_agreement import (
     GlooStopAgreement,
     build_stop_agreement,
     is_deadline_expiry,
+    timeout_contract_verified,
 )
 
 # Groups this module has finished with and must never let go of. See the module
@@ -73,6 +74,24 @@ def _require_ranks() -> Distributed:
     if dist.world_size == 1:
         pytest.skip(_SKIP_SINGLE_RANK)
     return dist
+
+
+def _require_a_short_bound() -> None:
+    """Skip a test whose bound is a few seconds only where that bound exists.
+
+    On a torch release the timeout behaviours were never read against, `_deadline`
+    returns `no_local_event_deadline()` -- the default group's own timeout, which is
+    tens of minutes in a parallel session -- so a test that arms a budget and expects
+    a short wait does not fail, it *hangs*, and the autouse SIGALRM cannot interrupt
+    a C++ condition-variable wait. `pyproject.toml` declares ``torch>=2.4.0``, so an
+    unverified release is a supported one; CI's image pins 2.8.0 and takes the short
+    path. Every rank reads the same version, so every rank skips together.
+    """
+    if not timeout_contract_verified():
+        pytest.skip(
+            f"torch {torch.__version__} has no verified operation-timeout bound, "
+            "so a rank giving up waits the default group's own timeout"
+        )
 
 
 @contextlib.contextmanager
@@ -143,6 +162,7 @@ def test_agreement_is_bounded_when_a_peer_never_joins(capfd):
     nor shortened afterwards.
     """
     dist = _require_ranks()
+    _require_a_short_bound()
     absent = dist.world_size - 1
     # Above `_MIN_DEADLINE`, so that the *budget* is what bounds the wait, which is
     # what this test is about. A budget under the floor is floored up to it, and
@@ -338,6 +358,7 @@ def test_destroying_an_abandoned_group_returns_without_reclaiming_it(capfd):
     the session, not fail the test.
     """
     dist = _require_ranks()
+    _require_a_short_bound()
     absent = dist.world_size - 1
     with _throwaway_agreement(destroy=False) as agreement:
         if dist.rank == absent:
@@ -403,5 +424,9 @@ def test_the_agreement_group_carries_the_backends_world_size():
     # which would make every stop unilateral and strand exactly the peers the
     # mechanism exists to keep
     assert dist.stop_agreement().world_size == dist.world_size
-    # the same object every call, so nothing issues a second unmatched `new_group`
+    # The backend holds one agreement object for its own lifetime, which is what
+    # `DistributedBackend.stop_agreement` documents. This says nothing about the
+    # cache in `new_stop_agreement` -- it reads the backend's attribute and never
+    # reaches that function; `test_cooperative_stop_exit.py` is where a real second
+    # `init_process_group` in one process exercises the cache.
     assert dist.stop_agreement() is dist.stop_agreement()

--- a/fme/core/distributed/parallel_tests/test_cooperative_stop.py
+++ b/fme/core/distributed/parallel_tests/test_cooperative_stop.py
@@ -1,0 +1,398 @@
+"""Tier 2: the agreement against a real communicator, several ranks, no signals.
+
+These tests send no signals. They drive the pending state through
+`PendingStop.request`, which is public precisely so that the collective is
+testable without sending a signal into a live pytest session -- a signal there
+would tear the session's own backend down.
+
+**Every test builds a throwaway agreement group and never releases it.** Both
+halves of that are mandatory and neither is tidiness.
+
+*Throwaway*, because a gloo context that has timed out is in an undefined state,
+so the session's process-wide group must never be the one that fails -- every
+later test in the session would inherit the damage. That is why
+`build_stop_agreement` exists beside `new_stop_agreement`: a cached accessor
+would hand the first test the session's own group and every later test a
+destroyed one, ``destroy_process_group(group)`` on a single group not flipping
+``is_initialized()``.
+
+*Never released*, because ``destroy_process_group(group)`` reclaims nothing --
+the group *object* dying is what runs ``~ProcessGroupGloo()``, and after a
+timed-out exchange that destructor's wait never ends. CPython's refcounting makes
+an ordinary function return enough to trigger it, so a test that merely returns
+is the hazard; no ``gc.collect()`` is required. **The autouse SIGALRM cannot
+rescue it**: a Python signal handler does not run while the main thread is inside
+a C++ condition-variable wait, so the session would hang until CI killed it.
+Hence `_leak_forever`.
+"""
+
+import contextlib
+import time
+import weakref
+from collections.abc import Iterator
+
+import pytest
+import torch
+import torch.distributed
+
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.distributed.cooperative_stop import (
+    CooperativeStop,
+    PeerStopRequested,
+    UnequalLoopLength,
+    _cooperative_scope,
+)
+from fme.core.distributed.shutdown import PendingStop, StopReason
+from fme.core.distributed.stop_agreement import (
+    GlooStopAgreement,
+    build_stop_agreement,
+    is_deadline_expiry,
+)
+
+# Groups this module has finished with and must never let go of. See the module
+# docstring: releasing one after a timed-out exchange hangs the pytest session.
+_leak_forever: list[GlooStopAgreement] = []
+
+# Long enough that an exchange every rank really reaches returns inside it, short
+# enough that a mistake becomes a raise rather than a hang the alarm cannot
+# interrupt. Not `NO_LOCAL_EVENT_DEADLINE`, which is 30 minutes.
+_VERIFY_TIMEOUT = 30.0
+
+_SKIP_SINGLE_RANK = "the agreement is only meaningful with more than one rank"
+
+
+def _marker_lines(event: str, captured: str) -> list[str]:
+    prefix = f"fme-stop:{event} "
+    return [line for line in captured.splitlines() if line.startswith(prefix)]
+
+
+def _require_ranks() -> Distributed:
+    dist = Distributed.get_instance()
+    if dist.world_size == 1:
+        pytest.skip(_SKIP_SINGLE_RANK)
+    return dist
+
+
+@contextlib.contextmanager
+def _throwaway_agreement(destroy: bool = True) -> Iterator[GlooStopAgreement]:
+    """A group of this test's own, leaked deliberately on the way out.
+
+    Args:
+        destroy: Clear torch's bookkeeping for the group here. ``False`` for a
+            test that destroys it itself, because that is the thing under test and
+            destroying it twice asks torch to forget a group it has forgotten.
+    """
+    dist = Distributed.get_instance()
+    agreement = build_stop_agreement(dist.world_size)
+    # before anything that could fail, so no path can be the last reference
+    _leak_forever.append(agreement)
+    try:
+        yield agreement
+    finally:
+        if destroy:
+            # returns at once and reclaims nothing, which is the point
+            torch.distributed.destroy_process_group(agreement.group)
+        # every rank leaves this test together, so the next one starts clean
+        dist.barrier()
+
+
+@pytest.mark.parallel
+def test_every_rank_leaves_the_loop_at_the_same_index():
+    """The whole point, with a real communicator.
+
+    One rank is told to stop at iteration 5. Every rank must leave having
+    completed exactly the same batches -- which no flag-only design can deliver,
+    because a rank standing at a boundary with its own flag set cannot know
+    whether a peer has already entered the next iteration, and a peer that has is
+    stranded in a collective nobody will complete.
+    """
+    dist = _require_ranks()
+    notice_at = 5
+    with _throwaway_agreement() as agreement:
+        pending = PendingStop(budget=10.0)
+        with _cooperative_scope(pending, agreement) as stop:
+            completed = 0
+            for index in range(20):
+                if dist.rank == dist.world_size - 1 and index == notice_at:
+                    pending.request(15)  # SIGTERM, without sending one
+                completed += 1
+                if stop.agreed(index):
+                    break
+
+        assert completed == notice_at + 1
+        # and the ranks agree on that, rather than each being locally consistent
+        _, high, low = agreement.exchange(0, completed, _VERIFY_TIMEOUT)
+        assert high == low == notice_at + 1
+        # a rank that was never signalled still knows it is leaving
+        if dist.rank != dist.world_size - 1:
+            assert pending.requested is False
+            assert pending.peer_stop is True
+
+
+@pytest.mark.parallel
+@pytest.mark.medium_duration
+def test_agreement_is_bounded_when_a_peer_never_joins(capfd):
+    """A rank that is leaving does not wait for a peer indefinitely.
+
+    This is the case the mechanism exists for: a peer whose main thread is inside
+    a C-level call never reaches a boundary, so the ranks that did reach one give
+    up on it and tear down without it. The bound is the per-operation deadline,
+    which is the design's only bound -- a gloo group can neither be created short
+    nor shortened afterwards.
+    """
+    dist = _require_ranks()
+    absent = dist.world_size - 1
+    budget = 1.0
+    with _throwaway_agreement() as agreement:
+        if dist.rank == absent:
+            return  # never joins, as a wedged rank never does
+
+        # `work.wait` must *raise* on expiry rather than return `False`. The whole
+        # bound rests on that, and it is a private torch behaviour rather than a
+        # documented one, so it is asserted rather than assumed.
+        with pytest.raises(RuntimeError) as caught:
+            agreement.exchange(0, 0, budget)
+        assert is_deadline_expiry(caught.value), caught.value
+
+        pending = PendingStop(budget=budget)
+        pending.request(15)
+        started = time.monotonic()
+        with _cooperative_scope(pending, agreement) as stop:
+            assert stop.agreed(1) is True
+        elapsed = time.monotonic() - started
+        pending.close()
+
+    assert elapsed < budget + 2.0, elapsed
+    captured = capfd.readouterr().err
+    assert len(_marker_lines("agreement-timeout", captured)) == 1
+    # the only line that says the group was left behind rather than reclaimed
+    assert len(_marker_lines("agreement-abandoned", captured)) == 1
+
+
+@pytest.mark.parallel
+@pytest.mark.medium_duration
+def test_agreement_without_a_pending_stop_has_no_deadline_of_its_own(capfd):
+    """The false-positive guard, with real collectives.
+
+    A rank with nothing pending of its own has no reason to hurry and no standing
+    to declare a peer dead, so it must not hold a short deadline. If it did, root
+    walking out of a multi-second periodic checkpoint write -- which happens on a
+    schedule, every ~1000 batches -- would make every other rank hard-exit a
+    perfectly healthy job, causing the exact fault this mechanism prevents.
+    """
+    dist = _require_ranks()
+    late = 0
+    lateness = 2.0
+    with _throwaway_agreement() as agreement:
+        # configured, but never armed: nothing calls `request`, so
+        # `seconds_remaining()` stays `None` and the group's own timeout applies
+        pending = PendingStop(budget=0.2)
+        with _cooperative_scope(pending, agreement) as stop:
+            if dist.rank == late:
+                time.sleep(lateness)  # standing in for root's checkpoint write
+            assert stop.agreed(0) is False
+
+        assert pending.seconds_remaining() is None
+        assert stop.abandoned is False
+
+    assert _marker_lines("agreement-timeout", capfd.readouterr().err) == []
+
+
+@pytest.mark.parallel
+def test_the_agreement_spans_spatial_co_ranks_where_reduce_max_does_not():
+    """The agreement must be world-wide, which is why it is not `reduce_max`.
+
+    Under a spatially-parallel backend `reduce_max` reduces over the "data" axis
+    of the device mesh, while the teardown destroys every group in the process. So
+    a stop originating on a spatial co-rank would never reach its data-parallel
+    peers, and reusing `reduce_max` would be a silent correctness bug under two of
+    the three configurations CI's GPU job runs.
+    """
+    dist = _require_ranks()
+    if dist.world_size == dist.total_data_parallel_ranks:
+        pytest.skip("no spatial co-ranks for the agreement to span")
+    originating = dist.world_size - 1
+    reason = StopReason.SIGNAL.value if dist.rank == originating else 0
+
+    with _throwaway_agreement() as agreement:
+        reduced, _, _ = agreement.exchange(reason, 0, _VERIFY_TIMEOUT)
+        assert reduced == StopReason.SIGNAL.value, "every rank must see the stop"
+
+        # rank 0 sits at (h, w) = (0, 0) and the originating rank at
+        # (H - 1, W - 1), so with spatial parallelism they are in different data
+        # groups and the data-parallel reduction cannot carry the stop
+        over_data = torch.tensor([reason], dtype=torch.int64, device=get_device())
+        dist.reduce_max(over_data)
+        if dist.rank == 0:
+            assert int(over_data.item()) == 0
+
+
+@pytest.mark.parallel
+def test_the_agreement_group_is_independent_of_the_gradient_communicator():
+    """An exchange is never matched against a collective on the default group.
+
+    NCCL matches collectives by issue order on a communicator rather than by tag,
+    so a control collective on the gradient communicator would be safe only while
+    every rank issued the identical sequence -- which is exactly the invariant a
+    stop breaks. On a group of its own a rank that stops issuing exchanges
+    mismatches nothing.
+
+    **Only really meaningful under NCCL** (CI's ``torch/1/1`` GPU configuration).
+    gloo tolerates the ordering this drives, so the CPU run is a smoke test that
+    the interleaving does not deadlock.
+    """
+    dist = _require_ranks()
+    with _throwaway_agreement() as agreement:
+        # issued asynchronously by every rank first, so that the rank-dependent
+        # ordering below cannot deadlock: neither group waits on the other
+        gradient = torch.tensor(
+            [float(dist.rank)], dtype=torch.float32, device=get_device()
+        )
+        work = torch.distributed.all_reduce(gradient, async_op=True)
+
+        if dist.rank % 2 == 1:
+            reduced = agreement.exchange(0, 7, _VERIFY_TIMEOUT)
+            work.wait()
+        else:
+            work.wait()
+            reduced = agreement.exchange(0, 7, _VERIFY_TIMEOUT)
+
+        expected = float(sum(range(dist.world_size)))
+        assert gradient.item() == pytest.approx(expected)
+        assert reduced == (0, 7, 7)
+
+
+@pytest.mark.parallel
+def test_a_peer_exception_between_iterations_stops_every_rank(capfd):
+    """A rank raising after the body's last collective does not strand its peers.
+
+    That window is the whole of what the exception rider covers, and it is
+    narrower than it looks because the body holds two collectives, not one: the
+    gradient all-reduce every iteration, and a metrics reduction every hundredth.
+    A raise before either leaves the peers stranded in it by the raise itself,
+    which no mechanism at this seam can fix.
+
+    The index the raising rank contributes is the point of the last assertion. It
+    never finished the body, so its own counter is one behind its peers' -- and
+    contributing that would fire ``index-mismatch`` on exactly the path this test
+    covers, turning the design's one self-check into noise.
+    """
+    dist = _require_ranks()
+    raiser = dist.world_size - 1
+    raise_at = 3
+
+    class _Boom(RuntimeError):
+        pass
+
+    def run() -> None:
+        pending = PendingStop(budget=10.0)
+        with _cooperative_scope(pending, agreement) as stop:
+            for index in range(10):
+                # the gradient all-reduce
+                every = torch.ones(1, device=get_device())
+                torch.distributed.all_reduce(every)
+                if index == raise_at:
+                    # and the every-hundredth-batch metrics reduction, on the very
+                    # iteration the raise happens, so the raise really is after
+                    # *both* of the body's collectives
+                    gated = torch.ones(1, device=get_device())
+                    torch.distributed.all_reduce(gated)
+                    if dist.rank == raiser:
+                        raise _Boom("something went wrong between iterations")
+                if stop.agreed(index):
+                    break
+        pending.close()
+
+    with _throwaway_agreement() as agreement:
+        expected = _Boom if dist.rank == raiser else PeerStopRequested
+        with pytest.raises(expected):
+            run()
+
+    captured = capfd.readouterr().err
+    assert _marker_lines("index-mismatch", captured) == []
+    agreed = _marker_lines("stop-agreed", captured)
+    assert len(agreed) == 1
+    assert f"batch={raise_at}" in agreed[0]
+    assert "reason=EXCEPTION" in agreed[0]
+
+
+@pytest.mark.parallel
+@pytest.mark.medium_duration
+def test_destroying_an_abandoned_group_returns_without_reclaiming_it(capfd):
+    """The bound after a timed-out exchange is exiting, not getting the group back.
+
+    ``destroy_process_group`` returns promptly and reclaims nothing -- which is
+    what makes the teardown reachable at all on this path, and hence the restart
+    checkpoint. The price is that the group is kept for the life of the process:
+    the only thing that drains gloo's work queue is ``~ProcessGroupGloo()``, whose
+    wait carries no deadline, so paying the reference back is unbounded.
+
+    This test deliberately does **not** drop the reference. Doing so would hang
+    the session, not fail the test.
+    """
+    dist = _require_ranks()
+    absent = dist.world_size - 1
+    with _throwaway_agreement(destroy=False) as agreement:
+        if dist.rank == absent:
+            torch.distributed.destroy_process_group(agreement.group)
+            return  # never joins, so it has nothing to give up on
+
+        pending = PendingStop(budget=1.0)
+        pending.request(15)
+        with _cooperative_scope(pending, agreement) as stop:
+            assert stop.agreed(2) is True
+        assert stop.abandoned is True
+        pending.close()
+
+        alive = weakref.ref(agreement.group)
+        started = time.monotonic()
+        torch.distributed.destroy_process_group(agreement.group)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 1.0, elapsed
+        assert alive() is not None, "the group was reclaimed, which can hang"
+        assert len(_marker_lines("agreement-abandoned", capfd.readouterr().err)) == 1
+
+
+@pytest.mark.parallel
+def test_unequal_loop_lengths_raise_on_every_rank_at_loop_entry():
+    """One exchange at loop entry, because the boundary ones could not see this.
+
+    An unequal per-rank batch count holds by construction today on both sampler
+    paths, so this is insurance against that construction changing. If it did, the
+    short rank would leave the loop and exchange nothing while the long rank sat
+    alone in one more exchange with the group's 30 minutes on it -- and the ±index
+    diagnostic would be blind to it, comparing values contributed to an exchange
+    only one rank is in.
+
+    Every rank reads the same reduced values, so every rank raises. That is what
+    makes this a symmetric precondition failure rather than one rank unilaterally
+    terminating a job.
+    """
+    dist = _require_ranks()
+    with _throwaway_agreement() as agreement:
+        equal = CooperativeStop(PendingStop(budget=10.0), agreement)
+        equal.assert_equal_loop_length(100)  # raises on no rank
+
+        unequal = CooperativeStop(PendingStop(budget=10.0), agreement)
+        length = 99 if dist.rank == dist.world_size - 1 else 100
+        with pytest.raises(UnequalLoopLength):
+            unequal.assert_equal_loop_length(length)
+
+
+@pytest.mark.parallel
+def test_the_agreement_group_carries_the_backends_world_size():
+    """The evidence line's ``world=`` has to come from the group, not the caller.
+
+    A reader counts ``stop-agreed`` lines against it to find the rank that never
+    reached the boundary, so a wrong value would make the absence unreadable.
+    """
+    dist = _require_ranks()
+    # at more than one rank this also proves the backend joined a real group
+    # rather than falling back to `SoloStopAgreement`, whose world size is 1 --
+    # which would make every stop unilateral and strand exactly the peers the
+    # mechanism exists to keep
+    assert dist.stop_agreement().world_size == dist.world_size
+    # the same object every call, so nothing issues a second unmatched `new_group`
+    assert dist.stop_agreement() is dist.stop_agreement()

--- a/fme/core/distributed/parallel_tests/test_cooperative_stop.py
+++ b/fme/core/distributed/parallel_tests/test_cooperative_stop.py
@@ -11,10 +11,9 @@ halves of that are mandatory and neither is tidiness.
 *Throwaway*, because a gloo context that has timed out is in an undefined state,
 so the session's process-wide group must never be the one that fails -- every
 later test in the session would inherit the damage. That is why
-`build_stop_agreement` exists beside `new_stop_agreement`: a cached accessor
-would hand the first test the session's own group and every later test a
-destroyed one, ``destroy_process_group(group)`` on a single group not flipping
-``is_initialized()``.
+`build_stop_agreement` exists beside `new_stop_agreement`: the session's default
+group never changes, so the cache in `new_stop_agreement` would hand every test
+the session's own group, which is exactly the one that must not fail.
 
 *Never released*, because ``destroy_process_group(group)`` reclaims nothing --
 the group *object* dying is what runs ``~ProcessGroupGloo()``, and after a
@@ -38,6 +37,7 @@ import torch.distributed
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.distributed.cooperative_stop import (
+    _MIN_DEADLINE,
     CooperativeStop,
     PeerStopRequested,
     UnequalLoopLength,
@@ -56,7 +56,8 @@ _leak_forever: list[GlooStopAgreement] = []
 
 # Long enough that an exchange every rank really reaches returns inside it, short
 # enough that a mistake becomes a raise rather than a hang the alarm cannot
-# interrupt. Not `NO_LOCAL_EVENT_DEADLINE`, which is 30 minutes.
+# interrupt. Not `no_local_event_deadline()`, which is the default group's own
+# timeout -- tens of minutes.
 _VERIFY_TIMEOUT = 30.0
 
 _SKIP_SINGLE_RANK = "the agreement is only meaningful with more than one rank"
@@ -143,16 +144,21 @@ def test_agreement_is_bounded_when_a_peer_never_joins(capfd):
     """
     dist = _require_ranks()
     absent = dist.world_size - 1
-    budget = 1.0
+    # Above `_MIN_DEADLINE`, so that the *budget* is what bounds the wait, which is
+    # what this test is about. A budget under the floor is floored up to it, and
+    # would also make `PendingStop`'s own overrun warning -- armed at twice the
+    # budget -- fire during a wait that is going to end normally.
+    budget = _MIN_DEADLINE + 1.0
     with _throwaway_agreement() as agreement:
         if dist.rank == absent:
             return  # never joins, as a wedged rank never does
 
         # `work.wait` must *raise* on expiry rather than return `False`. The whole
         # bound rests on that, and it is a private torch behaviour rather than a
-        # documented one, so it is asserted rather than assumed.
+        # documented one, so it is asserted rather than assumed. Passed straight to
+        # `exchange`, so no floor applies and the probe stays short.
         with pytest.raises(RuntimeError) as caught:
-            agreement.exchange(0, 0, budget)
+            agreement.exchange(0, 0, 1.0)
         assert is_deadline_expiry(caught.value), caught.value
 
         pending = PendingStop(budget=budget)
@@ -338,7 +344,9 @@ def test_destroying_an_abandoned_group_returns_without_reclaiming_it(capfd):
             torch.distributed.destroy_process_group(agreement.group)
             return  # never joins, so it has nothing to give up on
 
-        pending = PendingStop(budget=1.0)
+        # above `_MIN_DEADLINE`, for the reason given in
+        # `test_agreement_is_bounded_when_a_peer_never_joins`
+        pending = PendingStop(budget=_MIN_DEADLINE + 1.0)
         pending.request(15)
         with _cooperative_scope(pending, agreement) as stop:
             assert stop.agreed(2) is True
@@ -362,7 +370,8 @@ def test_unequal_loop_lengths_raise_on_every_rank_at_loop_entry():
     An unequal per-rank batch count holds by construction today on both sampler
     paths, so this is insurance against that construction changing. If it did, the
     short rank would leave the loop and exchange nothing while the long rank sat
-    alone in one more exchange with the group's 30 minutes on it -- and the ±index
+    alone in one more exchange with the default group's own timeout on it -- and the
+    ±index
     diagnostic would be blind to it, comparing values contributed to an exchange
     only one rank is in.
 

--- a/fme/core/distributed/parallel_tests/test_cooperative_stop.py
+++ b/fme/core/distributed/parallel_tests/test_cooperative_stop.py
@@ -90,7 +90,14 @@ def _require_a_short_bound() -> None:
     if not timeout_contract_verified():
         pytest.skip(
             f"torch {torch.__version__} has no verified operation-timeout bound, "
-            "so a rank giving up waits the default group's own timeout"
+            "so a rank giving up waits the default group's own timeout. This skip "
+            "removes CI's only coverage of that bound -- nothing else asserts that a "
+            "rank leaving stops waiting for a wedged peer, or that destroying an "
+            "abandoned group returns. If you are here after bumping torch in "
+            "constraints.txt, the action is to re-read `work.wait`'s raise on "
+            "expiry, `kNoTimeout` in `Work.hpp` and the pybind chrono caster's "
+            "millisecond truncation on the new release, then add it to "
+            "`_VERIFIED_TORCH` in fme/core/distributed/stop_agreement.py."
         )
 
 
@@ -131,14 +138,19 @@ def test_every_rank_leaves_the_loop_at_the_same_index():
     notice_at = 5
     with _throwaway_agreement() as agreement:
         pending = PendingStop(budget=10.0)
-        with _cooperative_scope(pending, agreement) as stop:
-            completed = 0
-            for index in range(20):
-                if dist.rank == dist.world_size - 1 and index == notice_at:
-                    pending.request(15)  # SIGTERM, without sending one
-                completed += 1
-                if stop.agreed(index):
-                    break
+        try:
+            with _cooperative_scope(pending, agreement) as stop:
+                completed = 0
+                for index in range(20):
+                    if dist.rank == dist.world_size - 1 and index == notice_at:
+                        pending.request(15)  # SIGTERM, without sending one
+                    completed += 1
+                    if stop.agreed(index):
+                        break
+        finally:
+            # `request` arms a 20s overrun timer; leaving it running writes
+            # `deferral-overrun` into whatever a later test is capturing
+            pending.close()
 
         assert completed == notice_at + 1
         # and the ranks agree on that, rather than each being locally consistent
@@ -313,22 +325,28 @@ def test_a_peer_exception_between_iterations_stops_every_rank(capfd):
 
     def run() -> None:
         pending = PendingStop(budget=10.0)
-        with _cooperative_scope(pending, agreement) as stop:
-            for index in range(10):
-                # the gradient all-reduce
-                every = torch.ones(1, device=get_device())
-                torch.distributed.all_reduce(every)
-                if index == raise_at:
-                    # and the every-hundredth-batch metrics reduction, on the very
-                    # iteration the raise happens, so the raise really is after
-                    # *both* of the body's collectives
-                    gated = torch.ones(1, device=get_device())
-                    torch.distributed.all_reduce(gated)
-                    if dist.rank == raiser:
-                        raise _Boom("something went wrong between iterations")
-                if stop.agreed(index):
-                    break
-        pending.close()
+        # in a `finally`, because every rank leaves this by raising, so the call was
+        # unreachable. Nothing arms a timer on this path today -- `request` is never
+        # called -- but a test that only cancels on the path it does not take is one
+        # edit away from leaking one into a later test's captured stderr.
+        try:
+            with _cooperative_scope(pending, agreement) as stop:
+                for index in range(10):
+                    # the gradient all-reduce
+                    every = torch.ones(1, device=get_device())
+                    torch.distributed.all_reduce(every)
+                    if index == raise_at:
+                        # and the every-hundredth-batch metrics reduction, on the
+                        # very iteration the raise happens, so the raise really is
+                        # after *both* of the body's collectives
+                        gated = torch.ones(1, device=get_device())
+                        torch.distributed.all_reduce(gated)
+                        if dist.rank == raiser:
+                            raise _Boom("something went wrong between iterations")
+                    if stop.agreed(index):
+                        break
+        finally:
+            pending.close()
 
     with _throwaway_agreement() as agreement:
         expected = _Boom if dist.rank == raiser else PeerStopRequested
@@ -392,9 +410,8 @@ def test_unequal_loop_lengths_raise_on_every_rank_at_loop_entry():
     paths, so this is insurance against that construction changing. If it did, the
     short rank would leave the loop and exchange nothing while the long rank sat
     alone in one more exchange with the default group's own timeout on it -- and the
-    ±index
-    diagnostic would be blind to it, comparing values contributed to an exchange
-    only one rank is in.
+    ±index diagnostic would be blind to it, comparing values contributed to an
+    exchange only one rank is in.
 
     Every rank reads the same reduced values, so every rank raises. That is what
     makes this a symmetric precondition failure rather than one rank unilaterally

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -104,6 +104,24 @@ _terminate: Callable[..., None] | None = None
 _installed_pid: int | None = None
 
 
+class StopReason(enum.Enum):
+    """Why a rank is leaving a loop, and the reason code an agreement carries.
+
+    The values are what the agreement's payload transports, so ``MAX`` over them
+    is both a logical OR and a choice of the more serious reason: if any rank
+    recorded a signal every rank reads at least ``1``, and if any rank is
+    unwinding on an exception every rank reads ``2``.
+
+    It lives here rather than beside the agreement so that the agreement stays a
+    torch-only leaf with no dependency on the signal handling: what crosses the
+    wire is the integer value, not the enum.
+    """
+
+    NONE = 0
+    SIGNAL = 1
+    EXCEPTION = 2
+
+
 class _Phase(enum.Enum):
     """How far the teardown has got, which is what a repeated signal turns on."""
 
@@ -138,6 +156,20 @@ def clear_post_shutdown_callbacks() -> None:
     callbacks need to reset it between cases.
     """
     _post_shutdown_callbacks.clear()
+
+
+def clear_pending_stop() -> None:
+    """Discard any registered deferral.
+
+    The counterpart of `clear_post_shutdown_callbacks`, and needed for the same
+    reason: the registry is process-global, and a test session that enters
+    `Distributed.context(handle_signals=False)` installs no handler, so
+    `handle_termination_signals`' own clear-on-exit never runs. A deferral left
+    behind by a failed test would otherwise make the next test's signal deferred
+    to a scope nobody polls.
+    """
+    global _pending_stop
+    _pending_stop = None
 
 
 def write_marker(event: str, **fields: str) -> None:

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -29,9 +29,12 @@ write it was meant to make room for.
 Tearing down from inside the handler is right everywhere except inside a batch
 loop, where the ranks share a rendezvous they could agree to leave at instead.
 **Only a scope that opens a deferral gets that**, and today that is one training
-loop: a signal arriving during validation, inline inference, or LR tuning is still
-acted on where it lands, and those paths hold collectives of their own. The
-deferral is the mechanism, not a claim about coverage.
+loop -- `fme.core.generics.trainer.Trainer.train_one_epoch`, and not
+`fme/downscaling/train.py`'s `Trainer.train_one_epoch`, which has a batch loop of
+its own and does not open a deferral. A signal arriving during validation, inline
+inference, or LR tuning is still acted on where it lands, and those paths hold
+collectives of their own. The deferral is the mechanism, not a claim about
+coverage.
 
 So this module owns three things: *deferral* -- ``defer_termination`` makes the
 handler record intent rather than act, and performs the teardown when the scope
@@ -70,12 +73,17 @@ TERMINATION_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT
 # SIGKILLs whoever is still alive. That 30s is one budget shared by every rank
 # rather than 30s each, so a slow rank spends its peers' allowance too.
 #
-# 20s of that 30s is this, and `DEFAULT_STOP_AGREEMENT_BUDGET` claims 5s more
-# ahead of it, so the post-shutdown callbacks -- the restart checkpoint -- begin
-# with about 5s left in the worst case. There is no margin beyond that: this is a
-# ceiling for a teardown that normally returns in well under a second, not a slice
-# reserved for it, but a teardown that really does use its 20s leaves the
-# checkpoint a sixth of the window and no more.
+# 20s of that 30s is this. What the agreement ahead of it spends is not a
+# constant: with `DEFAULT_STOP_AGREEMENT_BUDGET` = 5s and a floor of
+# `_MIN_DEADLINE` = 3s under every deadline, a rank whose local event was T
+# seconds before the boundary it next reaches finishes agreeing by max(5, T + 3),
+# so the callbacks -- the restart checkpoint -- begin with min(5, 7 - T) seconds
+# of the window left and with none at all once T >= 7s. The arithmetic is worked
+# out where those two constants are defined.
+#
+# There is no margin beyond that: this is a ceiling for a teardown that normally
+# returns in well under a second, not a slice reserved for it, but a teardown that
+# really does use its 20s leaves the checkpoint a sixth of the window at best.
 #
 # [1]: https://beaker-docs.apps.allenai.org/scheduling/interruption.html#automated-preemption
 DEFAULT_TEARDOWN_TIMEOUT = 20.0
@@ -183,6 +191,28 @@ def clear_pending_stop() -> None:
     _pending_stop = None
 
 
+# Longest field value a marker line will carry. gloo's messages run to a few
+# hundred characters, and a line has to stay far under `PIPE_BUF` for the atomicity
+# `write_marker` describes.
+_MAX_FIELD_LENGTH: int = 160
+
+
+def _field_value(value: str) -> str:
+    """Make one value fit the ``key=value`` contract, whatever it contains.
+
+    The contract is fixed space-separated ``key=value`` pairs, so a value may
+    contain neither a space nor a newline: a torch error message contains both,
+    and passing one through unencoded makes the line unparseable by the very
+    readers these lines exist for -- including the tests' own field parser. Runs of
+    whitespace become a single ``_`` rather than being percent-encoded, because a
+    human reads these lines first.
+    """
+    collapsed = "_".join(value.split())
+    if len(collapsed) <= _MAX_FIELD_LENGTH:
+        return collapsed
+    return collapsed[:_MAX_FIELD_LENGTH] + "..."
+
+
 def write_marker(event: str, **fields: str) -> None:
     """Write one machine-readable evidence line to stderr. Never raises.
 
@@ -205,6 +235,10 @@ def write_marker(event: str, **fields: str) -> None:
     from a parameter, so that callers with no access to the handler's locals --
     timer threads, and the loop-facing layer above this module -- emit lines one
     parser stays valid for. It is ``?`` where no handler is installed.
+
+    Every field value goes through `_field_value`, so the ``key=value`` contract
+    holds for all of them by construction rather than by each caller remembering
+    it. A caller passing a torch error message is the case that needs it.
     """
     try:
         rank = os.environ.get("RANK") or os.environ.get("SLURM_PROCID") or "?"
@@ -220,7 +254,7 @@ def write_marker(event: str, **fields: str) -> None:
             f"installed_pid={installed}",
             f"wall={time.time():.6f}",
             f"mono={time.monotonic():.6f}",
-            *(f"{name}={value}" for name, value in fields.items()),
+            *(f"{name}={_field_value(value)}" for name, value in fields.items()),
         ]
         os.write(2, (" ".join(parts) + "\n").encode())
     except BaseException:
@@ -273,6 +307,9 @@ class PendingStop:
         # `128 + signum`, meaningful once `requested`; until then the convention
         # for a stop that carries no signal number of its own
         self.exit_code = _PEER_STOP_EXIT_CODE
+        # the caller has left something behind that interpreter finalization
+        # cannot dispose of in bounded time; see `require_hard_exit`
+        self.hard_exit = False
         self._deadline: float | None = None
         self._overrun: threading.Timer | None = None
 
@@ -312,6 +349,27 @@ class PendingStop:
     def note_peer_stop(self) -> None:
         """Record that a peer is stopping, so that leaving the scope tears down."""
         self.peer_stop = True
+
+    def require_hard_exit(self) -> None:
+        """Ask for `os._exit` rather than `sys.exit` once the teardown is done.
+
+        For a caller that has left something behind which interpreter finalization
+        cannot dispose of in bounded time. The case this exists for is an abandoned
+        gloo group: ``~ProcessGroupGloo()`` joins the worker thread still holding
+        the abandoned operation, that destructor runs during ``Py_Finalize``, and
+        measured on torch 2.7.1 the wait ends only when the wedged peer's socket
+        closes -- 119.3s against a peer parked for 120s, 24.3s against one parked
+        for 25s, versus 0.05s with `os._exit`. So `sys.exit` hands the rank to
+        torchrun's SIGKILL and the launcher reads a signal death instead of the
+        ``128 + signum`` this module promises.
+
+        This does not weaken the rule that a hard exit is the fault to avoid. The
+        watchdog's `os._exit` is dangerous because it can drop live communicators
+        and skip the callbacks; this one runs *after* `shutdown` destroyed them and
+        *after* the callbacks completed, so nothing is skipped and no communicator
+        is dropped -- there is nothing left for finalization to do but block.
+        """
+        self.hard_exit = True
 
     def seconds_remaining(self) -> float | None:
         """Seconds left in the budget, or ``None`` when no budget is armed.
@@ -381,8 +439,18 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
     pending = PendingStop(budget)
     _pending_stop = pending
     raising = False
+    exiting = False
     try:
         yield pending
+    except SystemExit:
+        # Not `raising`. A caller leaving by `sys.exit` is asking for the very exit
+        # the dispatch below performs rather than surfacing a crash, and there is no
+        # traceback to protect -- so it takes the exit path, which is the only one
+        # that can honour `require_hard_exit`. `cooperative_stop` leaves this way
+        # when the loop-entry exchange is given up on, since the loop body must not
+        # run against peers that are gone.
+        exiting = True
+        raise
     except BaseException:
         raising = True
         raise
@@ -407,10 +475,14 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
             # a signal too. So tear down, run the callbacks, and return, leaving
             # the traceback to reach the interpreter.
             #
-            # The exit code still follows the signal where there was one, because
-            # the only thing it is used for from here is the watchdog's hard-exit
-            # backstop, and a rank asked to stop should report `128 + signum` even
-            # if it is the watchdog that ends it.
+            # What that trades away is the *process's* exit code: a rank that was
+            # preempted and also raised reports 1, and the preempted-versus-failed
+            # distinction is precisely what `128 + signum` carries to the scheduler.
+            # The code passed here still follows the signal, but from this branch it
+            # reaches only the watchdog's hard-exit backstop, so it does not restore
+            # that distinction where anything outside the process can read it.
+            # Masking a crash as a graceful stop would hide the crash, which is the
+            # worse of the two.
             _terminate(
                 pending.exit_code if pending.requested else _EXCEPTION_EXIT_CODE,
                 exit_process=False,
@@ -419,9 +491,14 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
             # A recorded signal takes precedence over a peer's deliberately: a
             # preemption is not a failure, and `128 + signum` is what the scheduler
             # and torchrun expect from a rank asked to stop.
-            _terminate(pending.exit_code)
+            _terminate(pending.exit_code, hard=pending.hard_exit)
         elif pending.peer_stop:
-            _terminate(_PEER_STOP_EXIT_CODE)
+            _terminate(_PEER_STOP_EXIT_CODE, hard=pending.hard_exit)
+        elif exiting:
+            # A `sys.exit` of the caller's own, with no stop recorded anywhere: tear
+            # the backend down and run the callbacks, then let the caller's own code
+            # reach the interpreter, exactly as the exception path does.
+            _terminate(_EXCEPTION_EXIT_CODE, exit_process=False)
 
 
 class _Deadlines:
@@ -613,7 +690,9 @@ def handle_termination_signals(
     installed_pid = os.getpid()
     phase = _Phase.RUNNING
 
-    def terminate(exit_code: int, *, exit_process: bool = True) -> None:
+    def terminate(
+        exit_code: int, *, exit_process: bool = True, hard: bool = False
+    ) -> None:
         """Release the backend, run the callbacks, and exit.
 
         The only teardown implementation there is, reached either from the
@@ -623,6 +702,13 @@ def handle_termination_signals(
         `exit_process=False` is for a caller that is already propagating an
         exception: everything happens except the final `sys.exit`, so the
         exception goes on propagating with its traceback intact.
+
+        `hard` replaces that final `sys.exit` with `os._exit`, for a caller that
+        has left something behind which interpreter finalization cannot dispose of
+        in bounded time -- see `PendingStop.require_hard_exit`, which is the only
+        thing that sets it. It is reached only here, after `shutdown` and after the
+        callbacks, so unlike the watchdog's hard exit it drops no communicator and
+        skips no work.
         """
         nonlocal phase
         phase = _Phase.COLLECTIVE
@@ -638,8 +724,23 @@ def handle_termination_signals(
             _run_post_shutdown_callbacks()
         finally:
             phase = _Phase.COMPLETE
-        if exit_process:
-            sys.exit(exit_code)
+        if not exit_process:
+            return
+        if hard:
+            write_marker("hard-exit", code=str(exit_code))
+            # `os._exit` skips the buffered streams, and the callbacks above are
+            # the code most likely to have written to them
+            for stream in (sys.stdout, sys.stderr):
+                try:
+                    stream.flush()
+                except BaseException:
+                    pass
+            os._exit(exit_code)
+        # reached in production only when `hard` is false; a test that stubbed
+        # `os._exit` out falls through to here rather than carrying on inside the
+        # scope that asked to be left, which is the same guard the handler's own
+        # hard-exit branches carry
+        sys.exit(exit_code)
 
     def handle(signum: int, frame: types.FrameType | None) -> None:
         nonlocal phase
@@ -727,6 +828,7 @@ def handle_termination_signals(
     previous = {sig: signal.getsignal(sig) for sig in TERMINATION_SIGNALS}
     previous_terminate = _terminate
     previous_installed_pid = _installed_pid
+    previous_callbacks = list(_post_shutdown_callbacks)
     _terminate = terminate
     _installed_pid = installed_pid
     for sig in TERMINATION_SIGNALS:
@@ -744,4 +846,10 @@ def handle_termination_signals(
         _pending_stop = None
         for sig, previous_handler in previous.items():
             signal.signal(sig, previous_handler)
-        clear_post_shutdown_callbacks()
+        # restored rather than cleared, for the same reason as the two globals
+        # above: this context claims nesting is legal, and an unconditional clear
+        # would take an outer context's callbacks with it when an inner one exits.
+        # Callbacks registered *inside* this scope are still discarded, which is
+        # what the clear was for -- the registry is process-global and its entries
+        # close over objects this scope's job built.
+        _post_shutdown_callbacks[:] = previous_callbacks

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -28,6 +28,11 @@ write it was meant to make room for.
 
 Tearing down from inside the handler is right everywhere except inside a batch
 loop, where the ranks share a rendezvous they could agree to leave at instead.
+**Only a scope that opens a deferral gets that**, and today that is one training
+loop: a signal arriving during validation, inline inference, or LR tuning is still
+acted on where it lands, and those paths hold collectives of their own. The
+deferral is the mechanism, not a claim about coverage.
+
 So this module owns three things: *deferral* -- ``defer_termination`` makes the
 handler record intent rather than act, and performs the teardown when the scope
 it guards is left -- the evidence marker writer ``write_marker``, whose lines
@@ -63,8 +68,14 @@ TERMINATION_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT
 # `LocalElasticAgent._shutdown` calls it without an argument
 # (torch/distributed/elastic/agent/server/local_elastic_agent.py:372), then
 # SIGKILLs whoever is still alive. That 30s is one budget shared by every rank
-# rather than 30s each, so a slow rank spends its peers' allowance too. 20s
-# leaves 10s of margin beneath it.
+# rather than 30s each, so a slow rank spends its peers' allowance too.
+#
+# 20s of that 30s is this, and `DEFAULT_STOP_AGREEMENT_BUDGET` claims 5s more
+# ahead of it, so the post-shutdown callbacks -- the restart checkpoint -- begin
+# with about 5s left in the worst case. There is no margin beyond that: this is a
+# ceiling for a teardown that normally returns in well under a second, not a slice
+# reserved for it, but a teardown that really does use its 20s leaves the
+# checkpoint a sixth of the window and no more.
 #
 # [1]: https://beaker-docs.apps.allenai.org/scheduling/interruption.html#automated-preemption
 DEFAULT_TEARDOWN_TIMEOUT = 20.0
@@ -181,8 +192,14 @@ def write_marker(event: str, **fields: str) -> None:
     (which rank failed to reach the stopping point, which rank's teardown did not
     return), so a rank-0 summary cannot serve. ``os.write`` also cannot deadlock
     on the logging lock, which matters because these lines are emitted from
-    signal handlers and timer threads, and a single short write is atomic on a
-    pipe, so several ranks' lines cannot interleave.
+    signal handlers and timer threads.
+
+    One line is one ``write``, which is what keeps several ranks' lines from
+    interleaving -- but only where that guarantee holds: a write under ``PIPE_BUF``
+    (4096 on Linux) is atomic *on a pipe*, while a container that redirects stderr
+    to a regular file relies on ``O_APPEND`` writes not interleaving instead, which
+    is a different promise. Lines here stay far under 4096 bytes, so the stronger
+    case applies wherever it applies at all.
 
     ``installed_pid`` comes from the module-level `_installed_pid` rather than
     from a parameter, so that callers with no access to the handler's locals --
@@ -354,7 +371,13 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
         yield PendingStop(budget)
         return
     if _pending_stop is not None:
-        raise RuntimeError("Nested defer_termination() is not supported.")
+        raise RuntimeError(
+            "Nested defer_termination() is not supported: the registry is "
+            "process-global and only one scope can own the teardown. "
+            "`fme.core.distributed.cooperative_stop` opens one, so two "
+            "cooperative_stop scopes at once -- nested batch loops, most likely -- "
+            "reach here as well."
+        )
     pending = PendingStop(budget)
     _pending_stop = pending
     raising = False
@@ -373,21 +396,32 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
         pending.close()
         if _terminate is None:
             pass  # no handler installed, so there is nothing to tear down
+        elif raising:
+            # A propagating exception wins, and it wins even over a recorded
+            # signal. `_terminate` raises `SystemExit` from this `finally`, so
+            # exiting here would *replace* the exception -- and the exception this
+            # discards is exactly the one the agreement went out of its way to
+            # surface: a peer's `Connection closed by peer`, re-raised at the
+            # boundary rather than masked as a graceful stop, on a rank that
+            # (because the scheduler signals the whole group) has usually recorded
+            # a signal too. So tear down, run the callbacks, and return, leaving
+            # the traceback to reach the interpreter.
+            #
+            # The exit code still follows the signal where there was one, because
+            # the only thing it is used for from here is the watchdog's hard-exit
+            # backstop, and a rank asked to stop should report `128 + signum` even
+            # if it is the watchdog that ends it.
+            _terminate(
+                pending.exit_code if pending.requested else _EXCEPTION_EXIT_CODE,
+                exit_process=False,
+            )
         elif pending.requested:
-            # A recorded signal takes precedence over an exception deliberately:
-            # a preemption is not a failure, and `128 + signum` is what the
-            # scheduler and torchrun expect from a rank asked to stop. The cost
-            # is that a rank which recorded a signal *and* raised loses the
-            # raise's exit code.
+            # A recorded signal takes precedence over a peer's deliberately: a
+            # preemption is not a failure, and `128 + signum` is what the scheduler
+            # and torchrun expect from a rank asked to stop.
             _terminate(pending.exit_code)
         elif pending.peer_stop:
             _terminate(_PEER_STOP_EXIT_CODE)
-        elif raising:
-            # Tear down and run the callbacks, then let the exception go on
-            # propagating: without this the rank would exit with its
-            # communicators open, and with a `sys.exit` here the traceback that
-            # brought us here would be replaced by an exit code.
-            _terminate(_EXCEPTION_EXIT_CODE, exit_process=False)
 
 
 class _Deadlines:

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -25,6 +25,17 @@ The watchdog covers the collective and stops there. Whatever runs afterwards --
 the restart checkpoint above all -- is deliberately unbounded: by then the
 peers are already out of the collective, so a deadline could only truncate the
 write it was meant to make room for.
+
+Tearing down from inside the handler is right everywhere except inside a batch
+loop, where the ranks share a rendezvous they could agree to leave at instead.
+So this module owns three things: *deferral* -- ``defer_termination`` makes the
+handler record intent rather than act, and performs the teardown when the scope
+it guards is left -- the evidence marker writer ``write_marker``, whose lines
+are the only per-rank record that survives non-root ranks' log level, and the
+watchdog, which now aborts the local communicator before its hard exit.
+Deciding *when* a deferred stop is acted on is the caller's, not this module's:
+nothing here knows about process groups or collectives, which is what keeps the
+signal handling testable single-rank and in process.
 """
 
 import contextlib
@@ -34,6 +45,7 @@ import os
 import signal
 import sys
 import threading
+import time
 import types
 from collections.abc import Callable, Generator
 
@@ -57,13 +69,46 @@ TERMINATION_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT
 # [1]: https://beaker-docs.apps.allenai.org/scheduling/interruption.html#automated-preemption
 DEFAULT_TEARDOWN_TIMEOUT = 20.0
 
+# Seconds between the watchdog aborting the local communicator and exiting the
+# process anyway. Deliberately shorter than the callbacks it sits over, which is
+# only safe because `_Deadlines` stands the backstop down by a flag rather than
+# by `Timer.cancel()`: a successful abort releases the main thread at once, and
+# exiting out from under the checkpoint write it then starts would be worse than
+# not aborting at all.
+_ABORT_BACKSTOP: float = 5.0
+
+# The exit code the watchdog and the escalating phases use when a rank is leaving
+# on an exception. Nothing calls `sys.exit` with it: the exception path returns so
+# that the original traceback reaches the interpreter unmasked.
+_EXCEPTION_EXIT_CODE: int = 1
+
+# A peer's stop carries no signal number, so a rank leaving because a peer was
+# signalled reports SIGTERM's conventional code.
+_PEER_STOP_EXIT_CODE: int = 128 + int(signal.SIGTERM)
+
 _post_shutdown_callbacks: list[Callable[[], None]] = []
+
+# The deferral registry. `None` means a signal is acted on immediately, which is
+# the right thing everywhere but inside a scope that has a rendezvous of its own.
+_pending_stop: "PendingStop | None" = None
+
+# Published by `handle_termination_signals` so that a deferral, which has no
+# access to that function's locals, can run the same teardown the handler would
+# have run. `None` means no handler is installed and there is nothing to tear
+# down -- the state every pytest session is in.
+_terminate: Callable[..., None] | None = None
+
+# The pid the handler was installed in, so that every marker line can be read
+# against it: a real rank has `pid == installed_pid`, while a fork-started
+# DataLoader worker sharing its parent's RANK does not.
+_installed_pid: int | None = None
 
 
 class _Phase(enum.Enum):
     """How far the teardown has got, which is what a repeated signal turns on."""
 
     RUNNING = enum.auto()
+    STOP_REQUESTED = enum.auto()
     COLLECTIVE = enum.auto()
     CALLBACKS = enum.auto()
     COMPLETE = enum.auto()
@@ -95,15 +140,303 @@ def clear_post_shutdown_callbacks() -> None:
     _post_shutdown_callbacks.clear()
 
 
-def _hard_exit_after(timeout: float, exit_code: int) -> threading.Timer:
-    """Exit the process if the graceful teardown has not finished in time.
+def write_marker(event: str, **fields: str) -> None:
+    """Write one machine-readable evidence line to stderr. Never raises.
+
+    ``logging`` cannot carry this: `fme/core/logging_utils.py` puts every
+    non-root rank at ERROR, so an INFO line from ranks 1-7 never reaches the
+    container log -- and the two things a reader needs are per-rank and negative
+    (which rank failed to reach the stopping point, which rank's teardown did not
+    return), so a rank-0 summary cannot serve. ``os.write`` also cannot deadlock
+    on the logging lock, which matters because these lines are emitted from
+    signal handlers and timer threads, and a single short write is atomic on a
+    pipe, so several ranks' lines cannot interleave.
+
+    ``installed_pid`` comes from the module-level `_installed_pid` rather than
+    from a parameter, so that callers with no access to the handler's locals --
+    timer threads, and the loop-facing layer above this module -- emit lines one
+    parser stays valid for. It is ``?`` where no handler is installed.
+    """
+    try:
+        rank = os.environ.get("RANK") or os.environ.get("SLURM_PROCID") or "?"
+        local_rank = (
+            os.environ.get("LOCAL_RANK") or os.environ.get("SLURM_LOCALID") or "?"
+        )
+        installed = "?" if _installed_pid is None else str(_installed_pid)
+        parts = [
+            f"fme-stop:{event}",
+            f"rank={rank}",
+            f"local_rank={local_rank}",
+            f"pid={os.getpid()}",
+            f"installed_pid={installed}",
+            f"wall={time.time():.6f}",
+            f"mono={time.monotonic():.6f}",
+            *(f"{name}={value}" for name, value in fields.items()),
+        ]
+        os.write(2, (" ".join(parts) + "\n").encode())
+    except BaseException:
+        # A marker is evidence about a teardown, so it may not become a second
+        # failure during one: a closed or full stderr must not raise out of a
+        # signal handler or a timer thread.
+        pass
+
+
+def _warn_after(timeout: float, message: str) -> threading.Timer:
+    """Report a deferral that is taking too long, without acting on it.
+
+    The only lever a timer thread has over a main thread wedged in a collective
+    is ``os._exit``, which is the fabric fault this mechanism exists to avoid;
+    taking it here would trade a rank we have merely lost track of for a node the
+    cluster cordons. So this only writes, which is still strictly better than
+    today, where a rank that rides to SIGKILL produces no line at all.
+
+    ``os.write`` rather than the logger, for the reason given in
+    `_hard_exit_after`.
+    """
+
+    def warn() -> None:
+        write_marker("deferral-overrun", since=f"{timeout:.0f}s")
+        os.write(2, message.encode())
+
+    timer = threading.Timer(timeout, warn)
+    timer.daemon = True
+    timer.start()
+    return timer
+
+
+class PendingStop:
+    """A stop recorded but not yet acted on. One per `defer_termination`.
+
+    The budget it holds is what bounds a rank that is leaving: it is absolute
+    from the first local event -- a signal recorded here, or an exception the
+    caller is raising -- so a caller cannot accumulate a fresh budget at each of
+    several rendezvous. A rank with no local event of its own arms nothing and
+    `seconds_remaining` stays ``None``, which is what keeps a healthy rank from
+    ever starting a clock it could then be killed by.
+    """
+
+    def __init__(self, budget: float) -> None:
+        self._budget = budget
+        # a signal was recorded on *this* rank
+        self.requested = False
+        # a peer's stop was reported to this rank by its caller
+        self.peer_stop = False
+        # `128 + signum`, meaningful once `requested`; until then the convention
+        # for a stop that carries no signal number of its own
+        self.exit_code = _PEER_STOP_EXIT_CODE
+        self._deadline: float | None = None
+        self._overrun: threading.Timer | None = None
+
+    def request(self, signum: int) -> None:
+        """From the handler: record the signal and arm the budget.
+
+        Public so that a caller can stop for a reason of its own -- a wall-clock
+        budget, say -- and so that multi-rank tests can drive the pending state
+        without sending a signal into a live pytest session.
+        """
+        self.requested = True
+        self.exit_code = 128 + signum
+        self.arm_budget()
+        if self._overrun is None:
+            # Starting a timer takes `threading`'s own locks, so a signal landing
+            # while the main thread holds one can deadlock -- the same hazard
+            # `_hard_exit_after` already carries, since today's handler starts a
+            # timer too. What is new is that this one fires on every deferral
+            # rather than only when a teardown is under way.
+            overrun = 2.0 * self._budget
+            self._overrun = _warn_after(
+                overrun,
+                f"A termination signal has been pending for {overrun:.0f}s "
+                "without reaching a stopping point; this rank may be killed with "
+                "its communicators open. GPUs on this node may need to be "
+                "reset.\n",
+            )
+
+    def arm_budget(self) -> None:
+        """Arm the budget with no signal, for a caller raising an exception.
+
+        Idempotent, so the budget stays absolute from the first local event.
+        """
+        if self._deadline is None:
+            self._deadline = time.monotonic() + self._budget
+
+    def note_peer_stop(self) -> None:
+        """Record that a peer is stopping, so that leaving the scope tears down."""
+        self.peer_stop = True
+
+    def seconds_remaining(self) -> float | None:
+        """Seconds left in the budget, or ``None`` when no budget is armed.
+
+        May be negative: a budget can be wholly spent before the rank reaches the
+        rendezvous it bounds, and arriving late is not the same as being
+        abandoned. What the caller does with a spent budget is the caller's.
+        """
+        if self._deadline is None:
+            return None
+        return self._deadline - time.monotonic()
+
+    def close(self) -> None:
+        """Cancel the diagnostic timer. Never raises."""
+        overrun = self._overrun
+        self._overrun = None
+        if overrun is not None:
+            # `Timer.cancel` only sets an event, so it cannot raise
+            overrun.cancel()
+
+
+@contextlib.contextmanager
+def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
+    """Record a termination signal instead of acting on it, for this scope.
+
+    Inside this context a signal sets the yielded `PendingStop` and returns, so
+    the caller can leave whatever it is doing at a point of its own choosing --
+    a batch boundary its peers also reach, rather than wherever the signal
+    happened to land. Leaving the context then runs the same teardown the
+    handler would have run: `shutdown`, the post-shutdown callbacks, and an exit.
+    Outside it, nothing changes and a signal is acted on immediately, which is
+    right because outside a loop there is no future rendezvous to wait for.
+
+    Well-defined with no handler installed: it yields a `PendingStop` that simply
+    never becomes requested, and finds nothing to tear down on the way out.
+
+    Args:
+        budget: Seconds a rank with a local event of its own is prepared to spend
+            before it stops waiting. Required rather than defaulted, because the
+            layer that decides deadlines sits above this module.
+
+    Raises:
+        RuntimeError: If a deferral is already registered. The registry is
+            process-global and only one scope can own the teardown.
+    """
+    global _pending_stop
+    if threading.current_thread() is not threading.main_thread():
+        # a thread cannot own the process's disposition, so no signal is recorded
+        # here and nothing would ever poll a registration
+        yield PendingStop(budget)
+        return
+    if in_dataloader_worker():
+        # The DataLoader owns its workers' lifecycle. A fork-started worker
+        # inherits both this registry and the handler, so registering here would
+        # let a worker's copy of the teardown run against a fork-inherited
+        # process group; `handle`'s pid guard is the other half of this.
+        yield PendingStop(budget)
+        return
+    if _pending_stop is not None:
+        raise RuntimeError("Nested defer_termination() is not supported.")
+    pending = PendingStop(budget)
+    _pending_stop = pending
+    raising = False
+    try:
+        yield pending
+    except BaseException:
+        raising = True
+        raise
+    finally:
+        # Clearing the registry *first* closes the window between the caller's
+        # last poll and here, in which a signal could otherwise be recorded by a
+        # deferral nobody will poll again: from now on a signal takes the
+        # immediate path, and its `sys.exit` propagates out of this `finally`
+        # rather than letting the teardown below run twice.
+        _pending_stop = None
+        pending.close()
+        if _terminate is None:
+            pass  # no handler installed, so there is nothing to tear down
+        elif pending.requested:
+            # A recorded signal takes precedence over an exception deliberately:
+            # a preemption is not a failure, and `128 + signum` is what the
+            # scheduler and torchrun expect from a rank asked to stop. The cost
+            # is that a rank which recorded a signal *and* raised loses the
+            # raise's exit code.
+            _terminate(pending.exit_code)
+        elif pending.peer_stop:
+            _terminate(_PEER_STOP_EXIT_CODE)
+        elif raising:
+            # Tear down and run the callbacks, then let the exception go on
+            # propagating: without this the rank would exit with its
+            # communicators open, and with a `sys.exit` here the traceback that
+            # brought us here would be replaced by an exit code.
+            _terminate(_EXCEPTION_EXIT_CODE, exit_process=False)
+
+
+class _Deadlines:
+    """The watchdog's deadline and its abort backstop, stood down together.
+
+    The flag, not ``Timer.cancel()``, is what stands the backstop down: a
+    successful abort releases the main thread immediately, so a cancel can arrive
+    while the watchdog thread is still between its abort and its
+    ``backstop.start()``, and ``cancel()`` on an unstarted timer does nothing.
+    The backstop would then start unopposed and exit the process out from under a
+    main thread that had already been released and was writing a checkpoint.
+
+    Constructed empty and given its timers afterwards, because both timers'
+    callbacks close over this object; taking them in ``__init__`` would be
+    circular.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cancelled = False
+        self._deadline: threading.Timer | None = None
+        self._backstop: threading.Timer | None = None
+
+    def set_timers(self, deadline: threading.Timer, backstop: threading.Timer) -> None:
+        with self._lock:
+            self._deadline = deadline
+            self._backstop = backstop
+
+    def arm_backstop(self) -> bool:
+        """Start the backstop, unless a cancel has already landed."""
+        with self._lock:
+            if self._cancelled or self._backstop is None:
+                return False
+            self._backstop.start()
+            return True
+
+    def backstop_may_exit(self) -> bool:
+        """Whether the process may still be exited, i.e. nothing stood us down."""
+        with self._lock:
+            return not self._cancelled
+
+    def cancel(self) -> None:
+        """Stand both timers down, whether or not either has been started."""
+        with self._lock:
+            self._cancelled = True
+            for timer in (self._deadline, self._backstop):
+                if timer is not None:
+                    timer.cancel()
+
+
+def _hard_exit_after(
+    timeout: float,
+    exit_code: int,
+    abort: Callable[[], None] | None = None,
+) -> _Deadlines:
+    """Abort the local communicator, then exit, if the teardown overruns.
 
     A blocked collective does not return to the interpreter, so a Python signal
     handler or ``signal.alarm`` would never run; only a separate thread can
     enforce the deadline.
+
+    Aborting first converts a hard exit taken with this rank's communicators open
+    into an ordered abort of those communicators followed by an exit, and it may
+    release this rank's own main thread from the collective -- in which case the
+    teardown continues gracefully and the backstop stands down. Whether an
+    aborted communicator leaves the fabric better off than one dropped by
+    ``os._exit`` is unverified, and the abort may fault the fabric sooner rather
+    than later, so ``os._exit`` remains as a named backstop and this is reversible
+    on the first GPU evidence.
     """
 
     def give_up() -> None:
+        # Arming *before* the abort, and refusing to arm once a cancel has landed,
+        # is the whole of the race: an abort that releases the main thread lets it
+        # cancel us, and a cancel must never find an unstarted timer.
+        if not deadlines.arm_backstop():
+            # `shutdown` returned as this thread woke: the peers are out, so
+            # there is nothing to abort and nothing to warn about
+            return
+        # the marker before the abort, so a log tells the two outcomes apart
+        write_marker("watchdog-abort", timeout=f"{timeout:.0f}")
         # `os.write` rather than the logger: a handler holds its lock across an
         # emit, so if the signal arrived inside that window the main thread holds
         # it and is now wedged below. Acquiring it from this thread would block
@@ -111,17 +444,41 @@ def _hard_exit_after(timeout: float, exit_code: int) -> threading.Timer:
         os.write(
             2,
             f"Distributed shutdown did not complete within {timeout:.0f}s, "
-            "exiting now. GPUs on this node may need to be reset.\n".encode(),
+            "aborting the local communicator. GPUs on this node may need to be "
+            "reset.\n".encode(),
         )
+        if abort is not None:
+            try:
+                abort()
+            except BaseException:
+                # nothing is left to try, and raising here would only lose the
+                # backstop that follows
+                logger.exception("Failed to abort the local communicator.")
+
+    def backstop_exit() -> None:
+        # Named backstop, not the primary action: if the abort did not release the
+        # main thread, holding the rank until the scheduler's SIGKILL would kill
+        # it with its communicators intact -- the outcome this module exists to
+        # avoid.
+        if not deadlines.backstop_may_exit():
+            # `shutdown` returned after the abort: the main thread is running the
+            # post-shutdown callbacks and must not be exited out from under them
+            return
         os._exit(exit_code)
 
-    timer = threading.Timer(timeout, give_up)
-    timer.daemon = True
-    timer.start()
-    return timer
+    # the two closures above read `deadlines` by name, which is legal so long as
+    # it is bound before either runs -- i.e. before the deadline timer starts
+    deadlines = _Deadlines()
+    deadline_timer = threading.Timer(timeout, give_up)
+    backstop_timer = threading.Timer(_ABORT_BACKSTOP, backstop_exit)
+    deadlines.set_timers(deadline_timer, backstop_timer)
+    deadline_timer.daemon = True
+    backstop_timer.daemon = True
+    deadline_timer.start()
+    return deadlines
 
 
-def _shut_down_backend(shutdown: Callable[[], None], deadline: threading.Timer) -> None:
+def _shut_down_backend(shutdown: Callable[[], None], deadline: _Deadlines) -> None:
     """Release the backend, then stand the watchdog down.
 
     Cancelling here rather than after the callbacks is the point: the moment
@@ -158,6 +515,7 @@ def _run_post_shutdown_callbacks() -> None:
 def handle_termination_signals(
     shutdown: Callable[[], None],
     teardown_timeout: float = DEFAULT_TEARDOWN_TIMEOUT,
+    abort: Callable[[], None] | None = None,
 ) -> Generator[None, None, None]:
     """Shut the distributed backend down before exiting on SIGTERM or SIGINT.
 
@@ -168,6 +526,10 @@ def handle_termination_signals(
         teardown_timeout: Seconds to allow `shutdown` before exiting
             regardless. It does not bound the callbacks that follow; those are
             left to run against the scheduler's clock.
+        abort: Aborts this rank's communicators, called by the watchdog before
+            its hard exit. A callable rather than a process group, so that this
+            module needs no torch import and every claim about signal handling
+            stays testable without a launcher.
     """
     if threading.current_thread() is not threading.main_thread():
         # only the main thread may install handlers; a thread shares the
@@ -185,6 +547,34 @@ def handle_termination_signals(
     installed_pid = os.getpid()
     phase = _Phase.RUNNING
 
+    def terminate(exit_code: int, *, exit_process: bool = True) -> None:
+        """Release the backend, run the callbacks, and exit.
+
+        The only teardown implementation there is, reached either from the
+        handler or from a deferral being left, so the phase transitions are
+        identical whichever entry ran.
+
+        `exit_process=False` is for a caller that is already propagating an
+        exception: everything happens except the final `sys.exit`, so the
+        exception goes on propagating with its traceback intact.
+        """
+        nonlocal phase
+        phase = _Phase.COLLECTIVE
+        started = time.monotonic()
+        # armed inside the argument expression so that `_shut_down_backend`'s
+        # `finally` cancels the exact deadline that bounds it
+        _shut_down_backend(
+            shutdown, _hard_exit_after(teardown_timeout, exit_code, abort)
+        )
+        write_marker("shutdown-returned", elapsed=f"{time.monotonic() - started:.2f}s")
+        phase = _Phase.CALLBACKS
+        try:
+            _run_post_shutdown_callbacks()
+        finally:
+            phase = _Phase.COMPLETE
+        if exit_process:
+            sys.exit(exit_code)
+
     def handle(signum: int, frame: types.FrameType | None) -> None:
         nonlocal phase
         exit_code = 128 + signum
@@ -194,8 +584,25 @@ def handle_termination_signals(
             # every worker would otherwise tear down a fork-inherited process
             # group and re-run the parent's callbacks, racing its checkpoint
             # write. Die as this process would have without the inheritance.
+            #
+            # This guard stays *first*, before the deferral branch below: a worker
+            # that recorded intent and returned would be left alive and deaf,
+            # having neither died as it would have nor gained anyone to poll it.
             signal.signal(signum, signal.SIG_DFL)
             signal.raise_signal(signum)
+            return
+        if phase is _Phase.STOP_REQUESTED:
+            # In production a second SIGTERM is the norm rather than an
+            # escalation: the scheduler signals the container's process group and
+            # torchrun's agent then signals every rank again. Tearing down here
+            # would therefore defeat the deferral on essentially every real
+            # preemption. The pending stop is bounded by the caller's own budget,
+            # so the reasoning at `_Phase.COLLECTIVE` below applies verbatim.
+            write_marker("signal-ignored", signal=signal.Signals(signum).name)
+            logger.info(
+                "Received %s while a stop is already pending; ignoring.",
+                signal.Signals(signum).name,
+            )
             return
         if phase is _Phase.COLLECTIVE:
             # a repeated Ctrl-C, or both the scheduler and torchrun signalling.
@@ -231,25 +638,44 @@ def handle_termination_signals(
             )
             os._exit(exit_code)
             return
-        phase = _Phase.COLLECTIVE
+        pending = _pending_stop
+        if pending is not None:
+            # Somebody is holding a rendezvous open that every rank reaches, so
+            # record the intent and let them leave it together rather than tearing
+            # the backend down from wherever this signal happened to land.
+            phase = _Phase.STOP_REQUESTED
+            pending.request(signum)
+            write_marker("signal-deferred", signal=signal.Signals(signum).name)
+            logger.info(
+                "Received %s, stopping at the next cooperative stopping point.",
+                signal.Signals(signum).name,
+            )
+            return
         logger.info(
             "Received %s, shutting down the distributed backend before exiting.",
             signal.Signals(signum).name,
         )
-        _shut_down_backend(shutdown, _hard_exit_after(teardown_timeout, exit_code))
-        phase = _Phase.CALLBACKS
-        try:
-            _run_post_shutdown_callbacks()
-        finally:
-            phase = _Phase.COMPLETE
-        sys.exit(exit_code)
+        terminate(exit_code)
 
+    global _terminate, _installed_pid, _pending_stop
     previous = {sig: signal.getsignal(sig) for sig in TERMINATION_SIGNALS}
+    previous_terminate = _terminate
+    previous_installed_pid = _installed_pid
+    _terminate = terminate
+    _installed_pid = installed_pid
     for sig in TERMINATION_SIGNALS:
         signal.signal(sig, handle)
     try:
         yield
     finally:
+        # restored rather than cleared, for the same reason the signal
+        # dispositions above are: nesting is legal, and clearing on an inner exit
+        # would leave an outer scope's deferral silently doing nothing
+        _terminate = previous_terminate
+        _installed_pid = previous_installed_pid
+        # cleared rather than restored, because `defer_termination` owns its own
+        # lifetime and reaching here with one registered is a bug, not a nesting
+        _pending_stop = None
         for sig, previous_handler in previous.items():
             signal.signal(sig, previous_handler)
         clear_post_shutdown_callbacks()

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -44,6 +44,65 @@ watchdog, which now aborts the local communicator before its hard exit.
 Deciding *when* a deferred stop is acted on is the caller's, not this module's:
 nothing here knows about process groups or collectives, which is what keeps the
 signal handling testable single-rank and in process.
+
+The ``fme-stop:`` event vocabulary
+----------------------------------
+
+**This is the canonical list of every event any module writes**, kept here because
+this module owns `write_marker`; the other modules point at it rather than
+restating it, and adding an event means adding an entry. Each entry gives the
+writing module, what the event means, and what a reader does with it. Every line
+carries ``rank``, ``local_rank``, ``pid``, ``installed_pid``, ``wall`` and
+``mono`` first, in that order, before the fields named below.
+
+``signal-deferred`` -- this module, `handle_termination_signals`
+    A termination signal was recorded rather than acted on. Its presence on *any*
+    rank is what separates a preemption from a hang.
+``signal-ignored`` -- this module, `handle_termination_signals`
+    A further signal arrived while a stop was already pending. Expected on every
+    real preemption: the scheduler signals the container, then torchrun's agent
+    signals every rank again.
+``shutdown-returned`` -- this module, ``terminate``
+    This rank's collective teardown returned, in ``elapsed``, rather than riding
+    to the scheduler's SIGKILL inside it.
+``hard-exit`` -- this module, ``terminate``
+    The process is ending in ``os._exit`` with ``code``. That code is what a
+    reader has instead of an exit status, no ``SystemExit`` being raised here.
+``deferral-overrun`` -- this module, `_warn_after`
+    A stop stayed pending for twice the budget without reaching a stopping point.
+    This rank may be SIGKILLed with its communicators open, so the node's GPUs may
+    need resetting.
+``watchdog-abort`` -- this module, `_hard_exit_after`
+    The collective teardown overran ``timeout`` and the local communicator is
+    being aborted, so this rank's teardown did not return.
+``watchdog-abort-unavailable`` -- `fme.core.distributed.torch_distributed`
+    The installed torch has no ``ProcessGroup.abort()``, so the watchdog fell
+    straight through to its hard exit. It distinguishes that from an abort that
+    was attempted and failed, which the watchdog would otherwise swallow
+    identically.
+``agreement-bound`` -- `fme.core.distributed.cooperative_stop`
+    Which deadline this rank applied, in ``bound``. ``budget`` is the design's
+    short bound; ``group-timeout`` means it was unavailable on this torch release,
+    so a give-up waits the default group's own timeout -- see
+    `fme.core.distributed.stop_agreement.timeout_contract_verified`.
+``agreement-expired`` -- `fme.core.distributed.cooperative_stop`
+    This rank reached an exchange with its budget already spent, so the floor
+    applied instead. It arrived late, normally out of a checkpoint write.
+``stop-agreed`` -- `fme.core.distributed.cooperative_stop`
+    One exchange completed, carrying ``batch``, ``world`` and ``reason``. **The
+    reader recipe:** count these lines against ``world=`` -- the rank with no line
+    is the one that never reached the boundary.
+``index-mismatch`` -- `fme.core.distributed.cooperative_stop`
+    Ranks contributed different iteration indices, ``min`` and ``max``. Diagnostic
+    only, written once per loop: the loops have desynchronised.
+``agreement-timeout`` -- `fme.core.distributed.cooperative_stop`
+    This rank gave up waiting for a peer that never reached ``batch``. Whether
+    that is a preemption this rank's own signal did not reach or a genuine hang is
+    told by ``signal-deferred`` appearing anywhere in the job's log.
+``agreement-abandoned`` -- `fme.core.distributed.cooperative_stop`
+    The gloo agreement group is held for the life of the process rather than
+    reclaimed. This is the only record of it, and the reason the rank then exits
+    hard.
 """
 
 import contextlib
@@ -54,8 +113,10 @@ import signal
 import sys
 import threading
 import time
+import traceback
 import types
 from collections.abc import Callable, Generator
+from typing import Protocol
 
 from fme.core.device import in_dataloader_worker
 
@@ -111,11 +172,26 @@ _post_shutdown_callbacks: list[Callable[[], None]] = []
 # the right thing everywhere but inside a scope that has a rendezvous of its own.
 _pending_stop: "PendingStop | None" = None
 
+
+class _Terminate(Protocol):
+    """The teardown `handle_termination_signals` publishes.
+
+    A `Protocol` rather than `Callable[..., None]`, which types the positional
+    argument and nothing else: the dispatch in `defer_termination` passes
+    ``exit_process=`` and ``hard=``, and under the looser annotation a misspelled
+    or wrongly-typed keyword there would reach production unchecked.
+    """
+
+    def __call__(
+        self, exit_code: int, *, exit_process: bool = True, hard: bool = False
+    ) -> None: ...
+
+
 # Published by `handle_termination_signals` so that a deferral, which has no
 # access to that function's locals, can run the same teardown the handler would
 # have run. `None` means no handler is installed and there is nothing to tear
 # down -- the state every pytest session is in.
-_terminate: Callable[..., None] | None = None
+_terminate: _Terminate | None = None
 
 # The pid the handler was installed in, so that every marker line can be read
 # against it: a real rank has `pid == installed_pid`, while a fork-started
@@ -354,14 +430,22 @@ class PendingStop:
         """Ask for `os._exit` rather than `sys.exit` once the teardown is done.
 
         For a caller that has left something behind which interpreter finalization
-        cannot dispose of in bounded time. The case this exists for is an abandoned
-        gloo group: ``~ProcessGroupGloo()`` joins the worker thread still holding
-        the abandoned operation, that destructor runs during ``Py_Finalize``, and
-        measured on torch 2.7.1 the wait ends only when the wedged peer's socket
-        closes -- 119.3s against a peer parked for 120s, 24.3s against one parked
-        for 25s, versus 0.05s with `os._exit`. So `sys.exit` hands the rank to
-        torchrun's SIGKILL and the launcher reads a signal death instead of the
-        ``128 + signum`` this module promises.
+        cannot dispose of in bounded time.
+
+        **This is the canonical statement of the measurement the whole hard-exit
+        rule rests on**; every other module and test that needs it refers here
+        rather than restating the figures, so that they cannot drift apart. The case
+        it exists for is an abandoned gloo group: ``~ProcessGroupGloo()`` joins the
+        worker thread still holding the abandoned operation, that destructor runs
+        during ``Py_Finalize``, and measured on torch 2.7.1 the wait ends only when
+        the wedged peer's socket closes -- 119.3s against a peer parked for 120s,
+        24.3s against one parked for 25s, versus 0.05s with `os._exit`. Whether
+        finalization joins that thread or leaks it is not deterministic; the same
+        shape measured through a module global, with only the default group
+        destroyed, leaked it and died in 4.66s under `sys.exit` against 3.02s under
+        `os._exit`. So `sys.exit` can hand the rank to torchrun's SIGKILL, and the
+        launcher then reads a signal death instead of the ``128 + signum`` this
+        module promises.
 
         This does not weaken the rule that a hard exit is the fault to avoid. The
         watchdog's `os._exit` is dangerous because it can drop live communicators
@@ -389,6 +473,40 @@ class PendingStop:
         if overrun is not None:
             # `Timer.cancel` only sets an event, so it cannot raise
             overrun.cancel()
+
+
+def _system_exit_code(code: object) -> int:
+    """The integer ``os._exit`` needs, from a ``SystemExit.code`` that may be anything.
+
+    ``SystemExit.code`` is ``int | str | None`` by CPython's own contract -- the
+    isinstance narrowing here is of a stdlib union this repository does not own, so
+    there is no type to refactor. ``None`` is a clean exit and a string is a message
+    the interpreter would have printed before exiting 1, which is what the hard exit
+    reports instead.
+    """
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    return _EXCEPTION_EXIT_CODE
+
+
+def _print_pending_traceback() -> None:
+    """Print the propagating exception to stderr, because nothing else will.
+
+    Reached only where the dispatch below is about to hard-exit while an exception
+    is unwinding: ``os._exit`` runs inside the ``finally`` that is unwinding it, so
+    the exception never reaches the interpreter's own handler and its traceback
+    would be lost. Keeping that traceback is the only reason the ordinary exception
+    path declines to exit at all, so the hard path prints it here rather than
+    trading it away.
+    """
+    try:
+        traceback.print_exc()
+        sys.stderr.flush()
+    except BaseException:
+        # evidence about a failure may not become a second failure during one
+        pass
 
 
 @contextlib.contextmanager
@@ -440,9 +558,12 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
     _pending_stop = pending
     raising = False
     exiting = False
+    # only meaningful once `exiting`; the caller's own code, so that a hard exit
+    # reports what its `sys.exit` asked for rather than a substitute
+    caller_exit_code = _EXCEPTION_EXIT_CODE
     try:
         yield pending
-    except SystemExit:
+    except SystemExit as err:
         # Not `raising`. A caller leaving by `sys.exit` is asking for the very exit
         # the dispatch below performs rather than surfacing a crash, and there is no
         # traceback to protect -- so it takes the exit path, which is the only one
@@ -450,6 +571,7 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
         # when the loop-entry exchange is given up on, since the loop body must not
         # run against peers that are gone.
         exiting = True
+        caller_exit_code = _system_exit_code(err.code)
         raise
     except BaseException:
         raising = True
@@ -482,11 +604,36 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
             # reaches only the watchdog's hard-exit backstop, so it does not restore
             # that distinction where anything outside the process can read it.
             # Masking a crash as a graceful stop would hide the crash, which is the
-            # worse of the two.
-            _terminate(
-                pending.exit_code if pending.requested else _EXCEPTION_EXIT_CODE,
-                exit_process=False,
-            )
+            # worse of the two. `CooperativeStop._local_reason` gives a recorded
+            # signal the opposite precedence, for the reason set out there, and the
+            # two are consistent: the *reason* peers read is the signal, because the
+            # scheduler signalled the whole group, while the *exit code* this rank
+            # reports is the exception's, because its traceback is the new
+            # information.
+            if pending.hard_exit:
+                # Returning here would leave the rank in interpreter finalization
+                # until the wedged peer dies, and torchrun would SIGKILL it inside
+                # the 30s window -- so the launcher would read a signal death, which
+                # is the very loss the paragraph above calls unacceptable in the
+                # other direction. It would also hold this rank's GPU allocation for
+                # that whole window with its backend already destroyed. The
+                # traceback, which is the only thing `exit_process=False` was
+                # protecting, is printed here instead; the exit code is the
+                # exception's, which is what the propagating exception would have
+                # produced anyway.
+                #
+                # A hard exit is safe *here specifically*, where the watchdog's is
+                # not: `_terminate` takes it only after `shutdown` destroyed the
+                # communicators and after the callbacks ran, so no communicator is
+                # dropped and no work is skipped. There is nothing left for
+                # finalization to do but block.
+                _print_pending_traceback()
+                _terminate(_EXCEPTION_EXIT_CODE, hard=True)
+            else:
+                _terminate(
+                    pending.exit_code if pending.requested else _EXCEPTION_EXIT_CODE,
+                    exit_process=False,
+                )
         elif pending.requested:
             # A recorded signal takes precedence over a peer's deliberately: a
             # preemption is not a failure, and `128 + signum` is what the scheduler
@@ -497,8 +644,14 @@ def defer_termination(budget: float) -> Generator[PendingStop, None, None]:
         elif exiting:
             # A `sys.exit` of the caller's own, with no stop recorded anywhere: tear
             # the backend down and run the callbacks, then let the caller's own code
-            # reach the interpreter, exactly as the exception path does.
-            _terminate(_EXCEPTION_EXIT_CODE, exit_process=False)
+            # reach the interpreter, exactly as the exception path does -- unless a
+            # hard exit was asked for, in which case returning would leave the rank
+            # in finalization until a wedged peer dies. The caller's own exit code is
+            # carried through, since that is what its `sys.exit` asked for.
+            if pending.hard_exit:
+                _terminate(caller_exit_code, hard=True)
+            else:
+                _terminate(_EXCEPTION_EXIT_CODE, exit_process=False)
 
 
 class _Deadlines:
@@ -568,6 +721,11 @@ def _hard_exit_after(
     ``os._exit`` is unverified, and the abort may fault the fabric sooner rather
     than later, so ``os._exit`` remains as a named backstop and this is reversible
     on the first GPU evidence.
+
+    An abort that is unavailable rather than merely unsuccessful is reported
+    separately, because the ``except BaseException`` below cannot tell the two
+    apart: see ``watchdog-abort-unavailable`` in the event vocabulary and
+    `fme.core.distributed.torch_distributed`, which owns the check.
     """
 
     def give_up() -> None:

--- a/fme/core/distributed/stop_agreement.py
+++ b/fme/core/distributed/stop_agreement.py
@@ -1,0 +1,283 @@
+"""Agree across ranks, in bounded time, that a loop is being left.
+
+A rank that decides on its own to leave a batch loop strands its peers: they are
+inside a gradient all-reduce nobody will complete, and a stranded rank can join
+no later collective, so no subsequent agreement can rescue it. The only way two
+ranks can leave at the same iteration is to communicate before either commits to
+entering the next one.
+
+This module owns that communication and nothing else. One
+``all_reduce(MAX)`` of a three-element CPU ``int64`` vector over a dedicated,
+world-wide gloo group, with a deadline the caller chooses per operation. It has
+no signal handling and no notion of *why* a rank is leaving, which is what keeps
+every claim about the collective testable multi-rank without sending a signal
+into a live pytest session.
+
+Two properties are load-bearing and neither is obvious.
+
+**The deadline is per operation, not per group.** A gloo group can neither be
+created with a short timeout -- creation then fails on every rank, asymmetrically,
+on launch jitter alone -- nor shortened afterwards, ``_set_pg_timeout`` being
+silently inert on an already-constructed gloo context. What does work is
+``work.wait(timedelta)``, which raises on expiry. `assert_timeout_contract` is
+what stops a torch upgrade removing that bound silently.
+
+**The group is never reclaimed.** ``~ProcessGroupGloo()`` waits without bound for
+a work queue that an abandoned exchange leaves non-empty, and nothing else drains
+it: gloo overrides neither ``shutdown()`` nor ``abort()``. So a group that has
+been given up on is *held* for the life of the process -- which is also what makes
+``destroy_process_group()`` return, since it only clears torch's own bookkeeping.
+The design's bound after an abandoned exchange is the process exiting, not the
+group coming back.
+"""
+
+import abc
+import datetime
+
+import torch
+import torch.distributed
+
+# The agreement group's own timeout, matching the 30 minutes
+# `torch_distributed.py` gives the default group. Creation is therefore exactly
+# as safe as `init_process_group` itself, and a rank with nothing pending of its
+# own can pass this as its operation deadline without inventing a second number.
+GROUP_TIMEOUT: datetime.timedelta = datetime.timedelta(minutes=30)
+
+# gloo reports a deadline expiry and a peer's socket closing as the same
+# `RuntimeError` type, so the message is the only thing that separates them.
+_TIMEOUT_MESSAGE: str = "Operation timed out!"
+
+# The torch releases whose private timeout behaviours have been read and, where
+# possible, measured: 2.7 is the development environment, 2.8 is what
+# `constraints.txt` pins for the Docker image. Compared as ``(major, minor)`` so a
+# patch bump does not fail a job. A release outside this set has not been checked
+# and may have moved a behaviour the design's only bound rests on.
+_VERIFIED_TORCH: frozenset[tuple[int, int]] = frozenset({(2, 7), (2, 8)})
+
+
+def assert_timeout_contract() -> None:
+    """Fail at group creation if torch's operation-timeout contract may have moved.
+
+    Three behaviours this module's only bound rests on are private torch
+    internals read out of headers rather than documented API:
+    ``work.wait(timedelta)`` raises rather than returning ``False`` on expiry;
+    ``kNoTimeout`` is ``milliseconds(0)``, so a *zero* deadline means *no*
+    deadline; and the pybind chrono caster truncates a ``timedelta`` to integral
+    milliseconds, so a sub-millisecond deadline becomes that same sentinel. None
+    can be probed without a collective made to time out, so what is checked here
+    is the release they were verified against.
+
+    ``_set_pg_timeout`` is the cautionary tale: it exists, is documented, and
+    explicitly handles ``ProcessGroupGloo`` -- and does nothing whatever to an
+    already-constructed gloo context. An upgrade that quietly changed any of the
+    three above would remove the bound just as silently, so this fails loudly
+    instead.
+
+    Raises:
+        RuntimeError: If the installed torch is not one of the verified releases.
+    """
+    major, minor = torch.__version__.split(".")[:2]
+    installed = (int(major), int(minor))
+    if installed not in _VERIFIED_TORCH:
+        verified = ", ".join(
+            f"{major}.{minor}" for major, minor in sorted(_VERIFIED_TORCH)
+        )
+        raise RuntimeError(
+            f"torch {torch.__version__} has not been checked against the "
+            "operation-timeout behaviours the cooperative stop relies on "
+            f"(verified: {verified}). Re-read `work.wait`'s raise on expiry, "
+            "`kNoTimeout` in `Work.hpp`, and the pybind chrono caster's "
+            "millisecond truncation, then add this release to "
+            "`_VERIFIED_TORCH`."
+        )
+
+
+def is_deadline_expiry(err: BaseException) -> bool:
+    """Whether ``work.wait`` raised because its own deadline expired.
+
+    The distinction is load-bearing: a deadline expiry means a peer is wedged and
+    this rank is giving up on it, while ``Connection closed by peer`` means the
+    peer's process has died and the caller should let that surface as the crash it
+    is rather than as a graceful stop. gloo raises the same ``RuntimeError`` type
+    for both, so only the message tells them apart -- which is why
+    `assert_timeout_contract` pins the release that message was read from.
+    """
+    return _TIMEOUT_MESSAGE in str(err)
+
+
+class StopAgreement(abc.ABC):
+    """One deadline-bounded exchange over a group every rank has joined."""
+
+    @property
+    @abc.abstractmethod
+    def world_size(self) -> int:
+        """Ranks taking part, carried so the evidence line can report it."""
+
+    @property
+    @abc.abstractmethod
+    def abandoned(self) -> bool:
+        """Whether an exchange was given up on, leaving work outstanding.
+
+        Once this is true the group can never be reclaimed in bounded time, so
+        the caller owes an ``agreement-abandoned`` evidence line and no code path
+        may drop the group's reference. Always ``False`` on `SoloStopAgreement`,
+        which never blocks.
+        """
+
+    @abc.abstractmethod
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        """Reduce ``[reason, +index, -index]`` with ``MAX``.
+
+        Args:
+            reason: A rank's reason code for leaving, ``0`` meaning it is not.
+                ``MAX`` over these is both a logical OR and a choice of the more
+                serious reason.
+            index: This rank's iteration index. Carried twice, negated once, so
+                the reduction yields both the highest and the lowest index any
+                rank contributed.
+            timeout: Seconds this rank will wait. Always strictly positive: zero
+                is torch's *no-timeout* sentinel rather than an immediate expiry,
+                so passing it would wait for the group's 30 minutes.
+
+        Returns:
+            ``(reason, max_index, min_index)``, the negation on the third element
+            already undone, so the caller's symmetry check is plain equality.
+
+        Raises:
+            RuntimeError: On expiry of ``timeout``, or when a peer's socket
+                closes. `is_deadline_expiry` separates the two.
+            ValueError: If ``timeout`` is not strictly positive.
+        """
+
+
+class GlooStopAgreement(StopAgreement):
+    """A real exchange, over a gloo group this object holds for good.
+
+    The group reference is what makes ``destroy_process_group()`` return: that
+    call clears torch's bookkeeping but drains nothing, and the gloo destructor --
+    the only thing that does drain the work queue, and unbounded -- runs only when
+    the last reference goes.
+    """
+
+    def __init__(self, group: torch.distributed.ProcessGroup, world_size: int) -> None:
+        self._group = group
+        self._world_size = world_size
+        self._abandoned = False
+
+    @property
+    def group(self) -> torch.distributed.ProcessGroup:
+        """The group itself, for a caller that needs to name it to torch.
+
+        Read it, do not keep it: this object's reference is what stops the group
+        being collected, and a caller that outlives it while holding the last
+        reference would run the unbounded destructor.
+        """
+        return self._group
+
+    @property
+    def world_size(self) -> int:
+        return self._world_size
+
+    @property
+    def abandoned(self) -> bool:
+        return self._abandoned
+
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        if timeout <= 0.0:
+            raise ValueError(
+                f"a stop agreement deadline must be positive, got {timeout}: "
+                "torch reads a zero-length timeout as *no* timeout, so this "
+                "would wait for the group's own 30 minutes"
+            )
+        payload = torch.tensor([reason, index, -index], dtype=torch.int64)
+        work = torch.distributed.all_reduce(
+            payload,
+            op=torch.distributed.ReduceOp.MAX,
+            group=self._group,
+            async_op=True,
+        )
+        try:
+            work.wait(datetime.timedelta(seconds=timeout))
+        except BaseException:
+            # The operation stays in gloo's work queue, so this group is now
+            # unreclaimable in bounded time and the caller has to say so.
+            self._abandoned = True
+            raise
+        reduced = payload.tolist()
+        return int(reduced[0]), int(reduced[1]), -int(reduced[2])
+
+
+class SoloStopAgreement(StopAgreement):
+    """One rank, or a DataLoader worker: no group, no collective.
+
+    `exchange` returns the caller's own values unreduced, so ``max_index ==
+    min_index`` holds trivially and no call site needs an ``isinstance`` or a
+    ``| None`` check. It never blocks and never raises.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 1
+
+    @property
+    def abandoned(self) -> bool:
+        return False
+
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        return reason, index, index
+
+
+# Groups that must never be collected, because dropping the last reference to a
+# gloo group with outstanding work blocks in `~ProcessGroupGloo()` without bound.
+# A superseded group is moved here rather than released.
+_leaked: list[StopAgreement] = []
+
+_agreement: StopAgreement | None = None
+
+
+def build_stop_agreement(world_size: int) -> GlooStopAgreement:
+    """Create a new agreement group. Uncached, and a collective on every rank.
+
+    ``new_group`` is itself a collective, so every rank must call this, and in
+    the same order relative to any other ``new_group``. The only production
+    caller is `new_stop_agreement`; the other callers are tests that want a
+    throwaway group of their own.
+
+    Separate from `new_stop_agreement` because a cache and a throwaway test group
+    cannot share one entry point: ``is_initialized()`` does not flip when a test
+    destroys a single group, so a cached accessor would hand the first test the
+    process-wide group -- the session's own -- and every later test a destroyed
+    one.
+
+    Args:
+        world_size: Ranks in the group. Not ``ranks``, which is ``new_group``'s
+            own parameter for a *list* of ranks; this group spans them all.
+    """
+    assert_timeout_contract()
+    group = torch.distributed.new_group(backend="gloo", timeout=GROUP_TIMEOUT)
+    return GlooStopAgreement(group, world_size)
+
+
+def new_stop_agreement(world_size: int) -> StopAgreement:
+    """The process-wide agreement group, created once. What backends call.
+
+    A second call in the same process returns the same group rather than issuing
+    a second ``new_group`` some ranks may not match -- which a backend
+    constructed twice in one process really does reach, since
+    ``DistributedManager.cleanup()`` wipes the state that would otherwise stop
+    it. ``is_initialized()`` is the invalidation predicate because
+    ``destroy_process_group()`` is what flips it, and it clears the bookkeeping
+    that would let the group be reused.
+
+    A superseded group is **moved, not released**: dropping the last reference to
+    a gloo group runs ``~ProcessGroupGloo()``, which waits without bound for a
+    work queue an abandoned exchange may have left non-empty.
+    """
+    global _agreement
+    if _agreement is not None:
+        if torch.distributed.is_initialized():
+            return _agreement
+        # never `_agreement = None`: that is the unbounded block
+        _leaked.append(_agreement)
+    _agreement = build_stop_agreement(world_size)
+    return _agreement

--- a/fme/core/distributed/stop_agreement.py
+++ b/fme/core/distributed/stop_agreement.py
@@ -19,8 +19,10 @@ Two properties are load-bearing and neither is obvious.
 created with a short timeout -- creation then fails on every rank, asymmetrically,
 on launch jitter alone -- nor shortened afterwards, ``_set_pg_timeout`` being
 silently inert on an already-constructed gloo context. What does work is
-``work.wait(timedelta)``, which raises on expiry. `assert_timeout_contract` is
-what stops a torch upgrade removing that bound silently.
+``work.wait(timedelta)``, which raises on expiry. `timeout_contract_verified` is
+what stops a torch upgrade removing that bound silently: on a release the
+behaviour was not read against, the caller degrades to the group's own timeout
+rather than pretending to a bound it may not have.
 
 **The group is never reclaimed.** ``~ProcessGroupGloo()`` waits without bound for
 a work queue that an abandoned exchange leaves non-empty, and nothing else drains
@@ -33,62 +35,169 @@ group coming back.
 
 import abc
 import datetime
+import logging
+import weakref
 
 import torch
 import torch.distributed
 
+from fme.core.device import get_device
+
+logger = logging.getLogger(__name__)
+
 # The agreement group's own timeout, matching the 30 minutes
-# `torch_distributed.py` gives the default group. Creation is therefore exactly
-# as safe as `init_process_group` itself, and a rank with nothing pending of its
-# own can pass this as its operation deadline without inventing a second number.
+# `torch_distributed.py` passes `init_process_group`. Creation is therefore
+# exactly as safe as `init_process_group` itself. It is *not* what a rank with
+# nothing pending of its own passes as an operation deadline -- that comes from
+# `default_group_timeout`, because the default group does not always carry 30
+# minutes.
 GROUP_TIMEOUT: datetime.timedelta = datetime.timedelta(minutes=30)
 
 # gloo reports a deadline expiry and a peer's socket closing as the same
 # `RuntimeError` type, so the message is the only thing that separates them.
+#
+# A substring match is the whole of that discrimination, and it fails silently in
+# both directions: a reworded expiry message would be read as a crash and
+# escalated, and a crash whose message happened to contain this would be read as a
+# wedge and given up on quietly. `_VERIFIED_TORCH` is what makes the first
+# direction safe on the releases the design was checked against, and it is the
+# thing to extend if a release ever reworks the message. The second direction is
+# not guarded at all and was not introduced here.
 _TIMEOUT_MESSAGE: str = "Operation timed out!"
 
 # The torch releases whose private timeout behaviours have been read and, where
 # possible, measured: 2.7 is the development environment, 2.8 is what
-# `constraints.txt` pins for the Docker image. Compared as ``(major, minor)`` so a
-# patch bump does not fail a job. A release outside this set has not been checked
-# and may have moved a behaviour the design's only bound rests on.
+# `constraints.txt` pins for the Docker image, which is what makes the verified
+# path the normal one. Compared as ``(major, minor)`` so a patch bump does not
+# change the answer. Deliberately not widened to releases nobody checked -- the
+# point of `timeout_contract_verified` is that an unverified release degrades to
+# the group's own timeout rather than pretending to a bound it may not have.
 _VERIFIED_TORCH: frozenset[tuple[int, int]] = frozenset({(2, 7), (2, 8)})
 
+# `warn_if_timeout_contract_unverified` writes once per process, not once per
+# group: a job builds one agreement group, but a test session builds many.
+_warned_unverified: bool = False
 
-def assert_timeout_contract() -> None:
-    """Fail at group creation if torch's operation-timeout contract may have moved.
 
-    Three behaviours this module's only bound rests on are private torch
-    internals read out of headers rather than documented API:
-    ``work.wait(timedelta)`` raises rather than returning ``False`` on expiry;
-    ``kNoTimeout`` is ``milliseconds(0)``, so a *zero* deadline means *no*
-    deadline; and the pybind chrono caster truncates a ``timedelta`` to integral
-    milliseconds, so a sub-millisecond deadline becomes that same sentinel. None
-    can be probed without a collective made to time out, so what is checked here
-    is the release they were verified against.
+def timeout_contract_verified() -> bool:
+    """Whether the installed torch is one whose timeout behaviours were checked.
+
+    Three behaviours the design's short bound rests on are private torch internals
+    read out of headers rather than documented API: ``work.wait(timedelta)``
+    raises rather than returning ``False`` on expiry; ``kNoTimeout`` is
+    ``milliseconds(0)``, so a *zero* deadline means *no* deadline; and the pybind
+    chrono caster truncates a ``timedelta`` to integral milliseconds, so a
+    sub-millisecond deadline becomes that same sentinel. None can be probed
+    without a collective made to time out, so what is checked here is the release
+    they were verified against.
 
     ``_set_pg_timeout`` is the cautionary tale: it exists, is documented, and
     explicitly handles ``ProcessGroupGloo`` -- and does nothing whatever to an
     already-constructed gloo context. An upgrade that quietly changed any of the
-    three above would remove the bound just as silently, so this fails loudly
-    instead.
+    three above would remove the bound just as silently.
 
-    Raises:
-        RuntimeError: If the installed torch is not one of the verified releases.
+    **``False`` degrades the mechanism; it never fails a job**, and both other
+    options were tried and are worse. `pyproject.toml` declares ``torch>=2.4.0``,
+    so unverified releases are supported releases, and every distributed job
+    builds an agreement group -- including inference and evaluator runs that never
+    stop cooperatively. Raising at construction breaks all of those: on torch
+    2.6.0, which the multi-rank CPU matrix runs, it errored all 80 parallel tests
+    at setup on all eight configurations. Raising at first use instead moves the
+    failure into a preemption, losing the job at the one moment the teardown
+    matters. So a rank on an unverified release agrees with its peers exactly as
+    usual and passes the default group's own timeout where it would have passed a
+    short one. That is `main`'s behaviour, not a new failure mode: the ranks still
+    leave together, and only the short bound on a rank *giving up* is unavailable.
     """
     major, minor = torch.__version__.split(".")[:2]
-    installed = (int(major), int(minor))
-    if installed not in _VERIFIED_TORCH:
-        verified = ", ".join(
-            f"{major}.{minor}" for major, minor in sorted(_VERIFIED_TORCH)
+    return (int(major), int(minor)) in _VERIFIED_TORCH
+
+
+def warn_if_timeout_contract_unverified() -> None:
+    """Say once per process, where the group is built, that the bound is degraded.
+
+    ``logging`` rather than `write_marker`: keeping this module free of any
+    dependency on the signal-handling half is what keeps every claim about the
+    collective testable multi-rank. `fme/core/logging_utils.py` puts non-root
+    ranks at ERROR, so in a real job this is root's line only -- which is enough
+    for a human, because the version is the same on every rank. The per-rank
+    machine-readable record is `cooperative_stop`'s ``agreement-bound`` marker,
+    emitted where the degraded bound is actually applied.
+    """
+    global _warned_unverified
+    if _warned_unverified or timeout_contract_verified():
+        return
+    _warned_unverified = True
+    verified = ", ".join(f"{major}.{minor}" for major, minor in sorted(_VERIFIED_TORCH))
+    logger.warning(
+        "torch %s has not been checked against the operation-timeout behaviours "
+        "the cooperative stop's short deadline relies on (verified: %s). Ranks "
+        "will still agree on a batch boundary to leave the loop at, but a rank "
+        "that gives up waiting for a peer is bounded only by the default group's "
+        "own timeout rather than by a few seconds. To restore the short bound, "
+        "re-read `work.wait`'s raise on expiry, `kNoTimeout` in `Work.hpp`, and "
+        "the pybind chrono caster's millisecond truncation, then add this release "
+        "to `_VERIFIED_TORCH`.",
+        torch.__version__,
+        verified,
+    )
+
+
+def default_group_timeout() -> float:
+    """Seconds the *default* group -- the gradient all-reduce's -- will wait.
+
+    Read off the group rather than restated, because the two backends configure it
+    differently and a restated figure was wrong for one of them:
+    `torch_distributed.py` passes `GROUP_TIMEOUT` to ``init_process_group``
+    explicitly, while `ModelTorchDistributed` initialises through
+    ``DistributedManager``, which passes none -- so on GPU that group carries
+    NCCL's default 10 minutes, a third of the figure a hardcoded 30 minutes would
+    claim to mirror.
+
+    Falls back to `GROUP_TIMEOUT` where there is no default group to read, which
+    is every single-rank run and every test that builds a `CooperativeStop`
+    without a communicator; there is no gradient all-reduce there to mirror, and
+    the agreement is `SoloStopAgreement`, which never blocks.
+
+    Falls back to it and says so if torch has moved the private attributes this
+    reads. Failing instead would break a training loop at entry over a diagnostic
+    figure, and the fallback is the value this was before it was derived -- so the
+    consequence is that the mirroring claim goes back to being asserted rather than
+    true, which the warning is there to report.
+    """
+    if not torch.distributed.is_initialized():
+        return GROUP_TIMEOUT.total_seconds()
+    try:
+        group = torch.distributed.distributed_c10d._get_default_group()
+        # the device this process computes on is the device the gradient all-reduce
+        # runs on, so it selects the backend whose deadline is the one to mirror
+        backend = group._get_backend(get_device())
+        timeout: datetime.timedelta = backend.options._timeout
+    except (AttributeError, RuntimeError, KeyError):
+        logger.warning(
+            "Could not read the default process group's own timeout, so the "
+            "cooperative stop will use %s for a rank with nothing pending of its "
+            "own. That figure is only correct where the default group carries it; "
+            "under a backend that took torch's own default it is too loose.",
+            GROUP_TIMEOUT,
+            exc_info=True,
         )
-        raise RuntimeError(
-            f"torch {torch.__version__} has not been checked against the "
-            "operation-timeout behaviours the cooperative stop relies on "
-            f"(verified: {verified}). Re-read `work.wait`'s raise on expiry, "
-            "`kNoTimeout` in `Work.hpp`, and the pybind chrono caster's "
-            "millisecond truncation, then add this release to "
-            "`_VERIFIED_TORCH`."
+        return GROUP_TIMEOUT.total_seconds()
+    return timeout.total_seconds()
+
+
+def _check_deadline(timeout: float) -> None:
+    """Reject a deadline torch would read as *no* deadline.
+
+    On every implementation, including `SoloStopAgreement`, so that the contract
+    `StopAgreement.exchange` documents holds for all of them rather than only the
+    one that blocks.
+    """
+    if timeout <= 0.0:
+        raise ValueError(
+            f"a stop agreement deadline must be positive, got {timeout}: "
+            "torch reads a zero-length timeout as *no* timeout, so this "
+            "would wait for the group's own timeout instead"
         )
 
 
@@ -100,7 +209,7 @@ def is_deadline_expiry(err: BaseException) -> bool:
     peer's process has died and the caller should let that surface as the crash it
     is rather than as a graceful stop. gloo raises the same ``RuntimeError`` type
     for both, so only the message tells them apart -- which is why
-    `assert_timeout_contract` pins the release that message was read from.
+    `_VERIFIED_TORCH` pins the releases that message was read from.
     """
     return _TIMEOUT_MESSAGE in str(err)
 
@@ -137,7 +246,10 @@ class StopAgreement(abc.ABC):
                 rank contributed.
             timeout: Seconds this rank will wait. Always strictly positive: zero
                 is torch's *no-timeout* sentinel rather than an immediate expiry,
-                so passing it would wait for the group's 30 minutes.
+                so passing it would wait for the group's own timeout. Checked on
+                every implementation, `SoloStopAgreement` included, so this
+                contract holds for all of them and not only for the one that
+                blocks.
 
         Returns:
             ``(reason, max_index, min_index)``, the negation on the third element
@@ -183,12 +295,7 @@ class GlooStopAgreement(StopAgreement):
         return self._abandoned
 
     def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
-        if timeout <= 0.0:
-            raise ValueError(
-                f"a stop agreement deadline must be positive, got {timeout}: "
-                "torch reads a zero-length timeout as *no* timeout, so this "
-                "would wait for the group's own 30 minutes"
-            )
+        _check_deadline(timeout)
         payload = torch.tensor([reason, index, -index], dtype=torch.int64)
         work = torch.distributed.all_reduce(
             payload,
@@ -212,7 +319,9 @@ class SoloStopAgreement(StopAgreement):
 
     `exchange` returns the caller's own values unreduced, so ``max_index ==
     min_index`` holds trivially and no call site needs an ``isinstance`` or a
-    ``| None`` check. It never blocks and never raises.
+    ``| None`` check. It never blocks, and the only thing it can raise is the
+    deadline check every implementation owes the abstract contract -- which fires
+    on a caller bug rather than on anything a peer did.
     """
 
     @property
@@ -224,6 +333,9 @@ class SoloStopAgreement(StopAgreement):
         return False
 
     def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        # checked despite never waiting, so a deadline this implementation would
+        # have ignored is still caught on the single-rank runs that exercise it
+        _check_deadline(timeout)
         return reason, index, index
 
 
@@ -233,6 +345,14 @@ class SoloStopAgreement(StopAgreement):
 _leaked: list[StopAgreement] = []
 
 _agreement: StopAgreement | None = None
+
+# A weak reference to the default group `_agreement` was built alongside, which is
+# what tells a cached group from one belonging to a world that has been destroyed
+# and re-initialised. Weak deliberately: a strong reference here would make this
+# module the potential last holder of the *default* group, whose destructor carries
+# the same unbounded wait, and a collected referent reads as "not the current
+# world", which is the answer we want anyway.
+_agreement_world: "weakref.ReferenceType[torch.distributed.ProcessGroup] | None" = None
 
 
 def build_stop_agreement(world_size: int) -> GlooStopAgreement:
@@ -244,40 +364,57 @@ def build_stop_agreement(world_size: int) -> GlooStopAgreement:
     throwaway group of their own.
 
     Separate from `new_stop_agreement` because a cache and a throwaway test group
-    cannot share one entry point: ``is_initialized()`` does not flip when a test
-    destroys a single group, so a cached accessor would hand the first test the
-    process-wide group -- the session's own -- and every later test a destroyed
-    one.
+    cannot share one entry point: a cached accessor would hand the first test the
+    process-wide group -- the session's own, which must never be the one a test
+    times out -- and every later test whatever that test left behind.
 
     Args:
         world_size: Ranks in the group. Not ``ranks``, which is ``new_group``'s
             own parameter for a *list* of ranks; this group spans them all.
     """
-    assert_timeout_contract()
+    # here, and not where a deadline is used, because this is the one point every
+    # job reaches exactly once. It warns and returns; see
+    # `timeout_contract_verified` for why it must not raise.
+    warn_if_timeout_contract_unverified()
     group = torch.distributed.new_group(backend="gloo", timeout=GROUP_TIMEOUT)
     return GlooStopAgreement(group, world_size)
 
 
-def new_stop_agreement(world_size: int) -> StopAgreement:
-    """The process-wide agreement group, created once. What backends call.
+def new_stop_agreement(
+    world_size: int, world: torch.distributed.ProcessGroup
+) -> StopAgreement:
+    """The process-wide agreement group, created once per world. What backends call.
 
-    A second call in the same process returns the same group rather than issuing
-    a second ``new_group`` some ranks may not match -- which a backend
+    A second call against the *same* world returns the same group rather than
+    issuing a second ``new_group`` some ranks may not match -- which a backend
     constructed twice in one process really does reach, since
-    ``DistributedManager.cleanup()`` wipes the state that would otherwise stop
-    it. ``is_initialized()`` is the invalidation predicate because
-    ``destroy_process_group()`` is what flips it, and it clears the bookkeeping
-    that would let the group be reused.
+    ``DistributedManager.cleanup()`` wipes the state that would otherwise stop it.
+
+    The invalidation predicate is the identity of the default group, because that
+    is the thing that actually changes: a cached group belongs to the world it was
+    created in, and after a ``destroy_process_group()`` and a fresh
+    ``init_process_group()`` its gloo context is no part of the new world's
+    bookkeeping. ``is_initialized()`` cannot answer this -- every production caller
+    runs immediately after ``init_process_group``, so it is always ``True`` there.
 
     A superseded group is **moved, not released**: dropping the last reference to
     a gloo group runs ``~ProcessGroupGloo()``, which waits without bound for a
     work queue an abandoned exchange may have left non-empty.
+
+    Args:
+        world_size: Ranks in the group, which spans the whole world.
+        world: The default group this agreement will belong to. Passed rather than
+            looked up so the caller's own ``_get_default_group()`` -- which every
+            caller already makes, to hold for the teardown watchdog -- is the one
+            identity in play.
     """
-    global _agreement
+    global _agreement, _agreement_world
     if _agreement is not None:
-        if torch.distributed.is_initialized():
+        cached = None if _agreement_world is None else _agreement_world()
+        if cached is world:
             return _agreement
         # never `_agreement = None`: that is the unbounded block
         _leaked.append(_agreement)
     _agreement = build_stop_agreement(world_size)
+    _agreement_world = weakref.ref(world)
     return _agreement

--- a/fme/core/distributed/stop_agreement.py
+++ b/fme/core/distributed/stop_agreement.py
@@ -33,11 +33,10 @@ The design's bound after an abandoned exchange is the process exiting, not the
 group coming back.
 
 That destructor also runs during ``Py_Finalize``, so "the process exiting" has to
-mean ``os._exit`` and not ``sys.exit``: measured on torch 2.7.1 with a peer parked
-for 120s, a rank that abandoned an exchange and then called ``sys.exit`` died after
-119.3s, when the peer's socket closed, against 0.05s for ``os._exit``. The caller
-that abandons an exchange is the one that owes that hard exit; see
-`fme.core.distributed.cooperative_stop`.
+mean ``os._exit`` and not ``sys.exit``. The measurement behind that is stated once,
+in `fme.core.distributed.shutdown.PendingStop.require_hard_exit`, and referred to
+from here rather than repeated. The caller that abandons an exchange is the one that
+owes the hard exit; see `fme.core.distributed.cooperative_stop`.
 """
 
 import abc
@@ -393,10 +392,11 @@ def build_stop_agreement(world_size: int) -> GlooStopAgreement:
         world_size: Ranks in the group. Not ``ranks``, which is ``new_group``'s
             own parameter for a *list* of ranks; this group spans them all. Checked
             against the group rather than trusted, because it is only ever read back
-            out as the ``world=`` field of an evidence line -- a reader counts
-            ``stop-agreed`` lines against it to find the rank that never reached the
-            boundary, so a value disagreeing with the group would make the absence
-            unreadable, and nothing else would ever notice.
+            out as the ``world=`` field of a ``stop-agreed`` evidence line, which a
+            reader counts lines against -- see the event vocabulary in
+            `fme.core.distributed.shutdown` for that recipe. A value disagreeing with
+            the group would make the missing rank unreadable, and nothing else would
+            ever notice.
 
     Raises:
         ValueError: If ``world_size`` disagrees with the group. A caller bug rather

--- a/fme/core/distributed/stop_agreement.py
+++ b/fme/core/distributed/stop_agreement.py
@@ -31,6 +31,13 @@ been given up on is *held* for the life of the process -- which is also what mak
 ``destroy_process_group()`` return, since it only clears torch's own bookkeeping.
 The design's bound after an abandoned exchange is the process exiting, not the
 group coming back.
+
+That destructor also runs during ``Py_Finalize``, so "the process exiting" has to
+mean ``os._exit`` and not ``sys.exit``: measured on torch 2.7.1 with a peer parked
+for 120s, a rank that abandoned an exchange and then called ``sys.exit`` died after
+119.3s, when the peer's socket closed, against 0.05s for ``os._exit``. The caller
+that abandons an exchange is the one that owes that hard exit; see
+`fme.core.distributed.cooperative_stop`.
 """
 
 import abc
@@ -108,9 +115,23 @@ def timeout_contract_verified() -> bool:
     usual and passes the default group's own timeout where it would have passed a
     short one. That is `main`'s behaviour, not a new failure mode: the ranks still
     leave together, and only the short bound on a rank *giving up* is unavailable.
+
+    A version string this cannot parse reads as unverified for the same reason. The
+    fields are not a documented format -- a nightly, a vendor build or a release
+    candidate can put a suffix where the minor version goes -- and letting
+    ``int()`` raise here would raise from `build_stop_agreement`, i.e. from backend
+    construction, which is exactly the failure this function exists to avoid. It
+    does not warn about that itself -- a predicate called once per loop is the wrong
+    place for a log line, and `warn_if_timeout_contract_unverified` already reports
+    the degradation once per process, naming the version it could not place.
     """
-    major, minor = torch.__version__.split(".")[:2]
-    return (int(major), int(minor)) in _VERIFIED_TORCH
+    major, _, rest = torch.__version__.partition(".")
+    minor, _, _ = rest.partition(".")
+    try:
+        version = (int(major), int(minor))
+    except ValueError:
+        return False
+    return version in _VERIFIED_TORCH
 
 
 def warn_if_timeout_contract_unverified() -> None:
@@ -370,13 +391,31 @@ def build_stop_agreement(world_size: int) -> GlooStopAgreement:
 
     Args:
         world_size: Ranks in the group. Not ``ranks``, which is ``new_group``'s
-            own parameter for a *list* of ranks; this group spans them all.
+            own parameter for a *list* of ranks; this group spans them all. Checked
+            against the group rather than trusted, because it is only ever read back
+            out as the ``world=`` field of an evidence line -- a reader counts
+            ``stop-agreed`` lines against it to find the rank that never reached the
+            boundary, so a value disagreeing with the group would make the absence
+            unreadable, and nothing else would ever notice.
+
+    Raises:
+        ValueError: If ``world_size`` disagrees with the group. A caller bug rather
+            than anything environmental -- every production caller passes the size
+            it has just read from torch -- which is why this may raise where
+            `warn_if_timeout_contract_unverified` may not.
     """
     # here, and not where a deadline is used, because this is the one point every
     # job reaches exactly once. It warns and returns; see
     # `timeout_contract_verified` for why it must not raise.
     warn_if_timeout_contract_unverified()
     group = torch.distributed.new_group(backend="gloo", timeout=GROUP_TIMEOUT)
+    actual = torch.distributed.get_world_size(group)
+    if actual != world_size:
+        raise ValueError(
+            f"the stop agreement group spans the whole world, so it has {actual} "
+            f"ranks, but it was told {world_size}; the evidence lines' `world=` "
+            "field is read off this figure"
+        )
     return GlooStopAgreement(group, world_size)
 
 

--- a/fme/core/distributed/test_cooperative_stop.py
+++ b/fme/core/distributed/test_cooperative_stop.py
@@ -11,7 +11,6 @@ They are unmarked, so they run in every tier including ``--very-fast``, and each
 takes milliseconds.
 """
 
-import importlib
 import logging
 import os
 import signal
@@ -42,12 +41,6 @@ from fme.core.distributed.shutdown import (
 from fme.core.distributed.stop_agreement import StopAgreement, is_deadline_expiry
 
 _BARRIER_TIMEOUT = 5.0
-
-# `from fme.core.distributed import cooperative_stop` binds the re-exported
-# *function* of that name, and setting an attribute on that patches nothing
-cooperative_stop_module = importlib.import_module(
-    "fme.core.distributed.cooperative_stop"
-)
 
 # What gloo says when a peer's process has died and closed its socket, as opposed to
 # when a deadline expired. Copied from a real gloo message rather than invented,
@@ -209,6 +202,19 @@ def _stop(
     return CooperativeStop(pending, agreement, first_index=first_index), pending
 
 
+def _record_signal_without_a_timer(pending: PendingStop) -> None:
+    """Record a signal as `PendingStop.request` does, minus its diagnostic timer.
+
+    `request` also arms `_warn_after` at twice the budget, and for the already-spent
+    budgets below that timer is due the moment it is armed -- so it fires at once and
+    writes ``deferral-overrun`` plus a "GPUs on this node may need to be reset" line
+    into whatever a *later* test happens to be capturing. What those tests are about
+    is the deadline, so the timer is left out rather than raced against.
+    """
+    pending.requested = True
+    pending.arm_budget()
+
+
 def test_stop_is_agreed_at_the_same_index_on_every_logical_rank():
     """Every rank leaves having completed the same number of batches.
 
@@ -226,16 +232,20 @@ def test_stop_is_agreed_at_the_same_index_on_every_logical_rank():
 
     def run(rank: int) -> None:
         stop, pending = _stop(agreement)
-        count = 0
-        for index in range(20):
-            if notice_at.get(rank) == index:
-                pending.request(signal.SIGTERM)
-            count += 1
-            if stop.agreed(index):
-                break
-        completed[rank] = count
-        reasons[rank] = StopReason.SIGNAL if pending.requested else None
-        pending.close()
+        try:
+            count = 0
+            for index in range(20):
+                if notice_at.get(rank) == index:
+                    pending.request(signal.SIGTERM)
+                count += 1
+                if stop.agreed(index):
+                    break
+            completed[rank] = count
+            reasons[rank] = StopReason.SIGNAL if pending.requested else None
+        finally:
+            # even where the body raised: an uncancelled 20s timer outlives this
+            # test and writes into a later test's captured stderr
+            pending.close()
 
     threads = [threading.Thread(target=run, args=(rank,)) for rank in range(world_size)]
     for thread in threads:
@@ -315,7 +325,7 @@ def test_an_expired_budget_exchanges_at_the_floor(capfd):
     """
     agreement = _SpyAgreement()
     stop, pending = _stop(agreement, budget=-1.0)  # already expired when armed
-    pending.request(signal.SIGTERM)
+    _record_signal_without_a_timer(pending)
     try:
         # true, not false: this rank contributed `SIGNAL` and a real `MAX` returns
         # at least that. What the test is about is the deadline, below.
@@ -329,7 +339,7 @@ def test_an_expired_budget_exchanges_at_the_floor(capfd):
     # a sub-millisecond remainder takes the same path rather than degenerating
     sliver = _SpyAgreement()
     stop, pending = _stop(sliver, budget=0.0004)
-    pending.request(signal.SIGTERM)
+    _record_signal_without_a_timer(pending)
     try:
         stop.agreed(8)
     finally:
@@ -340,33 +350,34 @@ def test_an_expired_budget_exchanges_at_the_floor(capfd):
     assert all(timeout > 0.0 for timeout in agreement.timeouts + sliver.timeouts)
 
 
-def test_an_index_mismatch_is_reported_once_and_does_not_force_a_stop(
-    capfd, monkeypatch
-):
+def test_an_index_mismatch_is_reported_once_per_scope_and_forces_no_stop(capfd):
     """The symmetry check is diagnostic only, deliberately, and it says so once.
 
     A desynchronised run is going to hang anyway, and a new mechanism
     unilaterally terminating healthy-looking jobs on a self-diagnosis is a worse
     failure mode than the one it reports.
 
-    Once per process, because the condition does not un-happen and the run it
-    reports is one where every rank would otherwise emit a line per batch -- tens of
-    thousands of them, on exactly the log a reader is trying to get through.
+    Once per *scope*, not once per boundary and not once per process. Per boundary
+    would put a line per batch on exactly the log a reader is trying to get through.
+    Per process -- which this was -- would make a fresh desynchronisation at epoch 50
+    of a multi-day run silent because epoch 1 had already reported one, and this is
+    the design's only self-verification.
     """
-    monkeypatch.setattr(cooperative_stop_module, "_reported_index_mismatch", False)
     agreement = _SpyAgreement(reason=0, high=12, low=11)
     stop, pending = _stop(agreement)
 
     assert stop.agreed(11) is False
     assert stop.agreed(12) is False
-    # a second loop in the same process, which is a second epoch in a real job
+    # a second loop in the same process, which is a second epoch in a real job, and
+    # it reports its own mismatch rather than inheriting the first one's silence
     later, later_pending = _stop(_SpyAgreement(reason=0, high=20, low=19))
     assert later.agreed(19) is False
 
     captured = capfd.readouterr().err
     mismatch = _marker_lines("index-mismatch", captured)
-    assert len(mismatch) == 1
+    assert len(mismatch) == 2, "one line per scope, not one per boundary or process"
     assert "min=11" in mismatch[0] and "max=12" in mismatch[0]
+    assert "min=19" in mismatch[1] and "max=20" in mismatch[1]
     assert _marker_lines("stop-agreed", captured) == []
     pending.close()
     later_pending.close()
@@ -503,6 +514,67 @@ def test_a_peer_exception_raises_rather_than_stopping_quietly():
     assert pending.peer_stop is False, "an exception is not a peer's signal"
 
 
+def test_a_signalled_rank_that_also_raises_contributes_signal_not_exception(capfd):
+    """A recorded signal wins over an exception, so peers read a preemption.
+
+    This is the combination the design says is *usual* -- the scheduler signals the
+    whole process group, so a rank whose peer has already gone is carrying a
+    ``Connection closed by peer`` and has recorded a signal too -- and it was the one
+    combination nothing exercised. The behaviour is deliberate and is what this pins:
+    the signal is the root cause when both are present, so the raising rank
+    contributes ``SIGNAL``, its peers take a clean preemption rather than
+    `PeerStopRequested`, and ``reason=EXCEPTION`` never appears. The raising rank
+    still exits 1 through `defer_termination`'s exception branch, so the job is
+    visibly failed at process level.
+    """
+    spy = _SpyAgreement()
+    stop, pending = _stop(spy, first_index=9)
+    pending.request(signal.SIGTERM)
+    try:
+        stop.close(stop.next_index())
+    finally:
+        pending.close()
+    assert spy.calls[0][0] == StopReason.SIGNAL.value, "the exception won the reason"
+
+    # and against a real `MAX` over two logical ranks, the peer reads a preemption
+    agreement = _LockstepAgreement(2)
+    outcome: dict[str, object] = {}
+
+    def signalled_and_raising() -> None:
+        raising_stop, raising_pending = _stop(agreement, first_index=9)
+        raising_pending.request(signal.SIGTERM)
+        try:
+            # the shape `_cooperative_scope`'s exception rider produces
+            raising_stop.close(raising_stop.next_index())
+        finally:
+            raising_pending.close()
+
+    def peer() -> None:
+        peer_stop, peer_pending = _stop(agreement, first_index=9)
+        try:
+            outcome["left"] = peer_stop.agreed(9)
+        except BaseException as err:  # a thread's exception would be lost
+            outcome["raised"] = err
+        finally:
+            peer_pending.close()
+
+    threads = [
+        threading.Thread(target=signalled_and_raising),
+        threading.Thread(target=peer),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=_BARRIER_TIMEOUT * 2)
+
+    assert "raised" not in outcome, outcome.get("raised")
+    assert outcome["left"] is True
+    agreed = _marker_lines("stop-agreed", capfd.readouterr().err)
+    assert agreed, "neither rank reported the exchange"
+    assert all("reason=SIGNAL" in line for line in agreed), agreed
+    assert not any("reason=EXCEPTION" in line for line in agreed), agreed
+
+
 def test_the_exit_exchange_happens_only_when_a_rank_originates_one():
     """`close` exchanges iff this rank is originating a stop its peers cannot know.
 
@@ -588,7 +660,7 @@ def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd, monkeypatc
             with defer_termination(budget=1.0) as pending:
                 assert (
                     pending.seconds_remaining() is None
-                ), "a budget is armed, so this is not the no-local-event path"
+                ), "no budget is armed, so this is the no-local-event path"
                 with _cooperative_scope(pending, agreement) as stop:
                     for index in range(10):
                         if stop.agreed(index):
@@ -601,7 +673,7 @@ def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd, monkeypatc
     assert excinfo.value.code == 128 + signal.SIGTERM
     assert (
         pending.requested is False
-    ), "a signal was recorded, so this is not the no-local-event path"
+    ), "no signal was recorded, so this is the no-local-event path"
     assert pending.peer_stop is True
     stderr = capfd.readouterr().err
     assert len(_marker_lines("agreement-timeout", stderr)) == 1

--- a/fme/core/distributed/test_cooperative_stop.py
+++ b/fme/core/distributed/test_cooperative_stop.py
@@ -1,0 +1,383 @@
+"""Tier 1: the agreement algorithm, single process, no process group at all.
+
+These tests never create a communicator. The agreement is a scripted or
+lockstep-threaded stand-in, which is legitimate because what is under test is the
+algorithm -- which deadline a rank applies, which index it contributes, what it
+does with a reduced value. Every claim that turns on a real collective lives in
+`parallel_tests/test_cooperative_stop.py`, and the exit paths live in
+`test_cooperative_stop_exit.py`.
+
+They are unmarked, so they run in every tier including ``--very-fast``, and each
+takes milliseconds.
+"""
+
+import signal
+import threading
+import time
+import weakref
+
+import pytest
+
+from fme.core.distributed import stop_agreement as stop_agreement_module
+from fme.core.distributed.cooperative_stop import (
+    _MIN_DEADLINE,
+    NO_LOCAL_EVENT_DEADLINE,
+    CooperativeStop,
+    PeerStopRequested,
+)
+from fme.core.distributed.shutdown import PendingStop, StopReason
+from fme.core.distributed.stop_agreement import StopAgreement
+
+_BARRIER_TIMEOUT = 5.0
+
+
+def _marker_lines(event: str, captured: str) -> list[str]:
+    prefix = f"fme-stop:{event} "
+    return [line for line in captured.splitlines() if line.startswith(prefix)]
+
+
+class _SpyAgreement(StopAgreement):
+    """Records every exchange and returns whatever the test scripted."""
+
+    def __init__(
+        self, reason: int = 0, high: int | None = None, low: int | None = None
+    ):
+        self.calls: list[tuple[int, int, float]] = []
+        self._reason = reason
+        self._high = high
+        self._low = low
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @property
+    def abandoned(self) -> bool:
+        return False
+
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        self.calls.append((reason, index, timeout))
+        high = index if self._high is None else self._high
+        low = index if self._low is None else self._low
+        return self._reason, high, low
+
+    @property
+    def timeouts(self) -> list[float]:
+        return [timeout for _, _, timeout in self.calls]
+
+
+class _LockstepAgreement(StopAgreement):
+    """A real ``MAX`` over several logical ranks running as threads.
+
+    One thread per logical rank, meeting at a `threading.Condition`, so the
+    reduction is genuinely across ranks and genuinely simultaneous -- which is
+    what the claim under test is about -- without a launcher or a communicator.
+    """
+
+    def __init__(self, world_size: int):
+        self._world_size = world_size
+        self._round = 0
+        self._contributions: list[tuple[int, int, int]] = []
+        # kept per round rather than overwritten, so a fast rank starting the next
+        # round cannot make a slow one read the wrong answer
+        self._reduced: dict[int, tuple[int, int, int]] = {}
+        self._met = threading.Condition()
+
+    @property
+    def world_size(self) -> int:
+        return self._world_size
+
+    @property
+    def abandoned(self) -> bool:
+        return False
+
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        with self._met:
+            this_round = self._round
+            self._contributions.append((reason, index, -index))
+            if len(self._contributions) == self._world_size:
+                contributions = self._contributions
+                self._reduced[this_round] = (
+                    max(payload[0] for payload in contributions),
+                    max(payload[1] for payload in contributions),
+                    max(payload[2] for payload in contributions),
+                )
+                self._contributions = []
+                self._round += 1
+                self._met.notify_all()
+            else:
+                give_up_at = time.monotonic() + _BARRIER_TIMEOUT
+                while this_round not in self._reduced:
+                    if time.monotonic() > give_up_at:
+                        raise AssertionError(
+                            f"only {len(self._contributions)} of "
+                            f"{self._world_size} logical ranks reached round "
+                            f"{this_round}"
+                        )
+                    self._met.wait(0.05)
+            reduced = self._reduced[this_round]
+        return reduced[0], reduced[1], -reduced[2]
+
+
+def _stop(
+    agreement: StopAgreement, budget: float = 10.0, first_index: int = 0
+) -> tuple[CooperativeStop, PendingStop]:
+    pending = PendingStop(budget)
+    return CooperativeStop(pending, agreement, first_index=first_index), pending
+
+
+def test_stop_is_agreed_at_the_same_index_on_every_logical_rank():
+    """Every rank leaves having completed the same number of batches.
+
+    This is the whole point of the mechanism, and the reason a flag alone will
+    not do: ranks notice at different indices -- legitimately, because root
+    spends seconds inside a periodic checkpoint write while its peers do not --
+    so the noticing indices have to be collapsed to one value by communication
+    before any rank commits to entering the next iteration.
+    """
+    world_size = 4
+    notice_at = {0: 3, 2: 5}
+    agreement = _LockstepAgreement(world_size)
+    completed: dict[int, int] = {}
+    reasons: dict[int, StopReason | None] = {}
+
+    def run(rank: int) -> None:
+        stop, pending = _stop(agreement)
+        count = 0
+        for index in range(20):
+            if notice_at.get(rank) == index:
+                pending.request(signal.SIGTERM)
+            count += 1
+            if stop.agreed(index):
+                break
+        completed[rank] = count
+        reasons[rank] = StopReason.SIGNAL if pending.requested else None
+        pending.close()
+
+    threads = [threading.Thread(target=run, args=(rank,)) for rank in range(world_size)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=_BARRIER_TIMEOUT * 2)
+
+    assert len(completed) == world_size
+    # the earliest noticing index is 3, so every rank completes batches 0-3
+    assert set(completed.values()) == {4}
+    # and only the rank that was signalled recorded a signal; the others joined
+    # the very exchange their peer entered
+    assert reasons == {0: StopReason.SIGNAL, 1: None, 2: None, 3: None}
+
+
+def test_a_rank_with_no_signal_applies_the_group_deadline():
+    """The false-positive guard, at unit level.
+
+    A short deadline on a healthy rank fires on a healthy job and hard-exits it,
+    causing the exact fabric fault this mechanism exists to prevent. So a rank
+    with no local event of its own passes the group's own 30 minutes, which
+    equals the deadline the gradient all-reduce already carries and therefore
+    cannot fire on a job that is not already dead.
+    """
+    agreement = _SpyAgreement()
+    stop, pending = _stop(agreement, budget=10.0)
+
+    assert stop.agreed(0) is False
+    assert stop.agreed(1) is False
+    assert agreement.timeouts == [NO_LOCAL_EVENT_DEADLINE, NO_LOCAL_EVENT_DEADLINE]
+
+    pending.request(signal.SIGTERM)
+    stop.agreed(2)
+    pending.close()
+
+    assert agreement.timeouts[2] < NO_LOCAL_EVENT_DEADLINE
+    assert agreement.timeouts[2] == pytest.approx(10.0, abs=0.5)
+
+
+def test_the_budget_is_absolute_from_the_local_event_not_per_boundary():
+    """A rank cannot accumulate a fresh budget at each of several boundaries.
+
+    If it could, a rank passing several boundaries while a peer never arrives
+    would wait indefinitely in budget-sized steps, and the bound the design
+    claims would not exist.
+    """
+    agreement = _SpyAgreement()
+    stop, pending = _stop(agreement, budget=10.0)
+    pending.request(signal.SIGTERM)
+    try:
+        for index in range(3):
+            time.sleep(0.02)
+            stop.agreed(index)
+    finally:
+        pending.close()
+
+    assert agreement.timeouts == sorted(agreement.timeouts, reverse=True)
+    assert agreement.timeouts[0] > agreement.timeouts[-1]
+    # and every one of them is a remainder of the same 10s, not a fresh 10s
+    assert all(timeout < 10.0 for timeout in agreement.timeouts)
+
+
+def test_an_expired_budget_exchanges_at_the_floor(capfd):
+    """A spent budget means this rank was late, not that a peer was missing.
+
+    So it still exchanges -- in the dominant case its peers are already blocked
+    in that exchange and it returns in microseconds -- and the deadline is
+    floored. The floor is not cosmetic: torch reads a zero-length timeout as *no*
+    timeout, and the pybind caster truncates a `timedelta` to integral
+    milliseconds, so an unfloored sliver of budget would wait 30 minutes.
+    """
+    agreement = _SpyAgreement()
+    stop, pending = _stop(agreement, budget=-1.0)  # already expired when armed
+    pending.request(signal.SIGTERM)
+    try:
+        assert stop.agreed(7) is False
+    finally:
+        pending.close()
+
+    assert agreement.timeouts == [_MIN_DEADLINE]
+    assert len(_marker_lines("agreement-expired", capfd.readouterr().err)) == 1
+
+    # a sub-millisecond remainder takes the same path rather than degenerating
+    sliver = _SpyAgreement()
+    stop, pending = _stop(sliver, budget=0.0004)
+    pending.request(signal.SIGTERM)
+    try:
+        stop.agreed(8)
+    finally:
+        pending.close()
+
+    assert sliver.timeouts == [_MIN_DEADLINE]
+    # no deadline anywhere is ever zero, on any path
+    assert all(timeout > 0.0 for timeout in agreement.timeouts + sliver.timeouts)
+
+
+def test_an_index_mismatch_is_reported_and_does_not_force_a_stop(capfd):
+    """The symmetry check is diagnostic only, deliberately.
+
+    A desynchronised run is going to hang anyway, and a new mechanism
+    unilaterally terminating healthy-looking jobs on a self-diagnosis is a worse
+    failure mode than the one it reports.
+    """
+    agreement = _SpyAgreement(reason=0, high=12, low=11)
+    stop, pending = _stop(agreement)
+
+    assert stop.agreed(11) is False
+
+    captured = capfd.readouterr().err
+    mismatch = _marker_lines("index-mismatch", captured)
+    assert len(mismatch) == 1
+    assert "min=11" in mismatch[0] and "max=12" in mismatch[0]
+    assert _marker_lines("stop-agreed", captured) == []
+    pending.close()
+
+
+def test_a_superseded_agreement_group_is_leaked_not_released(monkeypatch):
+    """Reclaiming an agreement group is the one thing the design must never do.
+
+    Dropping the last reference to a gloo group runs ``~ProcessGroupGloo()``,
+    which waits without bound for a work queue an abandoned exchange leaves
+    non-empty -- and nothing else drains it, gloo overriding neither
+    ``shutdown()`` nor ``abort()``. So a superseded group is *moved* to a
+    process-lifetime list, never replaced with ``None``.
+    """
+    built: list[_SpyAgreement] = []
+
+    def build(world_size: int) -> _SpyAgreement:
+        agreement = _SpyAgreement()
+        built.append(agreement)
+        return agreement
+
+    monkeypatch.setattr(stop_agreement_module, "build_stop_agreement", build)
+    monkeypatch.setattr(stop_agreement_module, "_agreement", None)
+    monkeypatch.setattr(stop_agreement_module, "_leaked", [])
+    # the invalidation predicate: a torn-down process group means the cached
+    # group's bookkeeping is gone and it can never be used again
+    monkeypatch.setattr(
+        stop_agreement_module.torch.distributed, "is_initialized", lambda: False
+    )
+
+    first = stop_agreement_module.new_stop_agreement(4)
+    alive = weakref.ref(first)
+    second = stop_agreement_module.new_stop_agreement(4)
+
+    assert second is not first
+    assert stop_agreement_module._leaked == [first]
+    del first
+    assert alive() is not None, "the superseded group was released, which can hang"
+
+    # and while the process group is up, the same group is returned rather than a
+    # second unmatched `new_group`
+    monkeypatch.setattr(
+        stop_agreement_module.torch.distributed, "is_initialized", lambda: True
+    )
+    assert stop_agreement_module.new_stop_agreement(4) is second
+    assert len(built) == 2
+
+
+def test_a_peer_exception_raises_rather_than_stopping_quietly():
+    """A peer unwinding is not a preemption, and must not be reported as one.
+
+    The reduced reason carries which it is, so a rank with nothing pending of its
+    own learns that it has joined an exception-driven stop and unwinds too --
+    exiting non-zero, so torchrun reports a failure rather than a clean stop.
+    """
+    agreement = _SpyAgreement(reason=StopReason.EXCEPTION.value)
+    stop, pending = _stop(agreement)
+
+    with pytest.raises(PeerStopRequested):
+        stop.agreed(4)
+
+    assert pending.peer_stop is False, "an exception is not a peer's signal"
+
+
+def test_the_exit_exchange_happens_only_when_a_rank_originates_one():
+    """`close` exchanges iff this rank is originating a stop its peers cannot know.
+
+    A rank leaving because it *observed* a stop would otherwise issue an
+    unmatched exchange against a peer that has already left -- and with nothing
+    pending of its own it would carry the group's 30 minutes, so it would sit
+    there.
+    """
+    observed = _SpyAgreement(reason=StopReason.SIGNAL.value)
+    stop, pending = _stop(observed)
+    assert stop.agreed(3) is True  # sets `_agreed`
+    stop.close(StopReason.EXCEPTION, stop.next_index())
+    assert len(observed.calls) == 1, "an observer must not exchange on the way out"
+    pending.close()
+
+    clean = _SpyAgreement()
+    stop, pending = _stop(clean)
+    stop.agreed(0)
+    stop.close(StopReason.NONE, stop.next_index())
+    assert len(clean.calls) == 1, "a clean end of loop must not exchange either"
+    pending.close()
+
+    originating = _SpyAgreement(reason=StopReason.EXCEPTION.value)
+    stop, pending = _stop(originating, first_index=5)
+    assert pending.seconds_remaining() is None
+    stop.close(StopReason.EXCEPTION, stop.next_index())
+    # the index its peers will contribute, not its own lagging counter
+    assert originating.calls[0][:2] == (StopReason.EXCEPTION.value, 5)
+    # and the raise is a local event, so the exchange carried a short deadline
+    assert originating.timeouts[0] < NO_LOCAL_EVENT_DEADLINE
+    pending.close()
+
+
+def test_close_never_raises_even_when_the_exchange_does():
+    """It is called from ``except BaseException: close(...); raise``.
+
+    On the mid-iteration path the exchange is *expected* to time out, so a
+    raising `close` would replace the original exception with a timeout and
+    defeat the whole point of leaving the traceback intact.
+    """
+
+    class _Failing(_SpyAgreement):
+        def exchange(self, reason, index, timeout):
+            super().exchange(reason, index, timeout)
+            raise RuntimeError("Operation timed out!")
+
+    agreement = _Failing()
+    stop, pending = _stop(agreement)
+
+    stop.close(StopReason.EXCEPTION, stop.next_index())
+
+    assert len(agreement.calls) == 1
+    pending.close()

--- a/fme/core/distributed/test_cooperative_stop.py
+++ b/fme/core/distributed/test_cooperative_stop.py
@@ -11,24 +11,39 @@ They are unmarked, so they run in every tier including ``--very-fast``, and each
 takes milliseconds.
 """
 
+import logging
 import signal
 import threading
 import time
 import weakref
+from typing import cast
 
 import pytest
+import torch
+import torch.distributed
 
 from fme.core.distributed import stop_agreement as stop_agreement_module
 from fme.core.distributed.cooperative_stop import (
     _MIN_DEADLINE,
-    NO_LOCAL_EVENT_DEADLINE,
     CooperativeStop,
     PeerStopRequested,
+    _cooperative_scope,
+    no_local_event_deadline,
 )
-from fme.core.distributed.shutdown import PendingStop, StopReason
+from fme.core.distributed.shutdown import (
+    PendingStop,
+    StopReason,
+    defer_termination,
+    handle_termination_signals,
+)
 from fme.core.distributed.stop_agreement import StopAgreement
 
 _BARRIER_TIMEOUT = 5.0
+
+# With no default group to read, the no-local-event deadline falls back to the
+# agreement group's own timeout. Read through the function so a test never has to
+# name the figure.
+_NO_LOCAL_EVENT_DEADLINE = no_local_event_deadline()
 
 
 def _marker_lines(event: str, captured: str) -> list[str]:
@@ -37,7 +52,13 @@ def _marker_lines(event: str, captured: str) -> list[str]:
 
 
 class _SpyAgreement(StopAgreement):
-    """Records every exchange and returns whatever the test scripted."""
+    """Records every exchange and returns the scripted peers' answer, reduced.
+
+    The reduction over ``reason`` is honoured rather than discarded. A stub that
+    returned its scripted value unreduced could answer ``0`` to a rank that had
+    just contributed ``1``, which a real ``MAX`` never does -- so every assertion
+    made around such a stub would be about an outcome production cannot produce.
+    """
 
     def __init__(
         self, reason: int = 0, high: int | None = None, low: int | None = None
@@ -59,11 +80,32 @@ class _SpyAgreement(StopAgreement):
         self.calls.append((reason, index, timeout))
         high = index if self._high is None else self._high
         low = index if self._low is None else self._low
-        return self._reason, high, low
+        return max(self._reason, reason), high, low
 
     @property
     def timeouts(self) -> list[float]:
         return [timeout for _, _, timeout in self.calls]
+
+
+class _WedgedPeerAgreement(StopAgreement):
+    """Every exchange expires, exactly as one against a wedged peer does."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int, float]] = []
+        self._abandoned = False
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @property
+    def abandoned(self) -> bool:
+        return self._abandoned
+
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        self.calls.append((reason, index, timeout))
+        self._abandoned = True
+        raise RuntimeError("Operation timed out!")
 
 
 class _LockstepAgreement(StopAgreement):
@@ -173,22 +215,27 @@ def test_a_rank_with_no_signal_applies_the_group_deadline():
 
     A short deadline on a healthy rank fires on a healthy job and hard-exits it,
     causing the exact fabric fault this mechanism exists to prevent. So a rank
-    with no local event of its own passes the group's own 30 minutes, which
-    equals the deadline the gradient all-reduce already carries and therefore
-    cannot fire on a job that is not already dead.
+    with no local event of its own passes the deadline the gradient all-reduce
+    already carries, which therefore cannot fire on a job that is not already
+    dead.
     """
     agreement = _SpyAgreement()
     stop, pending = _stop(agreement, budget=10.0)
 
     assert stop.agreed(0) is False
     assert stop.agreed(1) is False
-    assert agreement.timeouts == [NO_LOCAL_EVENT_DEADLINE, NO_LOCAL_EVENT_DEADLINE]
+    assert agreement.timeouts == [
+        _NO_LOCAL_EVENT_DEADLINE,
+        _NO_LOCAL_EVENT_DEADLINE,
+    ]
 
     pending.request(signal.SIGTERM)
-    stop.agreed(2)
+    # true, not false: this rank contributed `SIGNAL`, and a real `MAX` returns at
+    # least what the caller put in
+    assert stop.agreed(2) is True
     pending.close()
 
-    assert agreement.timeouts[2] < NO_LOCAL_EVENT_DEADLINE
+    assert agreement.timeouts[2] < _NO_LOCAL_EVENT_DEADLINE
     assert agreement.timeouts[2] == pytest.approx(10.0, abs=0.5)
 
 
@@ -222,13 +269,16 @@ def test_an_expired_budget_exchanges_at_the_floor(capfd):
     in that exchange and it returns in microseconds -- and the deadline is
     floored. The floor is not cosmetic: torch reads a zero-length timeout as *no*
     timeout, and the pybind caster truncates a `timedelta` to integral
-    milliseconds, so an unfloored sliver of budget would wait 30 minutes.
+    milliseconds, so an unfloored sliver of budget would wait the default group's
+    own timeout.
     """
     agreement = _SpyAgreement()
     stop, pending = _stop(agreement, budget=-1.0)  # already expired when armed
     pending.request(signal.SIGTERM)
     try:
-        assert stop.agreed(7) is False
+        # true, not false: this rank contributed `SIGNAL` and a real `MAX` returns
+        # at least that. What the test is about is the deadline, below.
+        assert stop.agreed(7) is True
     finally:
         pending.close()
 
@@ -269,6 +319,16 @@ def test_an_index_mismatch_is_reported_and_does_not_force_a_stop(capfd):
     pending.close()
 
 
+def _world(name: str) -> torch.distributed.ProcessGroup:
+    """One default group, standing in only for its identity.
+
+    A `cast` rather than a real group: what `new_stop_agreement` does with this is
+    compare it by identity and take a weak reference to it, so any object with a
+    ``__weakref__`` presents the state a call site presents.
+    """
+    return cast(torch.distributed.ProcessGroup, type(name, (), {})())
+
+
 def test_a_superseded_agreement_group_is_leaked_not_released(monkeypatch):
     """Reclaiming an agreement group is the one thing the design must never do.
 
@@ -277,6 +337,12 @@ def test_a_superseded_agreement_group_is_leaked_not_released(monkeypatch):
     non-empty -- and nothing else drains it, gloo overriding neither
     ``shutdown()`` nor ``abort()``. So a superseded group is *moved* to a
     process-lifetime list, never replaced with ``None``.
+
+    The state is the one a real call site presents: two successive default groups,
+    which is what a ``destroy_process_group()`` followed by a fresh
+    ``init_process_group()`` in one process leaves behind. It is not
+    ``is_initialized()`` going false -- every production caller runs immediately
+    after ``init_process_group``, so it never sees that.
     """
     built: list[_SpyAgreement] = []
 
@@ -287,29 +353,55 @@ def test_a_superseded_agreement_group_is_leaked_not_released(monkeypatch):
 
     monkeypatch.setattr(stop_agreement_module, "build_stop_agreement", build)
     monkeypatch.setattr(stop_agreement_module, "_agreement", None)
+    monkeypatch.setattr(stop_agreement_module, "_agreement_world", None)
     monkeypatch.setattr(stop_agreement_module, "_leaked", [])
-    # the invalidation predicate: a torn-down process group means the cached
-    # group's bookkeeping is gone and it can never be used again
-    monkeypatch.setattr(
-        stop_agreement_module.torch.distributed, "is_initialized", lambda: False
-    )
 
-    first = stop_agreement_module.new_stop_agreement(4)
+    before, after = _world("before"), _world("after")
+    first = stop_agreement_module.new_stop_agreement(4, before)
+
+    # the same world asks for the same group, rather than a second `new_group`
+    # some ranks would not match
+    assert stop_agreement_module.new_stop_agreement(4, before) is first
+    assert len(built) == 1
+
     alive = weakref.ref(first)
-    second = stop_agreement_module.new_stop_agreement(4)
+    second = stop_agreement_module.new_stop_agreement(4, after)
 
     assert second is not first
     assert stop_agreement_module._leaked == [first]
     del first
     assert alive() is not None, "the superseded group was released, which can hang"
-
-    # and while the process group is up, the same group is returned rather than a
-    # second unmatched `new_group`
-    monkeypatch.setattr(
-        stop_agreement_module.torch.distributed, "is_initialized", lambda: True
-    )
-    assert stop_agreement_module.new_stop_agreement(4) is second
     assert len(built) == 2
+
+
+def test_a_collected_world_invalidates_the_cached_agreement_group(monkeypatch):
+    """The cached world is held weakly, so a world that has gone invalidates.
+
+    A strong reference would make `stop_agreement` a potential last holder of the
+    *default* group, whose destructor carries the same unbounded wait as the
+    agreement group's. Held weakly, a world that has been collected reads as "not
+    the current one" -- which is the right answer, and the group it belonged to
+    still has to be moved aside rather than released.
+    """
+    built: list[_SpyAgreement] = []
+
+    def build(world_size: int) -> _SpyAgreement:
+        agreement = _SpyAgreement()
+        built.append(agreement)
+        return agreement
+
+    monkeypatch.setattr(stop_agreement_module, "build_stop_agreement", build)
+    monkeypatch.setattr(stop_agreement_module, "_agreement", None)
+    monkeypatch.setattr(stop_agreement_module, "_agreement_world", None)
+    monkeypatch.setattr(stop_agreement_module, "_leaked", [])
+
+    gone = _world("gone")
+    first = stop_agreement_module.new_stop_agreement(4, gone)
+    del gone
+
+    second = stop_agreement_module.new_stop_agreement(4, _world("current"))
+    assert second is not first
+    assert stop_agreement_module._leaked == [first]
 
 
 def test_a_peer_exception_raises_rather_than_stopping_quietly():
@@ -333,31 +425,34 @@ def test_the_exit_exchange_happens_only_when_a_rank_originates_one():
 
     A rank leaving because it *observed* a stop would otherwise issue an
     unmatched exchange against a peer that has already left -- and with nothing
-    pending of its own it would carry the group's 30 minutes, so it would sit
+    pending of its own it would carry the group's own timeout, so it would sit
     there.
     """
     observed = _SpyAgreement(reason=StopReason.SIGNAL.value)
     stop, pending = _stop(observed)
     assert stop.agreed(3) is True  # sets `_agreed`
-    stop.close(StopReason.EXCEPTION, stop.next_index())
+    stop.close(stop.next_index())
     assert len(observed.calls) == 1, "an observer must not exchange on the way out"
     pending.close()
 
+    # a clean end of loop exchanges once per boundary and not once more: the scope
+    # does not call `close` at all on that path, there being nothing its peers
+    # could learn that they are not learning by arriving at the same place
     clean = _SpyAgreement()
-    stop, pending = _stop(clean)
-    stop.agreed(0)
-    stop.close(StopReason.NONE, stop.next_index())
+    clean_pending = PendingStop(budget=10.0)
+    with _cooperative_scope(clean_pending, clean) as clean_stop:
+        assert clean_stop.agreed(0) is False
     assert len(clean.calls) == 1, "a clean end of loop must not exchange either"
-    pending.close()
+    clean_pending.close()
 
     originating = _SpyAgreement(reason=StopReason.EXCEPTION.value)
     stop, pending = _stop(originating, first_index=5)
     assert pending.seconds_remaining() is None
-    stop.close(StopReason.EXCEPTION, stop.next_index())
+    stop.close(stop.next_index())
     # the index its peers will contribute, not its own lagging counter
     assert originating.calls[0][:2] == (StopReason.EXCEPTION.value, 5)
     # and the raise is a local event, so the exchange carried a short deadline
-    assert originating.timeouts[0] < NO_LOCAL_EVENT_DEADLINE
+    assert originating.timeouts[0] < _NO_LOCAL_EVENT_DEADLINE
     pending.close()
 
 
@@ -377,7 +472,130 @@ def test_close_never_raises_even_when_the_exchange_does():
     agreement = _Failing()
     stop, pending = _stop(agreement)
 
-    stop.close(StopReason.EXCEPTION, stop.next_index())
+    stop.close(stop.next_index())
 
     assert len(agreement.calls) == 1
     pending.close()
+
+
+def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd):
+    """The one path that could leave the loop without tearing anything down.
+
+    A rank whose peer never joins gives up on the exchange. If it had recorded a
+    signal of its own, `defer_termination`'s dispatch would find that and tear
+    down; with **no** local event -- which is every rank the scheduler's signal
+    did not reach in time -- there is nothing else on the `PendingStop`, so
+    without an explicit record the rank would break out of the loop, tear nothing
+    down, and walk into the next collective whose peers have gone.
+
+    The assertion is not on a flag but on the dispatch: `shutdown` ran and a
+    `SystemExit` left the deferral, which is what the caller after the loop never
+    gets to see.
+    """
+    events: list[str] = []
+    after: list[str] = []
+    agreement = _WedgedPeerAgreement()
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit) as excinfo:
+            with defer_termination(budget=1.0) as pending:
+                assert pending.seconds_remaining() is None, "no local event"
+                with _cooperative_scope(pending, agreement) as stop:
+                    for index in range(10):
+                        if stop.agreed(index):
+                            break
+            after.append("kept going into the next collective")
+
+    assert after == [], "the rank left the loop and carried on"
+    assert events == ["shutdown"]
+    assert excinfo.value.code == 128 + signal.SIGTERM
+    assert pending.requested is False, "no signal ever reached this rank"
+    assert pending.peer_stop is True
+    stderr = capfd.readouterr().err
+    assert len(_marker_lines("agreement-timeout", stderr)) == 1
+    assert len(_marker_lines("agreement-abandoned", stderr)) == 1
+
+
+def test_a_give_up_in_the_loop_entry_exchange_names_no_batch(capfd):
+    """The abandonment marker must not report a batch that does not exist.
+
+    Reading one past the last index and subtracting gives ``batch=-1`` when the
+    give-up happened in the loop-entry exchange, before any boundary.
+    """
+    agreement = _WedgedPeerAgreement()
+    pending = PendingStop(budget=1.0)
+
+    with pytest.raises(RuntimeError, match="Operation timed out!"):
+        with _cooperative_scope(pending, agreement, loop_length=100):
+            pass  # never reached
+
+    abandoned = _marker_lines("agreement-abandoned", capfd.readouterr().err)
+    assert len(abandoned) == 1
+    assert "batch=loop-entry" in abandoned[0]
+    pending.close()
+
+
+def test_an_unverified_torch_degrades_the_bound_rather_than_failing(
+    monkeypatch, capfd, caplog
+):
+    """An unverified torch release must not fail a job, at startup or at use.
+
+    Every distributed job builds an agreement group, including inference and
+    evaluator runs that never stop cooperatively, so raising at construction
+    breaks work this design does not touch -- and raising at first use would raise
+    during a preemption, which is the worst possible moment. So a rank on an
+    unverified release passes the same unbounded deadline a healthy rank does, and
+    the log says which bound was in force.
+    """
+    monkeypatch.setattr(stop_agreement_module, "_VERIFIED_TORCH", frozenset())
+    monkeypatch.setattr(stop_agreement_module, "_warned_unverified", False)
+
+    # emitted where the group is built, and it warns rather than raising
+    with caplog.at_level(logging.WARNING):
+        stop_agreement_module.warn_if_timeout_contract_unverified()
+        stop_agreement_module.warn_if_timeout_contract_unverified()
+    warnings = [
+        record for record in caplog.records if "has not been checked" in record.message
+    ]
+    assert len(warnings) == 1, "once per process, not once per group"
+    assert torch.__version__ in warnings[0].getMessage()
+
+    agreement = _SpyAgreement()
+    stop, pending = _stop(agreement, budget=10.0)
+    pending.request(signal.SIGTERM)
+    try:
+        assert stop.agreed(4) is True
+    finally:
+        pending.close()
+
+    assert agreement.timeouts == [_NO_LOCAL_EVENT_DEADLINE]
+    bound = _marker_lines("agreement-bound", capfd.readouterr().err)
+    assert len(bound) == 1
+    assert "bound=group-timeout" in bound[0]
+    assert "batch=4" in bound[0]
+
+
+def test_a_verified_torch_reports_the_bound_it_applied(capfd):
+    """The degraded path cannot look like the bounded one in a container log.
+
+    A reader of a rank that sat for the group's whole timeout has to be able to
+    tell whether the short bound was in force and failed or was never available,
+    and the two produce the same ``stop-agreed`` line. Only a rank with a local
+    event of its own emits this, so a healthy loop stays silent.
+    """
+    agreement = _SpyAgreement()
+    stop, pending = _stop(agreement, budget=10.0)
+
+    assert stop.agreed(0) is False
+    assert _marker_lines("agreement-bound", capfd.readouterr().err) == []
+
+    pending.request(signal.SIGTERM)
+    try:
+        assert stop.agreed(1) is True
+    finally:
+        pending.close()
+
+    bound = _marker_lines("agreement-bound", capfd.readouterr().err)
+    assert len(bound) == 1
+    assert "bound=budget" in bound[0]
+    assert "batch=1" in bound[0]

--- a/fme/core/distributed/test_cooperative_stop.py
+++ b/fme/core/distributed/test_cooperative_stop.py
@@ -11,7 +11,9 @@ They are unmarked, so they run in every tier including ``--very-fast``, and each
 takes milliseconds.
 """
 
+import importlib
 import logging
+import os
 import signal
 import threading
 import time
@@ -27,6 +29,7 @@ from fme.core.distributed.cooperative_stop import (
     _MIN_DEADLINE,
     CooperativeStop,
     PeerStopRequested,
+    UnequalLoopLength,
     _cooperative_scope,
     no_local_event_deadline,
 )
@@ -36,9 +39,21 @@ from fme.core.distributed.shutdown import (
     defer_termination,
     handle_termination_signals,
 )
-from fme.core.distributed.stop_agreement import StopAgreement
+from fme.core.distributed.stop_agreement import StopAgreement, is_deadline_expiry
 
 _BARRIER_TIMEOUT = 5.0
+
+# `from fme.core.distributed import cooperative_stop` binds the re-exported
+# *function* of that name, and setting an attribute on that patches nothing
+cooperative_stop_module = importlib.import_module(
+    "fme.core.distributed.cooperative_stop"
+)
+
+# What gloo says when a peer's process has died and closed its socket, as opposed to
+# when a deadline expired. Copied from a real gloo message rather than invented,
+# because a substring match on the timeout text is the only thing separating the two
+# and the discrimination is what the tests below are about.
+_PEER_CRASH_MESSAGE = "Connection closed by peer [127.0.0.1]:45678"
 
 # With no default group to read, the no-local-event deadline falls back to the
 # agreement group's own timeout. Read through the function so a test never has to
@@ -106,6 +121,32 @@ class _WedgedPeerAgreement(StopAgreement):
         self.calls.append((reason, index, timeout))
         self._abandoned = True
         raise RuntimeError("Operation timed out!")
+
+
+class _CrashedPeerAgreement(StopAgreement):
+    """Every exchange fails the way one against a *dead* peer does.
+
+    gloo raises the same ``RuntimeError`` type for a deadline expiry and for a
+    peer's socket closing, and the group is abandoned either way -- the message is
+    the only thing that tells them apart.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int, float]] = []
+        self._abandoned = False
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @property
+    def abandoned(self) -> bool:
+        return self._abandoned
+
+    def exchange(self, reason: int, index: int, timeout: float) -> tuple[int, int, int]:
+        self.calls.append((reason, index, timeout))
+        self._abandoned = True
+        raise RuntimeError(_PEER_CRASH_MESSAGE)
 
 
 class _LockstepAgreement(StopAgreement):
@@ -299,17 +340,28 @@ def test_an_expired_budget_exchanges_at_the_floor(capfd):
     assert all(timeout > 0.0 for timeout in agreement.timeouts + sliver.timeouts)
 
 
-def test_an_index_mismatch_is_reported_and_does_not_force_a_stop(capfd):
-    """The symmetry check is diagnostic only, deliberately.
+def test_an_index_mismatch_is_reported_once_and_does_not_force_a_stop(
+    capfd, monkeypatch
+):
+    """The symmetry check is diagnostic only, deliberately, and it says so once.
 
     A desynchronised run is going to hang anyway, and a new mechanism
     unilaterally terminating healthy-looking jobs on a self-diagnosis is a worse
     failure mode than the one it reports.
+
+    Once per process, because the condition does not un-happen and the run it
+    reports is one where every rank would otherwise emit a line per batch -- tens of
+    thousands of them, on exactly the log a reader is trying to get through.
     """
+    monkeypatch.setattr(cooperative_stop_module, "_reported_index_mismatch", False)
     agreement = _SpyAgreement(reason=0, high=12, low=11)
     stop, pending = _stop(agreement)
 
     assert stop.agreed(11) is False
+    assert stop.agreed(12) is False
+    # a second loop in the same process, which is a second epoch in a real job
+    later, later_pending = _stop(_SpyAgreement(reason=0, high=20, low=19))
+    assert later.agreed(19) is False
 
     captured = capfd.readouterr().err
     mismatch = _marker_lines("index-mismatch", captured)
@@ -317,6 +369,37 @@ def test_an_index_mismatch_is_reported_and_does_not_force_a_stop(capfd):
     assert "min=11" in mismatch[0] and "max=12" in mismatch[0]
     assert _marker_lines("stop-agreed", captured) == []
     pending.close()
+    later_pending.close()
+
+
+def test_a_dead_peer_is_escalated_while_a_wedged_one_is_given_up_on(capfd):
+    """The one discrimination the whole give-up branch turns on, in both directions.
+
+    A false negative escalates a wedge into a crash the job reports as a failure; a
+    false positive masks a real crash as a graceful stop, which is worse. gloo gives
+    both the same exception type, so a substring match on the expiry message is all
+    there is -- and it was asserted only for the expiry.
+    """
+    assert is_deadline_expiry(RuntimeError("Operation timed out!")) is True
+    assert is_deadline_expiry(RuntimeError(_PEER_CRASH_MESSAGE)) is False
+
+    crashed = _CrashedPeerAgreement()
+    stop, pending = _stop(crashed, budget=1.0)
+    pending.request(signal.SIGTERM)
+    try:
+        with pytest.raises(RuntimeError, match="Connection closed by peer"):
+            stop.agreed(3)
+    finally:
+        pending.close()
+
+    # the crash escapes rather than being reported as a rank leaving cooperatively,
+    # so nothing claims a stop was agreed and nothing was noted as a peer's stop
+    stderr = capfd.readouterr().err
+    assert _marker_lines("agreement-timeout", stderr) == []
+    assert _marker_lines("stop-agreed", stderr) == []
+    assert pending.peer_stop is False
+    # but the group is gone either way, so the abandonment is still recorded
+    assert stop.abandoned is True
 
 
 def _world(name: str) -> torch.distributed.ProcessGroup:
@@ -478,7 +561,7 @@ def test_close_never_raises_even_when_the_exchange_does():
     pending.close()
 
 
-def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd):
+def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd, monkeypatch):
     """The one path that could leave the loop without tearing anything down.
 
     A rank whose peer never joins gives up on the exchange. If it had recorded a
@@ -488,18 +571,24 @@ def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd):
     without an explicit record the rank would break out of the loop, tear nothing
     down, and walk into the next collective whose peers have gone.
 
-    The assertion is not on a flag but on the dispatch: `shutdown` ran and a
-    `SystemExit` left the deferral, which is what the caller after the loop never
-    gets to see.
+    The assertion is not on a flag but on the dispatch: `shutdown` ran and the
+    process was exited, which is what the caller after the loop never gets to see.
+    The exit is a *hard* one, because the abandoned group makes interpreter
+    finalization wait for the wedged peer to die; `os._exit` is stubbed here, and
+    `test_cooperative_stop_exit.py` is where the real process death is observed.
     """
     events: list[str] = []
     after: list[str] = []
+    exited: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
     agreement = _WedgedPeerAgreement()
 
     with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
         with pytest.raises(SystemExit) as excinfo:
             with defer_termination(budget=1.0) as pending:
-                assert pending.seconds_remaining() is None, "no local event"
+                assert (
+                    pending.seconds_remaining() is None
+                ), "a budget is armed, so this is not the no-local-event path"
                 with _cooperative_scope(pending, agreement) as stop:
                     for index in range(10):
                         if stop.agreed(index):
@@ -508,30 +597,78 @@ def test_a_give_up_with_no_local_event_dispatches_the_teardown(capfd):
 
     assert after == [], "the rank left the loop and carried on"
     assert events == ["shutdown"]
+    assert exited == [128 + signal.SIGTERM], "the abandoned group needs a hard exit"
     assert excinfo.value.code == 128 + signal.SIGTERM
-    assert pending.requested is False, "no signal ever reached this rank"
+    assert (
+        pending.requested is False
+    ), "a signal was recorded, so this is not the no-local-event path"
     assert pending.peer_stop is True
     stderr = capfd.readouterr().err
     assert len(_marker_lines("agreement-timeout", stderr)) == 1
     assert len(_marker_lines("agreement-abandoned", stderr)) == 1
 
 
-def test_a_give_up_in_the_loop_entry_exchange_names_no_batch(capfd):
-    """The abandonment marker must not report a batch that does not exist.
+def test_a_give_up_in_the_loop_entry_exchange_stops_without_running_the_loop(capfd):
+    """Loop entry needs the give-up handling the boundary exchange has.
 
-    Reading one past the last index and subtracting gives ``batch=-1`` when the
-    give-up happened in the loop-entry exchange, before any boundary.
+    A signal landing between `defer_termination` yielding and loop entry arms the
+    budget, so this exchange carries a few seconds while unsignalled peers carry the
+    default group's own timeout -- and the window immediately before it respawns the
+    epoch's DataLoader workers, which routinely costs seconds. Without the handling
+    that expiry was a bare `RuntimeError` out of a preemption: exit 1 with a
+    traceback rather than a stop.
+
+    The body must not run either. Its first collective would strand this rank
+    against peers that are not there, which is the fault the module exists to
+    prevent, so the scope leaves by `SystemExit` -- the exit `defer_termination`
+    would have performed for it, with nothing to print.
+
+    The marker's ``batch`` field names the exchange rather than an index, because
+    reading one past the last index and subtracting reported ``batch=-1`` here.
     """
     agreement = _WedgedPeerAgreement()
     pending = PendingStop(budget=1.0)
+    ran: list[str] = []
 
-    with pytest.raises(RuntimeError, match="Operation timed out!"):
+    with pytest.raises(SystemExit) as excinfo:
+        with _cooperative_scope(pending, agreement, loop_length=100):
+            ran.append("the loop body ran against peers that are not there")
+
+    assert ran == []
+    # the peer-stop convention: no signal reached this rank, and the stop still
+    # carries the code a preempted rank reports
+    assert excinfo.value.code == 128 + int(signal.SIGTERM)
+    assert pending.peer_stop is True
+    assert pending.hard_exit is True, "an abandoned group cannot be left to finalize"
+    stderr = capfd.readouterr().err
+    timeout = _marker_lines("agreement-timeout", stderr)
+    assert len(timeout) == 1
+    assert "batch=loop-entry" in timeout[0]
+    # and the message is encoded, so the line is still one parseable field per space
+    assert "err=Operation_timed_out!" in timeout[0]
+    abandoned = _marker_lines("agreement-abandoned", stderr)
+    assert len(abandoned) == 1
+    assert "batch=loop-entry" in abandoned[0]
+    pending.close()
+
+
+def test_an_unequal_loop_length_still_raises_rather_than_stopping(capfd):
+    """The give-up handling at loop entry must not swallow the assertion.
+
+    An unequal loop length is a precondition failure every rank detects from the
+    same reduced values, so every rank raises -- as opposed to a give-up, where this
+    rank alone is leaving.
+    """
+    agreement = _SpyAgreement(high=101, low=99)
+    pending = PendingStop(budget=10.0)
+
+    with pytest.raises(UnequalLoopLength):
         with _cooperative_scope(pending, agreement, loop_length=100):
             pass  # never reached
 
-    abandoned = _marker_lines("agreement-abandoned", capfd.readouterr().err)
-    assert len(abandoned) == 1
-    assert "batch=loop-entry" in abandoned[0]
+    assert pending.peer_stop is False
+    assert pending.hard_exit is False
+    assert _marker_lines("agreement-abandoned", capfd.readouterr().err) == []
     pending.close()
 
 

--- a/fme/core/distributed/test_cooperative_stop_exit.py
+++ b/fme/core/distributed/test_cooperative_stop_exit.py
@@ -7,7 +7,7 @@ configuration. And `Distributed.context()` is already entered for the session an
 refuses to nest, while these tests are about what a real entrypoint does inside
 it.
 
-**They are not cheap.** Six torchrun launches, each ``@pytest.mark.serial``, so
+**They are not cheap.** Seven torchrun launches, each ``@pytest.mark.serial``, so
 each holds the xdist write lock for the whole of a ``make test`` run at roughly
 8-15s apiece. That is the price of asserting a process exit code at all; nothing
 cheaper can.
@@ -29,9 +29,11 @@ carries the code.
 **Where the claim is a bound on the exit, the exit is observed from outside.** A
 timestamp a driver writes before leaving measures the *call*, and the call is not
 what can block: an abandoned gloo group makes interpreter finalization wait for the
-wedged peer to die. So `_wait_for_death` watches ``/proc`` for the rank's own pid,
-and the wedged rank holds its socket open until the launcher says the rank under
-test is gone -- otherwise the peer's exit unblocks the very wait being measured.
+wedged peer to die -- see
+`fme.core.distributed.shutdown.PendingStop.require_hard_exit` for the measurement.
+So `_wait_for_death` watches ``/proc`` for the rank's own pid, and the wedged rank
+holds its socket open until the launcher says the rank under test is gone --
+otherwise the peer's exit unblocks the very wait being measured.
 """
 
 import os
@@ -326,9 +328,10 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
     Rank 0 raises its own SIGTERM rather than waiting for one from outside, so
     that its budget is provably armed before it enters the exchange rank 1 will
     never join. A signal from outside landing a moment later would find rank 0
-    already inside that exchange carrying the default group's own timeout, which
-    different case with a different bound. `test_both_ranks_exit_at_the_same_batch
-    _with_the_backend_released` is where the external signal is the claim.
+    already inside that exchange carrying the default group's own timeout, which is
+    a different case with a different bound; the test named
+    ``test_both_ranks_exit_at_the_same_batch_with_the_backend_released`` in this
+    module is where an external signal is the claim.
 
     **What is timed is rank 0's death, not its call to exit**, and rank 1 holds its
     socket open until that death: an abandoned gloo group is disposed of by
@@ -338,14 +341,13 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
     had already gone, is a test that cannot observe the thing it appears to bound.
 
     Which of the two assertions does the work is worth being exact about, because
-    the timing one does not. Whether finalization joins that thread or leaks it is
-    not deterministic: measured on torch 2.7.1, a minimal repro that held the group
-    in a local and destroyed both groups took 119.3s against a peer parked for 120s,
-    while *this* shape -- the group held by a module global, only the default group
-    destroyed -- leaked it and died in 4.66s with ``sys.exit`` against 3.02s with
-    ``os._exit``. So the bound below passes either way on this machine today, and
-    the ``hard-exit`` marker is what pins the exit actually being taken hard. The
-    bound is the backstop for the machine where it joins.
+    the timing one does not: whether finalization joins that thread or leaks it is
+    not deterministic, and the figures are in
+    `fme.core.distributed.shutdown.PendingStop.require_hard_exit`, which states them
+    once. This test's shape is the one that leaked, so the bound below passes either
+    way on this machine today and the ``hard-exit`` marker is what pins the exit
+    actually being taken hard. The bound is the backstop for the machine where it
+    joins.
     """
     child = _launch(
         f"""
@@ -536,6 +538,96 @@ def test_a_rank_that_gives_up_with_no_local_event_exits(tmp_path):
     # and with no local event it was never bounded by a budget, so it claims no
     # bound of its own
     assert "fme-stop:agreement-bound" not in stderr, stderr
+    assert (tmp_path / "callback.0").exists(), "the restart checkpoint was lost"
+
+
+@pytest.mark.slow
+@pytest.mark.medium_duration
+@pytest.mark.serial
+def test_a_raising_rank_that_abandons_an_exchange_dies_promptly_with_its_traceback(
+    tmp_path,
+):
+    """The exception rider owes the same hard exit as every other abandonment path.
+
+    Rank 0 raises inside the loop body with no signal anywhere, so its exit exchange
+    is the one its peers cannot answer -- rank 1 has parked before reaching that
+    boundary -- and the exchange is abandoned. Before this the branch returned with
+    ``exit_process=False`` to keep the traceback, which left the rank to block in
+    ``~ProcessGroupGloo()`` during finalization for as long as rank 1 lived and be
+    SIGKILLed there: the launcher would read a signal death rather than a failure,
+    and the rank would hold its GPU allocation throughout.
+
+    So all three claims are asserted together, because dropping any one of them is
+    how the fix regresses: the traceback still reaches stderr, the exit code is the
+    exception's, and the death is bounded by rank 0's own exchange rather than by
+    rank 1's demise -- rank 1 keeps its socket open until the launcher has seen rank
+    0 go, so the bound is genuinely rank 0's.
+    """
+    child = _launch(
+        """
+        import os, sys, time
+        from pathlib import Path
+
+        import torch
+        import torch.distributed
+
+        from fme.core.distributed import (
+            Distributed,
+            add_post_shutdown_callback,
+            cooperative_stop,
+        )
+
+        OUT = Path(sys.argv[1])
+        rank = int(os.environ["RANK"])
+        (OUT / f"pid.{rank}").write_text(str(os.getpid()))
+        leave_at = 2
+        add_post_shutdown_callback(
+            lambda: (OUT / f"callback.{rank}").write_text("ran")
+        )
+        with Distributed.context():
+            with cooperative_stop(budget=1.0) as stop:
+                for index in range(1000):
+                    torch.distributed.all_reduce(torch.ones(1))
+                    time.sleep(0.02)
+                    if index == leave_at:
+                        if rank == 1:
+                            # never reaches the boundary, and keeps its socket open
+                            # until rank 0 is gone, so rank 0's death is rank 0's
+                            give_up_at = time.monotonic() + 20.0
+                            while not (OUT / "dead").exists():
+                                if time.monotonic() > give_up_at:
+                                    break
+                                time.sleep(0.02)
+                            os._exit(0)
+                        (OUT / "raised").write_text(str(time.monotonic()))
+                        raise ValueError("a NaN in the loss")
+                    if stop.agreed(index):
+                        break
+        """,
+        tmp_path,
+    )
+    try:
+        _wait_for_file(tmp_path / "pid.0", child)
+        _wait_for_file(tmp_path / "raised", child)
+        died = _wait_for_death(int((tmp_path / "pid.0").read_text()), tmp_path)
+    except BaseException:
+        (tmp_path / "dead").write_text("go")
+        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        raise
+    stderr = _finish(child, tmp_path)
+
+    raised = float((tmp_path / "raised").read_text())
+    # the floored exit exchange plus the teardown and the callbacks, with slack, and
+    # measured against a peer that was still alive
+    assert died - raised < _MIN_DEADLINE + 4.0, died - raised
+    # 1, not `128 + SIGTERM`: no signal was sent, and an exception is a failure
+    assert _marker_fields("hard-exit", stderr, "code") == ["1"], stderr
+    # the only reason the branch used to decline to exit at all
+    assert "Traceback (most recent call last)" in stderr, stderr
+    assert "ValueError: a NaN in the loss" in stderr, stderr
+    # the index rank 0 would have reached, which is the one its peers contribute
+    assert _marker_fields("agreement-abandoned", stderr, "batch") == ["2"], stderr
+    assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 1, stderr
     assert (tmp_path / "callback.0").exists(), "the restart checkpoint was lost"
 
 

--- a/fme/core/distributed/test_cooperative_stop_exit.py
+++ b/fme/core/distributed/test_cooperative_stop_exit.py
@@ -7,12 +7,17 @@ configuration. And `Distributed.context()` is already entered for the session an
 refuses to nest, while these tests are about what a real entrypoint does inside
 it.
 
+**They are not cheap.** Six torchrun launches, each ``@pytest.mark.serial``, so
+each holds the xdist write lock for the whole of a ``make test`` run at roughly
+8-15s apiece. That is the price of asserting a process exit code at all; nothing
+cheaper can.
+
 So each writes a driver to ``tmp_path`` and launches it under ``torchrun``, the
 way `test_shutdown_dataloader.py` does: ``start_new_session=True`` as torchrun
 launches a rank, and ``os.killpg`` where the claim is about a scheduler signalling
 a container. ``FME_FORCE_CPU=1`` throughout, so gloo, so they run on the CPU job
-too. Every timeout is injected small: no driver waits out a real 10s budget or a
-real 20s teardown.
+too. Every timeout is injected small: no driver waits out a real agreement budget
+or a real 20s teardown.
 
 Ranks' stderr is inherited rather than redirected, so the ``fme-stop:`` marker
 lines land in the launcher's own stderr and are what the assertions read. Exit
@@ -30,6 +35,8 @@ from pathlib import Path
 
 import pytest
 
+from fme.core.distributed.cooperative_stop import _MIN_DEADLINE
+
 # torchrun's own environment would send the driver's ranks down a rendezvous that
 # is not theirs; the launcher below is the one that sets these.
 _RANK_ENV = (
@@ -44,10 +51,14 @@ _RANK_ENV = (
     "SLURM_NTASKS",
 )
 
-# Generous, because it only decides which diagnostic a hang produces: the suite's
-# autouse 90s alarm fires first either way. Observed runtime is ~8-15s.
-_LAUNCH_TIMEOUT = 60.0
-_READY_TIMEOUT = 40.0
+# Sized so that the module's *own* diagnostics are what a maintainer sees on a
+# hang, which is the case where a diagnostic is worth most: waiting for readiness
+# and then for the launch is 60s at worst, inside the suite's autouse 90s SIGALRM,
+# so the `AssertionError` texts below fire rather than "Test failed due to
+# timeout". Observed runtime is ~8-15s, so both are still several times the real
+# figure.
+_LAUNCH_TIMEOUT = 40.0
+_READY_TIMEOUT = 20.0
 
 _SIGTERM_EXIT_CODE = 128 + int(signal.SIGTERM)
 
@@ -257,7 +268,7 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
     Rank 0 raises its own SIGTERM rather than waiting for one from outside, so
     that its budget is provably armed before it enters the exchange rank 1 will
     never join. A signal from outside landing a moment later would find rank 0
-    already inside that exchange carrying the group's 30 minutes, which is a
+    already inside that exchange carrying the default group's own timeout, which
     different case with a different bound. `test_both_ranks_exit_at_the_same_batch
     _with_the_backend_released` is where the external signal is the claim.
     """
@@ -297,7 +308,7 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
                                 )
                                 while not (OUT / "wedged").exists():
                                     time.sleep(0.02)
-                                time.sleep(6.0)
+                                time.sleep(10.0)
                                 # a stand-in for the SIGKILL a real wedged rank
                                 # eventually gets; nothing is asserted about it
                                 os._exit(0)
@@ -318,13 +329,109 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
     assert _exit_codes(tmp_path, 2) == {"0": str(_SIGTERM_EXIT_CODE)}, stderr
     started = float((tmp_path / "started").read_text())
     done = float((tmp_path / "done.0").read_text())
-    # budget + teardown, with slack. The point is that it is bounded at all, and
-    # that it is nothing like rank 1's 6s park.
-    assert done - started < 5.0, done - started
+    # The deadline that binds plus the teardown, with slack. The driver's 1s budget
+    # is below `_MIN_DEADLINE` and so is floored up to it, which is the figure to
+    # compare against; the point is that it is bounded at all, and that it is
+    # nothing like rank 1's 10s park.
+    assert done - started < _MIN_DEADLINE + 4.0, done - started
     assert _marker_fields("agreement-timeout", stderr, "batch") == ["2"], stderr
     assert _marker_fields("agreement-abandoned", stderr, "batch") == ["2"], stderr
     assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 1, stderr
     assert "did not complete" not in stderr
+    assert (tmp_path / "callback.0").exists(), "the restart checkpoint was lost"
+
+
+@pytest.mark.slow
+@pytest.mark.medium_duration
+@pytest.mark.serial
+def test_a_rank_that_gives_up_with_no_local_event_exits(tmp_path):
+    """The give-up path must end in an exit even with nothing recorded locally.
+
+    No signal is sent anywhere in this test. Rank 1 simply stops reaching the
+    boundary and rank 0 gives up waiting for it, holding nothing on its
+    `PendingStop` -- no signal, no exception -- which is the state every rank the
+    scheduler's signal did not reach is in. The exit code, observed from outside
+    the interpreter, is the assertion: a rank that merely broke out of the loop
+    would run on into `alternate_shuffle` and the train-evaluation pass, hang there
+    against peers that had gone, and be SIGKILLed with its communicators open.
+
+    The no-local-event deadline is patched down from the default group's own
+    timeout, which is tens of minutes; nothing else about the path is altered, and
+    the deadline's *value* is what the tier-1 tests cover.
+    """
+    child = _launch(
+        f"""
+        import importlib, os, sys, time
+        from pathlib import Path
+
+        import torch
+        import torch.distributed
+
+        from fme.core.distributed import (
+            Distributed,
+            add_post_shutdown_callback,
+            cooperative_stop,
+        )
+
+        # `import ... as` would bind the re-exported *function* of the same name,
+        # and setting an attribute on that silently patches nothing
+        module = importlib.import_module("fme.core.distributed.cooperative_stop")
+        # tens of minutes otherwise, which is the whole point of that deadline
+        module.no_local_event_deadline = lambda: 2.0
+
+        OUT = Path(sys.argv[1])
+        {_RECORD_EXIT}
+        rank = int(os.environ["RANK"])
+        leave_at = 2
+        add_post_shutdown_callback(
+            lambda: (OUT / f"callback.{{rank}}").write_text("ran")
+        )
+        try:
+            with Distributed.context():
+                with cooperative_stop() as stop:
+                    for index in range(1000):
+                        torch.distributed.all_reduce(torch.ones(1))
+                        time.sleep(0.02)
+                        if index == leave_at and rank == 1:
+                            # stops reaching the boundary, while staying alive long
+                            # enough that rank 0 sees a deadline expiry rather than
+                            # a closed socket
+                            time.sleep(8.0)
+                            os._exit(0)
+                        if stop.agreed(index):
+                            break
+                    (OUT / f"loop-exited.{{rank}}").write_text("yes")
+                (OUT / f"scope-exited.{{rank}}").write_text("yes")
+                torch.distributed.all_reduce(torch.ones(1))  # never reached
+                (OUT / f"kept-going.{{rank}}").write_text("yes")
+        except SystemExit as err:
+            record_exit(err.code)
+            raise
+        """,
+        tmp_path,
+    )
+    stderr = _finish(child, tmp_path)
+
+    # no signal was sent, so `128 + SIGTERM` here is the peer-stop convention for a
+    # stop that carries no signal number of its own
+    assert _exit_codes(tmp_path, 2) == {"0": str(_SIGTERM_EXIT_CODE)}, stderr
+    assert not (
+        tmp_path / "kept-going.0"
+    ).exists(), "rank 0 left the loop and executed a further collective"
+    assert not (
+        tmp_path / "scope-exited.0"
+    ).exists(), "leaving the cooperative scope did not dispatch the teardown"
+    assert (tmp_path / "loop-exited.0").exists(), stderr
+    assert _marker_fields("agreement-timeout", stderr, "batch") == ["2"], stderr
+    assert _marker_fields("agreement-abandoned", stderr, "batch") == ["2"], stderr
+    assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 1, stderr
+    # No signal is sent by this test. Rank 1 may still record one -- the agent
+    # SIGTERMs it once rank 0 exits non-zero -- but rank 0, the rank under test,
+    # must have given up with nothing of its own recorded, which is the whole point.
+    assert "0" not in _marker_fields("signal-deferred", stderr, "rank"), stderr
+    # and with no local event it was never bounded by a budget, so it claims no
+    # bound of its own
+    assert "fme-stop:agreement-bound" not in stderr, stderr
     assert (tmp_path / "callback.0").exists(), "the restart checkpoint was lost"
 
 

--- a/fme/core/distributed/test_cooperative_stop_exit.py
+++ b/fme/core/distributed/test_cooperative_stop_exit.py
@@ -22,7 +22,16 @@ or a real 20s teardown.
 Ranks' stderr is inherited rather than redirected, so the ``fme-stop:`` marker
 lines land in the launcher's own stderr and are what the assertions read. Exit
 codes come from files the drivers write, because torchrun reports its own status
-rather than each rank's.
+rather than each rank's -- except on the paths that end in `os._exit`, where no
+``SystemExit`` is raised for a driver to catch and the ``hard-exit`` marker is what
+carries the code.
+
+**Where the claim is a bound on the exit, the exit is observed from outside.** A
+timestamp a driver writes before leaving measures the *call*, and the call is not
+what can block: an abandoned gloo group makes interpreter finalization wait for the
+wedged peer to die. So `_wait_for_death` watches ``/proc`` for the rank's own pid,
+and the wedged rank holds its socket open until the launcher says the rank under
+test is gone -- otherwise the peer's exit unblocks the very wait being measured.
 """
 
 import os
@@ -52,13 +61,16 @@ _RANK_ENV = (
 )
 
 # Sized so that the module's *own* diagnostics are what a maintainer sees on a
-# hang, which is the case where a diagnostic is worth most: waiting for readiness
-# and then for the launch is 60s at worst, inside the suite's autouse 90s SIGALRM,
-# so the `AssertionError` texts below fire rather than "Test failed due to
-# timeout". Observed runtime is ~8-15s, so both are still several times the real
-# figure.
-_LAUNCH_TIMEOUT = 40.0
-_READY_TIMEOUT = 20.0
+# hang, which is the case where a diagnostic is worth most. The figure that has to
+# hold is the sum along the longest path of any one test, against the suite's
+# autouse 90s SIGALRM: two readiness waits, one death wait and the launch, i.e.
+# 15 + 15 + 10 + 25 = 65s, leaving 25s of the alarm unspent. Process startup is
+# *inside* the first readiness wait rather than additional to it, since nothing is
+# waited on before the launch. Observed runtime is ~8-15s per test, so each figure
+# is still at least twice the real one.
+_LAUNCH_TIMEOUT = 25.0
+_READY_TIMEOUT = 15.0
+_DEATH_TIMEOUT = 10.0
 
 _SIGTERM_EXIT_CODE = 128 + int(signal.SIGTERM)
 
@@ -128,6 +140,50 @@ def _wait_for_file(path: Path, child: "subprocess.Popen[str]") -> None:
         time.sleep(0.05)
 
 
+def _running(pid: int) -> bool:
+    """Whether ``pid`` is still a live process, a zombie counting as dead.
+
+    The kernel sets ``Z`` when the process exits, and the parent that will reap it is
+    torchrun rather than this process, so waiting for the entry to disappear would
+    time a reap rather than a death.
+    """
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+    except (FileNotFoundError, ProcessLookupError, PermissionError):
+        return False
+    # the executable name is in parentheses and may itself contain spaces, so the
+    # state field is read after the last ``)`` rather than by splitting the line
+    fields = stat.rpartition(")")[2].split()
+    return bool(fields) and fields[0] != "Z"
+
+
+def _wait_for_death(pid: int, tmp_path: Path) -> float:
+    """When ``pid`` stopped running, observed from outside it.
+
+    The thing under test on the abandonment paths is how long the rank takes to
+    *die*, which nothing the rank writes can report: a timestamp written before the
+    exit measures the call, and the call is precisely what can block for as long as
+    a wedged peer lives.
+
+    Writes ``dead`` on the way out, whether or not the rank died in time, because a
+    wedged peer is waiting on that file to leave -- it must not close its socket
+    before this, since doing so would unblock the wait being measured.
+    """
+    give_up_at = time.monotonic() + _DEATH_TIMEOUT
+    try:
+        while _running(pid):
+            if time.monotonic() > give_up_at:
+                raise AssertionError(
+                    f"the rank under test (pid {pid}) was still running "
+                    f"{_DEATH_TIMEOUT:.0f}s after it began leaving, while its peer "
+                    "was still holding its socket open"
+                )
+            time.sleep(0.02)
+        return time.monotonic()
+    finally:
+        (tmp_path / "dead").write_text("go")
+
+
 def _finish(child: "subprocess.Popen[str]", tmp_path: Path) -> str:
     """Wait for the launch to end and return its stderr, killing it if it hangs."""
     pgid = os.getpgid(child.pid)
@@ -168,7 +224,9 @@ def _exit_codes(tmp_path: Path, nproc: int) -> dict[str, str]:
 
 
 # Recording the exit code from inside the driver, because torchrun reports its own
-# status rather than each rank's. Appended to every driver that has one to assert.
+# status rather than each rank's. Only for the drivers whose exit is a `SystemExit`:
+# on the abandonment paths the exit is an `os._exit`, nothing inside the interpreter
+# sees it coming, and the ``hard-exit`` marker is what carries the code instead.
 _RECORD_EXIT = """
         def record_exit(code):
             (OUT / f"exit.{os.environ['RANK']}").write_text(str(code))
@@ -271,6 +329,23 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
     already inside that exchange carrying the default group's own timeout, which
     different case with a different bound. `test_both_ranks_exit_at_the_same_batch
     _with_the_backend_released` is where the external signal is the claim.
+
+    **What is timed is rank 0's death, not its call to exit**, and rank 1 holds its
+    socket open until that death: an abandoned gloo group is disposed of by
+    ``~ProcessGroupGloo()`` during interpreter finalization, which joins the worker
+    thread still holding the abandoned operation and so ends only when the peer's
+    socket closes. Timing a timestamp written before the exit, against a peer that
+    had already gone, is a test that cannot observe the thing it appears to bound.
+
+    Which of the two assertions does the work is worth being exact about, because
+    the timing one does not. Whether finalization joins that thread or leaks it is
+    not deterministic: measured on torch 2.7.1, a minimal repro that held the group
+    in a local and destroyed both groups took 119.3s against a peer parked for 120s,
+    while *this* shape -- the group held by a module global, only the default group
+    destroyed -- leaked it and died in 4.66s with ``sys.exit`` against 3.02s with
+    ``os._exit``. So the bound below passes either way on this machine today, and
+    the ``hard-exit`` marker is what pins the exit actually being taken hard. The
+    bound is the backstop for the machine where it joins.
     """
     child = _launch(
         f"""
@@ -287,53 +362,63 @@ def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
         )
 
         OUT = Path(sys.argv[1])
-        {_RECORD_EXIT}
         rank = int(os.environ["RANK"])
+        (OUT / f"pid.{{rank}}").write_text(str(os.getpid()))
         wedge_at = 2
         add_post_shutdown_callback(
             lambda: (OUT / f"callback.{{rank}}").write_text("ran")
         )
-        try:
-            with Distributed.context():
-                with cooperative_stop(budget=1.0) as stop:
-                    for index in range(1000):
-                        torch.distributed.all_reduce(torch.ones(1))
-                        time.sleep(0.02)
-                        if index == wedge_at:
-                            if rank == 1:
-                                # the handler can never run, so this rank never
-                                # reaches the boundary below
-                                signal.pthread_sigmask(
-                                    signal.SIG_BLOCK, {{signal.SIGTERM}}
-                                )
-                                while not (OUT / "wedged").exists():
-                                    time.sleep(0.02)
-                                time.sleep(10.0)
-                                # a stand-in for the SIGKILL a real wedged rank
-                                # eventually gets; nothing is asserted about it
-                                os._exit(0)
-                            signal.raise_signal(signal.SIGTERM)
-                            (OUT / "wedged").write_text("go")
-                            (OUT / "started").write_text(str(time.monotonic()))
-                        if stop.agreed(index):
-                            break
-        except SystemExit as err:
-            record_exit(err.code)
-            (OUT / f"done.{{rank}}").write_text(str(time.monotonic()))
-            raise
+        with Distributed.context():
+            with cooperative_stop(budget=1.0) as stop:
+                for index in range(1000):
+                    torch.distributed.all_reduce(torch.ones(1))
+                    time.sleep(0.02)
+                    if index == wedge_at:
+                        if rank == 1:
+                            # the handler can never run, so this rank never
+                            # reaches the boundary below
+                            signal.pthread_sigmask(
+                                signal.SIG_BLOCK, {{signal.SIGTERM}}
+                            )
+                            # and its socket stays open until rank 0 is gone,
+                            # so rank 0's exit is bounded by rank 0 alone
+                            give_up_at = time.monotonic() + 20.0
+                            while not (OUT / "dead").exists():
+                                if time.monotonic() > give_up_at:
+                                    break
+                                time.sleep(0.02)
+                            # a stand-in for the SIGKILL a real wedged rank
+                            # eventually gets; nothing is asserted about it
+                            os._exit(0)
+                        signal.raise_signal(signal.SIGTERM)
+                        (OUT / "started").write_text(str(time.monotonic()))
+                    if stop.agreed(index):
+                        break
         """,
         tmp_path,
     )
+    try:
+        _wait_for_file(tmp_path / "pid.0", child)
+        _wait_for_file(tmp_path / "started", child)
+        died = _wait_for_death(int((tmp_path / "pid.0").read_text()), tmp_path)
+    except BaseException:
+        (tmp_path / "dead").write_text("go")
+        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        raise
     stderr = _finish(child, tmp_path)
 
-    assert _exit_codes(tmp_path, 2) == {"0": str(_SIGTERM_EXIT_CODE)}, stderr
     started = float((tmp_path / "started").read_text())
-    done = float((tmp_path / "done.0").read_text())
-    # The deadline that binds plus the teardown, with slack. The driver's 1s budget
-    # is below `_MIN_DEADLINE` and so is floored up to it, which is the figure to
-    # compare against; the point is that it is bounded at all, and that it is
-    # nothing like rank 1's 10s park.
-    assert done - started < _MIN_DEADLINE + 4.0, done - started
+    # The deadline that binds, plus the teardown and the callbacks, with slack. The
+    # driver's 1s budget is below `_MIN_DEADLINE` and so is floored up to it, which
+    # is the figure to compare against; the point is that it is bounded at all, and
+    # that it is nothing like the time rank 1 remains alive.
+    assert died - started < _MIN_DEADLINE + 4.0, died - started
+    # no `SystemExit` reaches the driver on this path -- the exit is hard, because
+    # the group left behind is what makes finalization wait for rank 1 -- so the
+    # code comes off the marker the hard exit writes
+    assert _marker_fields("hard-exit", stderr, "code") == [
+        str(_SIGTERM_EXIT_CODE)
+    ], stderr
     assert _marker_fields("agreement-timeout", stderr, "batch") == ["2"], stderr
     assert _marker_fields("agreement-abandoned", stderr, "batch") == ["2"], stderr
     assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 1, stderr
@@ -350,17 +435,21 @@ def test_a_rank_that_gives_up_with_no_local_event_exits(tmp_path):
     No signal is sent anywhere in this test. Rank 1 simply stops reaching the
     boundary and rank 0 gives up waiting for it, holding nothing on its
     `PendingStop` -- no signal, no exception -- which is the state every rank the
-    scheduler's signal did not reach is in. The exit code, observed from outside
-    the interpreter, is the assertion: a rank that merely broke out of the loop
-    would run on into `alternate_shuffle` and the train-evaluation pass, hang there
+    scheduler's signal did not reach is in. The exit, observed from outside the
+    interpreter, is the assertion: a rank that merely broke out of the loop would
+    run on into `alternate_shuffle` and the train-evaluation pass, hang there
     against peers that had gone, and be SIGKILLed with its communicators open.
+
+    Rank 1 stays alive with its socket open until rank 0 is observed dead, for two
+    reasons: so that rank 0 sees a deadline expiry rather than a closed socket, and
+    so that rank 0's death is bounded by rank 0's own exit rather than by rank 1's.
 
     The no-local-event deadline is patched down from the default group's own
     timeout, which is tens of minutes; nothing else about the path is altered, and
     the deadline's *value* is what the tier-1 tests cover.
     """
     child = _launch(
-        f"""
+        """
         import importlib, os, sys, time
         from pathlib import Path
 
@@ -380,41 +469,56 @@ def test_a_rank_that_gives_up_with_no_local_event_exits(tmp_path):
         module.no_local_event_deadline = lambda: 2.0
 
         OUT = Path(sys.argv[1])
-        {_RECORD_EXIT}
         rank = int(os.environ["RANK"])
+        (OUT / f"pid.{rank}").write_text(str(os.getpid()))
         leave_at = 2
         add_post_shutdown_callback(
-            lambda: (OUT / f"callback.{{rank}}").write_text("ran")
+            lambda: (OUT / f"callback.{rank}").write_text("ran")
         )
-        try:
-            with Distributed.context():
-                with cooperative_stop() as stop:
-                    for index in range(1000):
-                        torch.distributed.all_reduce(torch.ones(1))
-                        time.sleep(0.02)
-                        if index == leave_at and rank == 1:
-                            # stops reaching the boundary, while staying alive long
-                            # enough that rank 0 sees a deadline expiry rather than
-                            # a closed socket
-                            time.sleep(8.0)
-                            os._exit(0)
-                        if stop.agreed(index):
-                            break
-                    (OUT / f"loop-exited.{{rank}}").write_text("yes")
-                (OUT / f"scope-exited.{{rank}}").write_text("yes")
-                torch.distributed.all_reduce(torch.ones(1))  # never reached
-                (OUT / f"kept-going.{{rank}}").write_text("yes")
-        except SystemExit as err:
-            record_exit(err.code)
-            raise
+        with Distributed.context():
+            with cooperative_stop() as stop:
+                for index in range(1000):
+                    torch.distributed.all_reduce(torch.ones(1))
+                    time.sleep(0.02)
+                    if index == leave_at and rank == 1:
+                        (OUT / "left").write_text(str(time.monotonic()))
+                        give_up_at = time.monotonic() + 20.0
+                        while not (OUT / "dead").exists():
+                            if time.monotonic() > give_up_at:
+                                break
+                            time.sleep(0.02)
+                        os._exit(0)
+                    if stop.agreed(index):
+                        break
+                (OUT / f"loop-exited.{rank}").write_text("yes")
+            (OUT / f"scope-exited.{rank}").write_text("yes")
+            torch.distributed.all_reduce(torch.ones(1))  # never reached
+            (OUT / f"kept-going.{rank}").write_text("yes")
         """,
         tmp_path,
     )
+    try:
+        _wait_for_file(tmp_path / "pid.0", child)
+        _wait_for_file(tmp_path / "left", child)
+        died = _wait_for_death(int((tmp_path / "pid.0").read_text()), tmp_path)
+    except BaseException:
+        (tmp_path / "dead").write_text("go")
+        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        raise
     stderr = _finish(child, tmp_path)
 
+    # the patched 2s deadline, plus the teardown and the callbacks, with slack --
+    # and measured against a peer that was still alive, so it is rank 0's own exit
+    # that is bounded
+    left = float((tmp_path / "left").read_text())
+    assert died - left < 6.0, died - left
     # no signal was sent, so `128 + SIGTERM` here is the peer-stop convention for a
-    # stop that carries no signal number of its own
-    assert _exit_codes(tmp_path, 2) == {"0": str(_SIGTERM_EXIT_CODE)}, stderr
+    # stop that carries no signal number of its own. It comes off the hard exit's
+    # marker because no `SystemExit` is raised on this path: the group rank 0 left
+    # behind is what makes finalization wait for rank 1.
+    assert _marker_fields("hard-exit", stderr, "code") == [
+        str(_SIGTERM_EXIT_CODE)
+    ], stderr
     assert not (
         tmp_path / "kept-going.0"
     ).exists(), "rank 0 left the loop and executed a further collective"
@@ -535,13 +639,21 @@ def test_cooperative_stop_is_adoptable_by_a_bare_batch_loop(tmp_path):
     ],
 )
 def test_the_agreement_group_outlives_the_backend_teardown(tmp_path, backend_env):
-    """The teardown must not reclaim the agreement group.
+    """The teardown must not reclaim the group, and a second world gets a new one.
 
     ``destroy_process_group()`` clears torch's own bookkeeping and drains nothing,
     and gloo's ``shutdown()`` is an empty default -- so whether the call returns
     turns entirely on whether it dropped the last reference to the group. Two
     independent references stop it doing so, and either alone is sufficient: the
     module global in `stop_agreement` and the backend instance's own attribute.
+
+    Then a genuinely second ``init_process_group`` in the same process, which is the
+    state `new_stop_agreement`'s cache is about and the one thing the in-session
+    tests cannot build: they compare identities against ``cast``-faked worlds, so
+    nothing there exercises the predicate against real torch bookkeeping. The cached
+    group belongs to the destroyed world and its gloo context is no part of the new
+    world's, so it must be superseded -- and moved aside rather than released, since
+    releasing it runs the unbounded destructor.
 
     This runs in a subprocess rather than in-session, which is a departure from
     the plan: tearing the session's backend down would leave every later test in
@@ -551,12 +663,14 @@ def test_the_agreement_group_outlives_the_backend_teardown(tmp_path, backend_env
     """
     child = _launch(
         """
-        import sys, weakref
+        import importlib, os, sys, weakref
         from pathlib import Path
 
         import torch.distributed
 
         from fme.core.distributed import Distributed
+
+        module = importlib.import_module("fme.core.distributed.stop_agreement")
 
         OUT = Path(sys.argv[1])
         with Distributed.context():
@@ -567,6 +681,24 @@ def test_the_agreement_group_outlives_the_backend_teardown(tmp_path, backend_env
             dist.shutdown()
             assert not torch.distributed.is_initialized(), "the backend is still up"
             assert alive() is not None, "the agreement group was reclaimed"
+
+            first = module._agreement
+            world_size = int(os.environ["WORLD_SIZE"])
+            torch.distributed.init_process_group(
+                backend="gloo",
+                init_method="file://" + str(OUT / "second-world"),
+                rank=int(os.environ["RANK"]),
+                world_size=world_size,
+            )
+            world = torch.distributed.distributed_c10d._get_default_group()
+            second = module.new_stop_agreement(world_size, world)
+            assert second is not first, "a destroyed world's group was handed back"
+            assert module._leaked == [first], "the superseded group was not kept"
+            assert second.world_size == world_size
+            # and the same world asks for the same group rather than a second
+            # `new_group` some ranks would not match
+            assert module.new_stop_agreement(world_size, world) is second
+
             OUT.joinpath("survived." + str(dist.rank)).write_text("yes")
         """,
         tmp_path,

--- a/fme/core/distributed/test_cooperative_stop_exit.py
+++ b/fme/core/distributed/test_cooperative_stop_exit.py
@@ -1,0 +1,471 @@
+"""Tier 3: the exit paths, in subprocesses the test spawns.
+
+None of these can run in-session. `make test_parallel` is one pytest session per
+rank, so a rank that exits takes its whole session down without a summary and
+torchrun kills its peers, failing the entire ``-m parallel`` collection for that
+configuration. And `Distributed.context()` is already entered for the session and
+refuses to nest, while these tests are about what a real entrypoint does inside
+it.
+
+So each writes a driver to ``tmp_path`` and launches it under ``torchrun``, the
+way `test_shutdown_dataloader.py` does: ``start_new_session=True`` as torchrun
+launches a rank, and ``os.killpg`` where the claim is about a scheduler signalling
+a container. ``FME_FORCE_CPU=1`` throughout, so gloo, so they run on the CPU job
+too. Every timeout is injected small: no driver waits out a real 10s budget or a
+real 20s teardown.
+
+Ranks' stderr is inherited rather than redirected, so the ``fme-stop:`` marker
+lines land in the launcher's own stderr and are what the assertions read. Exit
+codes come from files the drivers write, because torchrun reports its own status
+rather than each rank's.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+# torchrun's own environment would send the driver's ranks down a rendezvous that
+# is not theirs; the launcher below is the one that sets these.
+_RANK_ENV = (
+    "RANK",
+    "LOCAL_RANK",
+    "WORLD_SIZE",
+    "LOCAL_WORLD_SIZE",
+    "GROUP_RANK",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+    "SLURM_PROCID",
+    "SLURM_NTASKS",
+)
+
+# Generous, because it only decides which diagnostic a hang produces: the suite's
+# autouse 90s alarm fires first either way. Observed runtime is ~8-15s.
+_LAUNCH_TIMEOUT = 60.0
+_READY_TIMEOUT = 40.0
+
+_SIGTERM_EXIT_CODE = 128 + int(signal.SIGTERM)
+
+# torchrun puts the *script's* directory on `sys.path`, not the working directory,
+# so a driver written to `tmp_path` would import whichever `fme` happens to be
+# installed rather than the one under test.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _driver_env(**overrides: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in _RANK_ENV}
+    env.pop("FME_DISTRIBUTED_BACKEND", None)
+    env.pop("FME_DISTRIBUTED_H", None)
+    env.pop("FME_DISTRIBUTED_W", None)
+    env["FME_FORCE_CPU"] = "1"
+    env["MASTER_ADDR"] = "127.0.0.1"
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(_REPO_ROOT), *filter(None, [os.environ.get("PYTHONPATH")])]
+    )
+    env.update(overrides)
+    return env
+
+
+def _launch(
+    source: str,
+    tmp_path: Path,
+    *,
+    nproc: int = 2,
+    env: dict[str, str] | None = None,
+) -> "subprocess.Popen[str]":
+    """Write a driver and launch it under torchrun in its own session."""
+    script = tmp_path / "driver.py"
+    script.write_text(textwrap.dedent(source))
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--nproc-per-node",
+            str(nproc),
+            "--rdzv-backend",
+            "c10d",
+            "--rdzv-endpoint",
+            "127.0.0.1:0",
+            str(script),
+            str(tmp_path),
+        ],
+        start_new_session=True,  # as torchrun launches a rank
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_driver_env() if env is None else env,
+    )
+
+
+def _wait_for_file(path: Path, child: "subprocess.Popen[str]") -> None:
+    give_up_at = time.monotonic() + _READY_TIMEOUT
+    while not path.exists():
+        if child.poll() is not None:
+            out, err = child.communicate()
+            raise AssertionError(
+                f"the driver exited with {child.returncode} before writing "
+                f"{path.name}\nstdout:\n{out}\nstderr:\n{err}"
+            )
+        if time.monotonic() > give_up_at:
+            raise AssertionError(f"timed out waiting for {path.name}")
+        time.sleep(0.05)
+
+
+def _finish(child: "subprocess.Popen[str]", tmp_path: Path) -> str:
+    """Wait for the launch to end and return its stderr, killing it if it hangs."""
+    pgid = os.getpgid(child.pid)
+    try:
+        _, err = child.communicate(timeout=_LAUNCH_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        os.killpg(pgid, signal.SIGKILL)
+        _, err = child.communicate()
+        raise AssertionError(f"the launch never finished; stderr:\n{err}")
+    finally:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    return err
+
+
+def _marker_fields(event: str, captured: str, field: str) -> list[str]:
+    """Every value of ``field`` on the ``event`` lines, one per emitting rank."""
+    prefix = f"fme-stop:{event} "
+    values = []
+    for line in captured.splitlines():
+        if not line.startswith(prefix):
+            continue
+        for part in line.split():
+            name, _, value = part.partition("=")
+            if name == field:
+                values.append(value)
+    return values
+
+
+def _exit_codes(tmp_path: Path, nproc: int) -> dict[str, str]:
+    return {
+        str(rank): (tmp_path / f"exit.{rank}").read_text()
+        for rank in range(nproc)
+        if (tmp_path / f"exit.{rank}").exists()
+    }
+
+
+# Recording the exit code from inside the driver, because torchrun reports its own
+# status rather than each rank's. Appended to every driver that has one to assert.
+_RECORD_EXIT = """
+        def record_exit(code):
+            (OUT / f"exit.{os.environ['RANK']}").write_text(str(code))
+"""
+
+
+@pytest.mark.slow
+@pytest.mark.medium_duration
+@pytest.mark.serial
+def test_both_ranks_exit_at_the_same_batch_with_the_backend_released(tmp_path):
+    """The whole thesis, end to end, and the evidence channel with it.
+
+    Two ranks under torchrun with a real per-iteration all-reduce on the default
+    group, signalled the way a scheduler signals a container: one ``killpg`` to
+    the whole process group. Both must leave the loop at the *same* batch, with
+    their backends released and their post-shutdown callbacks run -- which is
+    exactly what a reader has to be able to confirm from a container log, and
+    exactly what today's code cannot promise.
+    """
+    child = _launch(
+        f"""
+        import os, sys, time
+        from pathlib import Path
+
+        import torch
+        import torch.distributed
+
+        from fme.core.distributed import (
+            Distributed,
+            add_post_shutdown_callback,
+            cooperative_stop,
+        )
+
+        OUT = Path(sys.argv[1])
+        {_RECORD_EXIT}
+        rank = os.environ["RANK"]
+        add_post_shutdown_callback(
+            lambda: (OUT / f"callback.{{rank}}").write_text("ran")
+        )
+        try:
+            with Distributed.context():
+                with cooperative_stop(budget=1.0) as stop:
+                    for index in range(1000):
+                        torch.distributed.all_reduce(torch.ones(1))
+                        time.sleep(0.05)
+                        if index == 2:
+                            (OUT / f"ready.{{rank}}").write_text("go")
+                        if stop.agreed(index):
+                            break
+        except SystemExit as err:
+            record_exit(err.code)
+            raise
+        """,
+        tmp_path,
+    )
+    try:
+        _wait_for_file(tmp_path / "ready.0", child)
+        _wait_for_file(tmp_path / "ready.1", child)
+        os.killpg(os.getpgid(child.pid), signal.SIGTERM)  # as the scheduler does
+    except BaseException:
+        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        raise
+    stderr = _finish(child, tmp_path)
+
+    batches = _marker_fields("stop-agreed", stderr, "batch")
+    assert len(batches) == 2, stderr
+    assert len(set(batches)) == 1, f"the ranks stopped at different batches: {batches}"
+    assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 2, stderr
+    assert "did not complete" not in stderr
+    assert "fme-stop:agreement-timeout" not in stderr
+    assert "fme-stop:agreement-abandoned" not in stderr
+    assert "fme-stop:index-mismatch" not in stderr
+    assert _exit_codes(tmp_path, 2) == {
+        "0": str(_SIGTERM_EXIT_CODE),
+        "1": str(_SIGTERM_EXIT_CODE),
+    }
+    assert (tmp_path / "callback.0").exists() and (tmp_path / "callback.1").exists()
+
+
+@pytest.mark.slow
+@pytest.mark.medium_duration
+@pytest.mark.serial
+def test_a_wedged_rank_does_not_hold_a_healthy_rank_past_its_budget(tmp_path):
+    """A peer that never reaches the boundary does not hold the others there.
+
+    Rank 1 blocks SIGTERM with ``pthread_sigmask`` and parks, which is a
+    deterministic stand-in for "its main thread is inside a C-level call so its
+    handler cannot run" and needs no real NCCL wedge.
+
+    The two assertions that matter beyond the bound are that rank 0's teardown
+    *returned* and its callbacks *ran*. Both are true only because the abandoned
+    agreement group is left behind rather than reclaimed: reclaiming it would
+    block in the gloo destructor without bound, the phase would never reach the
+    callbacks, and the restart checkpoint would be lost by construction on exactly
+    the path where it is most valuable.
+
+    Rank 0 raises its own SIGTERM rather than waiting for one from outside, so
+    that its budget is provably armed before it enters the exchange rank 1 will
+    never join. A signal from outside landing a moment later would find rank 0
+    already inside that exchange carrying the group's 30 minutes, which is a
+    different case with a different bound. `test_both_ranks_exit_at_the_same_batch
+    _with_the_backend_released` is where the external signal is the claim.
+    """
+    child = _launch(
+        f"""
+        import os, signal, sys, time
+        from pathlib import Path
+
+        import torch
+        import torch.distributed
+
+        from fme.core.distributed import (
+            Distributed,
+            add_post_shutdown_callback,
+            cooperative_stop,
+        )
+
+        OUT = Path(sys.argv[1])
+        {_RECORD_EXIT}
+        rank = int(os.environ["RANK"])
+        wedge_at = 2
+        add_post_shutdown_callback(
+            lambda: (OUT / f"callback.{{rank}}").write_text("ran")
+        )
+        try:
+            with Distributed.context():
+                with cooperative_stop(budget=1.0) as stop:
+                    for index in range(1000):
+                        torch.distributed.all_reduce(torch.ones(1))
+                        time.sleep(0.02)
+                        if index == wedge_at:
+                            if rank == 1:
+                                # the handler can never run, so this rank never
+                                # reaches the boundary below
+                                signal.pthread_sigmask(
+                                    signal.SIG_BLOCK, {{signal.SIGTERM}}
+                                )
+                                while not (OUT / "wedged").exists():
+                                    time.sleep(0.02)
+                                time.sleep(6.0)
+                                # a stand-in for the SIGKILL a real wedged rank
+                                # eventually gets; nothing is asserted about it
+                                os._exit(0)
+                            signal.raise_signal(signal.SIGTERM)
+                            (OUT / "wedged").write_text("go")
+                            (OUT / "started").write_text(str(time.monotonic()))
+                        if stop.agreed(index):
+                            break
+        except SystemExit as err:
+            record_exit(err.code)
+            (OUT / f"done.{{rank}}").write_text(str(time.monotonic()))
+            raise
+        """,
+        tmp_path,
+    )
+    stderr = _finish(child, tmp_path)
+
+    assert _exit_codes(tmp_path, 2) == {"0": str(_SIGTERM_EXIT_CODE)}, stderr
+    started = float((tmp_path / "started").read_text())
+    done = float((tmp_path / "done.0").read_text())
+    # budget + teardown, with slack. The point is that it is bounded at all, and
+    # that it is nothing like rank 1's 6s park.
+    assert done - started < 5.0, done - started
+    assert _marker_fields("agreement-timeout", stderr, "batch") == ["2"], stderr
+    assert _marker_fields("agreement-abandoned", stderr, "batch") == ["2"], stderr
+    assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 1, stderr
+    assert "did not complete" not in stderr
+    assert (tmp_path / "callback.0").exists(), "the restart checkpoint was lost"
+
+
+@pytest.mark.slow
+@pytest.mark.medium_duration
+@pytest.mark.serial
+def test_cooperative_stop_is_adoptable_by_a_bare_batch_loop(tmp_path):
+    """Three public names and no `Trainer`, or the seam has failed.
+
+    The static assertion on the driver's own source is what makes this an
+    adoptability test rather than another end-to-end one: it fails if the
+    mechanism ever grows a dependency on the trainer, which is where a
+    `Trainer._should_stop()` design would show up.
+
+    This says nothing about whether a launcher or framework outside this
+    repository can adopt it.
+    """
+    source = f"""
+        \"\"\"A bare batch loop adopting the cooperative stop.
+
+        **The mechanism requires this process to exit after a stop.** An exchange
+        that is given up on can never be reclaimed in bounded time, so a caller
+        that means to carry on in the same process is outside what the design
+        bounds. This driver exits, and the assertion on its exit code is what
+        holds it to that.
+        \"\"\"
+        import os, sys, time
+        from pathlib import Path
+
+        import torch
+        import torch.distributed
+
+        from fme.core.distributed import (
+            Distributed,
+            add_post_shutdown_callback,
+            cooperative_stop,
+        )
+
+        OUT = Path(sys.argv[1])
+        {_RECORD_EXIT}
+        rank = os.environ["RANK"]
+        add_post_shutdown_callback(
+            lambda: (OUT / f"callback.{{rank}}").write_text("ran")
+        )
+        try:
+            with Distributed.context():
+                with cooperative_stop() as stop:
+                    for i in range(1000):
+                        time.sleep(0.05)
+                        torch.distributed.all_reduce(torch.ones(1))
+                        if i == 2:
+                            (OUT / f"ready.{{rank}}").write_text("go")
+                        if stop.agreed(i):
+                            break
+        except SystemExit as err:
+            record_exit(err.code)
+            raise
+        """
+    child = _launch(source, tmp_path)
+    try:
+        _wait_for_file(tmp_path / "ready.0", child)
+        _wait_for_file(tmp_path / "ready.1", child)
+        os.killpg(os.getpgid(child.pid), signal.SIGTERM)
+    except BaseException:
+        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        raise
+    stderr = _finish(child, tmp_path)
+
+    written = (tmp_path / "driver.py").read_text()
+    assert "fme.ace" not in written
+    assert "Trainer" not in written
+    assert "fme.core.generics" not in written
+    # the whole `fme` surface an adopter needs
+    assert written.count("from fme") == 1
+
+    batches = _marker_fields("stop-agreed", stderr, "batch")
+    assert len(batches) == 2 and len(set(batches)) == 1, stderr
+    assert len(_marker_fields("shutdown-returned", stderr, "elapsed")) == 2, stderr
+    assert _exit_codes(tmp_path, 2) == {
+        "0": str(_SIGTERM_EXIT_CODE),
+        "1": str(_SIGTERM_EXIT_CODE),
+    }
+    assert (tmp_path / "callback.0").exists() and (tmp_path / "callback.1").exists()
+
+
+@pytest.mark.slow
+@pytest.mark.medium_duration
+@pytest.mark.serial
+@pytest.mark.parametrize(
+    "backend_env",
+    [
+        pytest.param({"FME_DISTRIBUTED_BACKEND": "torch"}, id="torch"),
+        pytest.param(
+            {
+                "FME_DISTRIBUTED_BACKEND": "model",
+                "FME_DISTRIBUTED_H": "2",
+                "FME_DISTRIBUTED_W": "1",
+            },
+            id="model",
+        ),
+    ],
+)
+def test_the_agreement_group_outlives_the_backend_teardown(tmp_path, backend_env):
+    """The teardown must not reclaim the agreement group.
+
+    ``destroy_process_group()`` clears torch's own bookkeeping and drains nothing,
+    and gloo's ``shutdown()`` is an empty default -- so whether the call returns
+    turns entirely on whether it dropped the last reference to the group. Two
+    independent references stop it doing so, and either alone is sufficient: the
+    module global in `stop_agreement` and the backend instance's own attribute.
+
+    This runs in a subprocess rather than in-session, which is a departure from
+    the plan: tearing the session's backend down would leave every later test in
+    that rank's session without a process group, and nothing orders this test
+    last. The ``model`` parametrization is what covers
+    ``DistributedManager.cleanup()``.
+    """
+    child = _launch(
+        """
+        import sys, weakref
+        from pathlib import Path
+
+        import torch.distributed
+
+        from fme.core.distributed import Distributed
+
+        OUT = Path(sys.argv[1])
+        with Distributed.context():
+            dist = Distributed.get_instance()
+            agreement = dist.stop_agreement()
+            alive = weakref.ref(agreement.group)
+            del agreement
+            dist.shutdown()
+            assert not torch.distributed.is_initialized(), "the backend is still up"
+            assert alive() is not None, "the agreement group was reclaimed"
+            OUT.joinpath("survived." + str(dist.rank)).write_text("yes")
+        """,
+        tmp_path,
+        env=_driver_env(**backend_env),
+    )
+    stderr = _finish(child, tmp_path)
+
+    assert child.returncode == 0, stderr
+    assert (tmp_path / "survived.0").exists() and (tmp_path / "survived.1").exists()

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -14,6 +14,7 @@ from fme import get_device
 from fme.core.distributed import Distributed, model_torch_distributed, torch_distributed
 from fme.core.distributed.external.pnd_manager import DistributedManager
 from fme.core.distributed.model_torch_distributed import ModelTorchDistributed
+from fme.core.distributed.stop_agreement import SoloStopAgreement
 from fme.core.distributed.torch_distributed import (
     TorchDistributed,
     _gather_irregular,
@@ -367,6 +368,17 @@ def test_dataloader_worker_guard_does_not_affect_main_process(
     monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 8)
     monkeypatch.setattr(torch.distributed, "get_rank", lambda: 3)
     monkeypatch.setattr(torch.distributed, "init_process_group", lambda **kwargs: None)
+    # The constructor joins a world-wide gloo agreement group immediately after
+    # `init_process_group`, which this test skips by answering `is_initialized()`
+    # `True`. `new_group` is a real collective and there is no default group here
+    # for it to run on, so it is stubbed alongside `init_process_group` for the
+    # same reason. This test asserts nothing about the agreement group.
+    monkeypatch.setattr(
+        torch_distributed, "new_stop_agreement", lambda world_size: SoloStopAgreement()
+    )
+    monkeypatch.setattr(
+        torch.distributed.distributed_c10d, "_get_default_group", lambda: None
+    )
     set_devices: list[int] = []
     monkeypatch.setattr(torch.cuda, "set_device", set_devices.append)
 

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -14,6 +14,7 @@ from fme import get_device
 from fme.core.distributed import Distributed, model_torch_distributed, torch_distributed
 from fme.core.distributed.external.pnd_manager import DistributedManager
 from fme.core.distributed.model_torch_distributed import ModelTorchDistributed
+from fme.core.distributed.non_distributed import NonDistributed
 from fme.core.distributed.stop_agreement import SoloStopAgreement
 from fme.core.distributed.torch_distributed import (
     TorchDistributed,
@@ -374,7 +375,9 @@ def test_dataloader_worker_guard_does_not_affect_main_process(
     # for it to run on, so it is stubbed alongside `init_process_group` for the
     # same reason. This test asserts nothing about the agreement group.
     monkeypatch.setattr(
-        torch_distributed, "new_stop_agreement", lambda world_size: SoloStopAgreement()
+        torch_distributed,
+        "new_stop_agreement",
+        lambda world_size, world: SoloStopAgreement(),
     )
     monkeypatch.setattr(
         torch.distributed.distributed_c10d, "_get_default_group", lambda: None
@@ -387,6 +390,19 @@ def test_dataloader_worker_guard_does_not_affect_main_process(
     assert dist.rank == 3
     assert dist.total_ranks == 8
     assert set_devices == [expected_device_id]
+
+
+def test_the_agreement_object_is_created_with_the_backend_on_every_backend():
+    """The contract is one object per backend, and it holds without a launcher too.
+
+    `DistributedBackend.stop_agreement` documents the object as created with the
+    backend and not destroyed with it, and multi-rank tests assert exactly that for
+    the real backends. Returning a fresh one here is harmless today -- nothing
+    reads per-object state on `SoloStopAgreement` -- but a contract stated one way
+    and implemented two ways is how the harmless case stops being harmless.
+    """
+    backend = NonDistributed()
+    assert backend.stop_agreement() is backend.stop_agreement()
 
 
 def test_dataloader_worker_without_launcher_env_raises(monkeypatch):

--- a/fme/core/distributed/test_distributed.py
+++ b/fme/core/distributed/test_distributed.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import textwrap
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 import torch
@@ -403,6 +404,42 @@ def test_the_agreement_object_is_created_with_the_backend_on_every_backend():
     """
     backend = NonDistributed()
     assert backend.stop_agreement() is backend.stop_agreement()
+
+
+def test_an_unavailable_abort_is_reported_rather_than_swallowed(capfd):
+    """An unavailable abort and a failed abort must not read the same in a log.
+
+    `ProcessGroup.abort()` is not in every supported release -- `pyproject.toml`
+    declares ``torch>=2.4.0`` while `constraints.txt` pins ``torch==2.8.0`` -- and
+    the only caller is the watchdog, whose ``except BaseException`` would swallow an
+    `AttributeError` exactly as it swallows an abort that was attempted and failed.
+    A reader of a rank that hard-exited would then have no way to tell which
+    happened.
+    """
+
+    class _WithAbort:
+        def __init__(self) -> None:
+            self.aborted = 0
+
+        def abort(self) -> None:
+            self.aborted += 1
+
+    class _WithoutAbort:
+        pass
+
+    available = _WithAbort()
+    torch_distributed._abort_group(cast(Any, available))
+    assert available.aborted == 1
+    assert "fme-stop:watchdog-abort-unavailable" not in capfd.readouterr().err
+
+    torch_distributed._abort_group(cast(Any, _WithoutAbort()))
+    marker = capfd.readouterr().err
+    assert "fme-stop:watchdog-abort-unavailable" in marker, marker
+    assert f"torch={torch.__version__}" in marker, marker
+
+    # and no group at all is neither an abort nor a missing one
+    torch_distributed._abort_group(None)
+    assert "fme-stop:watchdog-abort-unavailable" not in capfd.readouterr().err
 
 
 def test_dataloader_worker_without_launcher_env_raises(monkeypatch):

--- a/fme/core/distributed/test_shutdown.py
+++ b/fme/core/distributed/test_shutdown.py
@@ -101,12 +101,12 @@ def test_a_hard_exit_is_taken_after_the_callbacks_and_not_before(monkeypatch, ca
 
     A caller that has left a gloo group behind asks for `os._exit`, because
     interpreter finalization joins the worker thread still holding the abandoned
-    operation and so waits for the wedged peer to die -- measured at 119.3s against
-    a peer parked for 120s, against 0.05s here. What makes that safe, where the
-    watchdog's hard exit is the fault this module exists to avoid, is *where* it
-    happens: after `shutdown` destroyed the communicators and after the callbacks
-    ran, so nothing is dropped and nothing is skipped. That ordering is the whole
-    claim, so it is what this asserts.
+    operation and so waits for the wedged peer to die; `PendingStop.require_hard_exit`
+    carries the measurement. What makes that safe, where the watchdog's hard exit is
+    the fault this module exists to avoid, is *where* it happens: after `shutdown`
+    destroyed the communicators and after the callbacks ran, so nothing is dropped
+    and nothing is skipped. That ordering is the whole claim, so it is what this
+    asserts.
     """
     events: list[str] = []
     exited: list[int] = []
@@ -174,6 +174,64 @@ def test_a_system_exit_from_a_pending_deferral_takes_the_exit_path(monkeypatch, 
     marker = _marker_lines("hard-exit", capfd.readouterr().err)
     assert len(marker) == 1
     assert f"code={128 + signal.SIGTERM}" in marker[0]
+
+
+def test_a_raising_deferral_that_asked_for_a_hard_exit_takes_one(monkeypatch, capfd):
+    """The exception path owes the hard exit too, and owes the traceback with it.
+
+    `exit_process=False` exists to leave a propagating exception's traceback intact,
+    but on a scope that abandoned a gloo group it also left the rank blocking in
+    finalization until its wedged peer died -- so torchrun SIGKILLed it and the
+    launcher read a signal death rather than a failure. The branch now prints the
+    traceback itself and exits hard with the exception's code, which is the code the
+    propagating exception would have produced anyway.
+    """
+    exited: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
+    events: list[str] = []
+    add_post_shutdown_callback(lambda: events.append("callback"))
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        # the stubbed `os._exit` falls through to `sys.exit`, which from a `finally`
+        # replaces the original exception -- so the `SystemExit` here is the evidence
+        # that the hard path was taken rather than the returning one
+        with pytest.raises(SystemExit) as excinfo:
+            with defer_termination(budget=1.0) as pending:
+                pending.require_hard_exit()
+                raise ValueError("a NaN in the loss")
+
+    assert exited == [1], "the rank was left to die in interpreter finalization"
+    assert excinfo.value.code == 1
+    assert events == ["shutdown", "callback"], "the hard exit skipped work"
+    stderr = capfd.readouterr().err
+    # the only thing `exit_process=False` was protecting
+    assert "ValueError: a NaN in the loss" in stderr, stderr
+    assert "code=1" in _marker_lines("hard-exit", stderr)[0]
+
+
+def test_a_system_exit_after_an_abandonment_hard_exits_with_the_callers_code(
+    monkeypatch, capfd
+):
+    """A caller's own `sys.exit` after an abandonment gets the hard exit and its code.
+
+    `defer_termination` is documented, exported behaviour, so this branch is reachable
+    by an adopter even though the trainer never takes it: a scope that abandoned an
+    exchange and then left by `sys.exit`, with no signal and no peer stop recorded,
+    previously got neither the hard exit nor an exit code of its own.
+    """
+    exited: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
+    events: list[str] = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=1.0) as pending:
+                pending.require_hard_exit()
+                raise SystemExit(17)  # nothing recorded: not a signal, not a peer
+
+    assert events == ["shutdown"]
+    assert exited == [17], "the caller's own exit code was replaced or not honoured"
+    assert "code=17" in _marker_lines("hard-exit", capfd.readouterr().err)[0]
 
 
 def test_a_marker_field_cannot_break_the_key_value_contract(capfd):

--- a/fme/core/distributed/test_shutdown.py
+++ b/fme/core/distributed/test_shutdown.py
@@ -565,6 +565,30 @@ def test_an_exception_inside_a_deferral_tears_down_without_masking_it():
     assert events == ["shutdown", "callback"]
 
 
+def test_a_signalled_rank_that_also_raises_keeps_the_exception():
+    """A propagating exception survives the dispatch, even beside a recorded signal.
+
+    This is the common case rather than a corner: the scheduler signals the whole
+    process group, so a rank whose peer *crashed* has usually recorded a signal
+    too -- and the exception it is carrying is the ``Connection closed by peer``
+    that the boundary exchange went out of its way to re-raise instead of masking
+    as a graceful stop. Exiting `128 + signum` from the dispatch would throw that
+    away and report a clean preemption.
+    """
+    events = []
+    add_post_shutdown_callback(lambda: events.append("callback"))
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(RuntimeError, match="Connection closed by peer"):
+            with defer_termination(budget=1.0) as pending:
+                signal.raise_signal(signal.SIGTERM)
+                assert pending.requested
+                raise RuntimeError("Connection closed by peer")
+
+    # the teardown still happened; only the `sys.exit` was withheld
+    assert events == ["shutdown", "callback"]
+
+
 def test_a_deferral_that_never_stops_writes_one_diagnostic_line(capfd):
     """A rank that never reaches a stopping point must not go unrecorded.
 

--- a/fme/core/distributed/test_shutdown.py
+++ b/fme/core/distributed/test_shutdown.py
@@ -12,8 +12,15 @@ import torch.utils.data
 
 from fme.core.distributed.shutdown import (
     add_post_shutdown_callback,
+    defer_termination,
     handle_termination_signals,
+    write_marker,
 )
+
+
+def _marker_lines(event: str, captured: str) -> list[str]:
+    prefix = f"fme-stop:{event} "
+    return [line for line in captured.splitlines() if line.startswith(prefix)]
 
 
 def _run_handler_program(program: str) -> "subprocess.CompletedProcess[str]":
@@ -400,3 +407,457 @@ def test_no_handler_installed_in_a_dataloader_worker(monkeypatch):
 
     with handle_termination_signals(shutdown=lambda: None):
         assert signal.getsignal(signal.SIGTERM) is original
+
+
+def test_signal_inside_a_deferral_does_not_shut_down(capfd):
+    """A signal must not tear the backend down while a rendezvous is open.
+
+    Tearing down from the handler is what strands peers: it happens wherever the
+    signal landed, which on one rank is a batch boundary and on another the
+    middle of a collective. Inside a deferral the signal is recorded instead, and
+    the caller decides where to act on it.
+    """
+    events = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=1.0) as pending:
+                signal.raise_signal(signal.SIGTERM)
+                assert pending.requested
+                assert pending.exit_code == 128 + signal.SIGTERM
+                assert events == []
+
+    assert events == ["shutdown"]
+    deferred = _marker_lines("signal-deferred", capfd.readouterr().err)
+    assert len(deferred) == 1
+    assert "signal=SIGTERM" in deferred[0]
+
+
+def test_deferred_stop_shuts_down_when_the_deferral_exits(capfd):
+    """Leaving the deferral must run the teardown the handler would have run."""
+    events = []
+    add_post_shutdown_callback(lambda: events.append("first callback"))
+    add_post_shutdown_callback(lambda: events.append("second callback"))
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit) as excinfo:
+            with defer_termination(budget=1.0):
+                signal.raise_signal(signal.SIGTERM)
+
+    assert events == ["shutdown", "first callback", "second callback"]
+    assert excinfo.value.code == 128 + signal.SIGTERM
+    # claim (b) of the evidence channel: this rank's teardown returned
+    assert len(_marker_lines("shutdown-returned", capfd.readouterr().err)) == 1
+
+
+def test_signal_outside_a_deferral_still_shuts_down_immediately():
+    """Outside a loop there is no rendezvous to wait for, so nothing changes.
+
+    Both sides of the deferral are checked: a signal before one has ever been
+    entered, and a signal after one has been left, must each tear down from the
+    handler as they do without this mechanism.
+    """
+    before = []
+    with handle_termination_signals(shutdown=lambda: before.append("shutdown")):
+        with pytest.raises(SystemExit) as excinfo:
+            signal.raise_signal(signal.SIGTERM)
+        assert before == ["shutdown"]
+    assert excinfo.value.code == 128 + signal.SIGTERM
+
+    after = []
+    with handle_termination_signals(shutdown=lambda: after.append("shutdown")):
+        with defer_termination(budget=1.0):
+            pass  # left with nothing pending, so nothing was torn down
+        assert after == []
+        with pytest.raises(SystemExit) as excinfo:
+            signal.raise_signal(signal.SIGTERM)
+        assert after == ["shutdown"]
+    assert excinfo.value.code == 128 + signal.SIGTERM
+
+
+def test_second_signal_while_a_stop_is_pending_is_ignored(monkeypatch, capfd):
+    """A repeated SIGTERM must not defeat the deferral.
+
+    In production a second SIGTERM is the norm rather than an escalation: the
+    scheduler signals the container's process group and torchrun's agent then
+    signals every rank again. Honouring it by tearing down immediately would
+    strand peers on essentially every real preemption.
+    """
+    exited = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
+    events = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=1.0) as pending:
+                signal.raise_signal(signal.SIGTERM)
+                signal.raise_signal(signal.SIGTERM)
+                signal.raise_signal(signal.SIGINT)
+                assert events == []
+                assert pending.exit_code == 128 + signal.SIGTERM
+
+    assert exited == []  # no escalation to a hard exit
+    assert events == ["shutdown"]
+    stderr = capfd.readouterr().err
+    assert len(_marker_lines("signal-deferred", stderr)) == 1
+    assert len(_marker_lines("signal-ignored", stderr)) == 2
+
+
+def test_the_budget_is_absolute_from_the_signal_not_per_boundary():
+    """A rank cannot accumulate a fresh budget at each rendezvous.
+
+    The budget bounds how long a rank that is leaving waits for peers that may
+    never arrive, measured from the local event, so time spent walking to a
+    rendezvous is spent out of it.
+    """
+    with handle_termination_signals(shutdown=lambda: None):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=0.3) as pending:
+                # nothing recorded yet, so no clock is running: a healthy rank
+                # must never be the one holding a short deadline
+                assert pending.seconds_remaining() is None
+                signal.raise_signal(signal.SIGTERM)
+                observed = []
+                for _ in range(3):
+                    time.sleep(0.01)
+                    remaining = pending.seconds_remaining()
+                    assert remaining is not None
+                    observed.append(remaining)
+                assert observed == sorted(observed, reverse=True)
+                assert len(set(observed)) == 3
+                assert max(observed) < 0.3
+
+
+def test_a_peer_stop_tears_down_even_though_no_signal_arrived():
+    """A rank that only ever read a peer's stop must still tear down.
+
+    Without this it would leave the loop and walk into the next collective, whose
+    peers have already left -- so it would hang there and be SIGKILLed with its
+    communicators open.
+    """
+    events = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit) as excinfo:
+            with defer_termination(budget=1.0) as pending:
+                pending.note_peer_stop()
+
+    assert events == ["shutdown"]
+    # a peer's stop carries no signal number, so SIGTERM's code by convention
+    assert excinfo.value.code == 128 + signal.SIGTERM
+
+
+def test_an_exception_inside_a_deferral_tears_down_without_masking_it():
+    """The exception path must tear down and still lose nothing of the raise.
+
+    Today an exception skips `shutdown()` entirely and the rank exits with its
+    communicators open. Tearing down here fixes that, but a `sys.exit` on the way
+    out would replace the traceback with an exit code, so this path returns.
+    """
+    events = []
+    add_post_shutdown_callback(lambda: events.append("callback"))
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(ValueError, match="a NaN in the loss"):
+            with defer_termination(budget=1.0):
+                raise ValueError("a NaN in the loss")
+
+    assert events == ["shutdown", "callback"]
+
+
+def test_a_deferral_that_never_stops_writes_one_diagnostic_line(capfd):
+    """A rank that never reaches a stopping point must not go unrecorded.
+
+    The timer only writes: the sole lever a timer thread has over a wedged main
+    thread is `os._exit`, which is the fabric fault this module exists to avoid.
+    """
+    with handle_termination_signals(shutdown=lambda: None):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=0.05) as pending:
+                signal.raise_signal(signal.SIGTERM)
+                assert pending.requested
+                time.sleep(0.3)  # past 2 x budget, without reaching a stop
+
+    overrun = _marker_lines("deferral-overrun", capfd.readouterr().err)
+    assert len(overrun) == 1
+    assert "since=0s" in overrun[0]
+
+
+def test_a_deferral_that_stops_promptly_writes_no_diagnostic_line(capfd):
+    with handle_termination_signals(shutdown=lambda: None):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=0.05) as pending:
+                signal.raise_signal(signal.SIGTERM)
+                assert pending.requested
+
+    time.sleep(0.3)  # long enough that an uncancelled timer would have fired
+    assert _marker_lines("deferral-overrun", capfd.readouterr().err) == []
+
+
+def test_deferral_is_inert_in_a_dataloader_worker(monkeypatch):
+    """A worker must not swallow the signal that would have killed it.
+
+    A fork-started worker inherits both the handler and the deferral registry, so
+    a deferral that registered here would leave the worker alive and deaf: it
+    would neither die as it would have without the inheritance nor gain anyone to
+    poll what it recorded.
+    """
+    events = []
+    pendings = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        monkeypatch.setattr(torch.utils.data, "get_worker_info", lambda: object())
+        with pytest.raises(SystemExit) as excinfo:
+            with defer_termination(budget=1.0) as pending:
+                pendings.append(pending)
+                signal.raise_signal(signal.SIGTERM)
+
+    assert pendings[0].requested is False
+    assert events == ["shutdown"]
+    assert excinfo.value.code == 128 + signal.SIGTERM
+
+
+def test_a_deferral_off_the_main_thread_does_not_claim_the_registry():
+    """A thread cannot own the disposition, so it must not own the registry.
+
+    Nothing would ever record a signal into it, and claiming it would lock the
+    main thread out of the one registration there is.
+    """
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            with defer_termination(budget=1.0):
+                with defer_termination(budget=1.0):
+                    pass
+        except BaseException as err:
+            errors.append(err)  # a thread's exception would otherwise be lost
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join()
+
+    assert errors == []
+
+
+def test_nested_defer_termination_is_rejected():
+    """The registry is process-global, so only one scope can own the teardown."""
+    with defer_termination(budget=1.0):
+        with pytest.raises(RuntimeError, match="Nested"):
+            with defer_termination(budget=1.0):
+                pass
+
+
+def test_a_forked_child_in_a_deferral_does_not_record_intent():
+    """The pid guard must run before the deferral branch.
+
+    A forked worker inherits the registry along with the handler, so if the
+    deferral branch ran first the worker would record intent and return -- left
+    alive, deaf, and with nobody to poll it -- instead of dying as it would have
+    without the inheritance.
+    """
+    read_fd, write_fd = os.pipe()
+
+    def report(event: bytes) -> None:
+        # the child cannot report back through the parent's objects
+        os.write(write_fd, event)
+
+    add_post_shutdown_callback(lambda: report(b"callback"))
+
+    with handle_termination_signals(shutdown=lambda: report(b"shutdown")):
+        with defer_termination(budget=1.0):
+            pid = os.fork()
+            if pid == 0:
+                # never let a forked copy of the test session escape back into
+                # pytest, whatever the handler does
+                try:
+                    os.close(read_fd)
+                    signal.raise_signal(signal.SIGTERM)
+                    report(b"deferred")
+                except BaseException:
+                    pass
+                finally:
+                    os._exit(0)
+
+            os.close(write_fd)
+            ready: list[int] = []
+            try:
+                ready, _, _ = select.select([read_fd], [], [], 30.0)
+                observed = os.read(read_fd, 4096) if ready else b"child hung"
+            finally:
+                os.close(read_fd)
+                if not ready:
+                    os.kill(pid, signal.SIGKILL)
+                _, status = os.waitpid(pid, 0)
+
+    assert observed == b""
+    assert os.WIFSIGNALED(status) and os.WTERMSIG(status) == signal.SIGTERM
+
+
+def test_marker_lines_carry_the_documented_fields(capfd, monkeypatch):
+    """One line, one write, fields in a fixed order.
+
+    The reader's whole recipe is `grep` over these lines, and a rank that failed
+    is identified by the absence of its own, so every line has to carry the rank
+    label and `installed_pid` -- which is what tells a real rank from a
+    fork-started DataLoader worker sharing its parent's RANK.
+    """
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+
+    with handle_termination_signals(shutdown=lambda: None):
+        write_marker("stop-agreed", batch="41200", world="8")
+    write_marker("stop-agreed", batch="41201", world="8")
+
+    installed, uninstalled = _marker_lines("stop-agreed", capfd.readouterr().err)
+    fields = installed.split(" ")
+    assert [field.split("=")[0] for field in fields[1:]] == [
+        "rank",
+        "local_rank",
+        "pid",
+        "installed_pid",
+        "wall",
+        "mono",
+        "batch",
+        "world",
+    ]
+    assert fields[0] == "fme-stop:stop-agreed"
+    assert f"rank=3 local_rank=1 pid={os.getpid()} installed_pid={os.getpid()}" in (
+        installed
+    )
+    assert "batch=41200 world=8" in installed
+    # with no handler installed there is no pid to compare against
+    assert "installed_pid=?" in uninstalled
+
+
+def test_marker_lines_survive_an_unwritable_stderr(monkeypatch):
+    """A marker is evidence about a failure and may not become one."""
+
+    def refuse(fd, data):
+        raise OSError("stderr is gone")
+
+    monkeypatch.setattr(os, "write", refuse)
+    write_marker("stop-agreed", batch="41200")
+
+
+@pytest.mark.medium_duration
+def test_the_watchdog_aborts_before_its_backstop_exit():
+    """A rank that gives up must abort its communicators, not just vanish.
+
+    An `os._exit` taken with communicators open is what drops this rank's NVLink
+    peers abruptly. Aborting first at least makes the release ordered, and may
+    release this rank's own main thread from the collective; the hard exit stays
+    as a named backstop for when it does not.
+    """
+    result = _run_handler_program(
+        """
+        import signal, threading
+        from fme.core.distributed import shutdown as shutdown_module
+        from fme.core.distributed.shutdown import handle_termination_signals
+
+        shutdown_module._ABORT_BACKSTOP = 0.3
+
+        def hang():
+            threading.Event().wait()
+
+        def abort():
+            print("abort ran", flush=True)
+
+        with handle_termination_signals(
+            shutdown=hang, teardown_timeout=1.0, abort=abort
+        ):
+            signal.raise_signal(signal.SIGTERM)
+        """
+    )
+
+    assert result.returncode == 128 + signal.SIGTERM
+    assert result.stdout.splitlines() == ["abort ran"]
+    assert "fme-stop:watchdog-abort" in result.stderr
+    assert "timeout=1" in result.stderr
+    assert (
+        "Distributed shutdown did not complete within 1s, aborting the local "
+        "communicator." in result.stderr
+    )
+
+
+@pytest.mark.medium_duration
+def test_a_released_main_thread_is_not_exited_mid_callback():
+    """The backstop must stand down if the abort released the main thread.
+
+    An abort that works releases the main thread at once, so it can cancel the
+    watchdog while the watchdog thread is still between its abort and its
+    backstop. `Timer.cancel()` on an unstarted timer does nothing, so without the
+    cancelled flag the backstop would start unopposed and exit the process out
+    from under the checkpoint write the released main thread had just begun.
+    """
+    result = _run_handler_program(
+        """
+        import signal, threading, time
+        from fme.core.distributed import shutdown as shutdown_module
+        from fme.core.distributed.shutdown import (
+            add_post_shutdown_callback,
+            handle_termination_signals,
+        )
+
+        shutdown_module._ABORT_BACKSTOP = 0.2
+
+        released = threading.Event()
+
+        def hang():
+            released.wait()      # the abort below is what lets this return
+
+        def abort():
+            released.set()
+
+        def slow_write():
+            time.sleep(1.0)      # stands in for the multi-GB torch.save
+            print("callback complete", flush=True)
+
+        add_post_shutdown_callback(slow_write)
+        try:
+            with handle_termination_signals(
+                shutdown=hang, teardown_timeout=0.5, abort=abort
+            ):
+                signal.raise_signal(signal.SIGTERM)
+        except SystemExit as err:
+            # the graceful exit and the backstop's os._exit share an exit code,
+            # so the code cannot be the evidence
+            print(f"sys.exit {err.code}", flush=True)
+            raise
+        """
+    )
+
+    assert result.stdout.splitlines() == [
+        "callback complete",
+        f"sys.exit {128 + signal.SIGTERM}",
+    ]
+    assert result.returncode == 128 + signal.SIGTERM
+
+
+@pytest.mark.medium_duration
+def test_a_signal_outside_a_deferral_exits_128_plus_signum():
+    """The immediate path is unchanged at process level, not only in process.
+
+    pytest catches the graceful `SystemExit`, so the exit code a real rank hands
+    the launcher can only be observed from outside.
+    """
+    result = _run_handler_program(
+        """
+        import signal
+        from fme.core.distributed.shutdown import (
+            defer_termination,
+            handle_termination_signals,
+        )
+
+        with handle_termination_signals(
+            shutdown=lambda: print("shutdown", flush=True)
+        ):
+            with defer_termination(budget=1.0):
+                pass
+            signal.raise_signal(signal.SIGTERM)
+        """
+    )
+
+    assert result.returncode == 128 + signal.SIGTERM
+    assert result.stdout.splitlines() == ["shutdown"]
+    assert "fme-stop:shutdown-returned" in result.stderr

--- a/fme/core/distributed/test_shutdown.py
+++ b/fme/core/distributed/test_shutdown.py
@@ -96,6 +96,123 @@ def test_later_callbacks_run_even_if_an_earlier_one_fails():
     assert events == ["callback"]
 
 
+def test_a_hard_exit_is_taken_after_the_callbacks_and_not_before(monkeypatch, capfd):
+    """The hard exit an abandoned group forces must skip nothing.
+
+    A caller that has left a gloo group behind asks for `os._exit`, because
+    interpreter finalization joins the worker thread still holding the abandoned
+    operation and so waits for the wedged peer to die -- measured at 119.3s against
+    a peer parked for 120s, against 0.05s here. What makes that safe, where the
+    watchdog's hard exit is the fault this module exists to avoid, is *where* it
+    happens: after `shutdown` destroyed the communicators and after the callbacks
+    ran, so nothing is dropped and nothing is skipped. That ordering is the whole
+    claim, so it is what this asserts.
+    """
+    events: list[str] = []
+    exited: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
+    add_post_shutdown_callback(lambda: events.append("callback"))
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        # the stubbed `os._exit` falls through to the ordinary `sys.exit`, which is
+        # what lets this run in-session at all
+        with pytest.raises(SystemExit) as excinfo:
+            with defer_termination(budget=1.0) as pending:
+                pending.require_hard_exit()
+                signal.raise_signal(signal.SIGTERM)
+
+    assert events == ["shutdown", "callback"]
+    assert exited == [128 + signal.SIGTERM]
+    assert excinfo.value.code == 128 + signal.SIGTERM
+    # and it says so, since a rank that ends this way writes no exit status anyone
+    # inside the process can read
+    hard = _marker_lines("hard-exit", capfd.readouterr().err)
+    assert len(hard) == 1
+    assert f"code={128 + signal.SIGTERM}" in hard[0]
+
+
+def test_a_deferral_left_without_a_pending_stop_does_not_hard_exit(monkeypatch):
+    """`require_hard_exit` is about how to exit, not a reason to exit.
+
+    A scope that asked for it and then reached its end with nothing recorded --
+    a loop that ran to completion after an earlier epoch abandoned an exchange, say
+    -- must exit no more eagerly than one that never asked.
+    """
+    exited: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
+    events: list[str] = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with defer_termination(budget=1.0) as pending:
+            pending.require_hard_exit()
+
+    assert exited == []
+    assert events == []
+
+
+def test_a_system_exit_from_a_pending_deferral_takes_the_exit_path(monkeypatch, capfd):
+    """A caller leaving by `sys.exit` gets the teardown, and the hard exit with it.
+
+    This is how `cooperative_stop` leaves when the loop-entry exchange is given up
+    on: the loop body must not run, and a context manager cannot skip its own body.
+    A `SystemExit` carries no traceback to protect, so unlike a real exception it
+    takes the exit path -- which is the only one that can honour a hard exit.
+    """
+    exited: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exited.append(code))
+    events: list[str] = []
+
+    with handle_termination_signals(shutdown=lambda: events.append("shutdown")):
+        with pytest.raises(SystemExit):
+            with defer_termination(budget=1.0) as pending:
+                pending.note_peer_stop()
+                pending.require_hard_exit()
+                raise SystemExit(128 + signal.SIGTERM)
+
+    assert events == ["shutdown"]
+    assert exited == [128 + signal.SIGTERM]
+    marker = _marker_lines("hard-exit", capfd.readouterr().err)
+    assert len(marker) == 1
+    assert f"code={128 + signal.SIGTERM}" in marker[0]
+
+
+def test_a_marker_field_cannot_break_the_key_value_contract(capfd):
+    """A torch error message contains spaces, and a marker line may not.
+
+    The lines are fixed space-separated ``key=value`` pairs, and the readers that
+    matter -- including the tests' own field parsers -- split on whitespace. So the
+    encoding is the writer's job rather than each caller's.
+    """
+    write_marker("agreement-timeout", err="Operation timed out!\nsecond line")
+
+    line = _marker_lines("agreement-timeout", capfd.readouterr().err)[0]
+    fields = dict(part.partition("=")[::2] for part in line.split())
+    assert fields["err"] == "Operation_timed_out!_second_line"
+    assert len(line.splitlines()) == 1
+
+
+def test_an_inner_handler_scope_does_not_discard_an_outer_scopes_callbacks():
+    """Nesting is legal, and leaving an inner scope must not disarm an outer one.
+
+    The restore-on-exit of `_terminate` says nesting is supported; clearing the
+    callback registry unconditionally said the opposite, since an inner scope
+    exiting took the outer job's restart-checkpoint callback with it.
+    """
+    ran: list[str] = []
+
+    with handle_termination_signals(shutdown=lambda: None):
+        add_post_shutdown_callback(lambda: ran.append("outer"))
+        with handle_termination_signals(shutdown=lambda: None):
+            add_post_shutdown_callback(lambda: ran.append("inner"))
+        assert ran == []
+        with pytest.raises(SystemExit):
+            signal.raise_signal(signal.SIGTERM)
+
+    # the outer scope's callback survived the inner scope's exit, and the inner
+    # scope's own did not outlive it
+    assert ran == ["outer"]
+
+
 def test_previous_handlers_and_callbacks_are_restored_on_exit():
     original = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
     ran = []

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -68,10 +68,14 @@ class TorchDistributed(DistributedBackend):
             self.world_size = torch.distributed.get_world_size()
             local_rank = int(os.environ["LOCAL_RANK"])
             self._rank = torch.distributed.get_rank()
-            self._stop_agreement = self._join_stop_agreement()
             if using_gpu():
                 self._device_id = local_rank
                 torch.cuda.set_device(self._device_id)
+            # after the device binding, which the `Distributed` class documents as
+            # coming first. A gloo `new_group` does not touch the device today, so
+            # this is ordering rather than a fix -- and a collective on the wrong
+            # side of a documented ordering is not worth leaving there.
+            self._stop_agreement = self._join_stop_agreement()
         elif using_srun():  # executing with srun
             shared_dist_file = os.environ["SRUN_DIST_FILE_PATH"]
             self._rank = int(os.environ["SLURM_PROCID"])
@@ -84,12 +88,13 @@ class TorchDistributed(DistributedBackend):
                 world_size=self.world_size,
                 timeout=timedelta(minutes=30),
             )
-            self._stop_agreement = self._join_stop_agreement()
             if using_gpu():
                 # this assumes one GPU per process in the SLURM setting
                 # --gpus-per-task=1 --gpu-bind=closest
                 self._device_id = 0
                 torch.cuda.set_device(self._device_id)
+            # after the device binding, for the reason given in the torchrun branch
+            self._stop_agreement = self._join_stop_agreement()
         else:
             raise ValueError(
                 "Distributed backend initialized without torchrun or srun."

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -18,6 +18,7 @@ from fme.core.disco import DiscreteContinuousConvS2
 
 from .base import DistributedBackend
 from .non_distributed import DummyWrapper
+from .shutdown import write_marker
 from .stop_agreement import SoloStopAgreement, StopAgreement, new_stop_agreement
 
 logger = logging.getLogger(__name__)
@@ -34,10 +35,40 @@ def _rank_metadata_from_env() -> tuple[int, int]:
     return int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
 
 
+def _abort_group(group: torch.distributed.ProcessGroup | None) -> None:
+    """Abort ``group``'s communicators, or record that this torch release cannot.
+
+    Shared by both torch-backed backends, because the availability question is the
+    installed release's rather than either backend's.
+
+    ``ProcessGroup.abort()`` is not present in every supported release:
+    `pyproject.toml` declares ``torch>=2.4.0``, while `constraints.txt` pins
+    ``torch==2.8.0`` for the Docker image -- so the pinned release has it and a
+    supported one may not. Checking rather than calling and letting the
+    ``AttributeError`` fly matters because the only caller is the watchdog's
+    ``give_up``, whose ``except BaseException`` would swallow it identically to an
+    abort that was attempted and failed. A reader of a rank that hard-exited would
+    then have no way to tell "this torch has no abort" from "the abort did not
+    work", so the two get different markers.
+    """
+    if group is None:
+        return
+    abort = getattr(group, "abort", None)
+    if abort is None:
+        write_marker("watchdog-abort-unavailable", torch=torch.__version__)
+        return
+    abort()
+
+
 class TorchDistributed(DistributedBackend):
     """A non-distributed backend implementation."""
 
     def __init__(self):
+        # Annotated here rather than on whichever branch happens to assign first,
+        # so that a later edit to the branching below cannot move the declaration
+        # out from under the paths that do not carry it.
+        self._stop_agreement: StopAgreement
+        self._default_group: torch.distributed.ProcessGroup | None = None
         if in_dataloader_worker():
             # a worker only needs the sharding metadata that tells it which
             # samples are its rank's. Joining the process group and setting the
@@ -48,8 +79,7 @@ class TorchDistributed(DistributedBackend):
             # not, since `new_group` is a collective its rank's real process is
             # not making. It inherits the parent's group file descriptors
             # harmlessly, issuing no collectives on them.
-            self._stop_agreement: StopAgreement = SoloStopAgreement()
-            self._default_group: torch.distributed.ProcessGroup | None = None
+            self._stop_agreement = SoloStopAgreement()
             return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun
             if not torch.distributed.is_initialized():
@@ -75,7 +105,7 @@ class TorchDistributed(DistributedBackend):
             # coming first. A gloo `new_group` does not touch the device today, so
             # this is ordering rather than a fix -- and a collective on the wrong
             # side of a documented ordering is not worth leaving there.
-            self._stop_agreement = self._join_stop_agreement()
+            self._stop_agreement, self._default_group = self._join_stop_agreement()
         elif using_srun():  # executing with srun
             shared_dist_file = os.environ["SRUN_DIST_FILE_PATH"]
             self._rank = int(os.environ["SLURM_PROCID"])
@@ -94,14 +124,21 @@ class TorchDistributed(DistributedBackend):
                 self._device_id = 0
                 torch.cuda.set_device(self._device_id)
             # after the device binding, for the reason given in the torchrun branch
-            self._stop_agreement = self._join_stop_agreement()
+            self._stop_agreement, self._default_group = self._join_stop_agreement()
         else:
             raise ValueError(
                 "Distributed backend initialized without torchrun or srun."
             )
 
-    def _join_stop_agreement(self) -> StopAgreement:
+    def _join_stop_agreement(
+        self,
+    ) -> tuple[StopAgreement, torch.distributed.ProcessGroup]:
         """Join the world-wide agreement group, eagerly and once per process.
+
+        Returns both the agreement and the default group it was built alongside,
+        rather than assigning the latter as a side effect: the watchdog's `abort`
+        needs that group and a returned pair is the version a reader of the
+        constructor can see.
 
         Eagerly because ``new_group`` for gloo is a blocking full-mesh rendezvous,
         so its creation point has to be one every rank provably reaches; the
@@ -116,8 +153,8 @@ class TorchDistributed(DistributedBackend):
         Once per process because the constructor is reached ad hoc, and a second
         unmatched ``new_group`` would hang whichever ranks did not make it.
         """
-        self._default_group = torch.distributed.distributed_c10d._get_default_group()
-        return new_stop_agreement(self.world_size, self._default_group)
+        default_group = torch.distributed.distributed_c10d._get_default_group()
+        return new_stop_agreement(self.world_size, default_group), default_group
 
     def stop_agreement(self) -> StopAgreement:
         return self._stop_agreement
@@ -128,8 +165,7 @@ class TorchDistributed(DistributedBackend):
         # and would race the main thread inside `destroy_process_group`, and
         # looking the default group up again would fail once that call has
         # cleared the bookkeeping.
-        if self._default_group is not None:
-            self._default_group.abort()
+        _abort_group(self._default_group)
 
     @classmethod
     def is_available(cls) -> bool:

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -112,7 +112,7 @@ class TorchDistributed(DistributedBackend):
         unmatched ``new_group`` would hang whichever ranks did not make it.
         """
         self._default_group = torch.distributed.distributed_c10d._get_default_group()
-        return new_stop_agreement(self.world_size)
+        return new_stop_agreement(self.world_size, self._default_group)
 
     def stop_agreement(self) -> StopAgreement:
         return self._stop_agreement

--- a/fme/core/distributed/torch_distributed.py
+++ b/fme/core/distributed/torch_distributed.py
@@ -18,6 +18,7 @@ from fme.core.disco import DiscreteContinuousConvS2
 
 from .base import DistributedBackend
 from .non_distributed import DummyWrapper
+from .stop_agreement import SoloStopAgreement, StopAgreement, new_stop_agreement
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,12 @@ class TorchDistributed(DistributedBackend):
             # device would buy it nothing and leave an idle ~520 MiB CUDA context
             # behind, GiB of it across several persistent worker pools per rank.
             self._rank, self.world_size = _rank_metadata_from_env()
+            # A worker joins no group, so it can agree with nobody -- and must
+            # not, since `new_group` is a collective its rank's real process is
+            # not making. It inherits the parent's group file descriptors
+            # harmlessly, issuing no collectives on them.
+            self._stop_agreement: StopAgreement = SoloStopAgreement()
+            self._default_group: torch.distributed.ProcessGroup | None = None
             return
         if "RANK" in os.environ and not using_srun():  # we were executed with torchrun
             if not torch.distributed.is_initialized():
@@ -61,6 +68,7 @@ class TorchDistributed(DistributedBackend):
             self.world_size = torch.distributed.get_world_size()
             local_rank = int(os.environ["LOCAL_RANK"])
             self._rank = torch.distributed.get_rank()
+            self._stop_agreement = self._join_stop_agreement()
             if using_gpu():
                 self._device_id = local_rank
                 torch.cuda.set_device(self._device_id)
@@ -76,6 +84,7 @@ class TorchDistributed(DistributedBackend):
                 world_size=self.world_size,
                 timeout=timedelta(minutes=30),
             )
+            self._stop_agreement = self._join_stop_agreement()
             if using_gpu():
                 # this assumes one GPU per process in the SLURM setting
                 # --gpus-per-task=1 --gpu-bind=closest
@@ -85,6 +94,37 @@ class TorchDistributed(DistributedBackend):
             raise ValueError(
                 "Distributed backend initialized without torchrun or srun."
             )
+
+    def _join_stop_agreement(self) -> StopAgreement:
+        """Join the world-wide agreement group, eagerly and once per process.
+
+        Eagerly because ``new_group`` for gloo is a blocking full-mesh rendezvous,
+        so its creation point has to be one every rank provably reaches; the
+        constructor immediately after ``init_process_group`` is, while a lazy
+        first use inside a training loop is not, a rank there possibly already
+        tearing down. The cost is real and is stated rather than hidden: this
+        becomes the process's first world-wide barrier, so it absorbs the launch
+        jitter ``init_process_group`` does not, inside the window before the
+        termination handler is installed. It is bounded by the same 30 minutes
+        ``init_process_group`` itself carries.
+
+        Once per process because the constructor is reached ad hoc, and a second
+        unmatched ``new_group`` would hang whichever ranks did not make it.
+        """
+        self._default_group = torch.distributed.distributed_c10d._get_default_group()
+        return new_stop_agreement(self.world_size)
+
+    def stop_agreement(self) -> StopAgreement:
+        return self._stop_agreement
+
+    def abort(self) -> None:
+        # `ProcessGroup.abort()` on the group captured at construction, not
+        # `_abort_process_group`: the module-level helper mutates torch's `_world`
+        # and would race the main thread inside `destroy_process_group`, and
+        # looking the default group up again would fail once that call has
+        # cleared the bookkeeping.
+        if self._default_group is not None:
+            self._default_group.abort()
 
     @classmethod
     def is_available(cls) -> bool:

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import signal
 import unittest.mock
+from collections.abc import Callable
 from typing import Any, Literal, TypeVar, cast
 
 import numpy as np
@@ -767,15 +768,34 @@ def test_resume_after_interrupted_training_during_epoch(
     assert set(stepper.train_batches_seen).isdisjoint(pre_interrupt_batches)
 
 
+def _count_restart_writes(trainer) -> tuple[list[int], Callable[[], None]]:
+    """Record ``num_batches_seen`` at every restart-checkpoint write.
+
+    Returns the list and the side effect to patch `_save_restart_checkpoints`
+    with, which counts both the periodic write and the terminate-time callback's --
+    they are the same method, and which of the two wrote is the thing the two tests
+    below distinguish.
+    """
+    writes: list[int] = []
+    original_write = trainer._save_restart_checkpoints
+
+    def counted() -> None:
+        writes.append(trainer.num_batches_seen)
+        return original_write()
+
+    return writes, counted
+
+
 def test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again(tmp_path: str):
     """The restart write is skipped when the periodic one already made that file.
 
-    This is what keeps a preemption landing inside root's periodic checkpoint
-    write inside the scheduler's grace period. The boundary every rank then agrees
-    on is the very index that write recorded -- the periodic block and the boundary
-    check are adjacent in the loop body -- so writing again would spend another
-    multi-GB `torch.save` reproducing a file that already exists, and be SIGKILLed
-    for it.
+    This is what keeps a preemption landing *inside* root's periodic checkpoint
+    write inside the scheduler's grace period. The handler cannot run while the
+    main thread is inside `torch.save`, so the write completes and the signal is
+    recorded after it -- and the boundary every rank then agrees on is the very
+    index that write recorded, the periodic block and the boundary check being
+    adjacent in the loop body. Writing again would spend another multi-GB
+    `torch.save` reproducing a file that already exists, and be SIGKILLed for it.
     """
     checkpoint_every_n_batches = 5
     _, trainer = get_trainer(
@@ -786,12 +806,56 @@ def test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again(tmp_path: s
         n_train_batches=checkpoint_every_n_batches * 4,
         checkpoint_every_n_batches=checkpoint_every_n_batches,
     )
-    writes = []
-    original_write = trainer._save_restart_checkpoints
+    writes, counted = _count_restart_writes(trainer)
 
-    def counted():
-        writes.append(trainer.num_batches_seen)
-        return original_write()
+    def write_then_signal() -> None:
+        counted()
+        # where a signal arriving during the write is delivered: not before it, the
+        # handler being unable to run while the main thread is inside `torch.save`
+        signal.raise_signal(signal.SIGTERM)
+
+    with (
+        unittest.mock.patch.object(
+            trainer, "_log_first_batch_metrics", return_value=None
+        ),
+        unittest.mock.patch.object(
+            trainer, "_save_restart_checkpoints", side_effect=write_then_signal
+        ),
+        handle_termination_signals(shutdown=lambda: None),
+    ):
+        with pytest.raises(SystemExit):
+            trainer.train()
+
+    # the periodic write, and nothing after it: the terminate-time callback found
+    # `num_batches_seen` equal to what the periodic write had already recorded
+    assert writes == [checkpoint_every_n_batches]
+    assert trainer._last_saved_num_batches_seen == checkpoint_every_n_batches
+
+
+def test_a_periodic_checkpoint_is_skipped_once_a_stop_is_pending(tmp_path: str):
+    """A multi-GB write between the signal and the boundary is skipped, not waited on.
+
+    A periodic checkpoint inside the deferral and *before* the boundary delays the
+    agreed stop by the whole `torch.save`, which is the largest single contributor
+    to a rank arriving late -- and it is redundant: the boundary the ranks are about
+    to agree on is the very index it would record, and the terminate-time restart
+    checkpoint records that after the teardown, which is where slow work belongs.
+
+    So the file is written exactly once either way. What changes is which side of
+    `destroy_process_group` the write happens on, and
+    `_last_saved_num_batches_seen` is what says: the periodic block sets it and the
+    callback does not.
+    """
+    checkpoint_every_n_batches = 5
+    _, trainer = get_trainer(
+        tmp_path,
+        stepper_state={"foo": "bar"},
+        checkpoint_save_epochs=Slice(start=0, stop=0),
+        max_epochs=1,
+        n_train_batches=checkpoint_every_n_batches * 4,
+        checkpoint_every_n_batches=checkpoint_every_n_batches,
+    )
+    writes, counted = _count_restart_writes(trainer)
 
     with (
         unittest.mock.patch.object(
@@ -801,15 +865,17 @@ def test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again(tmp_path: s
             trainer, "_save_restart_checkpoints", side_effect=counted
         ),
     ):
-        # the signal lands in the batch whose end the periodic write happens at
+        # the signal lands at the start of the batch the periodic write is due at
+        # the end of, so the write is scheduled *and* a stop is already pending
         with preempt_after_calls_patch(
             trainer.stepper, "train_on_batch", checkpoint_every_n_batches
         ):
             trainer.train()
 
-    # the periodic write, and nothing after it: the terminate-time callback found
-    # `num_batches_seen` equal to what the periodic write had already recorded
     assert writes == [checkpoint_every_n_batches]
+    assert (
+        trainer._last_saved_num_batches_seen == 0
+    ), "the periodic write ran, so the stop waited out a torch.save it did not need"
 
 
 @pytest.mark.parametrize("evaluate_before_training", [True, False])

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -755,16 +755,14 @@ def test_resume_after_interrupted_training_during_epoch(
         n_checkpointed_batches:
     ]
     assert stepper.train_batches_seen == expected_batches
-    # No batch is trained twice, on either path, and that is the improvement
-    # rather than an incidental number moving. The checkpoint is written at a
-    # boundary this rank completed, so the batches it resumes from are exactly the
-    # ones it had not reached -- where before a signal landing inside
-    # `train_on_batch` for batch k+1 recorded "k batches seen" while the
-    # parameters might already carry k+1's update, so k+1 was applied twice.
-    repeated_batches = get_batch_indices(trainer.train_data.loader)[
-        n_checkpointed_batches:n_trained_batches
-    ]
-    assert repeated_batches == []
+    # No batch is trained twice, on either path, and that is the improvement rather
+    # than an incidental number moving. The checkpoint is written at a boundary this
+    # rank completed, so the batches it resumes from are exactly the ones it had not
+    # reached -- where before a signal landing inside `train_on_batch` for batch k+1
+    # recorded "k batches seen" while the parameters might already carry k+1's
+    # update, so k+1 was applied twice. This `isdisjoint` is the whole check: an
+    # earlier version also asserted an empty slice of the loader above it, which was
+    # empty by construction and so could never have failed.
     assert set(stepper.train_batches_seen).isdisjoint(pre_interrupt_batches)
 
 
@@ -798,6 +796,12 @@ def test_a_stop_without_a_handler_does_not_record_a_complete_epoch(tmp_path: str
     `_epochs_trained`, so the resume point skips the rest of the epoch's data
     silently -- worse than the stop failing.
 
+    The truncated epoch's diagnostics are checked in the same place, because they
+    are the other half of the same bookkeeping: `_epochs_trained` counts *complete*
+    epochs, so leaving it alone on a stop means it still names the previous one, and
+    writing the truncated epoch's diagnostics under that name would overwrite a
+    completed epoch's.
+
     The seam is stubbed rather than driven by a signal, because the trainer's own
     bookkeeping is what is under test: a real stop needs a wedged peer or a handler,
     and both would take this out of a single-process test.
@@ -809,6 +813,9 @@ def test_a_stop_without_a_handler_does_not_record_a_complete_epoch(tmp_path: str
         max_epochs=1,
         n_train_batches=20,
     )
+    # a third epoch rather than the first, because the collision only shows once a
+    # completed epoch owns the subdirectory the truncated one would write to
+    trainer._epochs_trained = 2
 
     class _StopsAt:
         """The `cooperative_stop` surface `train_one_epoch` uses, and no more."""
@@ -828,13 +835,20 @@ def test_a_stop_without_a_handler_does_not_record_a_complete_epoch(tmp_path: str
             trainer, "_log_first_batch_metrics", return_value=None
         ),
         unittest.mock.patch("fme.core.generics.trainer.cooperative_stop", stops_at),
+        unittest.mock.patch.object(
+            TrainAggregator, "flush_diagnostics", autospec=True
+        ) as flush,
     ):
         trainer.train_one_epoch()
 
     assert trainer.num_batches_seen == stop_at
     # the pair of these is the resume point, and neither may move on a stop
-    assert trainer._epochs_trained == 0, "a truncated epoch was recorded as complete"
+    assert trainer._epochs_trained == 2, "a truncated epoch was recorded as complete"
     assert trainer._current_epoch_num_batches_seen == stop_at
+    # `epoch_0003`, the epoch that was truncated -- not `epoch_0002`, which the
+    # completed second epoch owns. A resume re-runs the third epoch and replaces
+    # these with the complete version.
+    assert flush.call_args.kwargs == {"subdir": "epoch_0003"}
 
 
 def test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again(tmp_path: str):

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -583,10 +583,18 @@ def fail_after_calls_patch(object, method: str, call_count: int):
 
     with unittest.mock.patch.object(object, method) as mock:
         mock.side_effect = wrapper
-        try:
-            yield mock
-        except TrainingInterrupted:
-            pass
+        # The handler is installed here for the same reason `preempt_after_calls
+        # _patch` installs it: `Distributed.context()` installs it around every
+        # entrypoint's whole job, so a run without it is a configuration that does
+        # not exist in production. It matters to an *exception* now that leaving a
+        # cooperative loop on one tears the backend down and runs the
+        # terminate-time callbacks; without a handler installed there is nothing
+        # registered to tear down, so the exception path would be silently inert.
+        with handle_termination_signals(shutdown=lambda: None):
+            try:
+                yield mock
+            except TrainingInterrupted:
+                pass
 
 
 @contextlib.contextmanager
@@ -677,15 +685,21 @@ def test_resume_after_interrupted_training_during_epoch(
     checkpoint_every_n_batches = 20
     batches_before_interrupt = 25
     if interrupt_method == "preempt":
-        # saves checkpoint gracefully during interrupt
-        n_checkpointed_batches = batches_before_interrupt
+        # The signal is recorded rather than acted on, so the batch it landed in
+        # runs to completion and the loop stops at the boundary *after* it. Before
+        # the cooperative stop the handler tore the backend down from inside
+        # `train_on_batch`, abandoning that batch, so 25 completed rather than 26.
+        n_trained_batches = batches_before_interrupt + 1
     else:
-        # exception leads to immediate termination without checkpointing
-        n_checkpointed_batches = (
-            batches_before_interrupt
-            // checkpoint_every_n_batches
-            * checkpoint_every_n_batches
-        )
+        # The exception is raised before `train_on_batch` does any work, so the
+        # batch it landed in is never trained.
+        n_trained_batches = batches_before_interrupt
+    # The checkpoint records exactly the batches that completed, on both paths.
+    # For the exception path that is new: leaving the loop's context now tears the
+    # backend down and runs the terminate-time callback, where before an exception
+    # bypassed both and the last *periodic* checkpoint -- 20 batches -- was all
+    # that survived.
+    n_checkpointed_batches = n_trained_batches
     n_train_batches = batches_before_interrupt * 2  # > batches_before_interrupt
     stepper_state = {"foo": "bar"}
     config, trainer = get_trainer(
@@ -712,10 +726,10 @@ def test_resume_after_interrupted_training_during_epoch(
         get_batch_indices(trainer.train_data.subset_loader(n_checkpointed_batches))
         == get_batch_indices(trainer.train_data.loader)[n_checkpointed_batches:]
     )  # check test subset_loader is implemented correctly
-    assert len(pre_interrupt_batches) == batches_before_interrupt
+    assert len(pre_interrupt_batches) == n_trained_batches
     assert (
         pre_interrupt_batches
-        == get_batch_indices(trainer.train_data.loader)[:batches_before_interrupt]
+        == get_batch_indices(trainer.train_data.loader)[:n_trained_batches]
     )
     paths = CheckpointPaths(config.checkpoint_dir)
     assert os.path.exists(paths.latest_checkpoint_path)
@@ -740,12 +754,62 @@ def test_resume_after_interrupted_training_during_epoch(
         n_checkpointed_batches:
     ]
     assert stepper.train_batches_seen == expected_batches
+    # No batch is trained twice, on either path, and that is the improvement
+    # rather than an incidental number moving. The checkpoint is written at a
+    # boundary this rank completed, so the batches it resumes from are exactly the
+    # ones it had not reached -- where before a signal landing inside
+    # `train_on_batch` for batch k+1 recorded "k batches seen" while the
+    # parameters might already carry k+1's update, so k+1 was applied twice.
     repeated_batches = get_batch_indices(trainer.train_data.loader)[
-        n_checkpointed_batches : batches_before_interrupt + 1
+        n_checkpointed_batches:n_trained_batches
     ]
-    assert set(stepper.train_batches_seen).intersection(repeated_batches) == set(
-        repeated_batches
+    assert repeated_batches == []
+    assert set(stepper.train_batches_seen).isdisjoint(pre_interrupt_batches)
+
+
+def test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again(tmp_path: str):
+    """The restart write is skipped when the periodic one already made that file.
+
+    This is what keeps a preemption landing inside root's periodic checkpoint
+    write inside the scheduler's grace period. The boundary every rank then agrees
+    on is the very index that write recorded -- the periodic block and the boundary
+    check are adjacent in the loop body -- so writing again would spend another
+    multi-GB `torch.save` reproducing a file that already exists, and be SIGKILLed
+    for it.
+    """
+    checkpoint_every_n_batches = 5
+    _, trainer = get_trainer(
+        tmp_path,
+        stepper_state={"foo": "bar"},
+        checkpoint_save_epochs=Slice(start=0, stop=0),
+        max_epochs=1,
+        n_train_batches=checkpoint_every_n_batches * 4,
+        checkpoint_every_n_batches=checkpoint_every_n_batches,
     )
+    writes = []
+    original_write = trainer._save_restart_checkpoints
+
+    def counted():
+        writes.append(trainer.num_batches_seen)
+        return original_write()
+
+    with (
+        unittest.mock.patch.object(
+            trainer, "_log_first_batch_metrics", return_value=None
+        ),
+        unittest.mock.patch.object(
+            trainer, "_save_restart_checkpoints", side_effect=counted
+        ),
+    ):
+        # the signal lands in the batch whose end the periodic write happens at
+        with preempt_after_calls_patch(
+            trainer.stepper, "train_on_batch", checkpoint_every_n_batches
+        ):
+            trainer.train()
+
+    # the periodic write, and nothing after it: the terminate-time callback found
+    # `num_batches_seen` equal to what the periodic write had already recorded
+    assert writes == [checkpoint_every_n_batches]
 
 
 @pytest.mark.parametrize("evaluate_before_training", [True, False])

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 from fme.core.device import get_device
-from fme.core.distributed.shutdown import handle_termination_signals
+from fme.core.distributed.shutdown import PendingStop, handle_termination_signals
 from fme.core.ema import EMAConfig, EMATracker
 from fme.core.generics.aggregator import (
     AggregatorABC,
@@ -784,6 +784,57 @@ def _count_restart_writes(trainer) -> tuple[list[int], Callable[[], None]]:
         return original_write()
 
     return writes, counted
+
+
+def test_a_stop_without_a_handler_does_not_record_a_complete_epoch(tmp_path: str):
+    """A truncated epoch is not a complete one, whether or not the process exits.
+
+    With a handler installed -- every entrypoint -- leaving the cooperative scope on
+    a stop exits, so nothing after the loop runs. With none installed there is
+    nothing registered to tear down and the loop simply falls through, which is the
+    state of the whole pytest session (`handle_signals=False`) and of any caller
+    using the documented `PendingStop.request` without a handler. Counting the epoch
+    as complete there resets `_current_epoch_num_batches_seen` and advances
+    `_epochs_trained`, so the resume point skips the rest of the epoch's data
+    silently -- worse than the stop failing.
+
+    The seam is stubbed rather than driven by a signal, because the trainer's own
+    bookkeeping is what is under test: a real stop needs a wedged peer or a handler,
+    and both would take this out of a single-process test.
+    """
+    stop_at = 3
+    _, trainer = get_trainer(
+        tmp_path,
+        stepper_state={"foo": "bar"},
+        max_epochs=1,
+        n_train_batches=20,
+    )
+
+    class _StopsAt:
+        """The `cooperative_stop` surface `train_one_epoch` uses, and no more."""
+
+        def __init__(self) -> None:
+            self.pending = PendingStop(budget=10.0)
+
+        def agreed(self, index: int) -> bool:
+            return index >= stop_at
+
+    @contextlib.contextmanager
+    def stops_at(**kwargs):
+        yield _StopsAt()
+
+    with (
+        unittest.mock.patch.object(
+            trainer, "_log_first_batch_metrics", return_value=None
+        ),
+        unittest.mock.patch("fme.core.generics.trainer.cooperative_stop", stops_at),
+    ):
+        trainer.train_one_epoch()
+
+    assert trainer.num_batches_seen == stop_at
+    # the pair of these is the resume point, and neither may move on a stop
+    assert trainer._epochs_trained == 0, "a truncated epoch was recorded as complete"
+    assert trainer._current_epoch_num_batches_seen == stop_at
 
 
 def test_a_stop_at_a_just_written_checkpoint_does_not_write_it_again(tmp_path: str):

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -618,6 +618,14 @@ class Trainer:
                     and self.params.checkpoint_every_n_batches > 0
                     and self.num_batches_seen % self.params.checkpoint_every_n_batches
                     == 0
+                    # A multi-GB `torch.save` between the signal and the boundary
+                    # delays the agreed stop by the whole write, and the write is
+                    # redundant: the boundary the ranks are about to agree on is
+                    # this very index, and the terminate-time restart checkpoint
+                    # records it after the teardown -- which is where slow work
+                    # belongs. Skipping leaves `_last_saved_num_batches_seen`
+                    # behind, which is what makes that callback write.
+                    and not stop.pending.requested
                 ):
                     self._save_restart_checkpoints()
                     self._last_saved_num_batches_seen = self.num_batches_seen

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -63,7 +63,7 @@ import torch
 
 import fme
 from fme.core.cli import remove_stale_tmp_checkpoints
-from fme.core.distributed import Distributed
+from fme.core.distributed import Distributed, cooperative_stop
 from fme.core.distributed.shutdown import add_post_shutdown_callback
 from fme.core.ema import EMATracker
 from fme.core.generics.aggregator import (
@@ -315,6 +315,12 @@ class Trainer:
         self._do_gc_collect = do_gc_collect
         self._in_ema_context = False
         self._started_training = False
+        # `train_one_epoch` resets this at the top of every epoch, but the
+        # terminate-time callback below reads it, and a signal can arrive before
+        # any epoch has started -- during startup, or during the validation pass
+        # of a mid-epoch resume, where `_current_epoch_num_batches_seen` is
+        # already non-zero and so does not short-circuit the read
+        self._last_saved_num_batches_seen = self.num_batches_seen
         self._validation_callback: ValidationCallback = validation_callback
         self._inference_callback: InferenceCallback = inference_callback
         self._validate_stepper_callback: ValidateStepper | None = validate_stepper
@@ -325,10 +331,19 @@ class Trainer:
             Runs after the process group has been destroyed, so it must stay
             free of collectives. `save_checkpoint` is root-only and reads local
             state, which satisfies that.
+
+            The third guard is what keeps a stop inside the scheduler's grace
+            period. A signal landing during root's periodic checkpoint write
+            leaves every rank agreeing on the very index that write recorded --
+            the periodic block and the boundary check are adjacent in the loop
+            body -- so without it root would spend another 20s or so reproducing
+            a file that already exists and be SIGKILLed for it. The same
+            predicate guards the epoch-boundary write for the same reason.
             """
             if (
                 self._current_epoch_num_batches_seen > 0
                 and self._should_save_checkpoints()
+                and self.num_batches_seen > self._last_saved_num_batches_seen
             ):
                 if self._in_ema_context:
                     logging.info(
@@ -558,42 +573,64 @@ class Trainer:
         self._started_training = True
         current_time = time.time()
         metrics_aggregator = MetricsAggregator()
-        for batch in epoch_data:
-            with GlobalTimer():
-                stepped = self.stepper.train_on_batch(batch, self.optimization)
-            self._end_of_batch_callback()
-            self._ema(model=self.stepper.modules)
-            # Step scheduler per-iteration if configured to do so
-            self.optimization.step_scheduler(is_iteration=True)
-            self.num_batches_seen += 1
-            self._current_epoch_num_batches_seen += 1
-            n_samples_seen_since_logging += self.train_data.batch_size
-            metrics_aggregator.record(stepped.get_metrics())
-            if (
-                self.params.log_train_every_n_batches > 0
-                and self.num_batches_seen % self.params.log_train_every_n_batches == 0
-            ):
-                metrics = {
-                    f"batch_{name}": value
-                    for name, value in metrics_aggregator.get_metrics().items()
-                }
-                metrics_aggregator.clear()
-                duration = time.time() - current_time
-                current_time = time.time()
-                samples_per_second = n_samples_seen_since_logging / duration
-                metrics["training_samples_per_second_on_rank_0"] = samples_per_second
-                metrics["lr"] = self.optimization.learning_rate
-                wandb.log(metrics, step=self.num_batches_seen)
-                metrics_to_log = {k: metrics[k] for k in names_to_log if k in metrics}
-                logging.info(f"Step {self.num_batches_seen}: {metrics_to_log}")
-                n_samples_seen_since_logging = 0
-            if (
-                self._should_save_checkpoints()
-                and self.params.checkpoint_every_n_batches > 0
-                and self.num_batches_seen % self.params.checkpoint_every_n_batches == 0
-            ):
-                self._save_restart_checkpoints()
-                self._last_saved_num_batches_seen = self.num_batches_seen
+        with cooperative_stop(
+            # the index the *first* iteration below will pass to `agreed`, so
+            # that a rank raising inside it contributes what its peers will
+            first_index=self.num_batches_seen + 1,
+            loop_length=len(epoch_data),
+        ) as stop:
+            for batch in epoch_data:
+                with GlobalTimer():
+                    stepped = self.stepper.train_on_batch(batch, self.optimization)
+                self._end_of_batch_callback()
+                self._ema(model=self.stepper.modules)
+                # Step scheduler per-iteration if configured to do so
+                self.optimization.step_scheduler(is_iteration=True)
+                self.num_batches_seen += 1
+                self._current_epoch_num_batches_seen += 1
+                n_samples_seen_since_logging += self.train_data.batch_size
+                metrics_aggregator.record(stepped.get_metrics())
+                if (
+                    self.params.log_train_every_n_batches > 0
+                    and self.num_batches_seen % self.params.log_train_every_n_batches
+                    == 0
+                ):
+                    metrics = {
+                        f"batch_{name}": value
+                        for name, value in metrics_aggregator.get_metrics().items()
+                    }
+                    metrics_aggregator.clear()
+                    duration = time.time() - current_time
+                    current_time = time.time()
+                    samples_per_second = n_samples_seen_since_logging / duration
+                    metrics["training_samples_per_second_on_rank_0"] = (
+                        samples_per_second
+                    )
+                    metrics["lr"] = self.optimization.learning_rate
+                    wandb.log(metrics, step=self.num_batches_seen)
+                    metrics_to_log = {
+                        k: metrics[k] for k in names_to_log if k in metrics
+                    }
+                    logging.info(f"Step {self.num_batches_seen}: {metrics_to_log}")
+                    n_samples_seen_since_logging = 0
+                if (
+                    self._should_save_checkpoints()
+                    and self.params.checkpoint_every_n_batches > 0
+                    and self.num_batches_seen % self.params.checkpoint_every_n_batches
+                    == 0
+                ):
+                    self._save_restart_checkpoints()
+                    self._last_saved_num_batches_seen = self.num_batches_seen
+                # last in the body, after the counters and after the periodic
+                # checkpoint: the boundary every rank then agrees on is one where
+                # their counters and parameters match, no scheduled checkpoint is
+                # skipped, and reaching the decision costs no further loader fetch
+                if stop.agreed(self.num_batches_seen):
+                    # leaving this context tears the backend down and exits, so
+                    # the shuffle, the train-evaluation pass and the epoch
+                    # increment below are skipped -- they are collectives, and
+                    # their peers have left
+                    break
         # evaluate after training on an independent shuffle of the data
         self.train_data.alternate_shuffle()
         aggregator = self._aggregator_builder.get_train_aggregator()

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -573,6 +573,15 @@ class Trainer:
         self._started_training = True
         current_time = time.time()
         metrics_aggregator = MetricsAggregator()
+        # Whether the loop below was left at an agreed stop rather than at the end
+        # of the epoch's data. With a handler installed the two are told apart by
+        # the process no longer being here -- but `handle_signals=False` (the whole
+        # test session) and `PendingStop.request` without a handler both leave the
+        # loop with nothing registered to tear down, and on those paths the epoch
+        # counters below decide the resume point. Recording a truncated epoch as
+        # complete would skip the rest of its data on resume, which is worse than
+        # the stop failing.
+        stopped = False
         with cooperative_stop(
             # the index the *first* iteration below will pass to `agreed`, so
             # that a rank raising inside it contributes what its peers will
@@ -634,10 +643,13 @@ class Trainer:
                 # their counters and parameters match, no scheduled checkpoint is
                 # skipped, and reaching the decision costs no further loader fetch
                 if stop.agreed(self.num_batches_seen):
-                    # leaving this context tears the backend down and exits, so
-                    # the shuffle, the train-evaluation pass and the epoch
-                    # increment below are skipped -- they are collectives, and
-                    # their peers have left
+                    # Where a handler is installed -- which is every entrypoint --
+                    # leaving this context tears the backend down and exits, so the
+                    # shuffle, the train-evaluation pass and everything below are
+                    # skipped: they are collectives, and their peers have left. The
+                    # flag is for the configurations where that exit does not
+                    # happen; see where it is declared.
+                    stopped = True
                     break
         # evaluate after training on an independent shuffle of the data
         self.train_data.alternate_shuffle()
@@ -660,8 +672,15 @@ class Trainer:
             self._save_restart_checkpoints()  # before incrementing epoch so we will validate after resuming  # noqa: E501
         # we will save restart checkpoints again after validation/inference
         # are recorded to wandb
-        self._epochs_trained += 1
-        self._current_epoch_num_batches_seen = 0
+        if not stopped:
+            # An epoch left at an agreed stop is not a complete epoch, so it is not
+            # counted as one and its batch counter is not cleared: the pair of them
+            # is the resume point, and `_current_epoch_num_batches_seen` is what
+            # `subset_loader` skips by on the way back in. Guarded rather than left
+            # to the exit, because the exit only happens where a handler is
+            # installed.
+            self._epochs_trained += 1
+            self._current_epoch_num_batches_seen = 0
         aggregator.flush_diagnostics(subdir=f"epoch_{self._epochs_trained:04d}")
         return aggregator.get_summary(label="train")
 

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -681,7 +681,14 @@ class Trainer:
             # installed.
             self._epochs_trained += 1
             self._current_epoch_num_batches_seen = 0
-        aggregator.flush_diagnostics(subdir=f"epoch_{self._epochs_trained:04d}")
+        # `_epochs_trained` is a count of *complete* epochs, so on a stop it still
+        # names the previous one and writing there would overwrite a completed
+        # epoch's diagnostics with a truncated epoch's. The subdirectory has to name
+        # the epoch the data belongs to, which on a stop is the one that was
+        # truncated -- the next. A resume re-runs that epoch and replaces these with
+        # the complete version, which is the outcome to want.
+        completed_or_truncated_epoch = self._epochs_trained + (1 if stopped else 0)
+        aggregator.flush_diagnostics(subdir=f"epoch_{completed_or_truncated_epoch:04d}")
         return aggregator.get_summary(label="train")
 
     def _save_restart_checkpoints(self):


### PR DESCRIPTION
## READ FIRST — decisions that are the maintainer's, not this branch's

Three questions this change cannot settle from inside itself. Each changes what ships, so each wants an answer before merge rather than after.

1. **Does the per-batch agreement need a config switch to disable it?** Today there is none: every training job, preempted or not, pays one blocking host-side gloo all-reduce per iteration on the critical path. A switch buys an escape hatch if the cost bites at production world size; it costs a supported configuration in which the fabric fault returns. The only measurement is 630 µs at 8 gloo ranks on an idle workstation over loopback, with no multi-node figure anywhere in the branch.
2. **Should the teardown/checkpoint split inside torchrun's 30 s window be re-cut?** `DEFAULT_TEARDOWN_TIMEOUT` claims 20 s of the 30 s, which leaves the restart checkpoint nothing once a rank reaches the boundary 7 s or more after its signal — the expected case for a preemption landing inside a multi-GB periodic checkpoint write. Cutting the ceiling to about 5 s and giving the checkpoint 20 s would fix that, and `_ABORT_BACKSTOP` already bounds a hung teardown at the ceiling plus 5 s; against it, a teardown that genuinely needs more than 5 s would then be aborted rather than allowed to finish. The arithmetic on both sides is derived rather than measured — no test waits out a real budget or a real teardown.
3. **Is the watchdog's new `ProcessGroup.abort()` wanted before any GPU evidence?** It is added to the one path whose purpose is avoiding a fabric fault, and whether an aborted communicator leaves the fabric better off than one dropped by `os._exit` is unverified; it may fault the fabric sooner instead. `os._exit` remains as a named backstop, so removing the abort is a one-line reversal either way.

---

A preempted whole-node training job faults its own GPU fabric on the way out, and the node is then cordoned. Internal analysis of preemptions on our H100 clusters over a two-week window found that 109 of the 145 preemptions which interrupted the training loop of an 8-GPU job faulted the fabric — 75%, scoped to 8-GPU jobs specifically, and counting priority preemptions and drains together. The mechanism is that one rank exits while a peer still has a collective in flight; the peer's next NVLink access is refused, the driver raises an unrecoverable NVSwitch error, and Beaker cordons the node, which kills co-tenants as well as the preempted job.

ai2cm/ace#1398 made the teardown orderly once a rank runs its handler, and said what it could not fix: a rank whose main thread is inside a C-level collective never services the signal, so it never starts the teardown, and a rank that did start one cannot finish it while such a peer still holds the communicator. In a deliberate 4-rank preemption during that change, two ranks hung in the teardown until the 20 s watchdog exited them and two never ran their handler at all.

This change makes the ranks agree on a batch boundary and leave the training loop together, so no rank leaves while a peer still has a collective in flight. A termination signal arriving inside the loop is recorded rather than acted on; every rank then finishes its current batch, exchanges a stop flag and its batch index at the boundary, and tears the backend down having agreed. Because no rank leaves early, a rank that was blocked in a collective when the signal arrived returns to the interpreter, runs its own pending handler, and reaches the same boundary. Outside the loop the immediate teardown is unchanged.

The mechanism is a component any entrypoint can adopt, not a `Trainer` detail: a caller with its own batch loop, holding no `Trainer` and importing nothing from `fme.ace`, can adopt it using only public names from `fme.core.distributed`, and a test constructs exactly that caller. It does not, however, address the case for putting this in the launcher or the framework so that jobs from other codebases benefit — that cannot be answered from inside this repository.

Three things are deliberately true and worth stating rather than discovering later.

The agreement runs on a dedicated world-wide gloo group rather than on the NCCL group. An unbounded all-reduce on the NCCL group would hang the healthy ranks whenever one rank never enters it, which is worse than today's behaviour; and `reduce_max` on the spatial-parallel backend operates on the data-parallel subgroup, so a stop originating on a spatial co-rank would never reach its data-parallel peers. Each exchange carries its own deadline, because a gloo group can neither be created with a short timeout nor have its timeout narrowed afterwards — `_set_pg_timeout` accepts a gloo group and has no effect on it, since the timeout is read once at context construction.

The agreement group is never destroyed, and a rank that abandoned an exchange exits hard. `ProcessGroupGloo`'s destructor waits without bound for its work queue to drain, and it overrides neither `shutdown()` nor `abort()`, so no call reclaims a gloo group that has an abandoned exchange outstanding. The group is therefore held for the life of the process, and holding it is what makes the post-shutdown callbacks reachable when an exchange is abandoned: had the teardown dropped the group, the handler would never leave its collective phase and the restart checkpoint would be lost by construction. Anyone editing this code must not drop that reference — a superseded group is moved aside, never released.

Interpreter finalization is not a way out of it either. That destructor also runs during `Py_Finalize`, where it joins the worker thread still holding the abandoned operation, so `sys.exit` waits for the wedged peer's socket to close: measured on torch 2.7.1, 119.3 s against a peer parked for 120 s and 24.3 s against one parked for 25 s, versus 0.05 s with `os._exit`. Whether it joins or leaks depends on what else still references the group, so the wait is not merely long but unbounded and non-deterministic — a rank left to finalize is SIGKILLed by torchrun and the launcher reads a signal death rather than the `128 + signum` the design promises. So once an exchange has been abandoned the teardown ends in `os._exit`, taken after the backend is released and after the callbacks have run: unlike the watchdog's hard exit it drops no communicator and skips no work, and it is the whole of the design's bound on that path.

The interrupt-time restart checkpoint is load-bearing here. The agreed boundary is chosen so that the checkpoint written by the post-shutdown callback is consistent, and the cooperative stop's value depends on that write happening. Removing the callback registry would remove it.

What this does not fix. A rank wedged for a reason independent of the signal still times out the agreement, still forces the healthy ranks out, and can still fault; that residual rate is unknown and is not zero. A rank that dies without running Python at all — a segfault, the OOM killer, SIGKILL — is not covered, and neither is it by the exception path. The mechanism is scoped to the training loop, so a preemption landing in validation, inference or startup keeps today's behaviour. Interrupting an epoch-boundary checkpoint write is a known regression: a non-root rank inside the loop defers toward a boundary that root, being outside the loop, will not reach.

What stays argued rather than measured. **No preemption trial has been run against this branch on real hardware.** The mechanism's exit paths pass under NCCL in CI's GPU job, at two ranks, including the torchrun cases that observe a rank's process death; production runs eight, where signal skew is widest. But the fault this change exists to prevent has never been provoked against the fix: the intended 4-GPU trial did not run because both H100 clusters were at zero free GPUs, and the 8-GPU whole-node trial is deliberately gated on a maintainer's approval. So the claim that the fabric fault stops happening is a design argument plus CPU and two-rank NCCL evidence, not a measurement. Relatedly, whether aborting a communicator releases a wedged peer, as opposed to only the aborting rank's own main thread, is untested — the one test that reaches the abort stubs it — and it is the difference between the fault disappearing and merely preserving the checkpoint. The per-batch cost is argued structurally and from CPU timing rather than benchmarked; the exchange is one small CPU all-reduce per optimizer step, on a step that already ends in a blocking gradient all-reduce, and there is no switch to disable it — a supported configuration in which the fault returns would be worse than the cost, but whether that judgement holds is decision 1 above rather than something this branch settled.

Changes:
- `fme.core.distributed.cooperative_stop`: new module. `cooperative_stop` wraps a batch loop, and `CooperativeStop.agreed` exchanges a stop reason and batch index at each boundary, returning whether to stop. Carries `PeerStopRequested` and `UnequalLoopLength`.
- `fme.core.distributed.stop_agreement`: new module. `StopAgreement` with gloo and single-rank implementations, and the cached and uncached group constructors — the cache keyed on the identity of the default group the agreement belongs to, so a world that has been destroyed and re-initialised gets a new agreement group and the stale one is moved aside. `timeout_contract_verified` reports whether the installed torch is one of the releases the operation-timeout behaviour the short deadline rests on was read against. It never fails a job: group construction warns once, and a rank on an unverified release passes the default group's own timeout where it would have passed a short one, which is `main`'s behaviour rather than a new failure mode. `default_group_timeout` reads that figure off the group instead of restating it, because `DistributedManager` passes `init_process_group` no timeout and so takes NCCL's default 10 minutes on GPU.
- `fme.core.distributed.shutdown`: a termination signal inside a registered scope records intent instead of tearing down, via `defer_termination` and `PendingStop`; `terminate` performs the teardown and callbacks for the deferred and exception paths, ending in `os._exit` where the caller asked for it with `PendingStop.require_hard_exit` — on the exception path too, which prints the propagating traceback itself before exiting, since that traceback was the only reason that path previously declined to exit at all; the phase machine gains a stop-requested state in which a repeat signal is ignored, because the scheduler and torchrun each signal every rank; the teardown watchdog gains an abort ahead of its hard exit, and a cancelled flag so a released main thread is not exited mid-write; `write_marker` emits one line per event to stderr.
- `fme.core.distributed.Distributed.stop_agreement` and `Distributed.abort`, with implementations on each backend, and the agreement group created alongside the process group.
- `fme.core.generics.Trainer.train_one_epoch`: the batch loop runs inside `cooperative_stop` and agrees at each boundary. The periodic checkpoint write is skipped once a stop is pending, because it would delay the agreed stop by a whole multi-GB `torch.save` to record the index the terminate-time restart checkpoint is about to record after the teardown; and `save_restart_checkpoints_on_terminate` skips a write the periodic checkpoint has just made, which is the case where the signal landed inside that write. An epoch left at an agreed stop is not counted as complete: the epoch counter and the epoch's batch counter are together the resume point, so recording a truncated epoch as complete would silently skip the rest of its data on resume, and the loop does not rely on the exit having happened to avoid that. The truncated epoch's train-evaluation diagnostics are written under that epoch's own number rather than into the last completed epoch's subdirectory, which is where an un-incremented counter would have put them.
- Evidence in the container log: every rank emits its agreed batch index, which bound was in force on it, and its teardown returning, by a direct write to stderr, because non-root ranks are pinned to `logging.ERROR` and `logger.info` from them never reaches the log. The whole `fme-stop:` event vocabulary — every event name, which module writes it, what it means, and what a reader does with it — is listed in one place, in `fme.core.distributed.shutdown`'s module docstring.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated




