### PR TITLE
Upload a Beaker dataset for time-coarsened stats

### DIFF
--- a/scripts/data_process/compute_dataset_argo_workflow.yaml
+++ b/scripts/data_process/compute_dataset_argo_workflow.yaml
@@ -100,6 +100,8 @@ spec:
             parameters:
             - name: python_script
               value: "{{workflow.parameters.upload_stats_script}}"
+            - name: stats_script
+              value: "{{workflow.parameters.get_stats_script}}"
             - name: config
               value: "{{workflow.parameters.config}}"
     - name: compute-fme-dataset-individual
@@ -317,6 +319,7 @@ spec:
       inputs:
         parameters:
           - name: python_script
+          - name: stats_script
           - name: config
       container:
         image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
@@ -332,6 +335,10 @@ spec:
           - |
             cat << EOF > script.py
             {{inputs.parameters.python_script}}
+            EOF
+
+            cat << EOF > get_stats.py
+            {{inputs.parameters.stats_script}}
             EOF
 
             cat << EOF > config.yaml

--- a/scripts/data_process/get_stats.py
+++ b/scripts/data_process/get_stats.py
@@ -89,10 +89,15 @@ class TimeCoarsenConfig:
     Attributes:
         data_output_directory: Directory to save the coarsened datasets as zarr stores.
         stats_output_directory: Directory to save the stats of the coarsened datasets.
