### PR TITLE
Resolve inline inference epochs against the training epochs only

### DIFF
--- a/fme/ace/train/test_train_config.py
+++ b/fme/ace/train/test_train_config.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -91,9 +92,15 @@ def _make_train_config(
     inference: InlineInferenceConfig | list[InlineInferenceConfig],
     max_epochs: int = 5,
     validation: InlineValidationConfig | list[InlineValidationConfig] | None = None,
+    evaluate_before_training: bool | None = None,
 ) -> TrainConfig:
     if validation is None:
         validation = _make_validation_config()
+    # Only forward evaluate_before_training when explicitly requested, so that
+    # tests which do not care about it keep seeing the class default.
+    extra_kwargs: dict[str, Any] = {}
+    if evaluate_before_training is not None:
+        extra_kwargs["evaluate_before_training"] = evaluate_before_training
     return TrainConfig(
         experiment_dir=str(tmp_path),
         stepper=_make_stepper_config(),
@@ -107,6 +114,7 @@ def _make_train_config(
         max_epochs=max_epochs,
         save_checkpoint=False,
         inference=inference,
+        **extra_kwargs,
     )
 
 
@@ -247,6 +255,87 @@ def test_get_inference_epoch_sets_different_weighted_epochs_raises(tmp_path):
             ],
             max_epochs=6,
         )
+
+
+def test_epoch_zero_evaluated_regardless_of_max_epochs_parity(tmp_path):
+    # An end-anchored "every other epoch, counting back from the last" request
+    # must still evaluate before training, whether max_epochs is odd or even.
+    odd = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=15,
+        evaluate_before_training=True,
+    )
+    even = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=20,
+        evaluate_before_training=True,
+    )
+    odd_epochs = odd.get_inference_epoch_sets()[0]
+    even_epochs = even.get_inference_epoch_sets()[0]
+    assert 0 in odd_epochs
+    assert 0 in even_epochs
+    assert odd_epochs == {0, 1, 3, 5, 7, 9, 11, 13, 15}
+    assert even_epochs == {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
+
+
+def test_evaluate_before_training_does_not_shift_selected_training_epochs(tmp_path):
+    # Asking for a pre-training evaluation adds epoch 0; it must not change
+    # which training epochs the slice picks out.
+    with_epoch_zero = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(step=2))],
+        max_epochs=6,
+        evaluate_before_training=True,
+    )
+    without_epoch_zero = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(step=2))],
+        max_epochs=6,
+        evaluate_before_training=False,
+    )
+    with_zero_epochs = with_epoch_zero.get_inference_epoch_sets()[0]
+    without_zero_epochs = without_epoch_zero.get_inference_epoch_sets()[0]
+    assert with_zero_epochs - {0} == without_zero_epochs
+    assert with_zero_epochs == without_zero_epochs | {0}
+    assert with_zero_epochs == {0, 1, 3, 5}
+    assert without_zero_epochs == {1, 3, 5}
+
+
+def test_epoch_zero_evaluated_even_when_slice_selects_no_training_epochs(tmp_path):
+    # There is no per-entry opt-out of the pre-training evaluation: an entry
+    # whose slice matches no training epoch still runs at epoch 0.
+    config = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=100))],
+        max_epochs=6,
+        evaluate_before_training=True,
+    )
+    assert config.get_inference_epoch_sets() == [{0}]
+
+
+def test_epoch_zero_not_evaluated_without_evaluate_before_training(tmp_path):
+    # Guard on the opposite case: with no pre-training evaluation requested,
+    # epoch 0 must never appear, at either parity of max_epochs.
+    odd = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=15,
+        evaluate_before_training=False,
+    )
+    even = _make_train_config(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=20,
+        evaluate_before_training=False,
+    )
+    odd_epochs = odd.get_inference_epoch_sets()[0]
+    even_epochs = even.get_inference_epoch_sets()[0]
+    assert 0 not in odd_epochs
+    assert 0 not in even_epochs
+    assert odd_epochs == {1, 3, 5, 7, 9, 11, 13, 15}
+    assert even_epochs == {2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
 
 
 def test_validation_negative_weight_raises():

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -120,7 +120,10 @@ class InlineInferenceConfig:
         forward_steps_in_memory: number of forward steps to take before
             re-reading data from disk
         n_ensemble_per_ic: number of initial condition based ensembles
-        epochs: epochs on which to run inference. By default runs inference every epoch.
+        epochs: positional slice over the training epochs 1 to max_epochs, so
+            index 0 selects epoch 1. By default runs inference every training
+            epoch. Epoch 0 is additionally included when
+            evaluate_before_training is true.
         aggregator: configuration of inline inference aggregator.
         name: name used as wandb log prefix and output subdirectory. If None,
             defaults to "inference" when there is a single inference config
@@ -557,9 +560,12 @@ class TrainConfig:
         inference = self.inference_list
         if not inference:
             return []
-        start_epoch = 0 if self.evaluate_before_training else 1
-        all_epochs = list(range(start_epoch, self.max_epochs + 1))
-        return [set(all_epochs[entry.epochs.slice]) for entry in inference]
+        training_epochs = list(range(1, self.max_epochs + 1))
+        pre_training_epochs = {0} if self.evaluate_before_training else set()
+        return [
+            set(training_epochs[entry.epochs.slice]) | pre_training_epochs
+            for entry in inference
+        ]
 
     def get_inference_epochs(self) -> list[int]:
         epoch_sets = self.get_inference_epoch_sets()

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -383,8 +383,8 @@ class TrainConfig:
             must be run in segments, e.g. due to wall clock limit.
         save_per_epoch_diagnostics: Whether to save per-epoch diagnostics from
             training, validation and inline inference aggregators.
-        evaluate_before_training: Whether to run validation and inline inference before
-            any training is done.
+        evaluate_before_training: Whether to run all validation and inline
+            inference before any training is done.
         save_best_inference_epoch_checkpoints: Whether to save a separate checkpoint
             for each epoch where best_inference_error achieves a new minimum.
             Checkpoints are saved as best_inference_ckpt_XXXX.tar.

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -122,8 +122,7 @@ class InlineInferenceConfig:
         n_ensemble_per_ic: number of initial condition based ensembles
         epochs: positional slice over the training epochs 1 to max_epochs, so
             index 0 selects epoch 1. By default runs inference every training
-            epoch. Epoch 0 is additionally included when
-            evaluate_before_training is true.
+            epoch.
         aggregator: configuration of inline inference aggregator.
         name: name used as wandb log prefix and output subdirectory. If None,
             defaults to "inference" when there is a single inference config

--- a/fme/coupled/train/test_train_config.py
+++ b/fme/coupled/train/test_train_config.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -111,7 +112,13 @@ def _make_train_config_for_inference(
     tmp_path,
     inference: InlineInferenceConfig | list[InlineInferenceConfig],
     max_epochs: int = 5,
+    evaluate_before_training: bool | None = None,
 ) -> TrainConfig:
+    # Only forward evaluate_before_training when explicitly requested, so that
+    # tests which do not care about it keep seeing the class default.
+    extra_kwargs: dict[str, Any] = {}
+    if evaluate_before_training is not None:
+        extra_kwargs["evaluate_before_training"] = evaluate_before_training
     return TrainConfig(
         train_loader=MagicMock(),
         validation=_make_validation_config(),
@@ -123,6 +130,7 @@ def _make_train_config_for_inference(
         save_checkpoint=False,
         experiment_dir=str(tmp_path),
         inference=inference,
+        **extra_kwargs,
     )
 
 
@@ -222,9 +230,90 @@ def test_get_inference_epoch_sets_per_config(tmp_path):
         max_epochs=6,
     )
     epoch_sets = config.get_inference_epoch_sets()
-    assert epoch_sets[0] == {0, 2, 4, 6}
-    assert epoch_sets[1] == {0, 3, 6}
-    assert config.get_inference_epochs() == [0, 2, 3, 4, 6]
+    assert epoch_sets[0] == {0, 1, 3, 5}
+    assert epoch_sets[1] == {0, 1, 4}
+    assert config.get_inference_epochs() == [0, 1, 3, 4, 5]
+
+
+def test_epoch_zero_evaluated_regardless_of_max_epochs_parity(tmp_path):
+    # An end-anchored "every other epoch, counting back from the last" request
+    # must still evaluate before training, whether max_epochs is odd or even.
+    odd = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=15,
+        evaluate_before_training=True,
+    )
+    even = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=20,
+        evaluate_before_training=True,
+    )
+    odd_epochs = odd.get_inference_epoch_sets()[0]
+    even_epochs = even.get_inference_epoch_sets()[0]
+    assert 0 in odd_epochs
+    assert 0 in even_epochs
+    assert odd_epochs == {0, 1, 3, 5, 7, 9, 11, 13, 15}
+    assert even_epochs == {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
+
+
+def test_evaluate_before_training_does_not_shift_selected_training_epochs(tmp_path):
+    # Asking for a pre-training evaluation adds epoch 0; it must not change
+    # which training epochs the slice picks out.
+    with_epoch_zero = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(step=2))],
+        max_epochs=6,
+        evaluate_before_training=True,
+    )
+    without_epoch_zero = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(step=2))],
+        max_epochs=6,
+        evaluate_before_training=False,
+    )
+    with_zero_epochs = with_epoch_zero.get_inference_epoch_sets()[0]
+    without_zero_epochs = without_epoch_zero.get_inference_epoch_sets()[0]
+    assert with_zero_epochs - {0} == without_zero_epochs
+    assert with_zero_epochs == without_zero_epochs | {0}
+    assert with_zero_epochs == {0, 1, 3, 5}
+    assert without_zero_epochs == {1, 3, 5}
+
+
+def test_epoch_zero_evaluated_even_when_slice_selects_no_training_epochs(tmp_path):
+    # There is no per-entry opt-out of the pre-training evaluation: an entry
+    # whose slice matches no training epoch still runs at epoch 0.
+    config = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=100))],
+        max_epochs=6,
+        evaluate_before_training=True,
+    )
+    assert config.get_inference_epoch_sets() == [{0}]
+
+
+def test_epoch_zero_not_evaluated_without_evaluate_before_training(tmp_path):
+    # Guard on the opposite case: with no pre-training evaluation requested,
+    # epoch 0 must never appear, at either parity of max_epochs.
+    odd = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=15,
+        evaluate_before_training=False,
+    )
+    even = _make_train_config_for_inference(
+        tmp_path,
+        [_make_inference_config(epochs=Slice(start=-1, step=-2))],
+        max_epochs=20,
+        evaluate_before_training=False,
+    )
+    odd_epochs = odd.get_inference_epoch_sets()[0]
+    even_epochs = even.get_inference_epoch_sets()[0]
+    assert 0 not in odd_epochs
+    assert 0 not in even_epochs
+    assert odd_epochs == {1, 3, 5, 7, 9, 11, 13, 15}
+    assert even_epochs == {2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
 
 
 def test_validate_n_steps_passes_when_unbounded():

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -150,7 +150,10 @@ class InlineInferenceConfig:
         n_coupled_steps: number of coupled forward steps to take
         coupled_steps_in_memory: number of coupled forward steps to take before
             re-reading data from disk
-        epochs: epochs on which to run inference. By default runs inference every epoch.
+        epochs: positional slice over the training epochs 1 to max_epochs, so
+            index 0 selects epoch 1. By default runs inference every training
+            epoch. Epoch 0 is additionally included when
+            evaluate_before_training is true.
         aggregator: configuration of inline coupled inference aggregator.
         name: name used as wandb log prefix and output subdirectory. If None,
             defaults to "inference" when there is a single inference config
@@ -511,9 +514,12 @@ class TrainConfig:
         inference = self.inference_list
         if not inference:
             return []
-        start_epoch = 0 if self.evaluate_before_training else 1
-        all_epochs = list(range(start_epoch, self.max_epochs + 1))
-        return [set(all_epochs[entry.epochs.slice]) for entry in inference]
+        training_epochs = list(range(1, self.max_epochs + 1))
+        pre_training_epochs = {0} if self.evaluate_before_training else set()
+        return [
+            set(training_epochs[entry.epochs.slice]) | pre_training_epochs
+            for entry in inference
+        ]
 
     def get_inference_epochs(self) -> list[int]:
         epoch_sets = self.get_inference_epoch_sets()

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -386,8 +386,8 @@ class TrainConfig:
             must be run in segments, e.g. due to wall clock limit.
         save_per_epoch_diagnostics: Whether to save per-epoch diagnostics from
             training, validation and inline inference aggregators.
-        evaluate_before_training: Whether to run validation and inline inference before
-            any training is done.
+        evaluate_before_training: Whether to run all validation and inline
+            inference before any training is done.
         save_best_inference_epoch_checkpoints: Whether to save a separate checkpoint
             for each epoch where best_inference_error achieves a new minimum.
             Checkpoints are saved as best_inference_ckpt_XXXX.tar.

--- a/fme/coupled/train/train_config.py
+++ b/fme/coupled/train/train_config.py
@@ -152,8 +152,7 @@ class InlineInferenceConfig:
             re-reading data from disk
         epochs: positional slice over the training epochs 1 to max_epochs, so
             index 0 selects epoch 1. By default runs inference every training
-            epoch. Epoch 0 is additionally included when
-            evaluate_before_training is true.
+            epoch.
         aggregator: configuration of inline coupled inference aggregator.
         name: name used as wandb log prefix and output subdirectory. If None,
             defaults to "inference" when there is a single inference config


### PR DESCRIPTION
`evaluate_before_training: true` only produced a pre-training inference pass when `max_epochs` was even: `get_inference_epoch_sets` prepended epoch 0 *before* applying each entry's positional `epochs` slice, so an end-anchored slice such as `epochs: {start: -1, step: -2}` reached epoch 0 only at even parity — silently, since the trainer logs `Starting inline inference before training` before consulting the epoch set. The same prepend made the slice's meaning depend on the flag: at `max_epochs: 6` with `epochs: {step: 2}`, the coupled package (flag true by default) selected training epochs 2, 4, 6 while ACE (flag false) selected 1, 3, 5. Each entry's slice now resolves against the training epochs `1..max_epochs` regardless of the flag, and epoch 0 is unioned into every entry's set — no per-entry opt-out, including `weight: 0` entries and entries whose slice resolves empty — when the flag is true. That is how ACE already behaved, so the coupled package now agrees with ACE rather than adopting a new convention, but coupled configs with a start-anchored slice do change which epochs they run inference on. One config class newly fails at startup: an ACE config whose `weight > 0` entries shared a schedule only because epoch 0 shifted their phase now trips `_validate_weighted_inference_epochs` instead of selecting checkpoints on an incomparable metric.

Changes:
- `fme.ace.train.train_config.TrainConfig.get_inference_epoch_sets` and `fme.coupled.train.train_config.TrainConfig.get_inference_epoch_sets`: resolve each entry's `epochs` slice against the training epochs `1..max_epochs`, then union epoch 0 into every returned set when `evaluate_before_training` is true. The signature and return type are unchanged, and `get_inference_epochs` still derives the union.
- `fme.ace.train.train_config.InlineInferenceConfig.epochs` and `fme.coupled.train.train_config.InlineInferenceConfig.epochs` docstrings: state that the value is a positional slice over the training epochs and that epoch 0 is additionally included when `evaluate_before_training` is true.
- Tests in both packages covering `max_epochs` parity under a true flag, the slice's independence from the flag, an entry whose slice selects no training epoch, and a guard that epoch 0 stays absent when the flag is false. Both config-building test helpers now accept `evaluate_before_training`, defaulting to each class's own default.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #1408