+        factor: Factor by which the time dimension is coarsened.
+        beaker_dataset: Name of the Beaker dataset to create from the coarsened stats.
+            If None, the coarsened stats are not uploaded to Beaker.
     """
 
     data_output_directory: str
     stats_output_directory: str
+    factor: int
+    beaker_dataset: str | None = None
 
 
 @dataclasses.dataclass

--- a/scripts/data_process/test_config.py
+++ b/scripts/data_process/test_config.py
@@ -90,17 +90,20 @@ def test_valid_create_coupled_ic_config(filename):
     )
 
 
+NATIVE_DATA_DIRECTORY = "gs://bucket/native-6hourly"
 NATIVE_STATS_DIRECTORY = "gs://bucket/native-stats"
 COARSENED_STATS_DIRECTORY = "gs://bucket/native-daily-stats"
 COARSENED_DATA_DIRECTORY = "gs://bucket/native-daily"
+COARSEN_CLAUSE = "Time coarsened by a factor of"
 
 
 def _upload_stats_config(
     stats_beaker_dataset: str | None = "native-stats",
     time_coarsen_beaker_dataset: str | None = None,
     include_time_coarsen: bool = False,
+    exclude_runs: list[str] | None = None,
 ) -> UploadStatsConfig:
-    stats = {
+    stats: dict = {
         "output_directory": NATIVE_STATS_DIRECTORY,
         "data_type": "CM4",
         "start_date": "0151-01-01T06:00:00",
@@ -108,9 +111,11 @@ def _upload_stats_config(
     }
     if stats_beaker_dataset is not None:
         stats["beaker_dataset"] = stats_beaker_dataset
+    if exclude_runs is not None:
+        stats["exclude_runs"] = exclude_runs
     config_data: dict = {
         "runs": {"run-a": "", "run-b": ""},
-        "data_output_directory": "gs://bucket",
+        "data_output_directory": NATIVE_DATA_DIRECTORY,
         "stats": stats,
     }
     if include_time_coarsen:
@@ -130,9 +135,16 @@ def test_upload_specs_native_only():
     assert len(specs) == 1
     assert specs[0].beaker_dataset == "native-stats"
     assert specs[0].combined_directory == NATIVE_STATS_DIRECTORY + "/combined/"
-    assert "gs://bucket" in specs[0].description
+    assert NATIVE_DATA_DIRECTORY in specs[0].description
     assert "run-a, run-b" in specs[0].description
     assert "0151-01-01T06:00:00" in specs[0].description
+    assert COARSEN_CLAUSE not in specs[0].description
+
+
+def test_upload_specs_description_omits_excluded_runs():
+    specs = _upload_specs(_upload_stats_config(exclude_runs=["run-b"]))
+    assert "run-a" in specs[0].description
+    assert "run-b" not in specs[0].description
 
 
 def test_upload_specs_skips_time_coarsened_without_beaker_dataset():
@@ -154,7 +166,8 @@ def test_upload_specs_includes_time_coarsened_dataset():
     coarsened = specs[1]
     assert coarsened.combined_directory == COARSENED_STATS_DIRECTORY + "/combined/"
     assert COARSENED_DATA_DIRECTORY in coarsened.description
-    assert "factor of 4" in coarsened.description
+    assert NATIVE_DATA_DIRECTORY not in coarsened.description
+    assert f"{COARSEN_CLAUSE} 4" in coarsened.description
 
 
 def test_upload_specs_time_coarsened_only():

--- a/scripts/data_process/test_config.py
+++ b/scripts/data_process/test_config.py
@@ -182,8 +182,11 @@ def test_upload_specs_time_coarsened_only():
     assert specs[0].combined_directory == COARSENED_STATS_DIRECTORY + "/combined/"
 
 
-def test_upload_specs_no_datasets_requested():
-    specs = _upload_specs(
+def test_upload_config_rejects_no_datasets_requested():
+    with pytest.raises(ValueError, match="No Beaker dataset to upload"):
         _upload_stats_config(stats_beaker_dataset=None, include_time_coarsen=True)
-    )
-    assert specs == []
+
+
+def test_upload_config_rejects_no_datasets_without_time_coarsen():
+    with pytest.raises(ValueError, match="No Beaker dataset to upload"):
+        _upload_stats_config(stats_beaker_dataset=None)

--- a/scripts/data_process/test_config.py
+++ b/scripts/data_process/test_config.py
@@ -9,6 +9,7 @@ from create_coupled_datasets import CreateCoupledDatasetsConfig
 from create_coupled_ic import CreateCoupledICConfig
 from get_stats import Config as GetStatsConfig
 from upload_stats import Config as UploadStatsConfig
+from upload_stats import _upload_specs
 
 DIRNAME = os.path.abspath(os.path.dirname(__file__))
 # list files in DIRNAME/config
@@ -87,3 +88,89 @@ def test_valid_create_coupled_ic_config(filename):
         data=config_data,
         config=dacite.Config(cast=[tuple], strict=True),
     )
+
+
+NATIVE_STATS_DIRECTORY = "gs://bucket/native-stats"
+COARSENED_STATS_DIRECTORY = "gs://bucket/native-daily-stats"
+COARSENED_DATA_DIRECTORY = "gs://bucket/native-daily"
+
+
+def _upload_stats_config(
+    stats_beaker_dataset: str | None = "native-stats",
+    time_coarsen_beaker_dataset: str | None = None,
+    include_time_coarsen: bool = False,
+) -> UploadStatsConfig:
+    stats = {
+        "output_directory": NATIVE_STATS_DIRECTORY,
+        "data_type": "CM4",
+        "start_date": "0151-01-01T06:00:00",
+        "end_date": "0351-01-01T00:00:00",
+    }
+    if stats_beaker_dataset is not None:
+        stats["beaker_dataset"] = stats_beaker_dataset
+    config_data: dict = {
+        "runs": {"run-a": "", "run-b": ""},
+        "data_output_directory": "gs://bucket",
+        "stats": stats,
+    }
+    if include_time_coarsen:
+        time_coarsen = {
+            "data_output_directory": COARSENED_DATA_DIRECTORY,
+            "stats_output_directory": COARSENED_STATS_DIRECTORY,
+            "factor": 4,
+        }
+        if time_coarsen_beaker_dataset is not None:
+            time_coarsen["beaker_dataset"] = time_coarsen_beaker_dataset
+        config_data["time_coarsen"] = time_coarsen
+    return dacite.from_dict(data_class=UploadStatsConfig, data=config_data)
+
+
+def test_upload_specs_native_only():
+    specs = _upload_specs(_upload_stats_config())
+    assert len(specs) == 1
+    assert specs[0].beaker_dataset == "native-stats"
+    assert specs[0].combined_directory == NATIVE_STATS_DIRECTORY + "/combined/"
+    assert "gs://bucket" in specs[0].description
+    assert "run-a, run-b" in specs[0].description
+    assert "0151-01-01T06:00:00" in specs[0].description
+
+
+def test_upload_specs_skips_time_coarsened_without_beaker_dataset():
+    specs = _upload_specs(_upload_stats_config(include_time_coarsen=True))
+    assert [spec.beaker_dataset for spec in specs] == ["native-stats"]
+
+
+def test_upload_specs_includes_time_coarsened_dataset():
+    specs = _upload_specs(
+        _upload_stats_config(
+            include_time_coarsen=True,
+            time_coarsen_beaker_dataset="native-daily-stats",
+        )
+    )
+    assert [spec.beaker_dataset for spec in specs] == [
+        "native-stats",
+        "native-daily-stats",
+    ]
+    coarsened = specs[1]
+    assert coarsened.combined_directory == COARSENED_STATS_DIRECTORY + "/combined/"
+    assert COARSENED_DATA_DIRECTORY in coarsened.description
+    assert "factor of 4" in coarsened.description
+
+
+def test_upload_specs_time_coarsened_only():
+    specs = _upload_specs(
+        _upload_stats_config(
+            stats_beaker_dataset=None,
+            include_time_coarsen=True,
+            time_coarsen_beaker_dataset="native-daily-stats",
+        )
+    )
+    assert [spec.beaker_dataset for spec in specs] == ["native-daily-stats"]
+    assert specs[0].combined_directory == COARSENED_STATS_DIRECTORY + "/combined/"
+
+
+def test_upload_specs_no_datasets_requested():
+    specs = _upload_specs(
+        _upload_stats_config(stats_beaker_dataset=None, include_time_coarsen=True)
+    )
+    assert specs == []

--- a/scripts/data_process/upload_stats.py
+++ b/scripts/data_process/upload_stats.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import sys
 import tempfile
-from typing import Dict, Optional
 
 import click
 import dacite
@@ -36,10 +35,10 @@ def copy(source: str, destination: str):
 
 @dataclasses.dataclass
 class Config:
-    runs: Dict[str, str]
+    runs: dict[str, str]
     data_output_directory: str
     stats: StatsConfig
-    time_coarsen: Optional[TimeCoarsenConfig] = None
+    time_coarsen: TimeCoarsenConfig | None = None
 
 
 @dataclasses.dataclass
@@ -59,7 +58,7 @@ class UploadSpec:
 
 
 def _describe(
-    config: Config, data_directory: str, coarsen_factor: Optional[int] = None
+    config: Config, data_directory: str, coarsen_factor: int | None = None
 ) -> str:
     runs = [run for run in config.runs if run not in config.stats.exclude_runs]
     run_names = ", ".join(runs)
@@ -76,7 +75,12 @@ def _describe(
 
 def _upload_specs(config: Config) -> list[UploadSpec]:
     specs = []
-    if config.stats.beaker_dataset is not None:
+    if config.stats.beaker_dataset is None:
+        logging.warning(
+            "No stats.beaker_dataset configured; stats at "
+            f"{config.stats.output_directory} will not be uploaded."
+        )
+    else:
         specs.append(
             UploadSpec(
                 beaker_dataset=config.stats.beaker_dataset,

--- a/scripts/data_process/upload_stats.py
+++ b/scripts/data_process/upload_stats.py
@@ -1,13 +1,25 @@
 import dataclasses
 import logging
+import os
 import shutil
+import sys
 import tempfile
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import click
 import dacite
 import fsspec
 import yaml
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from get_stats import StatsConfig, TimeCoarsenConfig
+
+STATS_FILENAMES = (
+    "centering.nc",
+    "scaling-full-field.nc",
+    "scaling-residual.nc",
+    "time-mean.nc",
+)
 
 
 def copy(source: str, destination: str):
@@ -23,81 +35,127 @@ def copy(source: str, destination: str):
 
 
 @dataclasses.dataclass
-class StatsConfig:
-    output_directory: str
-    beaker_dataset: str
-    exclude_runs: List[str] = dataclasses.field(default_factory=list)
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
-
-
-@dataclasses.dataclass
 class Config:
     runs: Dict[str, str]
     data_output_directory: str
     stats: StatsConfig
+    time_coarsen: Optional[TimeCoarsenConfig] = None
 
 
-@click.command()
-@click.argument("config_yaml", type=str)
-def main(config_yaml: str):
+@dataclasses.dataclass
+class UploadSpec:
     """
-    Combine statistics for the data processing pipeline.
+    A single Beaker dataset to create from a directory of combined stats.
 
-    Arguments:
-    config_yaml -- Path to the configuration file for the data processing pipeline.
+    Attributes:
+        beaker_dataset: Name of the Beaker dataset to create.
+        combined_directory: Directory holding the combined stats netCDFs.
+        description: Description to attach to the Beaker dataset.
     """
-    logging.basicConfig(level=logging.INFO)
 
-    # imported here so we don't need to install beaker for the tests
+    beaker_dataset: str
+    combined_directory: str
+    description: str
+
+
+def _describe(
+    config: Config, data_directory: str, coarsen_factor: Optional[int] = None
+) -> str:
+    runs = [run for run in config.runs if run not in config.stats.exclude_runs]
+    run_names = ", ".join(runs)
+    start = config.stats.start_date or "start of run"
+    end = config.stats.end_date or "end of run"
+    description = (
+        f"Coefficients for normalization for data {data_directory} "
+        f"runs {run_names}. Computed from {start} to {end}."
+    )
+    if coarsen_factor is not None:
+        description += f" Time coarsened by a factor of {coarsen_factor}."
+    return description
+
+
+def _upload_specs(config: Config) -> list[UploadSpec]:
+    specs = []
+    if config.stats.beaker_dataset is not None:
+        specs.append(
+            UploadSpec(
+                beaker_dataset=config.stats.beaker_dataset,
+                combined_directory=config.stats.output_directory + "/combined/",
+                description=_describe(config, config.data_output_directory),
+            )
+        )
+    if config.time_coarsen is not None:
+        if config.time_coarsen.beaker_dataset is None:
+            logging.warning(
+                "No time_coarsen.beaker_dataset configured; time coarsened stats at "
+                f"{config.time_coarsen.stats_output_directory} will not be uploaded."
+            )
+        else:
+            specs.append(
+                UploadSpec(
+                    beaker_dataset=config.time_coarsen.beaker_dataset,
+                    combined_directory=(
+                        config.time_coarsen.stats_output_directory + "/combined/"
+                    ),
+                    description=_describe(
+                        config,
+                        config.time_coarsen.data_output_directory,
+                        coarsen_factor=config.time_coarsen.factor,
+                    ),
+                )
+            )
+    return specs
+
+
+def _upload(beaker_client, spec: UploadSpec):
     import beaker as beaker_module
-    from beaker import Beaker
-
-    with open(config_yaml, "r") as f:
-        config_data = yaml.load(f, Loader=yaml.CLoader)
-    config = dacite.from_dict(data_class=Config, data=config_data)
-
-    stats_combined_dir = config.stats.output_directory + "/combined/"
-    beaker_client = Beaker.from_env()
 
     try:
-        beaker_client.dataset.get(config.stats.beaker_dataset)
+        beaker_client.dataset.get(spec.beaker_dataset)
         logging.info(
-            f"Beaker dataset '{config.stats.beaker_dataset}' already exists. "
-            "Skipping."
+            f"Beaker dataset '{spec.beaker_dataset}' already exists. Skipping."
         )
         return
     except beaker_module.exceptions.BeakerDatasetNotFound:
         pass
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        for filename in (
-            "centering.nc",
-            "scaling-full-field.nc",
-            "scaling-residual.nc",
-            "time-mean.nc",
-        ):
-            copy(stats_combined_dir + filename, tmpdir + "/" + filename)
-        runs = [run for run in config.runs if run not in config.stats.exclude_runs]
-        run_names = ", ".join(runs)
-        if config.stats.start_date is None:
-            start = "start of run"
-        else:
-            start = config.stats.start_date
-        if config.stats.end_date is None:
-            end = "end of run"
-        else:
-            end = config.stats.end_date
+        for filename in STATS_FILENAMES:
+            copy(spec.combined_directory + filename, tmpdir + "/" + filename)
         beaker_client.dataset.create(
-            config.stats.beaker_dataset,
+            spec.beaker_dataset,
             tmpdir,
             workspace="ai2/ace",
-            description=(
-                "Coefficients for normalization for data "
-                f"{config.data_output_directory} runs {run_names}. "
-                f"Computed from {start} to {end}."
-            ),
+            description=spec.description,
         )
+
+
+@click.command()
+@click.argument("config_yaml", type=str)
+def main(config_yaml: str):
+    """
+    Upload normalization statistics for the data processing pipeline to Beaker.
+
+    Arguments:
+    config_yaml -- Path to the configuration file for the data processing pipeline.
+    """
+    logging.basicConfig(level=logging.INFO)
+
+    with open(config_yaml, "r") as f:
+        config_data = yaml.load(f, Loader=yaml.CLoader)
+    config = dacite.from_dict(data_class=Config, data=config_data)
+
+    specs = _upload_specs(config)
+    if not specs:
+        logging.info("No Beaker datasets configured for upload.")
+        return
+
+    # imported here so we don't need to install beaker for the tests
+    from beaker import Beaker
+
+    beaker_client = Beaker.from_env()
+    for spec in specs:
+        _upload(beaker_client, spec)
 
 
 if __name__ == "__main__":

--- a/scripts/data_process/upload_stats.py
+++ b/scripts/data_process/upload_stats.py
@@ -40,6 +40,15 @@ class Config:
     stats: StatsConfig
     time_coarsen: TimeCoarsenConfig | None = None
 
+    def __post_init__(self):
+        if self.stats.beaker_dataset is None and (
+            self.time_coarsen is None or self.time_coarsen.beaker_dataset is None
+        ):
+            raise ValueError(
+                "No Beaker dataset to upload. Set stats.beaker_dataset, or set "
+                "time_coarsen.beaker_dataset to upload only the time-coarsened stats."
+            )
+
 
 @dataclasses.dataclass
 class UploadSpec:
@@ -150,9 +159,6 @@ def main(config_yaml: str):
     config = dacite.from_dict(data_class=Config, data=config_data)
 
     specs = _upload_specs(config)
-    if not specs:
-        logging.info("No Beaker datasets configured for upload.")
-        return
 
     # imported here so we don't need to install beaker for the tests
     from beaker import Beaker


### PR DESCRIPTION
`upload_stats.py` uploaded only the native-resolution stats to Beaker, so the time-coarsened (e.g. daily) stats that `get_stats.py` and `combine_stats.py` already compute could not be published. It now uploads one Beaker dataset per configured stats directory, driven by a new `time_coarsen.beaker_dataset`.

`upload_stats.py` imports `StatsConfig` and `TimeCoarsenConfig` from `get_stats.py` rather than declaring its own, which makes `stats.beaker_dataset` optional: omit it to upload only the coarsened stats. `Config.__post_init__` rejects a config naming no Beaker dataset at all, so that cannot silently become a no-op. Every checked-in config sets it, so none change behavior.

Changes:
- `scripts/data_process/upload_stats.py`: builds and uploads one `UploadSpec` per Beaker dataset, replacing the single hard-coded upload.
- `scripts/data_process/get_stats.py`: `TimeCoarsenConfig` gains `beaker_dataset`, and `factor` for the dataset description.
- `scripts/data_process/compute_dataset_argo_workflow.yaml`: provisions `get_stats.py` into the `upload-beaker-stats` step, as other steps already do.
- `scripts/data_process/test_config.py`: unit tests over the native/coarsened combinations, including the rejection case.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
