### PR TITLE
Temporal Downscaling Stage 1

### DIFF
--- a/configs/baselines/downscaling-temporal/train.yaml
+++ b/configs/baselines/downscaling-temporal/train.yaml
@@ -1,0 +1,192 @@
+# Canonical training config for the endpoint-conditioned video-PMD temporal
+# interpolation model (global 1deg, 24h -> 3h). Per-channel Ornstein-Uhlenbeck
+# noise kernels (temporal_noise_correlation: per_channel), plus subset-frame
+# training so the model can answer variable query sets. See
+# fme/downscaling/video_train.py and configs/experiments/2026-*-video-pmd-*
+# for the sweep this was selected from.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20
+max_test_batches: 50
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-per-channel-kernel-subset-cons0-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  # Subset training: half the batches train on a random subset of interior
+  # frames (endpoints always kept), so the model learns to answer variable
+  # query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # No marginal-consistency loss for this config; see
+  # configs/experiments/2026-07-14-video-pmd-bb-subset-cons10 and siblings
+  # for the L_marg sweep this was selected from.
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-06-29-video-pmd-smoke/run.sh
+++ b/configs/experiments/2026-06-29-video-pmd-smoke/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# CPU-only Beaker smoke run for the video PMD trainer, via gantry.
+#
+# Reads data from weka (climate-default), CPU-only (--gpus 0, FME_FORCE_CPU=1),
+# single process. Mirrors the weka pattern used by other ACE experiment runs
+# (e.g. configs/experiments/2025-11-15-ace2s-x-shield/run-ace2s-train.sh).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time):
+#   pip install beaker-gantry            # if gantry isn't installed
+#   beaker secret write --workspace ai2/chloeh CHLOE_WANDB_API_KEY <your-wandb-key>
+#
+# Run:  bash configs/experiments/2026-06-29-video-pmd-smoke/run.sh
+set -e
+
+JOB_NAME="video-pmd-regional-30-60-1degree-24to3-cpu-smoke"
+CONFIG_FILENAME="video_train_smoke.yaml"
+WORKSPACE="ai2/chloeh"
+CLUSTER="ai2/phobos"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name holding your W&B API key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'CPU smoke: endpoint-conditioned video interpolation (PMD), regional 30x60 1deg, 24h->3h' \
+    --workspace "$WORKSPACE" \
+    --priority normal \
+    --preemptible \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus 0 \
+    --shared-memory 10GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env FME_FORCE_CPU=1 \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- python -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-29-video-pmd-smoke/video_train_smoke.yaml
+++ b/configs/experiments/2026-06-29-video-pmd-smoke/video_train_smoke.yaml
@@ -1,0 +1,112 @@
+# Beaker CPU smoke config for the video PMD trainer (tiny + capped). Launch with run.sh.
+experiment_dir: /results
+max_epochs: 1
+max_train_batches: 3
+max_val_batches: 2
+validate_using_ema: true
+validate_interval: 1
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: regional-30-60-1degree-24to3-beaker-smoke
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.99
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 2
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 2
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+model:
+  n_timesteps: 9
+  model_channels: 16
+  n_heads: 2
+  num_freqs: 3
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 4
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_min: 0.005
+      p_max: 2000.0
+  sigma_min_by_channel:
+    PRATEsfc: 0.005
+  sigma_max_by_channel:
+    PRATEsfc: 2000.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:
+    means:
+      eastward_wind_at_ten_meters: -0.206107
+      northward_wind_at_ten_meters: 0.133348
+      PRMSL: 1009.104862
+      PRATEsfc: 0.000014
+    stds:
+      eastward_wind_at_ten_meters: 2.845158
+      northward_wind_at_ten_meters: 3.598240
+      PRMSL: 5.558873
+      PRATEsfc: 0.000098

--- a/configs/experiments/2026-06-29-video-pmd-titan/run.sh
+++ b/configs/experiments/2026-06-29-video-pmd-titan/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-29-video-pmd-titan/run.sh
+set -e
+
+JOB_NAME="video-pmd-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video interpolation (PMD), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-29-video-pmd-titan/video_train.yaml
+++ b/configs/experiments/2026-06-29-video-pmd-titan/video_train.yaml
@@ -1,0 +1,141 @@
+# Full GPU training: endpoint-conditioned global video interpolation (PMD), 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_mean: -1.2
+      p_std: 1.8
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/run.sh
+++ b/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (Brownian-bridge + per-channel noise), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/video_train.yaml
+++ b/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/video_train.yaml
@@ -1,0 +1,164 @@
+# Global video PMD (independent noise) with PER-CHANNEL noise schedule matched to
+# each channel's residual std. 4x B200 DDP. A/B partner of the bb-per-channel-noise run.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-06-30-video-pmd-bridge-titan/run.sh
+++ b/configs/experiments/2026-06-30-video-pmd-bridge-titan/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Variant of 2026-06-29-video-pmd-titan that uses endpoint-aware Brownian-bridge
+# temporal noise (temporal_noise_correlation: brownian_bridge) instead of the
+# default independent per-frame noise. Same data split and model as that run --
+# a controlled A/B against the independent-noise baseline.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-30-video-pmd-bridge-titan/run.sh
+set -e
+
+JOB_NAME="video-pmd-bridge-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video interpolation (PMD, Brownian-bridge noise), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-30-video-pmd-bridge-titan/video_train.yaml
+++ b/configs/experiments/2026-06-30-video-pmd-bridge-titan/video_train.yaml
@@ -1,0 +1,148 @@
+# Full GPU training: endpoint-conditioned global video interpolation (PMD), 4x B200 DDP.
+# Brownian-bridge temporal-noise variant of 2026-06-29-video-pmd-titan. Identical
+# data split and model to that run; the ONLY change is
+# temporal_noise_correlation: brownian_bridge, so this is a controlled A/B against
+# the independent-noise baseline.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bridge-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). The default
+  # is "independent"; this run uses the Brownian-bridge kernel on interior frames.
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_mean: -1.2
+      p_std: 1.8
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain (same window as the titan baseline)
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-06-30-video-pmd-per-channel-noise/run.sh
+++ b/configs/experiments/2026-06-30-video-pmd-per-channel-noise/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-30-video-pmd-per-channel-noise/run.sh
+set -e
+
+JOB_NAME="video-pmd-pcn-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (independent + per-channel noise), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-30-video-pmd-per-channel-noise/video_train.yaml
+++ b/configs/experiments/2026-06-30-video-pmd-per-channel-noise/video_train.yaml
@@ -1,0 +1,162 @@
+# Global video PMD (independent noise) with PER-CHANNEL noise schedule matched to
+# each channel's residual std. 4x B200 DDP. A/B partner of the bb-per-channel-noise run.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-pcn-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/run.sh
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training, NO marginal-consistency loss
+# (weight 0). A/B partner of the ...-subset-cons1 run.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training, no L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/video_train.yaml
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/video_train.yaml
@@ -1,0 +1,173 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training but
+# NO marginal-consistency loss (weight 0). A/B partner of the ...-subset-cons1 run:
+# identical in every way (data, normalization, per-channel bridge noise, subset
+# augmentation) EXCEPT marginal_consistency_weight, so the pair isolates L_marg.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons0-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # No marginal-consistency loss for this run (the A/B baseline).
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/run.sh
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training + marginal-consistency loss
+# (weight 1). A/B partner of the ...-subset-cons0 run.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons1-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training + L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/video_train.yaml
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/video_train.yaml
@@ -1,0 +1,175 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 1). A/B partner of the ...-subset-cons0 run:
+# identical in every way (data, normalization, per-channel bridge noise, subset
+# augmentation) EXCEPT marginal_consistency_weight, so the pair isolates L_marg.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons1-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg).
+  marginal_consistency_weight: 1.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/run.sh
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training + marginal-consistency loss
+# (weight 10). Third arm of the cons0 / cons1 / cons10 L_marg sweep.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training + L_marg weight 10), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/video_train.yaml
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/video_train.yaml
@@ -1,0 +1,176 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 10). Third arm of the ...-subset-cons0 /
+# ...-subset-cons1 sweep: identical in every way (data, normalization, per-channel
+# bridge noise, subset augmentation) EXCEPT marginal_consistency_weight, so the
+# three runs isolate the strength of L_marg (0 -> 1 -> 10). 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons10-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg). Weight 10
+  # pushes the consistency term hard relative to the two diffusion losses.
+  marginal_consistency_weight: 10.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/run.sh
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training + marginal-consistency loss
+# (weight 1) at the lighter subset rate 0.25. Pairs with ...-subset-cons1 (0.5).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset25-cons1-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training prob 0.25 + L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/video_train.yaml
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/video_train.yaml
@@ -1,0 +1,178 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 1), at a LIGHTER subset rate (0.25 instead
+# of 0.5). Same as ...-subset-cons1 in every way EXCEPT subset_augmentation_prob,
+# so the pair isolates how much the subset dilution costs the full-set task:
+# at 0.5 only ~57% of batches are full-grid, at 0.25 it is ~79%.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset25-cons1-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training at a lighter rate: a quarter of the batches train on a random
+  # subset of interior frames (endpoints always kept), so the model still learns to
+  # answer variable query sets but the full-grid task keeps ~79% of the batches
+  # (vs ~57% at prob 0.5), halving the dilution of the full-set metric.
+  subset_augmentation_prob: 0.25
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg).
+  marginal_consistency_weight: 1.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/run.sh
+++ b/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Test-set inference for global-1degree-24to3-pcn-v1: 32-member ensemble
+# infilling over the held-out test period, via gantry + torchrun DDP on
+# ai2/titan (4x B200). Reads data from weka (climate-default), reads the
+# trained checkpoint from its Beaker result dataset, writes the output zarr
+# back to weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KWDBK1BTEPRP6K7WRKVD1826
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/global-1degree-24to3-pcn-v1/test-2023-2024-ens32.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Smoke test first (small ensemble, capped batches) before the full run:
+#   Edit video_inference.yaml: n_ensemble: 2, add `max_batches: 4`, then run
+#   this script pointed at a scratch output_path. Confirms the checkpoint
+#   loads and ensemble_chunk_size fits in GPU memory before committing to the
+#   full test period.
+#
+# Run:  bash configs/experiments/2026-07-14-video-pmd-pcn-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-pcn-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBK1BTEPRP6K7WRKVD1826"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/video_inference.yaml
@@ -1,0 +1,117 @@
+# Test-set inference for global-1degree-24to3-pcn-v1: 32-member ensemble
+# infilling of the held-out test period (2023-01-01 .. 2024-01-04), using the
+# EMA weights from checkpoints/best.ckpt (Beaker dataset
+# 01KWDBK1BTEPRP6K7WRKVD1826). model:/data: are pasted verbatim from
+# ../2026-06-30-video-pmd-per-channel-noise/video_train.yaml's model:/test_data:
+# blocks -- do not hand-edit them out of sync with that file.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/global-1degree-24to3-pcn-v1/test-2023-2024-ens32.zarr
+# ensemble_chunk_size=8 (B_eff=local_batch_size*chunk=2*8=16) failed on the
+# first real run with `RuntimeError: Input tensor is too large.` -- a hard
+# int32 indexing overflow in the level-0 grouped blur conv (FIRBlur), not an
+# OOM: N*C*T*H*W*kH*kW = 16*128*9*180*360*9 ~= 10.7B elements, over the
+# 2^31-1 cuDNN/PyTorch limit for grouped conv3d. chunk_size=1 (B_eff=2)
+# matches the batch size training's own generate() calls already ran
+# successfully (generate_n_samples: 1, local batch 2) -- known-safe, not a
+# guess. Raise only after confirming a larger value clears the same op.
+n_ensemble: 32
+ensemble_chunk_size: 1
+use_ema: true
+# The first attempt crashed after initialize_store() had already created the
+# zarr, so a retry with the safe default (mode="w-") refuses to touch it.
+# Set back to false once a run is expected to actually complete, so a
+# finished store can't be clobbered by accident.
+overwrite: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-pcn-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/run.sh
+++ b/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training at prob 1.0 (every batch subset,
+# no full-grid batches) + marginal-consistency loss (weight 10). Extends the
+# subset-rate sweep (0.25 -> 0.5 -> 1.0) and the L_marg sweep (0 -> 1 -> 10)
+# to their combined extreme.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset100-cons10-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training prob 1.0 + L_marg weight 10), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/video_train.yaml
+++ b/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/video_train.yaml
@@ -1,0 +1,180 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AT
+# THE MAXIMUM RATE (prob 1.0 -- every batch trains on a random subset of interior
+# frames, never the full grid) AND the marginal-consistency loss at weight 10.
+# Extends the subset-rate sweep (0.25 -> 0.5 -> 1.0) and the L_marg sweep
+# (0 -> 1 -> 10) to their combined extreme: maximum variable-query diversity
+# paired with the strongest cross-query consistency penalty.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset100-cons10-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training at the maximum rate: every batch trains on a random subset
+  # of interior frames (endpoints always kept) -- there is no full-grid batch.
+  # Maximizes variable-query diversity at the cost of the full-set task never
+  # being trained on directly (that cost is what this run measures, paired
+  # with cons10's stronger L_marg to see if it compensates).
+  subset_augmentation_prob: 1.0
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg).
+  marginal_consistency_weight: 10.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/run.sh
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test-set inference for video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1:
+# 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained
+# checkpoint from its Beaker result dataset, writes the output zarr back to
+# weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KXGT4C82YJHGZ8VSHGE99D0N
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect this to take a similar order of magnitude as the first inference run
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture, same
+# ensemble size, same full-year test period.
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KXGT4C82YJHGZ8VSHGE99D0N"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, brownian-bridge + subset + L_marg weight 10), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/video_inference.yaml
@@ -1,0 +1,128 @@
+# Test-set inference for video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1:
+# 32-member ensemble infilling of the full held-out test period
+# (2023-01-01 .. 2024-01-04), using the EMA weights from checkpoints/best.ckpt
+# (Beaker dataset 01KXGT4C82YJHGZ8VSHGE99D0N). model:/data: are pasted
+# verbatim from ../2026-07-14-video-pmd-bb-subset-cons10/video_train.yaml's
+# model:/test_data: blocks -- do not hand-edit them out of sync with that
+# file. Unlike the first inference target (global-1degree-24to3-pcn-v1), this
+# model uses temporal_noise_correlation: brownian_bridge, which changes how
+# ensemble noise is drawn during generate() -- video_inference.py handles
+# this automatically since it just builds whatever VideoDiffusionModelConfig
+# it's given, but it's the reason this can't just reuse the other model's
+# inference config with the checkpoint path swapped.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Same architecture (model_channels=128, 5-level UNet) as the first
+# checkpoint, which hit an int32 indexing overflow in the level-0 grouped
+# blur conv at ensemble_chunk_size=8 (B_eff=local_batch_size*chunk=2*8=16,
+# ~10.7B elements > 2^31-1). chunk_size=1 (B_eff=2) is the known-safe value
+# from that fix -- see fme/downscaling/video_inference.py's load_video_model
+# docstring and configs/experiments/2026-07-14-video-pmd-pcn-test-inference/.
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). Affects
+  # generate()'s ensemble noise draw (see _sample_residual_noise /
+  # brownian_bridge_mixing_matrix in fme/downscaling/video_models.py) -- this
+  # is the functionally relevant difference from the first inference target.
+  temporal_noise_correlation: brownian_bridge
+  # Training-only fields (subset augmentation, marginal-consistency weight):
+  # generate() always produces the full grid (no frames= subset requested),
+  # so these don't affect inference, but are included verbatim for exact
+  # config fidelity with the training run.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  marginal_consistency_weight: 10.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/run.sh
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training (prob 0.5, unchanged) +
+# marginal-consistency loss (weight 100). Fourth arm of the cons0 / cons1 /
+# cons10 / cons100 L_marg sweep.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons100-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training + L_marg weight 100), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/video_train.yaml
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/video_train.yaml
@@ -1,0 +1,179 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 100). Fourth arm of the ...-subset-cons0 /
+# ...-subset-cons1 / ...-subset-cons10 sweep: identical in every way (data,
+# normalization, per-channel bridge noise, subset augmentation prob 0.5) EXCEPT
+# marginal_consistency_weight, so the runs isolate the strength of L_marg
+# (0 -> 1 -> 10 -> 100). 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons100-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  # Unchanged from the cons10 run.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg). Weight
+  # 100 (10x the cons10 run) pushes the consistency term much harder relative
+  # to the two diffusion losses.
+  marginal_consistency_weight: 100.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/run.sh
+++ b/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Test-set inference for video-pmd-bb-pcn-global-1degree-24to3-v1: 32-member
+# ensemble infilling over the full held-out test period (2023-01-01 ..
+# 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x B200). Reads data
+# from weka (climate-default), reads the trained checkpoint from its Beaker
+# result dataset, writes the output zarr back to weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KWDBKFBCWGKCAJD5B49H4TND
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect this to take a similar order of magnitude as the earlier inference
+# runs (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture, same
+# ensemble size, same full-year test period.
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBKFBCWGKCAJD5B49H4TND"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, brownian-bridge, no subset/L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/video_inference.yaml
@@ -1,0 +1,119 @@
+# Test-set inference for video-pmd-bb-pcn-global-1degree-24to3-v1: 32-member
+# ensemble infilling of the held-out test period (2023-01-01 .. 2024-01-04),
+# using the EMA weights from checkpoints/best.ckpt (Beaker dataset
+# 01KWDBKFBCWGKCAJD5B49H4TND, from experiment 01KWDBKF4ST6GH69GHP1Y8MNYK).
+# model:/data: are pasted verbatim from
+# ../2026-06-30-video-pmd-bb-per-channel-noise/video_train.yaml's
+# model:/test_data: blocks -- do not hand-edit them out of sync with that
+# file. This is the brownian-bridge counterpart of
+# ../2026-07-14-video-pmd-pcn-test-inference/ (global-1degree-24to3-pcn-v1):
+# identical architecture, normalization, and per-channel noise, with
+# temporal_noise_correlation: brownian_bridge instead of independent, and NO
+# subset training / L_marg (both default off, same as pcn-v1) -- isolates
+# the effect of the noise correlation scheme alone, independent of the
+# subset/L_marg confounds in the cons0/cons1/cons10/cons100 sweep.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (see
+# ../2026-07-14-video-pmd-pcn-test-inference/video_inference.yaml for the
+# int32 grouped-conv overflow this avoids) -- same architecture here.
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). Affects
+  # generate()'s ensemble noise draw -- the one functional difference from
+  # global-1degree-24to3-pcn-v1.
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/run.sh
+++ b/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test-set inference for video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1:
+# 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained
+# checkpoint from its Beaker result dataset, writes the output zarr back to
+# weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KWPZJFCNDYEM7266YFQSZXFM
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect this to take a similar order of magnitude as the earlier inference
+# runs (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture, same
+# ensemble size, same full-year test period.
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWPZJFCNDYEM7266YFQSZXFM"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, brownian-bridge + subset, no L_marg / weight 0), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/video_inference.yaml
@@ -1,0 +1,128 @@
+# Test-set inference for video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1:
+# 32-member ensemble infilling of the full held-out test period
+# (2023-01-01 .. 2024-01-04), using the EMA weights from checkpoints/best.ckpt
+# (Beaker dataset 01KWPZJFCNDYEM7266YFQSZXFM, from experiment
+# 01KWJC72G9AYF0ZVX8RNT1M24B). model:/data: are pasted verbatim from
+# ../2026-07-01-video-pmd-bb-subset-cons0/video_train.yaml's model:/test_data:
+# blocks -- do not hand-edit them out of sync with that file. This is the A/B
+# baseline (no marginal-consistency loss) for the cons0/cons1/cons10/cons100
+# L_marg sweep -- see ../2026-07-16-video-pmd-bb-subset-cons10-test-inference/
+# for the cons10 counterpart.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Same architecture (model_channels=128, 5-level UNet) as the first
+# checkpoint, which hit an int32 indexing overflow in the level-0 grouped
+# blur conv at ensemble_chunk_size=8 (B_eff=local_batch_size*chunk=2*8=16,
+# ~10.7B elements > 2^31-1). chunk_size=1 (B_eff=2) is the known-safe value
+# from that fix -- see fme/downscaling/video_inference.py's load_video_model
+# docstring and configs/experiments/2026-07-14-video-pmd-pcn-test-inference/.
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). Affects
+  # generate()'s ensemble noise draw (see _sample_residual_noise /
+  # brownian_bridge_mixing_matrix in fme/downscaling/video_models.py) -- this
+  # is the functionally relevant difference from the first inference target
+  # (global-1degree-24to3-pcn-v1).
+  temporal_noise_correlation: brownian_bridge
+  # Training-only fields (subset augmentation, marginal-consistency weight):
+  # generate() always produces the full grid (no frames= subset requested),
+  # so these don't affect inference, but are included verbatim for exact
+  # config fidelity with the training run. weight 0.0 is the A/B baseline
+  # (no L_marg loss).
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-20-video-pmd-5ch-flat/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-flat/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Model 1 of the 5-channel isolation set: flat/independent noise, 5 channels
+# (adds T2m). A/B baseline for models 2/3.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-5ch-flat/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-flat-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (flat/independent noise, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-5ch-flat/video_train.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-flat/video_train.yaml
@@ -1,0 +1,181 @@
+# Model 1 of the 5-channel isolation set: flat/independent noise (no temporal
+# correlation), 5 channels (adds air_temperature_at_two_meters to the
+# existing 4). Baseline for comparing against model 2 (per-channel OU/RBF
+# kernel) and model 3 (model 2 + subset training, L_marg=0) -- all three
+# share identical architecture/data/schedule, differing only in
+# temporal_noise_correlation and subset settings. 4x B200 DDP.
+#
+# T2m normalization/noise-schedule stats derived the same way as the
+# existing 4 channels (toy/compute_norm_stats.py -> global domain, train
+# split only; scripts/video_pmd_eval/compute_residual_std_5ch.py for
+# sigma_data/p_mean/sigma_max): mean=279.3386, std=20.2363,
+# resid_std=0.1403, p_mean=-1.96, sigma_max=22.4. The other 4 channels'
+# recomputed stats matched their existing baked-in values almost exactly,
+# cross-validating the methodology for T2m too.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-flat-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Flat/independent noise (no temporal correlation) -- this model's whole
+  # point is being the un-correlated baseline for models 2/3.
+  temporal_noise_correlation: independent
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Model 3 of the 5-channel isolation set: model 2's per-channel OU noise
+# kernel PLUS subset training, no marginal-consistency loss (weight 0).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (per-channel OU noise kernel + subset training, no L_marg, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/video_train.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/video_train.yaml
@@ -1,0 +1,194 @@
+# Model 3 of the 5-channel isolation set: model 2's per-channel noise kernel
+# (../2026-07-20-video-pmd-5ch-per-channel-kernel/) PLUS subset training,
+# with NO marginal-consistency loss (weight 0) -- i.e. the per-channel-kernel
+# analog of bb-subset-cons0 (../2026-07-01-video-pmd-bb-subset-cons0/), which
+# isolates subset training's own effect from L_marg using the OLD uniform
+# bridge kernel. This config does the same isolation but on top of the new
+# per-channel kernel instead. Identical to model 2 in every other way
+# (architecture, per-channel kernel choice/length scales, schedule). 4x B200
+# DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20
+max_test_batches: 50
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-per-channel-kernel-subset-cons0-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  # Subset training: half the batches train on a random subset of interior
+  # frames (endpoints always kept), so the model learns to answer variable
+  # query sets. Matches bb-subset-cons0's values exactly.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # No marginal-consistency loss for this run (the A/B baseline, matching
+  # bb-subset-cons0's own role for the bridge-kernel isolation grid).
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Model 2 of the 5-channel isolation set: per-channel noise kernel (OU for
+# every channel, see the config's own header for why), no subset training.
+# A/B partner of ../2026-07-20-video-pmd-5ch-flat/.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (per-channel OU noise kernel, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/video_train.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/video_train.yaml
@@ -1,0 +1,198 @@
+# Model 2 of the 5-channel isolation set: per-channel noise kernel (each
+# channel gets its own temporal correlation kernel, matched to
+# toy/process_residual_bridge_report.md's empirical fit over the TRAIN
+# split), no subset training / no L_marg. A/B partner of
+# ../2026-07-20-video-pmd-5ch-flat/ (identical except
+# temporal_noise_correlation) and the base model for model 3
+# (.../2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/, which adds
+# subset training on top of this). 4x B200 DDP.
+#
+# Per-channel kernel choice: OU for every channel. u10/v10/PRATEsfc were
+# OU's best fit outright (report's "best kernel" column). PRMSL and T2m's
+# best fit was RBF, but RBF's determinant there is ~1e-16 / ~1e-11 --
+# effectively rank-deficient/numerically degenerate as a mixing matrix (it
+# would collapse those channels' ensemble spread far more severely than
+# even the plain Brownian bridge already does) -- so both fall back to
+# their own second-best fit, OU, which is vastly better conditioned
+# (det ~3.6e-4 / ~4.7e-3) while still beating the bridge's fit error.
+# Length scales are per_channel_kernel_length_scale, in the model's
+# normalized-tau units (hours / 24h window), converted from the report's
+# raw-hour fits: u10 12.9h, v10 13.4h, PRMSL 19.3h, PRATEsfc 7.9h, T2m
+# 11.4h.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20
+max_test_batches: 50
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-per-channel-kernel-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cheap validation smoke test: does nonzero EDM churn (S_churn=20) restore
+# ensemble spread for the brownian-bridge noise scheme? 10-day window
+# (2023-01-01..2023-01-11), 32-member ensemble, 4x B200 DDP -- should take
+# ~O(30 min), not the ~16.5h a full-year run would.
+#
+# Checkpoint dataset (same as bb-pcn's own inference run):
+#   01KWDBKFBCWGKCAJD5B49H4TND
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn20-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-churn20-smoketest"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBKFBCWGKCAJD5B49H4TND"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Churn=20 smoke test for brownian-bridge video PMD noise (single 3-day window, 32-member ensemble)' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/video_inference.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/video_inference.yaml
@@ -1,0 +1,144 @@
+# Cheap validation smoke test: does nonzero EDM churn restore ensemble spread
+# for the brownian-bridge noise scheme? Same checkpoint as
+# ../2026-07-17-video-pmd-bb-pcn-test-inference/ (video-pmd-bb-pcn-global-
+# 1degree-24to3-v1, Beaker dataset 01KWDBKFBCWGKCAJD5B49H4TND), with two
+# changes only:
+#   - model.churn: 0.0 -> 20.0 (Karras EDM stochastic sampler S_churn; the
+#     mixing-matrix-aware churn_noise() path in _video_edm_sample already
+#     supports this, it's just never been exercised with churn>0 so far).
+#   - data restricted to a 10-day window (2023-01-01..2023-01-11, covering
+#     crps_eval.py's "winter (Jan)" SAMPLE_WINDOWS 3-day window plus margin)
+#     instead of the full test year, purely to keep this validation run
+#     cheap (~O(30 min) vs. ~16.5h for the full year at 4 GPUs, per the
+#     sibling config's timing note). If this looks promising, follow up
+#     with the full 4-season or full-year run.
+#   - batch_size: 8 -> 4 (global across 4 ranks, so 1 clip/rank/batch
+#     instead of 2) -- with only ~3 total clips in a 3-day window, 2/rank
+#     underflowed drop_last and StopIteration'd every rank on the first
+#     attempt at this run; widening to 10 days (~10 clips) plus a smaller
+#     batch gives comfortable margin.
+# See crps_eval_results_pcn-v1-bb-pcn-bb-subset-cons0-bb-subset-cons10/
+# COMPARISON_REPORT.md ("Why does brownian-bridge noise reduce spread?") for
+# why churn is the theoretically correct lever here: with churn=0, the
+# initial noise draw is the sole source of ensemble stochasticity, and
+# Brownian-bridge-correlated noise has strictly lower joint entropy than
+# independent noise at the same marginal variance.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn20-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+# The two earlier failed attempts (StopIteration, then an NCCL hang) each
+# left partial data at output_path, so the default mode="w-" now refuses to
+# write. True while this run keeps retrying; flip back to False once it's
+# expected to succeed, so a completed store can't be clobbered by accident.
+overwrite: true
+n_ensemble: 32
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-churn20-smoketest
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  # 4 (not 8) so each of the 4 ranks needs only 1 clip/batch -- a 10-day
+  # window gives ~10 tumbling 24h clips, comfortable margin over the
+  # per-rank minimum. The original 3-day window only yielded ~3 total
+  # clips, so with batch_size=8 (2/rank) every rank's DataLoader dropped its
+  # under-full batch and started empty -> StopIteration on all ranks.
+  batch_size: 4  # global across ranks
+  # REQUIRED for small/custom windows: ContiguousDistributedSampler's
+  # drop_last=False path (the default) does NOT pad ranks to equal size
+  # despite what its docstring claims -- it silently dumps the remainder
+  # clips onto the last rank only (datasets.py:919-921). With an uneven
+  # clip count across the 4 ranks, the DDP-wrapped model's per-forward
+  # collective sync falls out of lock-step once the short ranks finish
+  # their loop early, which is what caused the first attempt at this run to
+  # hang for 30 min and die on an NCCL ALLREDUCE watchdog timeout.
+  # drop_last=True takes the correct, actually-even-splitting code path.
+  drop_last: true
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 20.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cheap validation smoke test, take 2: does churn=5 (gentler than the
+# churn=20 attempt, which made calibration worse) behave differently?
+# 10-day window (2023-01-01..2023-01-11), 32-member ensemble, 4x B200 DDP --
+# should take ~O(30 min), not the ~16.5h a full-year run would.
+#
+# Checkpoint dataset (same as bb-pcn's own inference run):
+#   01KWDBKFBCWGKCAJD5B49H4TND
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn5-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-churn5-smoketest"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBKFBCWGKCAJD5B49H4TND"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Churn=5 smoke test for brownian-bridge video PMD noise (10-day window, 32-member ensemble)' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/video_inference.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/video_inference.yaml
@@ -1,0 +1,108 @@
+# Cheap validation smoke test, take 2: churn=20 (uniform, no S_tmin/S_tmax
+# gating) made calibration *worse* on the same window
+# (../2026-07-20-video-pmd-bb-pcn-churn20-smoketest/,
+# churn_smoketest_results/ -- ratio dropped from ~0.92-0.97 at churn=0 to
+# ~0.84-0.94 at churn=20 across all 4 channels). Testing whether a much
+# gentler kick behaves differently before writing off churn entirely: same
+# checkpoint, same 10-day window/batch/drop_last fixes as the churn=20
+# attempt, only model.churn: 20.0 -> 5.0.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn5-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+n_ensemble: 32
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-churn5-smoketest
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  batch_size: 4  # global across ranks (1/rank -- see churn20 config's notes)
+  drop_last: true  # required for small/custom windows -- see churn20 config's notes
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 5.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/run.sh
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test-set inference for video-pmd-5ch-flat-global-1degree-24to3-v1:
+# 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained checkpoint
+# from its Beaker result dataset, writes the output zarr back to weka.
+#
+# Checkpoint dataset (result of the SECOND job under this experiment --
+# Beaker auto-retried after the first job was preempted at ~4 min; the
+# second job completed cleanly, exitCode 0, 200 epochs. Contains
+# checkpoints/latest.ckpt, used deliberately over best.ckpt, see
+# video_inference.yaml's header):
+#   01KY0V8ZNN763G59S8QBY4304B
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-flat-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect a similar order of magnitude as the earlier 4-channel inference runs
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture family,
+# same ensemble size, same full-year test period, one extra channel (T2m).
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-flat-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KY0V8ZNN763G59S8QBY4304B"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, flat/independent noise, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/video_inference.yaml
@@ -1,0 +1,136 @@
+# Test-set inference for video-pmd-5ch-flat-global-1degree-24to3-v1:
+# 32-member ensemble infilling of the held-out test period (2023-01-01 ..
+# 2024-01-04), using the EMA weights from checkpoints/latest.ckpt (Beaker
+# dataset 01KY0V8ZNN763G59S8QBY4304B, from training experiment
+# 01KY0SQW5SFS5KEYZR94T6WDTZ). Note: this experiment's FIRST job attempt
+# (01KY0SQW9WRDQP4YE5NYD0693A) was preempted after ~4 min and produced no
+# usable checkpoint -- Beaker auto-retried under the same experiment ID, and
+# the SECOND job (01KY0V8ZS0130PRZA0HZQ99H2P) completed cleanly, exitCode 0,
+# 200 epochs, no further preemption. Use the second job's result dataset
+# (above), not the first's (01KY0SQW5YD34ABY98Y74DSVFE, near-empty).
+#
+# Deliberately latest.ckpt, not best.ckpt, for consistency with the
+# per-channel-kernel inference config (see its own header) even though this
+# run's validation kept improving later into training (last "Saving best
+# checkpoint" before epoch 151 of 200, vs. epoch ~92 of 200 for
+# per-channel-kernel) -- latest.ckpt is still the fully-trained final-epoch
+# weights either way. Same _save_checkpoint format for both files (module +
+# ema state dicts), so use_ema: true works identically.
+#
+# model:/data: are pasted verbatim from
+# ../2026-07-20-video-pmd-5ch-flat/video_train.yaml's model:/test_data:
+# blocks -- do not hand-edit them out of sync with that file.
+#
+# 5 channels (adds air_temperature_at_two_meters to the earlier 4-channel
+# models), flat/independent noise (the un-correlated baseline for the
+# per-channel-kernel isolation grid).
+checkpoint_path: /checkpoint/checkpoints/latest.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-flat-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (int32 grouped-conv overflow
+# at higher effective batch -- same architecture family here).
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-5ch-flat-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: independent
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/run.sh
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Test-set inference for video-pmd-5ch-per-channel-kernel-subset-cons0-
+# global-1degree-24to3-v1: 32-member ensemble infilling over the full
+# held-out test period (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP
+# on ai2/titan (4x B200). Reads data from weka (climate-default), reads the
+# trained checkpoint from its Beaker result dataset, writes the output zarr
+# back to weka.
+#
+# Checkpoint dataset (result of the 7th job under this experiment -- the
+# first 6 were each preempted by an urgent-priority job; contains
+# checkpoints/latest.ckpt, used deliberately over best.ckpt, see
+# video_inference.yaml's header. Training completed cleanly, exitCode 0,
+# 200 epochs):
+#   01KY3DB2WP9ME06KQYMVTFBRPY
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Priority is "high" (not "urgent" like the other two 5ch inference configs)
+# per explicit instruction for this run.
+#
+# Expect a similar order of magnitude as the earlier 4-channel inference runs
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture family,
+# same ensemble size, same full-year test period, one extra channel (T2m).
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KY3DB2WP9ME06KQYMVTFBRPY"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, per-channel OU noise kernel + subset training, no L_marg, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/video_inference.yaml
@@ -1,0 +1,146 @@
+# Test-set inference for video-pmd-5ch-per-channel-kernel-subset-cons0-
+# global-1degree-24to3-v1: 32-member ensemble infilling of the held-out test
+# period (2023-01-01 .. 2024-01-04), using the EMA weights from
+# checkpoints/latest.ckpt (Beaker dataset 01KY3DB2WP9ME06KQYMVTFBRPY, from
+# training experiment 01KY0VVAVTQDKD6NP0MDD8CKQ0). This experiment was
+# preempted SIX times (always a "high"-priority job bumped by an "urgent"
+# one) before the 7th job (01KY3DB2ZXDRXKQGDPZ0648FMD) finally ran
+# uninterrupted and completed cleanly, exitCode 0, 200 epochs.
+#
+# Deliberately latest.ckpt, not best.ckpt, for consistency with the other two
+# 5ch inference configs (see their headers for why) -- same
+# _save_checkpoint format either way, so use_ema: true applies identically.
+#
+# model:/data: are pasted verbatim from
+# ../2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/video_train.yaml's
+# model:/test_data: blocks -- do not hand-edit them out of sync with that
+# file.
+#
+# Model 3 of the 5-channel isolation set: model 2's per-channel OU noise
+# kernel PLUS subset training, L_marg=0 (the per-channel-kernel analog of
+# bb-subset-cons0).
+checkpoint_path: /checkpoint/checkpoints/latest.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (int32 grouped-conv overflow
+# at higher effective batch -- same architecture family here).
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/run.sh
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Test-set inference for video-pmd-5ch-per-channel-kernel-global-1degree-
+# 24to3-v1: 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained checkpoint
+# from its Beaker result dataset, writes the output zarr back to weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/latest.ckpt
+# -- used deliberately over best.ckpt, see video_inference.yaml's header;
+# training completed cleanly, exitCode 0, 200 epochs, no preemption):
+#   01KY0SRVAY199HM7TM8M9TXEVX
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect a similar order of magnitude as the earlier 4-channel inference runs
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture family,
+# same ensemble size, same full-year test period, one extra channel (T2m).
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KY0SRVAY199HM7TM8M9TXEVX"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, per-channel OU noise kernel, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/video_inference.yaml
@@ -1,0 +1,141 @@
+# Test-set inference for video-pmd-5ch-per-channel-kernel-global-1degree-
+# 24to3-v1: 32-member ensemble infilling of the held-out test period
+# (2023-01-01 .. 2024-01-04), using the EMA weights from
+# checkpoints/latest.ckpt (Beaker dataset 01KY0SRVAY199HM7TM8M9TXEVX, from
+# training experiment 01KY0SRVASWEECEGZHXF67E141, which completed cleanly --
+# exitCode 0, 200 epochs, no preemption). Deliberately latest.ckpt, not
+# best.ckpt: validation/loss stopped improving (no new "Saving best
+# checkpoint") after epoch ~92 and stayed flat through completion at epoch
+# 200, so best.ckpt is a stale ~epoch-92 snapshot -- latest.ckpt is the
+# fully-trained final-epoch weights. Same _save_checkpoint format for both
+# (module + ema state dicts), so use_ema: true works identically either way.
+# model:/data: are pasted verbatim from
+# ../2026-07-20-video-pmd-5ch-per-channel-kernel/video_train.yaml's model:/
+# test_data: blocks -- do not hand-edit them out of sync with that file.
+#
+# 5 channels (adds air_temperature_at_two_meters to the earlier 4-channel
+# models), per-channel OU noise kernel (see the training config's own header
+# for the per-channel kernel-choice rationale and the RBF->OU fallback for
+# PRMSL/T2m).
+checkpoint_path: /checkpoint/checkpoints/latest.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (int32 grouped-conv overflow
+# at higher effective batch -- same architecture family here).
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/fme/core/logging_utils.py
+++ b/fme/core/logging_utils.py
@@ -35,6 +35,8 @@ class LoggingConfig:
     Parameters:
         project: Name of the project in Weights & Biases.
         entity: Name of the entity in Weights & Biases.
+        name: Optional display name for the Weights & Biases run. If None, the
+            run name is auto-generated (or taken from the WANDB_NAME env var).
         log_to_screen: Whether to log to the screen.
         log_to_file: Whether to log to a file.
         log_to_wandb: Whether to log to Weights & Biases.
@@ -48,6 +50,7 @@ class LoggingConfig:
 
     project: str = "ace"
     entity: str = "ai2cm"
+    name: str | None = None
     log_to_screen: bool = True
     log_to_file: bool = True
     log_to_wandb: bool = True
@@ -155,7 +158,7 @@ class LoggingConfig:
             config=config_copy,
             # wandb reads WANDB_NAME only on the first init in a process, so pass
             # it explicitly for later runs (e.g. segments) to be named correctly.
-            name=os.environ.get("WANDB_NAME"),
+            name=self.name or os.environ.get("WANDB_NAME"),
             project=self.project,
             entity=self.entity,
             experiment_dir=experiment_dir,

--- a/fme/downscaling/aggregators/main.py
+++ b/fme/downscaling/aggregators/main.py
@@ -19,7 +19,7 @@ from fme.core.device import get_device
 from fme.core.distributed import Distributed
 from fme.core.histogram import ComparedDynamicTailsHistograms
 from fme.core.tensor_dict_accumulator import TensorDictAccumulator
-from fme.core.typing_ import TensorDict, TensorMapping
+from fme.core.typing_ import TensorMapping
 from fme.core.wandb import WandB
 from fme.downscaling.aggregators.adapters import ComparedDynamicTailsHistogramsAdapter
 from fme.downscaling.data import PairedBatchData
@@ -54,6 +54,15 @@ def _tensor_mapping_to_numpy(data: TensorMapping) -> TensorMapping:
 class LossVsNoiseAggregator:
     """
     Aggregates binned diffusion losses as a function of sampled noise level.
+
+    The "all_channels" total is a per-sample SUM across channels when sigma is
+    shared (not channelwise) -- with channelwise sigma, no such sum is
+    well-defined, since each (sample, channel) pair can land in a different
+    noise bin, so each is instead recorded as its own independent point. Note
+    this differs from this class's pre-per-channel-sigma-support behavior, in
+    which "all_channels" was a per-sample MEAN across channels: the
+    "all_channels" wandb curve is not directly comparable in scale to runs
+    logged before that change.
     """
 
     def __init__(
@@ -104,35 +113,75 @@ class LossVsNoiseAggregator:
         if outputs.sigma is None or not outputs.per_sample_channel_loss:
             return
 
-        sigma = outputs.sigma.detach().flatten()
+        sigma = outputs.sigma.detach()
         if torch.any(sigma <= 0):
             raise ValueError("Sigma must be strictly positive for log10 binning")
-        log_sigma = torch.log10(sigma)
-        in_range = (log_sigma >= self._log10_sigma_min) & (
-            log_sigma <= self._log10_sigma_max
-        )
-        if not torch.any(in_range):
-            return
-        # Indices in [0, n_bins-1] for values within the configured sigma range.
-        bin_indices = torch.bucketize(log_sigma[in_range], self._inner_edges)
 
-        per_channel: TensorDict = {}
-        for name, loss in outputs.per_sample_channel_loss.items():
+        # With a shared per-sample sigma every channel falls in the same bin, so
+        # the all_channels total is one observation per sample (summed across
+        # channels). With channelwise sigma each (sample, channel) is its own
+        # point binned at its own noise level.
+        channelwise = sigma.dim() == 2
+        per_sample_total: torch.Tensor | None = None
+        for i, (name, loss) in enumerate(outputs.per_sample_channel_loss.items()):
+            # Register every channel up front (regardless of whether any sample
+            # falls in the sigma range) so that under DDP all ranks accumulate
+            # the same channel set and issue matching `reduce_sum` collectives in
+            # `_get` -- otherwise an out-of-range channel on one rank only would
+            # desync the collectives and deadlock.
+            if name not in self._channel_sum:
+                self._channel_sum[name] = torch.zeros(
+                    self._n_bins, dtype=torch.float32, device=get_device()
+                )
+                self._channel_count[name] = torch.zeros(
+                    self._n_bins, dtype=torch.int64, device=get_device()
+                )
+            if sigma.dim() == 1:
+                channel_sigma = sigma.flatten()
+            elif sigma.dim() == 2:
+                channel_sigma = sigma[:, i].flatten()
+            else:
+                raise ValueError(
+                    "Expected sigma to have shape (batch,) or (batch, channel)"
+                )
             channel_loss = loss.detach().flatten()
-            if channel_loss.shape != sigma.shape:
+            if channel_loss.shape != channel_sigma.shape:
                 raise ValueError(
                     "Expected per-sample channel losses and sigma to share batch shape"
                 )
-            per_channel[name] = channel_loss[in_range]
+            log_sigma = torch.log10(channel_sigma)
+            in_range = (log_sigma >= self._log10_sigma_min) & (
+                log_sigma <= self._log10_sigma_max
+            )
+            if torch.any(in_range):
+                # Indices in [0, n_bins-1] for values within the sigma range.
+                bin_indices = torch.bucketize(log_sigma[in_range], self._inner_edges)
+                self._accumulate(
+                    values=channel_loss[in_range], bin_indices=bin_indices, name=name
+                )
+                if channelwise:
+                    self._total_sum.scatter_add_(0, bin_indices, channel_loss[in_range])
+                    self._total_count.scatter_add_(
+                        0, bin_indices, torch.ones_like(bin_indices, dtype=torch.int64)
+                    )
+            if not channelwise:
+                per_sample_total = (
+                    channel_loss
+                    if per_sample_total is None
+                    else per_sample_total + channel_loss
+                )
 
-        stacked = torch.stack(list(per_channel.values()), dim=-1)
-        total_loss = torch.mean(stacked, dim=-1)
-        self._total_sum.scatter_add_(0, bin_indices, total_loss)
-        self._total_count.scatter_add_(
-            0, bin_indices, torch.ones_like(bin_indices, dtype=torch.int64)
-        )
-        for name, values in per_channel.items():
-            self._accumulate(values=values, bin_indices=bin_indices, name=name)
+        if not channelwise and per_sample_total is not None:
+            log_sigma = torch.log10(sigma.flatten())
+            in_range = (log_sigma >= self._log10_sigma_min) & (
+                log_sigma <= self._log10_sigma_max
+            )
+            if torch.any(in_range):
+                bin_indices = torch.bucketize(log_sigma[in_range], self._inner_edges)
+                self._total_sum.scatter_add_(0, bin_indices, per_sample_total[in_range])
+                self._total_count.scatter_add_(
+                    0, bin_indices, torch.ones_like(bin_indices, dtype=torch.int64)
+                )
 
     def _plot_binned(self, y_values: np.ndarray, counts: np.ndarray, title: str) -> Any:
         wandb = WandB.get_instance()

--- a/fme/downscaling/aggregators/test_aggregators.py
+++ b/fme/downscaling/aggregators/test_aggregators.py
@@ -250,6 +250,57 @@ def test_loss_vs_noise_aggregator_get_wandb(prefix: str):
         assert isinstance(value, wandb.Image)
 
 
+def test_loss_vs_noise_aggregator_all_channels_totals_sum_across_channels():
+    """With a shared (non-channelwise) sigma, the "all_channels" total is a
+    per-sample SUM across channels, not a mean -- this changed from the
+    pre-existing mean behavior when per-channel sigma binning was added, so
+    the "all_channels" wandb curve is on a different scale than runs logged
+    before this change. This test locks in the new (sum) semantics.
+    """
+    aggregator = LossVsNoiseAggregator(n_bins=8)
+    outputs = ModelOutputs(
+        prediction={},
+        target={},
+        latent_steps=[],
+        loss=torch.tensor(0.0, device=get_device()),
+        sigma=torch.tensor([1.0, 1.0], device=get_device()),  # shared, same bin
+        per_sample_channel_loss={
+            "x": torch.tensor([1.0, 3.0], device=get_device()),
+            "y": torch.tensor([2.0, 5.0], device=get_device()),
+        },
+    )
+
+    aggregator.record_batch(outputs)
+
+    # sum, not mean, across channels per sample: (1+2) + (3+5) = 11
+    assert aggregator._total_sum.sum().item() == pytest.approx(11.0)
+    assert int(aggregator._total_count.sum().item()) == 2
+    # per-channel totals are unaffected by the all_channels aggregation mode
+    assert aggregator._channel_sum["x"].sum().item() == pytest.approx(4.0)
+    assert aggregator._channel_sum["y"].sum().item() == pytest.approx(7.0)
+
+
+def test_loss_vs_noise_aggregator_accepts_channelwise_sigma():
+    aggregator = LossVsNoiseAggregator(n_bins=8)
+    outputs = ModelOutputs(
+        prediction={},
+        target={},
+        latent_steps=[],
+        loss=torch.tensor(0.0, device=get_device()),
+        sigma=torch.tensor([[0.1, 1000.0], [1.0, 2000.0]], device=get_device()),
+        per_sample_channel_loss={
+            "x": torch.tensor([1.0, 2.0], device=get_device()),
+            "prate": torch.tensor([3.0, 4.0], device=get_device()),
+        },
+    )
+
+    aggregator.record_batch(outputs)
+
+    assert int(aggregator._total_count.sum().item()) == 4
+    assert int(aggregator._channel_count["x"].sum().item()) == 2
+    assert int(aggregator._channel_count["prate"].sum().item()) == 2
+
+
 @pytest.mark.parametrize("n_latent_steps", [0, 2])
 def test_aggregator_integration(n_latent_steps, percentiles=[99.999]):
     downscale_factor = 2

--- a/fme/downscaling/configs/video_train_xshield.yaml
+++ b/fme/downscaling/configs/video_train_xshield.yaml
@@ -1,0 +1,111 @@
+# Endpoint-conditioned temporal video interpolation on X-SHiELD AMIP 3-hourly data.
+# Train/val/test split is chronological via each dataset's `subset` TimeSlice.
+experiment_dir: /will/be/overwritten
+max_epochs: 20
+validate_using_ema: true
+validate_interval: 1
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: regional-30-60-1degree-24to3
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 4
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 4
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+model:
+  n_timesteps: 9
+  model_channels: 64
+  n_heads: 4
+  num_freqs: 4
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 18
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_min: 0.005
+      p_max: 2000.0
+  sigma_min_by_channel:
+    PRATEsfc: 0.005
+  sigma_max_by_channel:
+    PRATEsfc: 2000.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only; recompute via toy/compute_norm_stats.py if box/range/channels change
+    means:
+      eastward_wind_at_ten_meters: -0.206107
+      northward_wind_at_ten_meters: 0.133348
+      PRMSL: 1009.104862
+      PRATEsfc: 0.000014
+    stds:
+      eastward_wind_at_ten_meters: 2.845158
+      northward_wind_at_ten_meters: 3.598240
+      PRMSL: 5.558873
+      PRATEsfc: 0.000098

--- a/fme/downscaling/configs/video_train_xshield_smoke.yaml
+++ b/fme/downscaling/configs/video_train_xshield_smoke.yaml
@@ -1,0 +1,114 @@
+# CPU smoke config (tiny + capped) for video_train_xshield.yaml.
+# Run: FME_FORCE_CPU=1 python -m fme.downscaling.video_train \
+#   fme/downscaling/configs/video_train_xshield_smoke.yaml
+experiment_dir: /tmp/video_smoke
+max_epochs: 1
+max_train_batches: 3
+max_val_batches: 2
+validate_using_ema: true
+validate_interval: 1
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: false
+  project: ace-temporal-interp
+  name: regional-30-60-1degree-24to3-smoke
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.99
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 2
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: gs://vcm-ml-scratch/andrep
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 2
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+model:
+  n_timesteps: 9
+  model_channels: 16
+  n_heads: 2
+  num_freqs: 3
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 4
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_min: 0.005
+      p_max: 2000.0
+  sigma_min_by_channel:
+    PRATEsfc: 0.005
+  sigma_max_by_channel:
+    PRATEsfc: 2000.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:
+    means:
+      eastward_wind_at_ten_meters: -0.206107
+      northward_wind_at_ten_meters: 0.133348
+      PRMSL: 1009.104862
+      PRATEsfc: 0.000014
+    stds:
+      eastward_wind_at_ten_meters: 2.845158
+      northward_wind_at_ten_meters: 3.598240
+      PRMSL: 5.558873
+      PRATEsfc: 0.000098

--- a/fme/downscaling/data/__init__.py
+++ b/fme/downscaling/data/__init__.py
@@ -11,9 +11,17 @@ from .datasets import (
     PairedBatchData,
     PairedBatchItem,
     PairedGriddedData,
+    PairedVideoBatchData,
+    PairedVideoBatchItem,
+    PairedVideoGriddedData,
     RegionSamplingConfig,
+    VideoBatchData,
+    VideoBatchItem,
+    VideoBatchItemDatasetAdapter,
+    VideoFineCoarsePairedDataset,
 )
 from .static import StaticInput, StaticInputs, load_coords_from_path, load_static_inputs
+from .time_encoding import compute_calendar_features
 from .utils import (
     BatchedLatLonCoordinates,
     ClosedInterval,

--- a/fme/downscaling/data/config.py
+++ b/fme/downscaling/data/config.py
@@ -2,7 +2,7 @@ import dataclasses
 from collections.abc import Sequence
 
 import torch
-from torch.utils.data import DataLoader, Dataset, RandomSampler
+from torch.utils.data import DataLoader, Dataset, RandomSampler, Subset
 from torch.utils.data.distributed import DistributedSampler
 
 from fme.core.coordinates import LatLonCoordinates
@@ -23,6 +23,10 @@ from fme.downscaling.data.datasets import (
     HorizontalSubsetDataset,
     PairedBatchData,
     PairedGriddedData,
+    PairedVideoBatchData,
+    PairedVideoGriddedData,
+    VideoBatchItemDatasetAdapter,
+    VideoFineCoarsePairedDataset,
 )
 from fme.downscaling.data.utils import (
     ClosedInterval,
@@ -448,6 +452,8 @@ class PairedDataLoaderConfig:
     topography: str | None = None
     sample_with_replacement: int | None = None
     drop_last: bool = False
+    n_timesteps: int = 1
+    time_stride: int | None = None
 
     def __post_init__(self):
         enforce_lat_bounds(self.lat_extent)
@@ -457,6 +463,19 @@ class PairedDataLoaderConfig:
                 "will be removed in a future release. `StaticInputs` are now stored "
                 "within the model when it is first built and trained."
             )
+        if self.n_timesteps < 1:
+            raise ValueError(f"n_timesteps must be >= 1, got {self.n_timesteps}.")
+        if self.time_stride is not None and self.time_stride < 1:
+            raise ValueError(f"time_stride must be >= 1, got {self.time_stride}.")
+
+    @property
+    def clip_start_stride(self) -> int:
+        """Frames between consecutive video-clip starts; defaults to
+        ``n_timesteps - 1`` (clips sharing only their boundary frame).
+        """
+        if self.time_stride is not None:
+            return self.time_stride
+        return max(1, self.n_timesteps - 1)
 
     def _first_data_config(
         self,
@@ -602,6 +621,120 @@ class PairedDataLoaderConfig:
             all_times=all_times,
             fine_coords=get_latlon_coords_from_properties(properties_fine),
             coarse_extent_latlon_coords=example.coarse.latlon_coordinates,
+        )
+
+    def build_video(
+        self,
+        train: bool,
+        requirements: DataRequirements,
+        dist: Distributed | None = None,
+    ) -> PairedVideoGriddedData:
+        """Build a paired fine/coarse loader of video clips.
+
+        Each sample is a clip of ``self.n_timesteps`` consecutive frames with an
+        explicit leading time axis, spaced ``self.clip_start_stride`` apart.
+        """
+        if dist is None:
+            dist = Distributed.get_instance()
+
+        n_timesteps = IntSchedule.from_constant(self.n_timesteps)
+        dataset_fine, properties_fine = build_from_config_sequence(
+            configs=self.fine,
+            names=requirements.fine_names,
+            n_timesteps=n_timesteps,
+            strict_ensemble=self.strict_ensemble,
+        )
+        dataset_coarse, properties_coarse = build_from_config_sequence(
+            configs=self.coarse,
+            names=requirements.coarse_names,
+            n_timesteps=n_timesteps,
+            strict_ensemble=self.strict_ensemble,
+        )
+
+        if not isinstance(
+            properties_coarse.horizontal_coordinates, LatLonCoordinates
+        ) or not isinstance(properties_fine.horizontal_coordinates, LatLonCoordinates):
+            raise ValueError(
+                "Downscaling data loader only supports datasets with latlon coords."
+            )
+        if not dataset_fine.sample_start_times.equals(
+            dataset_coarse.sample_start_times
+        ):
+            raise ValueError(
+                "Fine and coarse datasets must have the same sample start times."
+            )
+        if dataset_fine.sample_n_times != self.n_timesteps:
+            raise ValueError(
+                f"Expected clips of {self.n_timesteps} timesteps, got "
+                f"{dataset_fine.sample_n_times}."
+            )
+        all_times = dataset_fine.sample_start_times
+
+        dataset_fine = self._repeat_if_requested(dataset_fine)
+        dataset_coarse = self._repeat_if_requested(dataset_coarse)
+
+        dataset_fine_subset, dataset_coarse_subset = _build_aligned_subset_pair(
+            dataset_fine=dataset_fine,
+            properties_fine=properties_fine,
+            dataset_coarse=dataset_coarse,
+            properties_coarse=properties_coarse,
+            lat_extent=self.lat_extent,
+            lon_extent=self.lon_extent,
+        )
+
+        fine_adapter = VideoBatchItemDatasetAdapter(
+            dataset_fine_subset,
+            dataset_fine_subset.subset_latlon_coordinates,
+            properties=properties_fine,
+        )
+        coarse_adapter = VideoBatchItemDatasetAdapter(
+            dataset_coarse_subset,
+            dataset_coarse_subset.subset_latlon_coordinates,
+            properties=properties_coarse,
+        )
+
+        paired_dataset = VideoFineCoarsePairedDataset(fine_adapter, coarse_adapter)
+
+        # Subsample the (stride-one) clip starts to the requested clip spacing.
+        stride = self.clip_start_stride
+        dataset: Dataset
+        if stride > 1:
+            keep = list(range(0, len(paired_dataset), stride))
+            dataset = Subset(paired_dataset, keep)
+            all_times = all_times[::stride]
+        else:
+            dataset = paired_dataset
+
+        sampler = self._get_sampler(
+            dataset=dataset, dist=dist, train=train, drop_last=self.drop_last
+        )
+        dataloader = DataLoader(
+            dataset,
+            batch_size=dist.local_batch_size(int(self.batch_size)),
+            num_workers=self.num_data_workers,
+            shuffle=(sampler is None) and train,
+            sampler=sampler,
+            drop_last=True,
+            pin_memory=using_gpu(),
+            collate_fn=PairedVideoBatchData.from_sequence,
+            multiprocessing_context=self._mp_context(),
+            persistent_workers=True if self.num_data_workers > 0 else False,
+        )
+
+        example = dataset[0]
+        variable_metadata = {
+            **fine_adapter.variable_metadata,
+            **coarse_adapter.variable_metadata,
+        }
+        return PairedVideoGriddedData(
+            _loader=dataloader,
+            coarse_shape=example.coarse.horizontal_shape,
+            downscale_factor=example.downscale_factor,
+            n_timesteps=self.n_timesteps,
+            dims=example.fine.latlon_coordinates.dims,
+            variable_metadata=variable_metadata,
+            all_times=all_times,
+            fine_coords=get_latlon_coords_from_properties(properties_fine),
         )
 
     def _get_sampler(

--- a/fme/downscaling/data/datasets.py
+++ b/fme/downscaling/data/datasets.py
@@ -21,6 +21,7 @@ from fme.core.device import get_device, move_tensordict_to_device
 from fme.core.generics.data import SizedMap
 from fme.core.typing_ import TensorMapping
 from fme.downscaling.data.patching import Patch, get_patches
+from fme.downscaling.data.time_encoding import compute_calendar_features
 from fme.downscaling.data.utils import (
     BatchedLatLonCoordinates,
     ClosedInterval,
@@ -606,6 +607,282 @@ class PairedBatchData:
 
         for coarse_batch, fine_batch in zip(coarse_gen, fine_gen):
             yield PairedBatchData(fine=fine_batch, coarse=coarse_batch)
+
+
+# Video (temporal) data containers: clips of ``T`` frames with an explicit
+# leading time axis and per-frame physical-time features.
+
+
+@dataclasses.dataclass
+class VideoBatchItem:
+    """A single downscaling video clip (each field ``(T, lat, lon)``)."""
+
+    data: TensorMapping
+    time: xr.DataArray
+    latlon_coordinates: LatLonCoordinates
+    day_of_year: torch.Tensor
+    second_of_day: torch.Tensor
+
+    def _validate(self):
+        n_times: int | None = None
+        for key, value in self.data.items():
+            if value.dim() != 3:
+                raise ValueError(
+                    f"Expected 3D (time, lat, lon) data, got shape {value.shape} "
+                    f"({key})"
+                )
+            if n_times is None:
+                n_times = value.shape[0]
+            elif value.shape[0] != n_times:
+                raise ValueError(
+                    "All variables must have the same number of frames, got "
+                    f"{value.shape[0]} and {n_times}."
+                )
+        if n_times is None:
+            raise ValueError("VideoBatchItem must have at least one variable.")
+        if self.time.shape != (n_times,):
+            raise ValueError(
+                f"Expected time of shape ({n_times},), got {self.time.shape}"
+            )
+        for name, feature in (
+            ("day_of_year", self.day_of_year),
+            ("second_of_day", self.second_of_day),
+        ):
+            if feature.shape != (n_times,):
+                raise ValueError(
+                    f"Expected {name} of shape ({n_times},), got "
+                    f"{tuple(feature.shape)}"
+                )
+        if self.latlon_coordinates.lat.dim() != 1:
+            raise ValueError(
+                "Expected 1D lat coordinates, got shape "
+                f"{self.latlon_coordinates.lat.shape}"
+            )
+        if self.latlon_coordinates.lon.dim() != 1:
+            raise ValueError(
+                "Expected 1D lon coordinates, got shape "
+                f"{self.latlon_coordinates.lon.shape}"
+            )
+        return n_times
+
+    def __post_init__(self):
+        self._n_times = self._validate()
+        self._horizontal_shape = next(iter(self.data.values())).shape[-2:]
+
+    @property
+    def n_times(self) -> int:
+        return self._n_times
+
+    @property
+    def horizontal_shape(self) -> tuple[int, int]:
+        return self._horizontal_shape
+
+    def __iter__(self):
+        return iter(
+            [
+                self.data,
+                self.time,
+                self.latlon_coordinates,
+                self.day_of_year,
+                self.second_of_day,
+            ]
+        )
+
+    def to_device(self) -> "VideoBatchItem":
+        device = get_device()
+        device_latlon = LatLonCoordinates(
+            lat=self.latlon_coordinates.lat.to(device),
+            lon=self.latlon_coordinates.lon.to(device),
+        )
+        return VideoBatchItem(
+            move_tensordict_to_device(self.data),
+            self.time,
+            device_latlon,
+            self.day_of_year.to(device),
+            self.second_of_day.to(device),
+        )
+
+
+class VideoBatchItemDatasetAdapter(torch.utils.data.Dataset):
+    """Adapts a multi-timestep dataset to return a ``VideoBatchItem``,
+    preserving the time axis and attaching per-frame physical-time features.
+    """
+
+    def __init__(
+        self,
+        dataset: HorizontalSubsetDataset | XarrayConcat,
+        coordinates: LatLonCoordinates,
+        properties: DatasetProperties | None = None,
+    ):
+        self._dataset = dataset
+        self._coordinates = coordinates
+        self._properties = properties
+
+    def __len__(self):
+        return len(self._dataset)
+
+    def __getitem__(self, idx) -> VideoBatchItem:
+        fields, time, _, _, missing_names = self._dataset[idx]
+        assert (
+            missing_names is None
+        ), "Variable masking is not supported in downscaling."
+        day_of_year, second_of_day = compute_calendar_features(time)
+        return VideoBatchItem(
+            dict(fields), time, self._coordinates, day_of_year, second_of_day
+        )
+
+    @property
+    def variable_metadata(self) -> dict[str, VariableMetadata]:
+        if self._properties is None:
+            raise ValueError("Properties not set for this dataset.")
+        return self._properties.variable_metadata
+
+
+@dataclasses.dataclass
+class VideoBatchData:
+    """A batch of video clips with leading ``(batch, T, ...)`` dimensions."""
+
+    data: TensorMapping
+    time: xr.DataArray
+    latlon_coordinates: BatchedLatLonCoordinates
+    day_of_year: torch.Tensor
+    second_of_day: torch.Tensor
+
+    @classmethod
+    def from_sequence(
+        cls,
+        items: Sequence[VideoBatchItem],
+        dim_name: str = "batch",
+    ) -> Self:
+        data, times, latlon_coordinates, day_of_year, second_of_day = zip(*items)
+        return cls(
+            torch.utils.data.default_collate(data),
+            xr.concat(times, dim_name),
+            BatchedLatLonCoordinates.from_sequence(latlon_coordinates),
+            torch.stack(day_of_year, dim=0),
+            torch.stack(second_of_day, dim=0),
+        )
+
+    def to_device(self) -> "VideoBatchData":
+        device = get_device()
+        return VideoBatchData(
+            move_tensordict_to_device(self.data),
+            self.time,
+            self.latlon_coordinates.to_device(),
+            self.day_of_year.to(device),
+            self.second_of_day.to(device),
+        )
+
+    def __len__(self):
+        return self.day_of_year.shape[0]
+
+
+class VideoFineCoarsePairedDataset(torch.utils.data.Dataset):
+    """Returns a paired fine/coarse ``VideoBatchItem`` from paired datasets."""
+
+    def __init__(
+        self,
+        fine: VideoBatchItemDatasetAdapter,
+        coarse: VideoBatchItemDatasetAdapter,
+    ):
+        self.fine = fine
+        self.coarse = coarse
+        if len(self.fine) != len(self.coarse):
+            raise ValueError("Datasets must have the same number of items.")
+
+    def __len__(self):
+        return len(self.fine)
+
+    def __getitem__(self, idx) -> "PairedVideoBatchItem":
+        return PairedVideoBatchItem(self.fine[idx], self.coarse[idx])
+
+
+def _validated_video_scale_factor(
+    fine: tuple[int, int], coarse: tuple[int, int]
+) -> int:
+    if fine[0] // coarse[0] != fine[1] // coarse[1]:
+        raise ValueError(
+            "Fine and coarse datasets must have the same scale factor "
+            f"between lat and lon dimensions. Got fine {fine} and coarse {coarse}"
+        )
+    if fine[0] % coarse[0] != 0 or fine[1] % coarse[1] != 0:
+        raise ValueError(
+            "Fine and coarse horizontal dimensions must be evenly divisible."
+            f" Got fine {fine} and coarse {coarse}"
+        )
+    return fine[0] // coarse[0]
+
+
+@dataclasses.dataclass
+class PairedVideoBatchItem:
+    """Container pairing a fine and coarse ``VideoBatchItem``."""
+
+    fine: VideoBatchItem
+    coarse: VideoBatchItem
+
+    def _validate(self):
+        if self.fine.n_times != self.coarse.n_times:
+            raise ValueError("Fine and coarse clips must have the same length.")
+        if not (self.fine.time.values == self.coarse.time.values).all():
+            raise ValueError("Time must match between fine and coarse items.")
+        self.downscale_factor = _validated_video_scale_factor(
+            self.fine.horizontal_shape, self.coarse.horizontal_shape
+        )
+
+    def __post_init__(self):
+        self._validate()
+
+    def to_device(self) -> "PairedVideoBatchItem":
+        return PairedVideoBatchItem(self.fine.to_device(), self.coarse.to_device())
+
+    def __iter__(self):
+        return iter([self.fine, self.coarse])
+
+
+@dataclasses.dataclass
+class PairedVideoBatchData:
+    """A batch of paired fine/coarse video clips."""
+
+    fine: VideoBatchData
+    coarse: VideoBatchData
+
+    @classmethod
+    def from_sequence(cls, items: Sequence[PairedVideoBatchItem]) -> Self:
+        fine, coarse = zip(*items)
+        return cls(
+            VideoBatchData.from_sequence(fine),
+            VideoBatchData.from_sequence(coarse),
+        )
+
+    def to_device(self) -> "PairedVideoBatchData":
+        return PairedVideoBatchData(self.fine.to_device(), self.coarse.to_device())
+
+    def __len__(self):
+        return len(self.fine)
+
+
+@dataclasses.dataclass
+class PairedVideoGriddedData:
+    """Loader wrapper analogous to ``PairedGriddedData`` for video clips."""
+
+    _loader: torch.utils.data.DataLoader
+    coarse_shape: tuple[int, int]
+    downscale_factor: int
+    n_timesteps: int
+    dims: list[str]
+    variable_metadata: Mapping[str, VariableMetadata]
+    all_times: xr.CFTimeIndex
+    fine_coords: LatLonCoordinates
+
+    @property
+    def loader(self) -> DataLoader[PairedVideoBatchData]:
+        def on_device(batch: PairedVideoBatchData) -> PairedVideoBatchData:
+            return batch.to_device()
+
+        return SizedMap(on_device, self._loader)
+
+    def get_generator(self) -> Iterator["PairedVideoBatchData"]:
+        yield from self.loader
 
 
 class ContiguousDistributedSampler(DistributedSampler):

--- a/fme/downscaling/data/test_video.py
+++ b/fme/downscaling/data/test_video.py
@@ -1,0 +1,153 @@
+import datetime
+
+import cftime
+import pytest
+import torch
+import xarray as xr
+
+from fme.core.coordinates import LatLonCoordinates
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.downscaling.data.config import PairedDataLoaderConfig
+from fme.downscaling.data.datasets import (
+    PairedVideoBatchData,
+    VideoBatchData,
+    VideoBatchItem,
+)
+from fme.downscaling.data.time_encoding import compute_calendar_features
+from fme.downscaling.data.utils import ClosedInterval
+from fme.downscaling.requirements import DataRequirements
+from fme.downscaling.test_utils import data_paths_helper
+
+
+def _times(n, start_hour=0, step_hours=3):
+    base = cftime.DatetimeProlepticGregorian(2013, 1, 2, start_hour)
+    vals = [base + datetime.timedelta(hours=step_hours * i) for i in range(n)]
+    return xr.DataArray(vals, dims=["time"])
+
+
+def _video_item(n_times=9, lat=4, lon=5, varnames=("x",)):
+    data = {v: torch.rand(n_times, lat, lon) for v in varnames}
+    time = _times(n_times)
+    coords = LatLonCoordinates(
+        lat=torch.linspace(0.0, 90.0, lat), lon=torch.linspace(0.0, 360.0, lon)
+    )
+    day_of_year, second_of_day = compute_calendar_features(time)
+    return VideoBatchItem(data, time, coords, day_of_year, second_of_day)
+
+
+def test_compute_calendar_features_24h_clip():
+    # 9 frames at 0,3,...,24h starting Jan 2 2013 00:00 -> crosses into Jan 3.
+    time = _times(9, start_hour=0, step_hours=3)
+    day_of_year, second_of_day = compute_calendar_features(time)
+    assert day_of_year.shape == (9,)
+    assert second_of_day.shape == (9,)
+    assert second_of_day[0].item() == 0
+    assert second_of_day[1].item() == 3 * 3600
+    assert second_of_day[-1].item() == 0  # 24h -> next midnight
+    assert day_of_year[0].item() == 2  # Jan 2 is day-of-year 2
+    assert day_of_year[-1].item() == 3  # rolled to Jan 3
+
+
+def test_video_batch_item_shapes():
+    item = _video_item()
+    assert item.n_times == 9
+    assert item.horizontal_shape == (4, 5)
+    moved = item.to_device()
+    assert moved.day_of_year.shape == (9,)
+
+
+def test_video_batch_item_validation():
+    good = _video_item()
+    # 2-D (image) field is rejected -- video requires a leading time axis
+    with pytest.raises(ValueError):
+        VideoBatchItem(
+            {"x": torch.rand(4, 5)},
+            good.time,
+            good.latlon_coordinates,
+            good.day_of_year,
+            good.second_of_day,
+        )
+    # time length must match the number of frames
+    with pytest.raises(ValueError):
+        VideoBatchItem(
+            good.data,
+            _times(3),
+            good.latlon_coordinates,
+            good.day_of_year,
+            good.second_of_day,
+        )
+
+
+def test_video_batch_data_from_sequence():
+    items = [_video_item(varnames=("x", "y")) for _ in range(3)]
+    batch = VideoBatchData.from_sequence(items)
+    assert batch.data["x"].shape == (3, 9, 4, 5)
+    assert batch.data["y"].shape == (3, 9, 4, 5)
+    assert batch.day_of_year.shape == (3, 9)
+    assert batch.second_of_day.shape == (3, 9)
+    assert batch.latlon_coordinates.lat.shape == (3, 4)
+    assert len(batch) == 3
+    batch.to_device()
+
+
+def _video_config(paths, **kwargs):
+    return PairedDataLoaderConfig(
+        fine=[XarrayDataConfig(paths.fine)],
+        coarse=[XarrayDataConfig(paths.coarse)],
+        batch_size=1,
+        num_data_workers=0,
+        strict_ensemble=False,
+        lat_extent=ClosedInterval(1, 4),
+        lon_extent=ClosedInterval(0, 3),
+        n_timesteps=9,
+        **kwargs,
+    )
+
+
+def _requirements():
+    return DataRequirements(
+        fine_names=["var0", "var1"],
+        coarse_names=["var0", "var1"],
+        n_timesteps=1,  # ignored by build_video; clip length comes from config
+        use_fine_topography=False,
+    )
+
+
+def test_build_video_shapes_and_time_features(tmp_path):
+    paths = data_paths_helper(tmp_path, num_timesteps=18)
+    data = _video_config(paths).build_video(train=False, requirements=_requirements())
+    assert data.n_timesteps == 9
+    assert data.downscale_factor == 2
+
+    batch = next(iter(data.loader))
+    assert isinstance(batch, PairedVideoBatchData)
+    fine = batch.fine.data["var0"]
+    coarse = batch.coarse.data["var0"]
+    # explicit (batch, T, lat, lon) layout
+    assert fine.ndim == 4 and fine.shape[1] == 9 and coarse.shape[1] == 9
+    # 2x spatial downscaling preserved on both spatial axes
+    assert fine.shape[-1] == coarse.shape[-1] * 2
+    assert fine.shape[-2] == coarse.shape[-2] * 2
+    # per-frame physical-time features attached, aligned across fine/coarse
+    assert batch.fine.day_of_year.shape == (1, 9)
+    assert torch.equal(batch.fine.day_of_year, batch.coarse.day_of_year)
+    # daily timesteps in the fixture -> every frame at midnight UTC
+    assert torch.all(batch.fine.second_of_day == 0)
+
+
+def test_build_video_default_is_per_day_non_overlapping(tmp_path):
+    # 18 timesteps, clip length 9 -> 10 stride-one clip starts.
+    paths = data_paths_helper(tmp_path, num_timesteps=18)
+    requirements = _requirements()
+
+    # Default: per-day non-overlapping (stride = n_timesteps - 1 = 8) -> starts 0, 8.
+    default_data = _video_config(paths).build_video(
+        train=False, requirements=requirements
+    )
+    assert len(default_data.loader) == 2
+
+    # Opt-in full sliding window (stride 1) -> all 10 clips.
+    sliding_data = _video_config(paths, time_stride=1).build_video(
+        train=False, requirements=requirements
+    )
+    assert len(sliding_data.loader) == 10

--- a/fme/downscaling/data/time_encoding.py
+++ b/fme/downscaling/data/time_encoding.py
@@ -1,0 +1,35 @@
+"""Per-frame physical-time features (UTC ``day_of_year``/``second_of_day``)
+for video downscaling, consumed by a cBottle-style ``CalendarEmbedding``.
+"""
+
+import numpy as np
+import torch
+import xarray as xr
+
+
+def compute_calendar_features(
+    time: xr.DataArray,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-frame UTC ``(day_of_year, second_of_day)`` for a clip.
+
+    Returns two ``float32`` tensors of shape ``(T,)``: 1-based day-of-year and
+    second-of-day in ``[0, 86400)``.
+    """
+    try:
+        day_of_year = np.asarray(time.dt.dayofyear).reshape(-1)
+        second_of_day = (
+            np.asarray(time.dt.hour) * 3600
+            + np.asarray(time.dt.minute) * 60
+            + np.asarray(time.dt.second)
+        ).reshape(-1)
+    except (AttributeError, TypeError):
+        values = np.asarray(time.values).reshape(-1)
+        day_of_year = np.array([t.dayofyr for t in values])
+        second_of_day = np.array(
+            [t.hour * 3600 + t.minute * 60 + t.second for t in values]
+        )
+
+    return (
+        torch.as_tensor(day_of_year, dtype=torch.float32),
+        torch.as_tensor(second_of_day, dtype=torch.float32),
+    )

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -47,6 +47,8 @@ class ModelOutputs:
     channel_losses: TensorDict = dataclasses.field(default_factory=dict)
     sigma: torch.Tensor | None = None
     per_sample_channel_loss: TensorDict = dataclasses.field(default_factory=dict)
+    # Optional marginal-consistency term (video PMD), for logging only.
+    marginal_consistency_loss: torch.Tensor | None = None
 
 
 def _rename_normalizer(

--- a/fme/downscaling/modules/physicsnemo_unets_v2/layers.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v2/layers.py
@@ -181,6 +181,7 @@ class Conv2d(torch.nn.Module):
         init_bias: float = 0.0,
         fused_conv_bias: bool = False,
         amp_mode: bool = False,
+        periodic: bool = False,
     ):
         if up and down:
             raise ValueError("Both 'up' and 'down' cannot be true at the same time.")
@@ -199,6 +200,10 @@ class Conv2d(torch.nn.Module):
         self.fused_resample = fused_resample
         self.fused_conv_bias = fused_conv_bias
         self.amp_mode = amp_mode
+        # When True, the main 3x3 conv pads circularly in W (longitude) and zero
+        # in H (latitude) instead of symmetric zero padding -- for global lat/lon
+        # fields. Off by default, so the standard (image) path is unchanged.
+        self.periodic = periodic
         init_kwargs = dict(
             mode=init_mode,
             fan_in=in_channels * kernel * kernel,
@@ -240,6 +245,18 @@ class Conv2d(torch.nn.Module):
         f = resample_filter if resample_filter is not None else None
         w_pad = w.shape[-1] // 2 if w is not None else 0
         f_pad = (f.shape[-1] - 1) // 2 if f is not None else 0
+        if self.periodic and f_pad > 0:
+            # Only the main (odd-kernel) weight-conv branch below implements
+            # circular padding in W. The up/down resample-filter convs above
+            # still zero-pad, which is silently fine today only because the
+            # default resample_filter=[1, 1] gives f_pad=0 (no padding at
+            # all). Fail loudly rather than silently reintroducing a
+            # longitude discontinuity if a wider resample_filter is ever used
+            # with periodic=True.
+            raise NotImplementedError(
+                "periodic=True is not implemented for up/down-sampling with "
+                f"a resample_filter wider than 2 taps (got f_pad={f_pad})."
+            )
 
         if self.fused_resample and self.up and w is not None:
             x = torch.nn.functional.conv_transpose2d(
@@ -290,10 +307,17 @@ class Conv2d(torch.nn.Module):
                     padding=f_pad,
                 )
             if w is not None:  # ask in corrdiff channel whether w will ever be none
-                if self.fused_conv_bias:
-                    x = torch.nn.functional.conv2d(x, w, padding=w_pad, bias=b)
+                if self.periodic and w_pad > 0:
+                    # circular in longitude (W), zero in latitude (H)
+                    x = torch.cat([x[..., -w_pad:], x, x[..., :w_pad]], dim=-1)
+                    x = torch.nn.functional.pad(x, (0, 0, w_pad, w_pad))
+                    pad = 0
                 else:
-                    x = torch.nn.functional.conv2d(x, w, padding=w_pad)
+                    pad = w_pad
+                if self.fused_conv_bias:
+                    x = torch.nn.functional.conv2d(x, w, padding=pad, bias=b)
+                else:
+                    x = torch.nn.functional.conv2d(x, w, padding=pad)
         if b is not None and not self.fused_conv_bias:
             x = x.add_(b.reshape(1, -1, 1, 1))
         return x

--- a/fme/downscaling/modules/physicsnemo_unets_v2/test_periodic.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v2/test_periodic.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import Conv2d
+from fme.downscaling.modules.physicsnemo_unets_v2.unets import SongUNetv2
+
+
+def test_periodic_conv2d_is_circular_shift_equivariant_in_w():
+    conv = Conv2d(in_channels=2, out_channels=2, kernel=3, periodic=True)
+    x = torch.randn(1, 2, 6, 8)
+    x_rolled = torch.roll(x, shifts=3, dims=-1)
+
+    y = conv(x)
+    y_from_rolled = conv(x_rolled)
+
+    torch.testing.assert_close(y_from_rolled, torch.roll(y, shifts=3, dims=-1))
+
+
+def test_periodic_conv2d_up_down_resample_guard():
+    """The main (odd-kernel) conv branch implements circular padding, but the
+    up/down resample-filter branches do not. With the default 2-tap
+    resample_filter ([1, 1], f_pad=0) that branch never pads, so the gap is
+    inert -- this locks in the guard that fails loudly if a wider filter
+    (f_pad > 0) is ever combined with periodic=True, instead of silently
+    reintroducing a zero-padding discontinuity at the antimeridian.
+    """
+    conv = Conv2d(
+        in_channels=2,
+        out_channels=2,
+        kernel=3,
+        down=True,
+        resample_filter=[1, 3, 3, 1],
+        periodic=True,
+    )
+    with pytest.raises(NotImplementedError):
+        conv(torch.randn(1, 2, 8, 8))
+
+
+def test_periodic_songunet_is_circular_shift_equivariant_in_w():
+    """End-to-end check that setting periodic=True on every Conv2d in a
+    SongUNetv2 (as VideoSongUNet does) makes the whole network -- including
+    its up/down-sampling blocks -- circular-shift equivariant in longitude,
+    not just the main conv branch tested in isolation above.
+    """
+    torch.manual_seed(0)
+    net = SongUNetv2(
+        img_resolution=[16, 16],
+        in_channels=3,
+        out_channels=3,
+        model_channels=8,
+        channel_mult=[1, 2],
+        num_blocks=1,
+        attn_resolutions=[],
+        use_apex_gn=False,
+    )
+    for m in net.modules():
+        if isinstance(m, Conv2d):
+            m.periodic = True
+    net.eval()
+
+    x = torch.randn(1, 3, 16, 16)
+    shift = 4  # multiple of the deepest stride (2) to stay phase-aligned
+    x_rolled = torch.roll(x, shifts=shift, dims=-1)
+
+    with torch.no_grad():
+        y = net(x, noise_labels=torch.zeros(1), class_labels=None)
+        y_from_rolled = net(x_rolled, noise_labels=torch.zeros(1), class_labels=None)
+
+    torch.testing.assert_close(
+        y_from_rolled, torch.roll(y, shifts=shift, dims=-1), atol=1e-5, rtol=1e-5
+    )

--- a/fme/downscaling/modules/video_modules.py
+++ b/fme/downscaling/modules/video_modules.py
@@ -1,0 +1,477 @@
+"""Network building blocks for video (temporal) diffusion downscaling.
+
+Compact 5-D ``(B, C, T, H, W)`` backbone with cBottle-style calendar embedding
+and temporal attention, wrapped in EDM preconditioning (Karras 2022).
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import (
+    FourierEmbedding,
+    PositionalEmbedding,
+)
+
+
+class NoiseEmbedding(nn.Module):
+    """Positional (DDPM++) or Fourier (NCSN++) embedding of the log-noise level,
+    mapped through an MLP -- matches HiRO/SongUNet noise conditioning.
+    """
+
+    def __init__(self, dim: int, embedding_type: str = "positional"):
+        super().__init__()
+        if dim % 2 != 0:
+            raise ValueError("NoiseEmbedding dim must be even.")
+        if embedding_type == "fourier":
+            self.embed: nn.Module = FourierEmbedding(dim)
+        elif embedding_type == "positional":
+            self.embed = PositionalEmbedding(dim)
+        else:
+            raise ValueError(f"unknown noise embedding_type {embedding_type!r}")
+        self.mlp = nn.Sequential(nn.Linear(dim, dim), nn.SiLU(), nn.Linear(dim, dim))
+
+    def forward(self, c_noise: torch.Tensor) -> torch.Tensor:
+        return self.mlp(self.embed(c_noise.float()))
+
+
+class FrequencyEmbedding(nn.Module):
+    """Periodic sinusoidal encoding on the circle for x in [0, 1)."""
+
+    def __init__(self, num_freqs: int):
+        super().__init__()
+        self.num_freqs = num_freqs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        k = torch.arange(1, self.num_freqs + 1, device=x.device, dtype=x.dtype)
+        ang = 2 * math.pi * x.unsqueeze(-1) * k
+        return torch.cat([ang.cos(), ang.sin()], dim=-1)
+
+
+class CalendarEmbedding(nn.Module):
+    """cBottle-style absolute-time embedding (diurnal + seasonal).
+
+    ``second_of_day`` is shifted by longitude into local solar time so the
+    diurnal phase is correct per pixel.
+    """
+
+    def __init__(self, num_freqs: int = 4):
+        super().__init__()
+        self.embed = FrequencyEmbedding(num_freqs)
+        self.out_channels = 4 * num_freqs
+
+    def forward(
+        self,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        height: int,
+    ) -> torch.Tensor:
+        lon = lon.to(second_of_day.device, second_of_day.dtype)
+        local = second_of_day[:, :, None] + lon[None, None, :] * 86400.0 / 360.0
+        local = local % 86400.0
+        diurnal = self.embed(local / 86400.0)
+        diurnal = diurnal.permute(0, 3, 1, 2)
+        diurnal = diurnal.unsqueeze(3).expand(-1, -1, -1, height, -1)
+
+        seasonal = self.embed((day_of_year / 365.25) % 1.0)
+        seasonal = seasonal.permute(0, 2, 1)[:, :, :, None, None]
+        seasonal = seasonal.expand(-1, -1, -1, height, diurnal.shape[-1])
+        return torch.cat([diurnal, seasonal], dim=1)
+
+
+def _groups(channels: int) -> int:
+    g = min(32, channels)
+    while channels % g != 0:
+        g -= 1
+    return g
+
+
+class PeriodicConv3d(nn.Module):
+    """Per-frame spatial Conv3d, periodic in longitude (W) and zero-padded in
+    latitude (H) for global lat/lon fields.
+    """
+
+    def __init__(self, in_ch, out_ch, kernel=(1, 3, 3), stride=(1, 1, 1)):
+        super().__init__()
+        self.ph = kernel[1] // 2
+        self.pw = kernel[2] // 2
+        self.conv = nn.Conv3d(in_ch, out_ch, kernel, stride=stride, padding=0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.pw:
+            x = torch.cat([x[..., -self.pw :], x, x[..., : self.pw]], dim=-1)
+        if self.ph:
+            x = F.pad(x, (0, 0, self.ph, self.ph))
+        return self.conv(x)
+
+
+class ResBlock(nn.Module):
+    """Per-frame spatial residual block with adaptive GroupNorm (AdaGN)
+    noise-level conditioning and ``1/sqrt(2)`` skip scaling (cBottle/EDM style).
+    """
+
+    def __init__(self, in_ch: int, out_ch: int, emb_dim: int, skip_scale=2**-0.5):
+        super().__init__()
+        self.norm1 = nn.GroupNorm(_groups(in_ch), in_ch)
+        self.conv1 = PeriodicConv3d(in_ch, out_ch)
+        self.emb = nn.Linear(emb_dim, 2 * out_ch)
+        self.norm2 = nn.GroupNorm(_groups(out_ch), out_ch)
+        self.conv2 = PeriodicConv3d(out_ch, out_ch)
+        self.skip = nn.Conv3d(in_ch, out_ch, 1) if in_ch != out_ch else nn.Identity()
+        self.skip_scale = skip_scale
+
+    def forward(self, x: torch.Tensor, emb: torch.Tensor) -> torch.Tensor:
+        h = self.conv1(F.silu(self.norm1(x)))
+        scale, shift = self.emb(emb)[:, :, None, None, None].chunk(2, dim=1)
+        h = self.conv2(F.silu(self.norm2(h) * (1 + scale) + shift))
+        return (self.skip(x) + h) * self.skip_scale
+
+
+class TemporalAttention(nn.Module):
+    """Self-attention along the time axis with learned relative-position bias.
+
+    Each pixel attends across all ``T`` frames; output projection is
+    zero-initialized so the block starts as near-identity.
+    """
+
+    def __init__(self, channels: int, n_heads: int, seq_length: int):
+        super().__init__()
+        if channels % n_heads != 0:
+            raise ValueError("channels must be divisible by n_heads.")
+        self.n_heads = n_heads
+        self.seq_length = seq_length
+        self.norm = nn.GroupNorm(min(32, channels), channels)
+        self.qkv = nn.Conv3d(channels, channels * 3, 1)
+        self.proj = nn.Conv3d(channels, channels, 1)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+        self.relative_embedding = nn.Parameter(torch.zeros(n_heads, 2 * seq_length))
+
+    def forward(
+        self, x: torch.Tensor, frame_index: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        B, C, T, H, W = x.shape
+        if T > self.seq_length:
+            raise ValueError(
+                f"clip length {T} exceeds configured seq_length {self.seq_length}."
+            )
+        cdim = C // self.n_heads
+        qkv = self.qkv(self.norm(x))
+        q, k, v = qkv.chunk(3, dim=1)
+
+        def reshape(t):
+            t = t.reshape(B, self.n_heads, cdim, T, H, W)
+            return t.permute(0, 4, 5, 1, 3, 2).reshape(B * H * W, self.n_heads, T, cdim)
+
+        q, k, v = reshape(q), reshape(k), reshape(v)
+        attn = torch.einsum("nhqc,nhkc->nhqk", q, k) / math.sqrt(cdim)
+        # ``frame_index`` gives each frame's position on the full n_timesteps grid,
+        # so the learned relative bias reflects true frame spacing. For a subset it
+        # is the frames' true grid indices (e.g. [0, 4, 8]); the default arange is
+        # the full grid, identical to the pre-subset behavior.
+        if frame_index is None:
+            i = torch.arange(T, device=x.device)
+        else:
+            if frame_index.numel() != T:
+                raise ValueError(
+                    f"frame_index length {frame_index.numel()} != clip length {T}."
+                )
+            i = frame_index.to(device=x.device, dtype=torch.long)
+        pairwise = (i[:, None] - i[None, :]) + self.seq_length - 1
+        bias = self.relative_embedding[:, pairwise]
+        attn = (attn + bias[None]).softmax(dim=-1)
+        out = torch.einsum("nhqk,nhkc->nhqc", attn, v)
+        out = out.reshape(B, H, W, self.n_heads, T, cdim)
+        out = out.permute(0, 3, 5, 4, 1, 2).reshape(B, C, T, H, W)
+        return x + self.proj(out)
+
+
+class SpatialAttention(nn.Module):
+    """Multi-head self-attention over the spatial (H*W) plane, per frame.
+
+    Cost is O((H*W)^2), so use at coarser levels only; output projection is
+    zero-initialized so the block starts as near-identity.
+    """
+
+    def __init__(self, channels: int, n_heads: int):
+        super().__init__()
+        if channels % n_heads != 0:
+            raise ValueError("channels must be divisible by n_heads.")
+        self.n_heads = n_heads
+        self.norm = nn.GroupNorm(_groups(channels), channels)
+        self.qkv = nn.Conv3d(channels, channels * 3, 1)
+        self.proj = nn.Conv3d(channels, channels, 1)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, C, T, H, W = x.shape
+        cdim = C // self.n_heads
+        qkv = self.qkv(self.norm(x))
+        q, k, v = qkv.chunk(3, dim=1)
+
+        def reshape(t):
+            t = t.reshape(B, self.n_heads, cdim, T, H * W)
+            return t.permute(0, 3, 1, 4, 2).reshape(B * T, self.n_heads, H * W, cdim)
+
+        q, k, v = reshape(q), reshape(k), reshape(v)
+        attn = torch.einsum("nhqc,nhkc->nhqk", q, k) / math.sqrt(cdim)
+        attn = attn.softmax(dim=-1)
+        out = torch.einsum("nhqk,nhkc->nhqc", attn, v)
+        out = out.reshape(B, T, self.n_heads, H, W, cdim)
+        out = out.permute(0, 2, 5, 1, 3, 4).reshape(B, C, T, H, W)
+        return x + self.proj(out)
+
+
+class _BlockAttn(nn.Module):
+    """Optional spatial and/or temporal self-attention for a U-Net block.
+
+    Temporal attention is cheap and runs at every level so time is mixed
+    throughout; spatial attention is restricted to coarse levels.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        n_heads: int,
+        seq_length: int,
+        spatial: bool,
+        temporal: bool,
+    ):
+        super().__init__()
+        self.spatial = SpatialAttention(channels, n_heads) if spatial else None
+        self.temporal = (
+            TemporalAttention(channels, n_heads, seq_length) if temporal else None
+        )
+
+    def forward(
+        self, x: torch.Tensor, frame_index: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        if self.spatial is not None:
+            x = self.spatial(x)
+        if self.temporal is not None:
+            x = self.temporal(x, frame_index)
+        return x
+
+
+class FIRBlur(nn.Module):
+    """Depthwise binomial (FIR) low-pass applied per frame, periodic in longitude.
+
+    Anti-aliases before down-sampling and smooths after up-sampling. The kernel
+    is a fixed constant buffer, so it is identical on every rank (DDP-safe).
+    """
+
+    def __init__(self):
+        super().__init__()
+        f = torch.tensor([1.0, 2.0, 1.0])
+        k = torch.outer(f, f)
+        self.register_buffer("kernel", (k / k.sum())[None, None, None])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        c = x.shape[1]
+        # Materialize the conv weight into its own storage rather than an
+        # ``expand`` view of ``kernel``. Under DDP (broadcast_buffers=True) each
+        # forward re-syncs buffers with an in-place copy_ into ``kernel``; if two
+        # forwards run before one backward (e.g. the marginal-consistency loss),
+        # the second forward's sync would bump the shared buffer's version and
+        # invalidate the first forward's saved-for-backward weight. A copy
+        # decouples each forward's weight from the mutated buffer.
+        w = self.kernel.expand(c, 1, 1, 3, 3).contiguous()
+        x = torch.cat([x[..., -1:], x, x[..., :1]], dim=-1)
+        x = F.pad(x, (0, 0, 1, 1))
+        return F.conv3d(x, w, groups=c)
+
+
+def _resize_spatial(
+    x: torch.Tensor, size, blur: nn.Module | None = None
+) -> torch.Tensor:
+    """Resize the (H, W) of a (B, C, T, H, W) tensor to ``size`` (keeps T),
+    with an optional FIR low-pass applied only when the size actually changes.
+    """
+    if tuple(x.shape[-2:]) == tuple(size):
+        return x
+    x = F.interpolate(x, size=(x.shape[2], size[0], size[1]), mode="nearest")
+    return blur(x) if blur is not None else x
+
+
+class VideoUNet(nn.Module):
+    """Multi-scale video denoiser: per-frame conv U-Net with spatial + temporal
+    self-attention (cBottle-style). Down/up-sampling changes only (H, W); the
+    time axis is preserved and handled by ``TemporalAttention``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        seq_length: int,
+        model_channels: int = 64,
+        channel_mult: tuple[int, ...] = (1, 2, 2),
+        num_blocks: int = 2,
+        n_heads: int = 4,
+        attention_levels: tuple[int, ...] = (1, 2),
+        temporal_attention_levels: tuple[int, ...] | None = None,
+        num_freqs: int = 4,
+        noise_embedding_type: str = "positional",
+    ):
+        super().__init__()
+        self.levels = len(channel_mult)
+        self.num_blocks = num_blocks
+        emb_dim = model_channels
+        self.noise_embed = NoiseEmbedding(model_channels, noise_embedding_type)
+        self.blur = FIRBlur()
+        self.calendar = CalendarEmbedding(num_freqs)
+        chs = [model_channels * m for m in channel_mult]
+        attn_spatial = set(attention_levels)
+        attn_temporal = (
+            set(temporal_attention_levels)
+            if temporal_attention_levels is not None
+            else set(range(self.levels))
+        )
+
+        self.in_conv = PeriodicConv3d(in_channels + self.calendar.out_channels, chs[0])
+
+        self.enc_blocks = nn.ModuleList()
+        self.enc_attn = nn.ModuleList()
+        self.downsamples = nn.ModuleList()
+        skip_ch = [chs[0]]
+        ch = chs[0]
+        for level in range(self.levels):
+            for _ in range(num_blocks):
+                self.enc_blocks.append(ResBlock(ch, chs[level], emb_dim))
+                ch = chs[level]
+                self.enc_attn.append(
+                    _BlockAttn(
+                        ch,
+                        n_heads,
+                        seq_length,
+                        level in attn_spatial,
+                        level in attn_temporal,
+                    )
+                )
+                skip_ch.append(ch)
+            if level < self.levels - 1:
+                self.downsamples.append(
+                    PeriodicConv3d(ch, ch, (1, 3, 3), stride=(1, 2, 2))
+                )
+                skip_ch.append(ch)
+
+        self.mid_block1 = ResBlock(ch, ch, emb_dim)
+        self.mid_attn = _BlockAttn(ch, n_heads, seq_length, True, True)
+        self.mid_block2 = ResBlock(ch, ch, emb_dim)
+
+        self.dec_blocks = nn.ModuleList()
+        self.dec_attn = nn.ModuleList()
+        for level in reversed(range(self.levels)):
+            for _ in range(num_blocks + 1):
+                sch = skip_ch.pop()
+                self.dec_blocks.append(ResBlock(ch + sch, chs[level], emb_dim))
+                ch = chs[level]
+                self.dec_attn.append(
+                    _BlockAttn(
+                        ch,
+                        n_heads,
+                        seq_length,
+                        level in attn_spatial,
+                        level in attn_temporal,
+                    )
+                )
+
+        self.out_norm = nn.GroupNorm(_groups(ch), ch)
+        self.out_conv = PeriodicConv3d(ch, out_channels)
+        nn.init.zeros_(self.out_conv.conv.weight)
+        nn.init.zeros_(self.out_conv.conv.bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        c_noise: torch.Tensor,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        frame_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        cal = self.calendar(day_of_year, second_of_day, lon, x.shape[-2])
+        emb = self.noise_embed(c_noise)
+        h = self.in_conv(torch.cat([x, cal], dim=1))
+
+        skips = [h]
+        idx = 0
+        for level in range(self.levels):
+            for _ in range(self.num_blocks):
+                h = self.enc_attn[idx](self.enc_blocks[idx](h, emb), frame_index)
+                skips.append(h)
+                idx += 1
+            if level < self.levels - 1:
+                h = self.downsamples[level](self.blur(h))
+                skips.append(h)
+
+        h = self.mid_block1(h, emb)
+        h = self.mid_block2(self.mid_attn(h, frame_index), emb)
+
+        for idx in range(len(self.dec_blocks)):
+            skip = skips.pop()
+            h = torch.cat([_resize_spatial(h, skip.shape[-2:], self.blur), skip], dim=1)
+            h = self.dec_attn[idx](self.dec_blocks[idx](h, emb), frame_index)
+
+        return self.out_conv(F.silu(self.out_norm(h)))
+
+
+class VideoEDMPrecond(nn.Module):
+    """EDM preconditioning (Karras 2022) for the 5-D video tensor."""
+
+    def __init__(self, model: VideoUNet, sigma_data: float | torch.Tensor = 1.0):
+        super().__init__()
+        self.model = model
+        # Scalar or per-channel; stored as a (1, C, 1, 1, 1) buffer (constant,
+        # so identical on every rank -> DDP-safe) that broadcasts against sigma.
+        if not isinstance(sigma_data, torch.Tensor):
+            sigma_data = torch.tensor([float(sigma_data)])
+        self.register_buffer("sigma_data", sigma_data.reshape(1, -1, 1, 1, 1))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        condition: torch.Tensor | None,
+        sigma: torch.Tensor,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        frame_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        x = x.to(torch.float32)
+        sigma = sigma.to(torch.float32)
+        if sigma.dim() == 0:
+            sigma = sigma.reshape(1, 1, 1, 1, 1)
+        elif sigma.dim() == 1:
+            if sigma.shape[0] == x.shape[0]:
+                sigma = sigma.reshape(-1, 1, 1, 1, 1)
+            elif sigma.shape[0] == x.shape[1]:
+                sigma = sigma.reshape(1, -1, 1, 1, 1)
+            else:
+                sigma = sigma.reshape(-1, 1, 1, 1, 1)
+        elif sigma.dim() == 2:
+            sigma = sigma.reshape(sigma.shape[0], sigma.shape[1], 1, 1, 1)
+        else:
+            sigma = sigma.reshape(*sigma.shape[:2], 1, 1, 1)
+        c_skip = self.sigma_data**2 / (sigma**2 + self.sigma_data**2)
+        c_out = sigma * self.sigma_data / (sigma**2 + self.sigma_data**2).sqrt()
+        c_in = 1 / (self.sigma_data**2 + sigma**2).sqrt()
+        if sigma.shape[1] == 1:
+            c_noise = (sigma.log() / 4).flatten()
+        else:
+            c_noise = sigma.log().mean(dim=1).flatten() / 4
+
+        arg = c_in * x
+        sigma_features = (sigma.log() / 4).expand(
+            x.shape[0], x.shape[1], x.shape[2], x.shape[3], x.shape[4]
+        )
+        if condition is not None:
+            arg = torch.cat([arg, condition, sigma_features], dim=1)
+        else:
+            arg = torch.cat([arg, sigma_features], dim=1)
+        f_x = self.model(arg, c_noise, day_of_year, second_of_day, lon, frame_index)
+        return c_skip * x + c_out * f_x

--- a/fme/downscaling/modules/video_song_unet.py
+++ b/fme/downscaling/modules/video_song_unet.py
@@ -1,0 +1,87 @@
+"""Video backbone: ACE/HiRO's ``SongUNetv2`` with cBottle-style temporal
+attention injected via forward hooks on the attention-resolution ``UNetBlock``s.
+"""
+
+import torch
+import torch.nn as nn
+
+from fme.downscaling.modules.physicsnemo_unets_v2 import SongUNetv2
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import Conv2d as _Conv2d
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import UNetBlock
+from fme.downscaling.modules.video_modules import CalendarEmbedding, TemporalAttention
+
+
+class VideoSongUNet(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        img_resolution: list[int],
+        seq_length: int,
+        model_channels: int = 128,
+        channel_mult: tuple[int, ...] = (1, 2, 2, 2),
+        num_blocks: int = 2,
+        n_heads: int = 8,
+        attn_resolutions: tuple[int, ...] = (22,),
+        num_freqs: int = 4,
+        periodic: bool = True,
+    ):
+        super().__init__()
+        self.seq_length = seq_length
+        self.calendar = CalendarEmbedding(num_freqs)
+        self.unet = SongUNetv2(
+            img_resolution=list(img_resolution),
+            in_channels=in_channels + self.calendar.out_channels,
+            out_channels=out_channels,
+            model_channels=model_channels,
+            channel_mult=list(channel_mult),
+            num_blocks=num_blocks,
+            attn_resolutions=list(attn_resolutions),
+            use_apex_gn=False,
+        )
+        if periodic:
+            for m in self.unet.modules():
+                if isinstance(m, _Conv2d):
+                    m.periodic = True
+
+        self._temporal = nn.ModuleList()
+        self._bt = (1, 1)
+        self._frame_index: torch.Tensor | None = None
+        for name, block in list(self.unet.enc.items()) + list(self.unet.dec.items()):
+            if isinstance(block, UNetBlock) and getattr(block, "attention", False):
+                ta = TemporalAttention(block.out_channels, n_heads, seq_length)
+                self._temporal.append(ta)
+                block.register_forward_hook(self._make_hook(ta))
+
+    def _make_hook(self, temporal: nn.Module):
+        def hook(module, inputs, output):
+            b, t = self._bt
+            bt, c, h, w = output.shape
+            x = output.reshape(b, t, c, h, w).permute(0, 2, 1, 3, 4)
+            x = temporal(x, self._frame_index)
+            return x.permute(0, 2, 1, 3, 4).reshape(bt, c, h, w)
+
+        return hook
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        c_noise: torch.Tensor,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        frame_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        b, _, t, h, w = x.shape
+        cal = self.calendar(day_of_year, second_of_day, lon, h)
+        inp = torch.cat([x, cal], dim=1)
+        folded = inp.permute(0, 2, 1, 3, 4).reshape(b * t, inp.shape[1], h, w)
+        noise = c_noise.reshape(-1)
+        if noise.shape[0] == b:
+            noise = noise.repeat_interleave(t)
+        self._bt = (b, t)
+        # stashed for the temporal-attention forward hooks (true grid positions of
+        # the frames, so the relative bias reflects real spacing; None = full grid)
+        self._frame_index = frame_index
+        out = self.unet(folded, noise, None)
+        return out.reshape(b, t, -1, h, w).permute(0, 2, 1, 3, 4)

--- a/fme/downscaling/noise.py
+++ b/fme/downscaling/noise.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+from collections.abc import Callable
 
 import torch
 
@@ -54,6 +55,142 @@ class LogUniformNoiseDistribution(NoiseDistribution):
             shape=(batch_size, 1, 1, 1),
             dtype=torch.float32,
         ).to(device)
+
+
+def uniform_frame_times(n_timesteps: int) -> torch.Tensor:
+    """Normalized times of ``n_timesteps`` uniformly spaced frames on ``[0, 1]``.
+
+    Endpoints land exactly on 0 and 1; interior frames on ``k / (T - 1)``.
+    """
+    return torch.linspace(0.0, 1.0, n_timesteps, dtype=torch.float64)
+
+
+def brownian_bridge_mixing_matrix(tau: torch.Tensor) -> torch.Tensor:
+    """Temporal mixing matrix for endpoint-pinned, time-correlated noise.
+
+    Given the normalized frame times ``tau`` (1-D, length ``T``, with
+    ``tau[0] == 0`` and ``tau[-1] == 1`` marking the pinned endpoints and the
+    interior strictly inside ``(0, 1)``), returns a ``(T, T)`` matrix ``M`` such
+    that white noise ``Z ~ N(0, I)`` mixed along the time axis as ``E = M @ Z``
+    has a Brownian-bridge *correlation* structure across the interior frames and
+    is exactly zero on the two endpoint frames.
+
+    The Brownian-bridge covariance ``k_BB(s, t) = min(s, t) - s * t`` (bridge
+    length 1) vanishes at both endpoints, matching the endpoint-pinned residual
+    the video model diffuses. We normalize it to a *correlation* matrix (unit
+    diagonal on the interior) so that, when scaled by the EDM noise level
+    ``sigma``, each frame's marginal noise std stays ``sigma`` -- only the
+    cross-time correlation is introduced. ``M`` is the Cholesky factor of that
+    correlation matrix placed into the interior block; the endpoint rows/cols are
+    all zero.
+
+    Because every entry depends only on its own pair ``(tau_i, tau_j)``, the
+    matrix built for any *subset* of frame times equals the full-grid matrix
+    restricted to those frames. Generating a subset of frames therefore draws
+    from the exact *marginal* of the full-window bridge -- the noise obeys the
+    same process whether or not the other frames are requested.
+
+    Args:
+        tau: Normalized frame times, shape ``(T,)`` with ``T >= 3``, sorted with
+            endpoints at 0 and 1 and interior values in ``(0, 1)``.
+
+    Returns:
+        A ``(T, T)`` float32 tensor on ``tau``'s device.
+    """
+    if tau.ndim != 1 or tau.shape[0] < 3:
+        raise ValueError(
+            "Brownian-bridge noise needs at least 3 frames (2 endpoints + 1 "
+            f"interior); got tau with shape {tuple(tau.shape)}."
+        )
+    n_timesteps = tau.shape[0]
+    n_interior = n_timesteps - 2
+    tau_i = tau[1:-1].to(torch.float64)
+    s = tau_i.reshape(-1, 1)
+    t = tau_i.reshape(1, -1)
+    cov = torch.minimum(s, t) - s * t  # interior Brownian-bridge covariance
+    std = cov.diagonal().sqrt()
+    corr = cov / torch.outer(std, std)  # normalize to unit diagonal
+    chol = torch.linalg.cholesky(corr)  # lower-triangular, corr == chol @ chol.T
+    mixing = torch.zeros(
+        n_timesteps, n_timesteps, dtype=torch.float64, device=tau.device
+    )
+    mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = chol
+    return mixing.to(torch.float32)
+
+
+def _interior_cholesky_mixing_matrix(
+    tau: torch.Tensor, corr_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+) -> torch.Tensor:
+    """Shared scaffold for endpoint-pinned mixing matrices: builds the
+    unit-diagonal interior correlation matrix via ``corr_fn(tau_i, tau_j)``,
+    Cholesky-factors it, and embeds it in a zero-padded ``(T, T)`` matrix
+    (endpoint rows/cols zero). Used by ``brownian_bridge_mixing_matrix``,
+    ``ou_mixing_matrix``, and ``rbf_mixing_matrix`` -- they differ only in
+    ``corr_fn``.
+    """
+    if tau.ndim != 1 or tau.shape[0] < 3:
+        raise ValueError(
+            "Endpoint-pinned noise needs at least 3 frames (2 endpoints + 1 "
+            f"interior); got tau with shape {tuple(tau.shape)}."
+        )
+    n_timesteps = tau.shape[0]
+    n_interior = n_timesteps - 2
+    tau_i = tau[1:-1].to(torch.float64)
+    s = tau_i.reshape(-1, 1)
+    t = tau_i.reshape(1, -1)
+    corr = corr_fn(s, t)
+    chol = torch.linalg.cholesky(corr)  # lower-triangular, corr == chol @ chol.T
+    mixing = torch.zeros(
+        n_timesteps, n_timesteps, dtype=torch.float64, device=tau.device
+    )
+    mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = chol
+    return mixing.to(torch.float32)
+
+
+def ou_mixing_matrix(tau: torch.Tensor, length_scale: float) -> torch.Tensor:
+    """Temporal mixing matrix for endpoint-pinned, Ornstein-Uhlenbeck-
+    correlated noise: ``corr(s, t) = exp(-|s - t| / length_scale)``.
+
+    Same endpoint-pinned-interior-Cholesky structure as
+    ``brownian_bridge_mixing_matrix`` (see its docstring for the subset-
+    marginal property, which holds here too since OU correlation is also a
+    pure function of each frame-time pair), but with an OU kernel instead of
+    the Brownian-bridge kernel. Empirically (see
+    ``toy/process_residual_bridge_report.md``), real interior-frame
+    correlations for wind/precipitation channels decay more like OU than
+    like a bridge.
+
+    Args:
+        tau: Normalized frame times, shape ``(T,)``, as in
+            ``brownian_bridge_mixing_matrix``.
+        length_scale: OU decorrelation length, in the same units as ``tau``
+            (hours, for this codebase's frame times).
+    """
+    return _interior_cholesky_mixing_matrix(
+        tau, lambda s, t: torch.exp(-torch.abs(s - t) / length_scale)
+    )
+
+
+def rbf_mixing_matrix(tau: torch.Tensor, length_scale: float) -> torch.Tensor:
+    """Temporal mixing matrix for endpoint-pinned, RBF/squared-exponential-
+    correlated noise: ``corr(s, t) = exp(-(s - t)^2 / (2 * length_scale^2))``.
+
+    See ``ou_mixing_matrix`` for the shared structure. **Caution:** RBF
+    kernels become numerically near-singular fast as ``length_scale`` grows
+    relative to the frame spacing -- verify ``det`` isn't degenerate before
+    using this in training (see ``toy/process_residual_bridge_report.md``:
+    RBF was empirically the best-fitting kernel for PRMSL and T2m, but its
+    determinant there is ~1e-16 / ~1e-11, i.e. effectively rank-deficient --
+    OU was used for those channels instead for exactly this reason).
+
+    Args:
+        tau: Normalized frame times, shape ``(T,)``, as in
+            ``brownian_bridge_mixing_matrix``.
+        length_scale: RBF length scale, in the same units as ``tau``.
+    """
+    return _interior_cholesky_mixing_matrix(
+        tau, lambda s, t: torch.exp(-((s - t) ** 2) / (2 * length_scale**2))
+    )
 
 
 def condition_with_noise_for_training(

--- a/fme/downscaling/test_noise.py
+++ b/fme/downscaling/test_noise.py
@@ -4,6 +4,8 @@ import torch
 from fme.downscaling.noise import (
     LogNormalNoiseDistribution,
     LogUniformNoiseDistribution,
+    brownian_bridge_mixing_matrix,
+    uniform_frame_times,
 )
 
 
@@ -19,3 +21,53 @@ def test_noise_distribution(noise_distribution):
     noise = noise_distribution.sample(batch_size=batch_size, device="cpu")
     assert noise.shape == (batch_size, 1, 1, 1)
     assert noise.dtype == torch.float32
+
+
+def _bridge_corr(tau):
+    """Reference unit-diagonal Brownian-bridge correlation on interior times."""
+    s, t = tau.reshape(-1, 1), tau.reshape(1, -1)
+    bb = torch.minimum(s, t) - s * t
+    std = bb.diagonal().sqrt()
+    return (bb / torch.outer(std, std)).to(torch.float32)
+
+
+@pytest.mark.parametrize("n_timesteps", [3, 5, 9])
+def test_brownian_bridge_mixing_matrix(n_timesteps):
+    tau = uniform_frame_times(n_timesteps)
+    mixing = brownian_bridge_mixing_matrix(tau)
+    assert mixing.shape == (n_timesteps, n_timesteps)
+    assert mixing.dtype == torch.float32
+
+    cov = mixing @ mixing.T  # covariance of M @ Z for white Z
+
+    # Endpoints carry no noise.
+    assert torch.allclose(cov[0], torch.zeros(n_timesteps))
+    assert torch.allclose(cov[-1], torch.zeros(n_timesteps))
+    assert torch.allclose(cov[:, 0], torch.zeros(n_timesteps))
+    assert torch.allclose(cov[:, -1], torch.zeros(n_timesteps))
+
+    # Interior block matches the unit-diagonal (correlation) Brownian bridge.
+    expected_corr = _bridge_corr(tau[1:-1])
+    interior = cov[1:-1, 1:-1]
+    assert torch.allclose(interior.diagonal(), torch.ones(n_timesteps - 2), atol=1e-5)
+    assert torch.allclose(interior, expected_corr, atol=1e-5)
+
+
+def test_brownian_bridge_subset_matches_full_grid_marginal():
+    """A subset's mixing matrix reproduces the full grid's correlations exactly:
+    generating a subset of frames draws from the full-window bridge's marginal."""
+    full_tau = uniform_frame_times(9)
+    full_cov = brownian_bridge_mixing_matrix(full_tau)
+    full_cov = full_cov @ full_cov.T
+
+    # keep endpoints (0, 8) and a non-uniform interior subset (3, 6)
+    idx = torch.tensor([0, 3, 6, 8])
+    subset = brownian_bridge_mixing_matrix(full_tau[idx])
+    subset_cov = subset @ subset.T
+
+    assert torch.allclose(subset_cov, full_cov[idx][:, idx], atol=1e-5)
+
+
+def test_brownian_bridge_mixing_matrix_requires_interior():
+    with pytest.raises(ValueError, match="at least 3 frames"):
+        brownian_bridge_mixing_matrix(uniform_frame_times(2))

--- a/fme/downscaling/test_video_inference.py
+++ b/fme/downscaling/test_video_inference.py
@@ -1,0 +1,50 @@
+import torch
+
+from fme.core.device import get_device
+from fme.downscaling.test_video_train import _trainer_config
+from fme.downscaling.video_inference import load_video_model
+from fme.downscaling.video_train import _save_checkpoint
+
+
+def _state_dict_cpu(module: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {k: v.detach().cpu().clone() for k, v in module.state_dict().items()}
+
+
+def _bare_module(model) -> torch.nn.Module:
+    return getattr(model.module, "module", model.module)
+
+
+def test_load_video_model_round_trip(tmp_path):
+    """``video_inference.load_video_model`` is the actual production
+    checkpoint->inference path (distinct from, and previously untested by,
+    ``VideoTrainer``'s own resume mechanism). It hand-parses the checkpoint's
+    ``module``/``ema`` dict and strips a ``module.`` prefix -- this proves
+    that round trip preserves weights exactly, for both EMA and raw loading.
+
+    A checkpoint is saved explicitly (rather than reusing ``best.ckpt``) right
+    after capturing the expected state, so the comparison isn't confounded by
+    ``best.ckpt`` reflecting an earlier epoch than the trainer's final state.
+    """
+    config = _trainer_config(tmp_path)
+    trainer = config.build()
+    trainer.train()
+
+    with trainer._ema_context():
+        expected_ema_state = _state_dict_cpu(_bare_module(trainer.model))
+    expected_raw_state = _state_dict_cpu(_bare_module(trainer.model))
+
+    ckpt_path = str(tmp_path / "round_trip.ckpt")
+    _save_checkpoint(trainer, ckpt_path)
+
+    device = get_device()
+    loaded_ema = load_video_model(config.model, ckpt_path, device, use_ema=True)
+    actual_ema_state = _state_dict_cpu(_bare_module(loaded_ema))
+    assert actual_ema_state.keys() == expected_ema_state.keys()
+    for key, expected in expected_ema_state.items():
+        torch.testing.assert_close(actual_ema_state[key], expected)
+
+    loaded_raw = load_video_model(config.model, ckpt_path, device, use_ema=False)
+    actual_raw_state = _state_dict_cpu(_bare_module(loaded_raw))
+    assert actual_raw_state.keys() == expected_raw_state.keys()
+    for key, expected in expected_raw_state.items():
+        torch.testing.assert_close(actual_raw_state[key], expected)

--- a/fme/downscaling/test_video_inference.py
+++ b/fme/downscaling/test_video_inference.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from fme.core.device import get_device
@@ -14,6 +15,7 @@ def _bare_module(model) -> torch.nn.Module:
     return getattr(model.module, "module", model.module)
 
 
+@pytest.mark.medium_duration
 def test_load_video_model_round_trip(tmp_path):
     """``video_inference.load_video_model`` is the actual production
     checkpoint->inference path (distinct from, and previously untested by,

--- a/fme/downscaling/test_video_models.py
+++ b/fme/downscaling/test_video_models.py
@@ -6,6 +6,7 @@ import torch
 import xarray as xr
 
 from fme.core.coordinates import LatLonCoordinates
+from fme.core.device import get_device
 from fme.core.normalizer import NormalizationConfig
 from fme.core.optimization import NullOptimization
 from fme.core.rand import set_seed
@@ -33,11 +34,13 @@ def _times(n):
 
 
 def _video_item(n_times, height, width):
-    data = {v: torch.rand(n_times, height, width) for v in OUT_NAMES}
+    data = {
+        v: torch.rand(n_times, height, width, device=get_device()) for v in OUT_NAMES
+    }
     time = _times(n_times)
     coords = LatLonCoordinates(
-        lat=torch.linspace(-10.0, 10.0, height),
-        lon=torch.linspace(0.0, 30.0, width),
+        lat=torch.linspace(-10.0, 10.0, height, device=get_device()),
+        lon=torch.linspace(0.0, 30.0, width, device=get_device()),
     )
     doy, sod = compute_calendar_features(time)
     return VideoBatchItem(data, time, coords, doy, sod)
@@ -138,8 +141,12 @@ def test_train_on_batch_supports_per_channel_noise():
     assert outputs.sigma is not None
     assert outputs.sigma.shape == (2, 2)
     sigma_min, sigma_max = config.generation_sigma_bounds(outputs.sigma.device)
-    assert torch.allclose(sigma_min, torch.tensor([0.002, 0.005]))
-    assert torch.allclose(sigma_max, torch.tensor([150.0, 2000.0]))
+    assert torch.allclose(
+        sigma_min, torch.tensor([0.002, 0.005], device=sigma_min.device)
+    )
+    assert torch.allclose(
+        sigma_max, torch.tensor([150.0, 2000.0], device=sigma_max.device)
+    )
 
 
 def test_per_channel_sigma_data():

--- a/fme/downscaling/test_video_models.py
+++ b/fme/downscaling/test_video_models.py
@@ -1,0 +1,454 @@
+import datetime
+
+import cftime
+import pytest
+import torch
+import xarray as xr
+
+from fme.core.coordinates import LatLonCoordinates
+from fme.core.normalizer import NormalizationConfig
+from fme.core.optimization import NullOptimization
+from fme.core.rand import set_seed
+from fme.downscaling.data.datasets import (
+    PairedVideoBatchData,
+    VideoBatchData,
+    VideoBatchItem,
+)
+from fme.downscaling.data.time_encoding import compute_calendar_features
+from fme.downscaling.modules.video_modules import FIRBlur, TemporalAttention
+from fme.downscaling.noise import (
+    LogNormalNoiseDistribution,
+    LogUniformNoiseDistribution,
+)
+from fme.downscaling.video_models import VideoDiffusionModelConfig
+
+OUT_NAMES = ["var0", "var1"]
+
+
+def _times(n):
+    base = cftime.DatetimeProlepticGregorian(2013, 1, 2)
+    return xr.DataArray(
+        [base + datetime.timedelta(hours=3 * i) for i in range(n)], dims=["time"]
+    )
+
+
+def _video_item(n_times, height, width):
+    data = {v: torch.rand(n_times, height, width) for v in OUT_NAMES}
+    time = _times(n_times)
+    coords = LatLonCoordinates(
+        lat=torch.linspace(-10.0, 10.0, height),
+        lon=torch.linspace(0.0, 30.0, width),
+    )
+    doy, sod = compute_calendar_features(time)
+    return VideoBatchItem(data, time, coords, doy, sod)
+
+
+def _paired_batch(batch_size, n_times, height, width):
+    items = [_video_item(n_times, height, width) for _ in range(batch_size)]
+    clip = VideoBatchData.from_sequence(items)
+    # coarse is unused by the temporal-only model; reuse the fine clip.
+    return PairedVideoBatchData(fine=clip, coarse=clip)
+
+
+def _model(n_times, temporal_noise_correlation="independent", **config_kwargs):
+    config = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=n_times,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        num_diffusion_generation_steps=4,
+        model_channels=16,
+        n_heads=2,
+        num_freqs=3,
+        temporal_noise_correlation=temporal_noise_correlation,
+        **config_kwargs,
+    )
+    return config.build()
+
+
+def test_train_on_batch_runs_and_backprops():
+    n_times, height, width = 5, 8, 8
+    model = _model(n_times)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    # gradients flow into the network
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+    # prediction is a full clip per variable
+    assert outputs.prediction["var0"].shape == (2, n_times, height, width)
+
+
+def test_train_on_batch_runs_and_backprops_songunet_backbone():
+    """The songunet backbone has its own network construction path (image
+    resolution, attention-level defaults, periodic-conv setup in
+    VideoSongUNet) entirely separate from the default "simple" backbone
+    exercised by every other test in this file -- cover it directly so a
+    break there isn't silent.
+    """
+    n_times, height, width = 5, 8, 8
+    model = _model(
+        n_times,
+        backbone="songunet",
+        img_resolution=[height, width],
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+    assert outputs.prediction["var0"].shape == (2, n_times, height, width)
+
+
+def test_train_on_batch_supports_per_channel_noise():
+    n_times, height, width = 5, 8, 8
+    config = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=n_times,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        num_diffusion_generation_steps=4,
+        model_channels=16,
+        n_heads=2,
+        num_freqs=3,
+        training_noise_distributions={
+            "var0": LogNormalNoiseDistribution(p_mean=-1.2, p_std=1.8),
+            "var1": LogUniformNoiseDistribution(p_min=0.005, p_max=2000.0),
+        },
+        sigma_min=0.002,
+        sigma_max=150.0,
+        sigma_min_by_channel={"var1": 0.005},
+        sigma_max_by_channel={"var1": 2000.0},
+    )
+    model = config.build()
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+
+    assert outputs.sigma is not None
+    assert outputs.sigma.shape == (2, 2)
+    sigma_min, sigma_max = config.generation_sigma_bounds(outputs.sigma.device)
+    assert torch.allclose(sigma_min, torch.tensor([0.002, 0.005]))
+    assert torch.allclose(sigma_max, torch.tensor([150.0, 2000.0]))
+
+
+def test_per_channel_sigma_data():
+    n_times, height, width = 5, 8, 8
+    config = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=n_times,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        num_diffusion_generation_steps=4,
+        model_channels=16,
+        n_heads=2,
+        sigma_min=0.002,
+        sigma_max=150.0,
+        sigma_data_by_channel={"var0": 0.2},  # var1 falls back to 1.0
+    )
+    model = config.build()
+    bare = getattr(model.module, "module", model.module)
+    assert torch.allclose(
+        bare.sigma_data.flatten(),
+        torch.tensor([0.2, 1.0], device=bare.sigma_data.device),
+    )
+    assert model.sigma_data.shape == (1, 2, 1, 1, 1)
+    # train + generate still run end to end with per-channel sigma_data
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+    model.train_on_batch(batch, NullOptimization())
+    generated = model.generate(batch, n_samples=2)
+    assert set(generated) == set(OUT_NAMES)
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_generate_pins_observed_endpoints(temporal_noise_correlation):
+    n_times, height, width = 5, 8, 8
+    model = _model(n_times, temporal_noise_correlation=temporal_noise_correlation)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    generated = model.generate(batch, n_samples=3)
+    out = generated["var0"]
+    assert out.shape == (2, 3, n_times, height, width)
+    assert torch.isfinite(out).all()
+
+    # observed endpoints (t=0 and t=-1) must be reproduced exactly for every
+    # sample; only the interior is generated.
+    truth = batch.fine.data["var0"]  # (B, T, H, W)
+    for s in range(3):
+        assert torch.allclose(out[:, s, 0], truth[:, 0], atol=1e-4)
+        assert torch.allclose(out[:, s, -1], truth[:, -1], atol=1e-4)
+
+
+def test_train_on_batch_runs_with_brownian_bridge_noise():
+    n_times, height, width = 5, 8, 8
+    model = _model(n_times, temporal_noise_correlation="brownian_bridge")
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+def test_brownian_bridge_noise_has_expected_temporal_covariance():
+    n_times = 9
+    model = _model(n_times, temporal_noise_correlation="brownian_bridge")
+    set_seed(0)
+    # (samples, C=1, T, H=1, W=1): treat sample dim as the population.
+    like = torch.empty(20000, 1, n_times, 1, 1)
+    noise = model._sample_residual_noise(like)
+    flat = noise[:, 0, :, 0, 0]  # (samples, T)
+
+    emp_cov = (flat.T @ flat) / flat.shape[0]
+    expected = (model._noise_mixing @ model._noise_mixing.T).cpu()
+    assert torch.allclose(emp_cov, expected, atol=0.03)
+    # endpoints are noise-free; interior frames are correlated (off-diagonal != 0)
+    assert torch.allclose(emp_cov[0], torch.zeros(n_times))
+    assert torch.allclose(emp_cov[-1], torch.zeros(n_times))
+    assert emp_cov[1, 2].abs() > 0.1
+
+
+def test_independent_noise_is_uncorrelated_in_time():
+    n_times = 9
+    model = _model(n_times, temporal_noise_correlation="independent")
+    assert model._noise_mixing is None
+    set_seed(0)
+    like = torch.empty(20000, 1, n_times, 1, 1)
+    flat = model._sample_residual_noise(like)[:, 0, :, 0, 0]
+    emp_cov = (flat.T @ flat) / flat.shape[0]
+    assert torch.allclose(emp_cov, torch.eye(n_times), atol=0.05)
+
+
+def test_invalid_temporal_noise_correlation_rejected():
+    with pytest.raises(ValueError, match="temporal_noise_correlation"):
+        VideoDiffusionModelConfig(
+            out_names=OUT_NAMES,
+            n_timesteps=5,
+            normalization=NormalizationConfig(
+                means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+            ),
+            temporal_noise_correlation="bridge",
+        )
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_generate_subset_frames(temporal_noise_correlation):
+    # full grid is 9 frames (00..24 at 3h); request a non-uniform subset
+    n_times, height, width = 9, 8, 8
+    model = _model(n_times, temporal_noise_correlation=temporal_noise_correlation)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    frames = [0, 3, 7, 8]  # endpoints + two non-uniformly spaced interior frames
+    generated = model.generate(batch, n_samples=3, frames=frames)
+    out = generated["var0"]
+    assert out.shape == (2, 3, len(frames), height, width)
+    assert torch.isfinite(out).all()
+
+    # observed endpoints (first/last of the subset) reproduced exactly
+    truth = batch.fine.data["var0"]
+    for s in range(3):
+        assert torch.allclose(out[:, s, 0], truth[:, 0], atol=1e-4)
+        assert torch.allclose(out[:, s, -1], truth[:, -1], atol=1e-4)
+
+
+def test_generate_rejects_invalid_frames():
+    n_times = 9
+    model = _model(n_times)
+    batch = _paired_batch(batch_size=1, n_times=n_times, height=8, width=8)
+    # must include both endpoints
+    with pytest.raises(ValueError, match="start at 0 and end at"):
+        model.generate(batch, frames=[0, 3, 6])
+    # must be strictly increasing
+    with pytest.raises(ValueError, match="strictly increasing"):
+        model.generate(batch, frames=[0, 3, 3, 8])
+    # needs at least one interior frame
+    with pytest.raises(ValueError, match="at least 3 frame indices"):
+        model.generate(batch, frames=[0, 8])
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_subset_augmented_training_runs(temporal_noise_correlation):
+    n_times, height, width = 9, 8, 8
+    model = _model(
+        n_times,
+        temporal_noise_correlation=temporal_noise_correlation,
+        subset_augmentation_prob=1.0,  # always subset, to exercise the path
+        subset_min_interior=1,
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+    set_seed(0)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0 and all(torch.isfinite(g).all() for g in grads)
+    # prediction and target stay aligned on the (subset) frame axis
+    assert outputs.prediction["var0"].shape == outputs.target["var0"].shape
+    assert outputs.prediction["var0"].shape[1] < n_times
+
+
+def test_subset_augmentation_prob_zero_is_full_grid():
+    n_times = 9
+    model = _model(n_times, subset_augmentation_prob=0.0)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=8, width=8)
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert outputs.prediction["var0"].shape[1] == n_times
+
+
+def test_invalid_subset_config_rejected():
+    with pytest.raises(ValueError, match="subset_augmentation_prob"):
+        _model(5, subset_augmentation_prob=1.5)
+    with pytest.raises(ValueError, match="subset_min_interior"):
+        _model(5, subset_min_interior=4)  # n_timesteps - 2 == 3
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_marginal_consistency_loss_trains(temporal_noise_correlation):
+    n_times, height, width = 9, 8, 8
+    model = _model(
+        n_times,
+        temporal_noise_correlation=temporal_noise_correlation,
+        marginal_consistency_weight=0.5,
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+    set_seed(0)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss) and outputs.loss.requires_grad
+    # the consistency term is surfaced, finite, and non-negative
+    assert outputs.marginal_consistency_loss is not None
+    assert torch.isfinite(outputs.marginal_consistency_loss)
+    assert outputs.marginal_consistency_loss.item() >= 0.0
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0 and all(torch.isfinite(g).all() for g in grads)
+    # ModelOutputs still describes the full-grid pass
+    assert outputs.prediction["var0"].shape == (2, n_times, height, width)
+    assert outputs.target["var0"].shape == (2, n_times, height, width)
+
+
+def test_marginal_consistency_disabled_by_default():
+    model = _model(9)
+    batch = _paired_batch(batch_size=2, n_times=9, height=8, width=8)
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert outputs.marginal_consistency_loss is None
+
+
+def test_consistency_subset_is_strict():
+    model = _model(9, marginal_consistency_weight=1.0)
+    for _ in range(20):
+        idx = model._sample_consistency_subset_indices(9, torch.device("cpu"))
+        # endpoints kept, at least one interior frame kept AND at least one dropped
+        assert int(idx[0]) == 0 and int(idx[-1]) == 8
+        assert 3 <= idx.numel() < 9
+        assert bool(torch.all(idx[1:] > idx[:-1]))
+
+
+def test_marginal_consistency_is_reproducible():
+    # same seed -> same subset choice and same shared noise -> same L_marg
+    model = _model(9, marginal_consistency_weight=1.0)
+    batch = _paired_batch(batch_size=2, n_times=9, height=8, width=8)
+    set_seed(3)
+    a = model.train_on_batch(batch, NullOptimization()).marginal_consistency_loss
+    set_seed(3)
+    b = model.train_on_batch(batch, NullOptimization()).marginal_consistency_loss
+    assert a is not None and b is not None
+    assert a.item() == b.item()
+
+
+def test_marginal_consistency_with_subset_augmentation_compose():
+    # subset augmentation and the consistency loss may be combined: same subset
+    # exposure in the first pass, plus the consistency tie via the second pass.
+    model = _model(
+        9,
+        marginal_consistency_weight=1.0,
+        subset_augmentation_prob=1.0,  # always augment, to exercise the combo
+    )
+    batch = _paired_batch(batch_size=2, n_times=9, height=8, width=8)
+    set_seed(0)
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss) and outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0 and all(torch.isfinite(g).all() for g in grads)
+
+
+def test_marginal_consistency_config_validation():
+    with pytest.raises(ValueError, match="marginal_consistency_weight must be >= 0"):
+        _model(9, marginal_consistency_weight=-0.1)
+    with pytest.raises(ValueError, match="n_timesteps >="):
+        _model(3, marginal_consistency_weight=1.0)  # only 1 interior frame
+
+
+def _temporal_attention(seq_length, channels=8, n_heads=2):
+    attn = TemporalAttention(channels, n_heads, seq_length)
+    # relative_embedding and the output projection are zero-initialized (the block
+    # starts as identity), so the positional bias has no effect until trained;
+    # randomize both so tests can observe the frame_index dependence.
+    with torch.no_grad():
+        attn.relative_embedding.normal_()
+        attn.proj.weight.normal_()
+        attn.proj.bias.normal_()
+    return attn
+
+
+def test_temporal_attention_frame_index_default_matches_arange():
+    # Backward compat: the full-grid default (frame_index=None) must equal passing
+    # the contiguous arange positions, so pre-subset full-set behavior is unchanged.
+    attn = _temporal_attention(seq_length=9)
+    x = torch.randn(2, 8, 9, 4, 4)
+    default = attn(x)
+    explicit = attn(x, torch.arange(9))
+    assert torch.allclose(default, explicit, atol=1e-6)
+
+
+def test_temporal_attention_uses_true_frame_spacing():
+    # A subset packed to contiguous positions [0,1,2] must NOT be treated the same
+    # as its true grid positions [0,4,8]: the relative positional bias should
+    # reflect real spacing. Feeding true grid indices changes the output.
+    attn = _temporal_attention(seq_length=9)
+    x = torch.randn(2, 8, 3, 4, 4)
+    packed = attn(x)  # default arange([0,1,2]) -- the old (buggy) behavior
+    true_grid = attn(x, torch.tensor([0, 4, 8]))
+    assert not torch.allclose(packed, true_grid, atol=1e-5)
+    # ...and a subset's bias equals the full-grid bias restricted to those frames.
+    full = attn(torch.randn(2, 8, 9, 4, 4))  # smoke: full grid still runs
+    assert full.shape == (2, 8, 9, 4, 4)
+
+
+def test_firblur_survives_inplace_kernel_mutation():
+    # Regression: under DDP (broadcast_buffers=True) each forward re-syncs buffers
+    # with an in-place copy_ into the kernel. When two forwards run before one
+    # backward (the marginal-consistency loss), that mutation must not invalidate
+    # the first forward's saved-for-backward conv weight. Simulate the buffer sync
+    # by mutating the kernel in place between forward and backward.
+    blur = FIRBlur()
+    x = torch.randn(2, 8, 3, 8, 8, requires_grad=True)
+    y = blur(x)
+    with torch.no_grad():
+        blur.kernel.copy_(blur.kernel)  # what DDP's buffer broadcast does
+    y.sum().backward()  # must not raise "modified by an inplace operation"
+    assert x.grad is not None and torch.isfinite(x.grad).all()

--- a/fme/downscaling/test_video_train.py
+++ b/fme/downscaling/test_video_train.py
@@ -1,3 +1,5 @@
+import pytest
+
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.ema import EMAConfig
 from fme.core.logging_utils import LoggingConfig
@@ -58,6 +60,7 @@ def _trainer_config(tmp_path):
     )
 
 
+@pytest.mark.medium_duration
 def test_video_trainer_runs_and_checkpoints(tmp_path):
     config = _trainer_config(tmp_path)
     trainer = config.build()
@@ -74,6 +77,7 @@ def test_video_trainer_runs_and_checkpoints(tmp_path):
     assert os.path.isfile(os.path.join(config.checkpoint_dir, "best.ckpt"))
 
 
+@pytest.mark.medium_duration
 def test_video_trainer_resume(tmp_path):
     config = _trainer_config(tmp_path)
     trainer = config.build()

--- a/fme/downscaling/test_video_train.py
+++ b/fme/downscaling/test_video_train.py
@@ -1,0 +1,89 @@
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.core.ema import EMAConfig
+from fme.core.logging_utils import LoggingConfig
+from fme.core.normalizer import NormalizationConfig
+from fme.core.optimization import OptimizationConfig
+from fme.downscaling.data.config import PairedDataLoaderConfig
+from fme.downscaling.data.utils import ClosedInterval
+from fme.downscaling.test_utils import data_paths_helper
+from fme.downscaling.video_models import VideoDiffusionModelConfig
+from fme.downscaling.video_train import VideoTrainerConfig, restore_checkpoint
+
+OUT_NAMES = ["var0", "var1"]
+N_TIMESTEPS = 5
+
+
+def _data_config(paths):
+    return PairedDataLoaderConfig(
+        fine=[XarrayDataConfig(paths.fine)],
+        coarse=[XarrayDataConfig(paths.fine)],  # temporal-only: same store
+        batch_size=2,
+        num_data_workers=0,
+        strict_ensemble=False,
+        lat_extent=ClosedInterval(1, 6),
+        lon_extent=ClosedInterval(0, 8),
+        n_timesteps=N_TIMESTEPS,
+    )
+
+
+def _trainer_config(tmp_path):
+    paths = data_paths_helper(tmp_path, num_timesteps=18)
+    model = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=N_TIMESTEPS,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        model_channels=16,
+        n_heads=2,
+        num_freqs=3,
+        num_diffusion_generation_steps=4,
+    )
+    return VideoTrainerConfig(
+        model=model,
+        optimization=OptimizationConfig(lr=1e-3),
+        train_data=_data_config(paths),
+        validation_data=_data_config(paths),
+        test_data=_data_config(paths),
+        test_interval=1,
+        max_epochs=2,
+        experiment_dir=str(tmp_path / "exp"),
+        logging=LoggingConfig(
+            log_to_screen=False, log_to_wandb=False, log_to_file=False
+        ),
+        save_checkpoints=True,
+        validate_using_ema=True,
+        ema=EMAConfig(decay=0.99),
+        generate_n_samples=1,
+    )
+
+
+def test_video_trainer_runs_and_checkpoints(tmp_path):
+    config = _trainer_config(tmp_path)
+    trainer = config.build()
+    assert len(trainer.train_data.loader) > 0
+    trainer.train()
+
+    # ran all epochs, recorded a finite best validation loss, wrote checkpoints
+    assert trainer.startEpoch == 2
+    assert trainer.num_batches_seen > 0
+    assert trainer.best_valid_loss < float("inf")
+    import os
+
+    assert os.path.isfile(os.path.join(config.checkpoint_dir, "latest.ckpt"))
+    assert os.path.isfile(os.path.join(config.checkpoint_dir, "best.ckpt"))
+
+
+def test_video_trainer_resume(tmp_path):
+    config = _trainer_config(tmp_path)
+    trainer = config.build()
+    trainer.train()
+    seen, epoch = trainer.num_batches_seen, trainer.startEpoch
+
+    # a fresh trainer over the same dir resumes from the latest checkpoint
+    resumed = config.build()
+    assert resumed.resuming
+    restore_checkpoint(resumed)
+    assert resumed.num_batches_seen == seen
+    assert resumed.startEpoch == epoch
+    assert resumed.best_valid_loss == trainer.best_valid_loss

--- a/fme/downscaling/video_inference.py
+++ b/fme/downscaling/video_inference.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, Allen Institute for AI
+# SPDX-License-Identifier: Apache-2.0
+"""Test-set inference for the endpoint-conditioned video diffusion model.
+
+Given a trained checkpoint, runs an ensemble of samples over a test split:
+observed daily endpoint snapshots (0h, 24h) in, infilled 3-hourly interior
+frames (3h..21h) out. Writes a single zarr store matching the input dataset's
+format -- dims (time, ensemble, latitude, longitude) -- covering the full test
+period with no gaps: endpoint frames are the observed ground truth broadcast
+across the ensemble dimension, interior frames are the generated ensemble. A
+``frame_source`` time-coordinate flags observed (0) vs. generated (1) frames.
+
+Run (mirrors video_train.py's invocation):
+    torchrun --nproc_per_node N -m fme.downscaling.video_inference <config.yaml>
+"""
+
+import argparse
+import dataclasses
+import itertools
+import logging
+import os
+from dataclasses import dataclass
+
+import dacite
+import numpy as np
+import torch
+import xarray as xr
+import yaml
+
+from fme.core.cli import prepare_directory
+from fme.core.dataset.time import TimeSlice
+from fme.core.dataset.xarray import XarrayDataConfig
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.ema import EMATracker
+from fme.core.generics.trainer import count_parameters
+from fme.core.logging_utils import LoggingConfig
+from fme.core.writer import ZarrWriter
+from fme.downscaling.data import PairedDataLoaderConfig
+from fme.downscaling.inference.zarr_utils import determine_zarr_chunks
+from fme.downscaling.video_models import VideoDiffusionModel, VideoDiffusionModelConfig
+
+logger = logging.getLogger(__name__)
+
+TIME_NAME = "time"
+ENSEMBLE_NAME = "ensemble"
+LAT_NAME = "latitude"
+LON_NAME = "longitude"
+DIMS = (TIME_NAME, ENSEMBLE_NAME, LAT_NAME, LON_NAME)
+
+
+def load_video_model(
+    model_config: VideoDiffusionModelConfig,
+    checkpoint_path: str,
+    device: torch.device,
+    use_ema: bool = True,
+) -> VideoDiffusionModel:
+    """Build the model from config and load trained weights.
+
+    The training config used ``validate_using_ema: true``, so the checkpoint
+    that was selected as "best" was evaluated with EMA-swapped weights. To
+    reproduce that quality at inference time, load the raw state dict first
+    (establishes buffers) and then overwrite the trainable params with the
+    EMA shadow, exactly mirroring ``VideoTrainer._ema_context()``.
+
+    ``model.module`` is always wrapped (``DummyWrapper`` outside torchrun,
+    ``DistributedDataParallel`` under it), both under the attribute name
+    ``module``. DDP's own ``state_dict()``/``load_state_dict()`` transparently
+    forward to that inner module (no prefix), which is what training's saved
+    checkpoint contains -- but ``DummyWrapper`` does *not* override those
+    methods, so loading directly into ``model.module`` only works under DDP.
+    Loading into ``getattr(model.module, "module", model.module)`` instead
+    reaches the raw net directly in both cases (mirrors the proven pattern in
+    ``toy/eval_video_ckpt.py``).
+    """
+    model = model_config.build()
+    ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    state_dict = {
+        (key[len("module.") :] if key.startswith("module.") else key): value
+        for key, value in ckpt["module"].items()
+    }
+    bare = getattr(model.module, "module", model.module)
+    bare.load_state_dict(state_dict)
+    if use_ema:
+        if "ema" not in ckpt:
+            raise ValueError(
+                f"use_ema=True but checkpoint {checkpoint_path} has no 'ema' state."
+            )
+        ema = EMATracker.from_state(ckpt["ema"], model.modules)
+        ema.copy_to(model.modules)
+        logger.info("Loaded EMA weights for inference.")
+    else:
+        logger.info("Loaded raw (non-EMA) weights for inference.")
+    model.module.eval()
+    logger.info(
+        f"Loaded checkpoint {checkpoint_path} "
+        f"(epoch {ckpt.get('startEpoch')}, "
+        f"best_valid_loss {ckpt.get('best_valid_loss')})"
+    )
+    return model
+
+
+def _reference_time_and_attrs(
+    data_config: PairedDataLoaderConfig, out_names: list[str]
+) -> tuple[np.ndarray, dict[str, dict[str, str]]]:
+    """Read the input zarr's own time coordinate + variable attrs for the test
+    subset, so the output's timestamps and metadata match the input exactly.
+    """
+    src = data_config.fine[0]
+    if not isinstance(src, XarrayDataConfig):
+        raise ValueError(
+            "Expected an XarrayDataConfig for data.fine[0] for video inference, "
+            f"got {type(src)}."
+        )
+    ds = xr.open_zarr(os.path.join(src.data_path, src.file_pattern))
+    subset = src.subset
+    if not isinstance(subset, TimeSlice):
+        raise ValueError(
+            "Expected a TimeSlice subset on data.fine[0] for video inference, "
+            f"got {type(subset)}."
+        )
+    ds = ds.sel(time=slice(subset.start_time, subset.stop_time))
+    time = ds["time"].values
+    attrs = {name: dict(ds[name].attrs) for name in out_names if name in ds}
+    return time, attrs
+
+
+@dataclass
+class VideoInferenceConfig:
+    """Config for running test-set inference with a trained video PMD model.
+
+    ``model`` and ``data`` are pasted verbatim from the training config's
+    ``model:`` and ``test_data:`` blocks -- no new schema for those.
+    """
+
+    checkpoint_path: str
+    model: VideoDiffusionModelConfig
+    data: PairedDataLoaderConfig
+    output_path: str
+    experiment_dir: str
+    logging: LoggingConfig
+    n_ensemble: int = 32
+    ensemble_chunk_size: int = 8
+    use_ema: bool = True
+    # Cap the number of batches processed per rank; for smoke tests.
+    max_batches: int | None = None
+    # If True, overwrite an existing store at output_path (mode="w") instead
+    # of the safe default (mode="w-", fail if it already exists). Use this
+    # while iterating on a run that keeps failing/retrying; leave False once
+    # a run is expected to succeed, so a completed store can't be clobbered
+    # by accident.
+    overwrite: bool = False
+
+    def configure_logging(self, log_filename: str) -> None:
+        config = dataclasses.asdict(self)
+        self.logging.configure_logging(
+            self.experiment_dir, log_filename, config=config, resumable=True
+        )
+
+
+def run_inference(config: VideoInferenceConfig) -> None:
+    dist = Distributed.get_instance()
+    device = get_device()
+
+    model = load_video_model(
+        config.model, config.checkpoint_path, device, use_ema=config.use_ema
+    )
+    logger.info(f"Number of parameters: {count_parameters(model.modules)}")
+
+    griddata = config.data.build_video(
+        train=False, requirements=config.model.data_requirements
+    )
+
+    time, var_attrs = _reference_time_and_attrs(config.data, model.out_names)
+    n_time = len(time)
+    n_timesteps = config.model.n_timesteps
+    clip_stride = n_timesteps - 1  # tumbling clips share only their boundary frame
+
+    # Observed at every clip boundary (0, clip_stride, 2*clip_stride, ...),
+    # generated everywhere else. If the dataloader's drop_last truncates the
+    # final partial batch, the tail of this array is simply never written and
+    # will show up as a gap (fill value) in the output -- see run.sh / README
+    # verification notes.
+    frame_source = np.ones(n_time, dtype=np.int8)
+    frame_source[0::clip_stride] = 0
+
+    # griddata.fine_coords reflects the *pre*-lat_extent/lon_extent-crop
+    # domain (it's built from build_from_config_sequence's properties, before
+    # _build_aligned_subset_pair applies the crop) -- e.g. with
+    # lat_extent: {-88, 88} the raw store has 180 latitude points but the
+    # data actually fed to the model, and hence generate()'s output, is
+    # cropped to 176. Get the true post-crop lat/lon from the first real
+    # batch's own coordinates instead, which is what the model actually used.
+    batch_iterator = griddata.get_generator()
+    first_batch = next(batch_iterator)
+    lat = first_batch.fine.latlon_coordinates.lat[0].cpu().numpy()
+    lon = first_batch.fine.latlon_coordinates.lon[0].cpu().numpy()
+    n_lat, n_lon = len(lat), len(lon)
+
+    coords = {
+        TIME_NAME: time,
+        ENSEMBLE_NAME: np.arange(config.n_ensemble),
+        LAT_NAME: lat,
+        LON_NAME: lon,
+    }
+    chunks = determine_zarr_chunks(
+        dims=DIMS,
+        data_shape=(n_time, config.n_ensemble, n_lat, n_lon),
+        bytes_per_element=4,
+    )
+
+    writer = ZarrWriter(
+        path=config.output_path,
+        dims=DIMS,
+        coords=coords,
+        data_vars=model.out_names,
+        chunks=chunks,
+        array_attributes=var_attrs,
+        group_attributes={
+            "description": (
+                "Test-set inference: endpoint-conditioned video diffusion "
+                "infilling, ensemble of independent noise draws."
+            ),
+            "checkpoint_path": config.checkpoint_path,
+            "n_ensemble": str(config.n_ensemble),
+            "use_ema": str(config.use_ema),
+        },
+        nondim_coords={
+            "frame_source": xr.DataArray(frame_source, dims=[TIME_NAME]),
+        },
+        mode="w" if config.overwrite else "w-",
+        time_calendar="julian",
+    )
+    writer.initialize_store(data_dtype=np.float32)
+
+    n_batches = len(griddata.loader)
+    for i, batch in enumerate(itertools.chain([first_batch], batch_iterator)):
+        if config.max_batches is not None and i >= config.max_batches:
+            break
+
+        remaining = config.n_ensemble
+        ensemble_chunks: dict[str, list[torch.Tensor]] = {
+            name: [] for name in model.out_names
+        }
+        while remaining > 0:
+            n = min(config.ensemble_chunk_size, remaining)
+            generated = model.generate(batch, n_samples=n)
+            for name in model.out_names:
+                ensemble_chunks[name].append(generated[name])
+            remaining -= n
+        # (B, n_ensemble, T, H, W); splice in exact observed endpoints.
+        full = {
+            name: torch.cat(chunks_, dim=1) for name, chunks_ in ensemble_chunks.items()
+        }
+        for name in model.out_names:
+            gt = batch.fine.data[name]  # (B, T, H, W)
+            full[name][:, :, 0] = gt[:, None, 0].expand(-1, config.n_ensemble, -1, -1)
+            full[name][:, :, -1] = gt[:, None, -1].expand(-1, config.n_ensemble, -1, -1)
+
+        clip_times = batch.fine.time.values  # (B, T) cftime
+        batch_size = clip_times.shape[0]
+        for b in range(batch_size):
+            start_idx = int(np.searchsorted(time, clip_times[b, 0]))
+            if time[start_idx] != clip_times[b, 0]:
+                raise ValueError(
+                    f"Clip start time {clip_times[b, 0]} not found in the "
+                    "reference test time axis; data/config mismatch."
+                )
+            is_last_clip = start_idx + (n_timesteps - 1) == n_time - 1
+            n_frames_to_write = n_timesteps if is_last_clip else n_timesteps - 1
+            time_slice = slice(start_idx, start_idx + n_frames_to_write)
+
+            write_data = {
+                name: full[name][b, :, :n_frames_to_write]
+                .permute(1, 0, 2, 3)  # (n_ensemble, T', H, W) -> (T', n_ensemble, H, W)
+                .to(torch.float32)
+                .cpu()
+                .numpy()
+                for name in model.out_names
+            }
+            writer.record_batch(
+                write_data,
+                position_slices={
+                    TIME_NAME: time_slice,
+                    ENSEMBLE_NAME: slice(0, config.n_ensemble),
+                },
+            )
+
+        logger.info(f"Rank {dist.rank}: batch {i + 1}/{n_batches} written")
+
+    if dist.is_distributed():
+        dist.barrier()
+    logger.info(f"Completed inference. Output: {config.output_path}")
+
+
+def main(config_path: str) -> None:
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    inference_config: VideoInferenceConfig = dacite.from_dict(
+        data_class=VideoInferenceConfig,
+        data=config,
+        config=dacite.Config(strict=True),
+    )
+    prepare_directory(inference_config.experiment_dir, config)
+    inference_config.configure_logging(log_filename="out.log")
+    logging.info("Starting video diffusion test-set inference")
+    run_inference(inference_config)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Video PMD test-set inference")
+    parser.add_argument("config_path", type=str, help="Path to the config file")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    with Distributed.context():
+        main(args.config_path)

--- a/fme/downscaling/video_models.py
+++ b/fme/downscaling/video_models.py
@@ -1,0 +1,972 @@
+"""Endpoint-conditioned video interpolation diffusion (temporal-only).
+
+Diffuses the residual over a temporal linear interpolation of observed endpoints;
+only interior frames are denoised. Operates on the fine clip only.
+"""
+
+import dataclasses
+
+import torch
+
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.normalizer import NormalizationConfig, StandardNormalizer
+from fme.core.packer import Packer
+from fme.core.rand import randn_like
+from fme.core.typing_ import TensorDict, TensorMapping
+from fme.downscaling.data import PairedVideoBatchData
+from fme.downscaling.models import ModelOutputs
+from fme.downscaling.modules.video_modules import VideoEDMPrecond, VideoUNet
+from fme.downscaling.noise import (
+    LogNormalNoiseDistribution,
+    LogUniformNoiseDistribution,
+    NoiseDistribution,
+    brownian_bridge_mixing_matrix,
+    ou_mixing_matrix,
+    rbf_mixing_matrix,
+    uniform_frame_times,
+)
+from fme.downscaling.requirements import DataRequirements
+
+CHANNEL_AXIS = 1
+
+
+def _interior_mask(n_times: int, device: torch.device) -> torch.Tensor:
+    """(1, 1, T, 1, 1) mask: 1 on interior frames, 0 on observed endpoints."""
+    mask = torch.ones(n_times, device=device)
+    mask[0] = 0.0
+    mask[-1] = 0.0
+    return mask.reshape(1, 1, n_times, 1, 1)
+
+
+def _linear_interp_endpoints(
+    field: torch.Tensor, tau: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Temporal linear interpolation of the two endpoints along the time axis.
+
+    ``tau`` gives the normalized time of each frame in ``[0, 1]`` (endpoints at 0
+    and 1). When omitted the frames are assumed uniformly spaced, reproducing the
+    ``linspace`` weights; passing the true ``tau`` lets the baseline stay correct
+    for a non-uniform subset of frames.
+    """
+    n_times = field.shape[-3]
+    shape = [1] * field.dim()
+    shape[-3] = n_times
+    if tau is None:
+        w = torch.linspace(0.0, 1.0, n_times, device=field.device)
+    else:
+        w = tau.to(device=field.device, dtype=field.dtype)
+    w = w.reshape(shape)
+    x0 = field[..., 0:1, :, :]
+    xT = field[..., n_times - 1 : n_times, :, :]
+    return (1 - w) * x0 + w * xT
+
+
+@dataclasses.dataclass
+class VideoDiffusionModelConfig:
+    """Configuration for the temporal-interpolation video diffusion model."""
+
+    out_names: list[str]
+    n_timesteps: int
+    normalization: NormalizationConfig | None = None
+    sigma_min: float = 0.002
+    sigma_max: float = 80.0
+    churn: float = 0.0
+    num_diffusion_generation_steps: int = 18
+    model_channels: int = 64
+    n_heads: int = 4
+    num_freqs: int = 4
+    # log-noise embedding for the simple backbone: "positional" or "fourier".
+    noise_embedding_type: str = "positional"
+    # Multi-scale U-Net: one channel multiplier per resolution level (0 = finest).
+    channel_mult: list[int] = dataclasses.field(default_factory=lambda: [1, 2, 2])
+    num_blocks: int = 2
+    # spatial attention levels; temporal attention defaults to all levels (None).
+    attention_levels: list[int] = dataclasses.field(default_factory=lambda: [1, 2])
+    temporal_attention_levels: list[int] | None = None
+    # backbone: "simple" (periodic VideoUNet) or "songunet" (SongUNetv2).
+    backbone: str = "simple"
+    img_resolution: list[int] | None = None  # [H, W], required for songunet
+    attn_resolutions: list[int] | None = None
+    training_noise_distribution: (
+        LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
+    ) = None
+    training_noise_distributions: (
+        dict[str, LogNormalNoiseDistribution | LogUniformNoiseDistribution] | None
+    ) = None
+    sigma_min_by_channel: dict[str, float] | None = None
+    sigma_max_by_channel: dict[str, float] | None = None
+    # Per-channel EDM sigma_data (std of the diffused residual). Channels left
+    # unset default to 1.0. Setting it to the measured residual std per channel
+    # fixes the preconditioning/loss weighting for residual diffusion.
+    sigma_data_by_channel: dict[str, float] | None = None
+    loss_weight_exponent: float = 1.0
+    # Channels modeled in log space via log1p(x*scale); maps channel to scale.
+    log_transform_channels: dict[str, float] | None = None
+    # Temporal correlation of the residual noise: "independent" (per-frame white
+    # noise, default), "brownian_bridge" (endpoint-pinned time-correlated noise,
+    # same kernel for every channel), or "per_channel" (a different kernel per
+    # channel, via per_channel_noise_kernel/per_channel_kernel_length_scale below
+    # -- e.g. matching each channel to whichever of bridge/OU/RBF best fits its
+    # real temporal correlation, see toy/process_residual_bridge_report.md).
+    temporal_noise_correlation: str = "independent"
+    # Required iff temporal_noise_correlation == "per_channel": maps every
+    # out_names entry to "independent", "brownian_bridge", "ou", or "rbf".
+    per_channel_noise_kernel: dict[str, str] | None = None
+    # Required iff per_channel_noise_kernel has any "ou"/"rbf" entries: maps
+    # those channels to their kernel length scale, in the same normalized
+    # [0, 1]-over-the-full-window units as uniform_frame_times (i.e. hours /
+    # total_window_hours, NOT raw hours -- e.g. an empirically-fit 12.9h OU
+    # length scale over a 24h window is 12.9/24 = 0.5375 here).
+    per_channel_kernel_length_scale: dict[str, float] | None = None
+    # Fraction of training batches trained on a random subset of interior frames
+    # (the two endpoints are always kept) instead of the full uniform grid, so the
+    # model learns to answer variable query sets and stays consistent across them.
+    # 0.0 (default) trains only on the full grid -- exact prior behavior.
+    subset_augmentation_prob: float = 0.0
+    # Minimum number of interior frames to keep when a batch is subsetted.
+    subset_min_interior: int = 1
+    # Weight of the marginal-consistency loss (video PMD L_marg). When > 0, each
+    # training step runs a second pass on a random strict subset of the (possibly
+    # augmentation-subset) interior frames -- sharing the first pass's noised
+    # inputs on the shared frames -- and penalizes disagreement between the first
+    # pass's prediction restricted to the subset and the subset-native prediction.
+    # May be combined with subset_augmentation_prob (holds subset exposure fixed
+    # while toggling the loss). 0.0 (default) disables it (single pass, exact
+    # prior behavior).
+    marginal_consistency_weight: float = 0.0
+
+    def __post_init__(self):
+        if self.n_timesteps < 3:
+            raise ValueError(
+                "Video interpolation needs at least 3 frames (2 endpoints + 1 "
+                f"interior), got n_timesteps={self.n_timesteps}."
+            )
+        for field_name in (
+            "training_noise_distributions",
+            "sigma_min_by_channel",
+            "sigma_max_by_channel",
+            "sigma_data_by_channel",
+        ):
+            values = getattr(self, field_name)
+            if values is None:
+                continue
+            unknown = set(values) - set(self.out_names)
+            if unknown:
+                raise ValueError(
+                    f"{field_name} contains channels not in out_names: "
+                    f"{sorted(unknown)}"
+                )
+        if self.training_noise_distributions is not None:
+            missing = set(self.out_names) - set(self.training_noise_distributions)
+            if missing:
+                raise ValueError(
+                    "training_noise_distributions must specify every output "
+                    f"channel; missing {sorted(missing)}"
+                )
+        if (self.sigma_min_by_channel is None) != (self.sigma_max_by_channel is None):
+            raise ValueError(
+                "sigma_min_by_channel and sigma_max_by_channel must be specified "
+                "together."
+            )
+        if (
+            self.training_noise_distribution is not None
+            and self.training_noise_distributions is not None
+        ):
+            raise ValueError(
+                "Specify only one of training_noise_distribution or "
+                "training_noise_distributions."
+            )
+        unknown_log = set(self.log_transform_channels or {}) - set(self.out_names)
+        if unknown_log:
+            raise ValueError(
+                "log_transform_channels contains channels not in out_names: "
+                f"{sorted(unknown_log)}"
+            )
+        if any(
+            lvl not in range(len(self.channel_mult)) for lvl in self.attention_levels
+        ):
+            raise ValueError(
+                f"attention_levels {self.attention_levels} must index into "
+                f"channel_mult (0..{len(self.channel_mult) - 1})."
+            )
+        for m in self.channel_mult:
+            if (self.model_channels * m) % self.n_heads != 0:
+                raise ValueError(
+                    f"model_channels*{m}={self.model_channels * m} not divisible "
+                    f"by n_heads={self.n_heads}."
+                )
+        if self.temporal_noise_correlation not in (
+            "independent",
+            "brownian_bridge",
+            "per_channel",
+        ):
+            raise ValueError(
+                "temporal_noise_correlation must be 'independent', "
+                f"'brownian_bridge', or 'per_channel', got "
+                f"{self.temporal_noise_correlation}."
+            )
+        if self.temporal_noise_correlation == "per_channel":
+            if self.per_channel_noise_kernel is None:
+                raise ValueError(
+                    "temporal_noise_correlation == 'per_channel' requires "
+                    "per_channel_noise_kernel."
+                )
+            missing = set(self.out_names) - set(self.per_channel_noise_kernel)
+            extra = set(self.per_channel_noise_kernel) - set(self.out_names)
+            if missing or extra:
+                raise ValueError(
+                    "per_channel_noise_kernel must specify exactly out_names: "
+                    f"missing {sorted(missing)}, unexpected {sorted(extra)}."
+                )
+            bad_kernels = {
+                k
+                for k in self.per_channel_noise_kernel.values()
+                if k not in ("independent", "brownian_bridge", "ou", "rbf")
+            }
+            if bad_kernels:
+                raise ValueError(
+                    "per_channel_noise_kernel values must be 'independent', "
+                    f"'brownian_bridge', 'ou', or 'rbf', got {sorted(bad_kernels)}."
+                )
+            needs_length_scale = {
+                name
+                for name, k in self.per_channel_noise_kernel.items()
+                if k in ("ou", "rbf")
+            }
+            have_length_scale = set(self.per_channel_kernel_length_scale or {})
+            missing_ell = needs_length_scale - have_length_scale
+            if missing_ell:
+                raise ValueError(
+                    "per_channel_kernel_length_scale missing entries for "
+                    f"ou/rbf channels: {sorted(missing_ell)}."
+                )
+            bad_ell = {
+                name: ell
+                for name, ell in (self.per_channel_kernel_length_scale or {}).items()
+                if ell <= 0.0
+            }
+            if bad_ell:
+                raise ValueError(
+                    f"per_channel_kernel_length_scale must be > 0, got {bad_ell}."
+                )
+        elif self.per_channel_noise_kernel is not None:
+            raise ValueError(
+                "per_channel_noise_kernel is only used when "
+                "temporal_noise_correlation == 'per_channel'."
+            )
+        if not 0.0 <= self.subset_augmentation_prob <= 1.0:
+            raise ValueError(
+                "subset_augmentation_prob must be in [0, 1], got "
+                f"{self.subset_augmentation_prob}."
+            )
+        max_interior = self.n_timesteps - 2
+        if not 1 <= self.subset_min_interior <= max_interior:
+            raise ValueError(
+                f"subset_min_interior must be in [1, {max_interior}] "
+                f"(n_timesteps - 2), got {self.subset_min_interior}."
+            )
+        if self.marginal_consistency_weight < 0.0:
+            raise ValueError(
+                "marginal_consistency_weight must be >= 0, got "
+                f"{self.marginal_consistency_weight}."
+            )
+        if self.marginal_consistency_weight > 0.0:
+            # The full grid must admit a strict interior subset (keep in
+            # [subset_min_interior, n_interior - 1]), so n_interior >=
+            # subset_min_interior + 1. May be combined with subset_augmentation:
+            # when an augmented batch is too small to form a strict subset the
+            # consistency pass is skipped for that batch (see train_on_batch).
+            if self.n_timesteps - 2 < self.subset_min_interior + 1:
+                raise ValueError(
+                    "marginal_consistency_weight > 0 needs n_timesteps >= "
+                    f"subset_min_interior + 3 (got n_timesteps={self.n_timesteps}, "
+                    f"subset_min_interior={self.subset_min_interior})."
+                )
+        if self.backbone not in ("simple", "songunet"):
+            raise ValueError(
+                f"backbone must be 'simple' or 'songunet', got {self.backbone}."
+            )
+        if self.noise_embedding_type not in ("positional", "fourier"):
+            raise ValueError(
+                "noise_embedding_type must be 'positional' or 'fourier', got "
+                f"{self.noise_embedding_type}."
+            )
+        if self.backbone == "songunet" and self.img_resolution is None:
+            raise ValueError("songunet backbone requires img_resolution [H, W].")
+
+    @property
+    def noise_distribution(self) -> NoiseDistribution:
+        if self.training_noise_distribution is not None:
+            return self.training_noise_distribution
+        return LogNormalNoiseDistribution(p_mean=-1.2, p_std=1.2)
+
+    def sample_training_noise(
+        self, batch_size: int, device: torch.device
+    ) -> torch.Tensor:
+        if self.training_noise_distributions is None:
+            return self.noise_distribution.sample(batch_size, device)
+        sigma_by_channel = [
+            self.training_noise_distributions[name].sample(batch_size, device)
+            for name in self.out_names
+        ]
+        return torch.cat(sigma_by_channel, dim=1)
+
+    def sigma_data_tensor(self, device: torch.device) -> torch.Tensor:
+        """Per-channel sigma_data (default 1.0), ordered by out_names."""
+        return torch.tensor(
+            [
+                1.0
+                if self.sigma_data_by_channel is None
+                else self.sigma_data_by_channel.get(name, 1.0)
+                for name in self.out_names
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+
+    def generation_sigma_bounds(
+        self, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        sigma_min = torch.tensor(
+            [
+                self.sigma_min
+                if self.sigma_min_by_channel is None
+                else self.sigma_min_by_channel.get(name, self.sigma_min)
+                for name in self.out_names
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        sigma_max = torch.tensor(
+            [
+                self.sigma_max
+                if self.sigma_max_by_channel is None
+                else self.sigma_max_by_channel.get(name, self.sigma_max)
+                for name in self.out_names
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        return sigma_min, sigma_max
+
+    @property
+    def data_requirements(self) -> "DataRequirements":
+        # Temporal-only: fine == coarse; clip length comes from the data config.
+        return DataRequirements(
+            fine_names=self.out_names,
+            coarse_names=self.out_names,
+            n_timesteps=1,
+            use_fine_topography=False,
+        )
+
+    def build(
+        self, normalizer: StandardNormalizer | None = None
+    ) -> "VideoDiffusionModel":
+        if normalizer is None:
+            if self.normalization is None:
+                raise ValueError(
+                    "Either `normalization` config or a prebuilt `normalizer` "
+                    "must be provided."
+                )
+            normalizer = self.normalization.build(self.out_names)
+
+        n_channels = len(self.out_names)
+        # noisy residual (C) + endpoint values (C) + mask (1) + log-sigma (C)
+        in_channels = 3 * n_channels + 1
+        if self.backbone == "songunet":
+            from fme.downscaling.modules.video_song_unet import VideoSongUNet
+
+            if self.img_resolution is None:
+                # unreachable: __post_init__ already enforces this
+                raise ValueError("songunet backbone requires img_resolution [H, W].")
+            default_attn = self.img_resolution[0] >> (len(self.channel_mult) - 1)
+            net = VideoSongUNet(
+                in_channels=in_channels,
+                out_channels=n_channels,
+                img_resolution=self.img_resolution,
+                seq_length=self.n_timesteps,
+                model_channels=self.model_channels,
+                channel_mult=tuple(self.channel_mult),
+                num_blocks=self.num_blocks,
+                n_heads=self.n_heads,
+                attn_resolutions=tuple(self.attn_resolutions or [default_attn]),
+                num_freqs=self.num_freqs,
+            )
+        else:
+            net = VideoUNet(
+                in_channels=in_channels,
+                out_channels=n_channels,
+                seq_length=self.n_timesteps,
+                model_channels=self.model_channels,
+                channel_mult=tuple(self.channel_mult),
+                num_blocks=self.num_blocks,
+                n_heads=self.n_heads,
+                attention_levels=tuple(self.attention_levels),
+                temporal_attention_levels=(
+                    None
+                    if self.temporal_attention_levels is None
+                    else tuple(self.temporal_attention_levels)
+                ),
+                num_freqs=self.num_freqs,
+                noise_embedding_type=self.noise_embedding_type,
+            )
+        module = VideoEDMPrecond(net, sigma_data=self.sigma_data_tensor(get_device()))
+        return VideoDiffusionModel(self, module, normalizer, self.out_names)
+
+
+def _channel_mixing_matrix(
+    tau: torch.Tensor, kernel: str, length_scale: float | None
+) -> torch.Tensor:
+    """``(T, T)`` mixing matrix for one channel's chosen kernel -- the
+    per-channel building block for ``temporal_noise_correlation ==
+    'per_channel'``. ``"independent"`` embeds an identity in the interior
+    block (endpoints still zero), giving unmixed white noise for that
+    channel while still stacking cleanly into a per-channel tensor.
+    """
+    if kernel == "independent":
+        n_timesteps = tau.shape[0]
+        n_interior = n_timesteps - 2
+        mixing = torch.zeros(
+            n_timesteps, n_timesteps, dtype=torch.float32, device=tau.device
+        )
+        mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = torch.eye(
+            n_interior, device=tau.device
+        )
+        return mixing
+    if kernel == "brownian_bridge":
+        return brownian_bridge_mixing_matrix(tau)
+    if kernel == "ou":
+        assert length_scale is not None
+        return ou_mixing_matrix(tau, length_scale)
+    if kernel == "rbf":
+        assert length_scale is not None
+        return rbf_mixing_matrix(tau, length_scale)
+    raise ValueError(f"Unknown per-channel noise kernel {kernel!r}")
+
+
+def _per_channel_mixing_tensor(
+    tau: torch.Tensor,
+    out_names: list[str],
+    kernel_map: dict[str, str],
+    length_scale_map: dict[str, float] | None,
+) -> torch.Tensor:
+    """``(C, T, T)`` stacked per-channel mixing matrices, ordered by
+    ``out_names`` -- each channel's own kernel/length-scale choice.
+    """
+    mats = [
+        _channel_mixing_matrix(
+            tau, kernel_map[name], (length_scale_map or {}).get(name)
+        )
+        for name in out_names
+    ]
+    return torch.stack(mats, dim=0)
+
+
+class VideoDiffusionModel:
+    def __init__(
+        self,
+        config: VideoDiffusionModelConfig,
+        module: torch.nn.Module,
+        normalizer: StandardNormalizer,
+        out_names: list[str],
+    ):
+        self.config = config
+        # (1, C, 1, 1, 1) so it broadcasts against the per-channel sigma tensor.
+        self.sigma_data = config.sigma_data_tensor(get_device()).reshape(1, -1, 1, 1, 1)
+        dist = Distributed.get_instance()
+        self.module = dist.wrap_module(module.to(get_device()))
+        self.normalizer = normalizer
+        self.out_names = out_names
+        self.packer = Packer(out_names)
+        self.n_timesteps = config.n_timesteps
+        self.log_transform_channels = dict(config.log_transform_channels or {})
+        # normalized full-grid frame times (endpoints at 0/1) used to derive the
+        # baseline weights and bridge kernel for whatever frame subset is in play.
+        self._full_tau = uniform_frame_times(config.n_timesteps)
+        self._marginal_consistency_weight = config.marginal_consistency_weight
+        self._bridge_noise = config.temporal_noise_correlation == "brownian_bridge"
+        self._per_channel_noise = config.temporal_noise_correlation == "per_channel"
+        if self._bridge_noise:
+            self._noise_mixing: torch.Tensor | None = brownian_bridge_mixing_matrix(
+                self._full_tau
+            ).to(get_device())
+        elif self._per_channel_noise:
+            assert (
+                config.per_channel_noise_kernel is not None
+            )  # validated in __post_init__
+            self._noise_mixing = _per_channel_mixing_tensor(
+                self._full_tau,
+                out_names,
+                config.per_channel_noise_kernel,
+                config.per_channel_kernel_length_scale,
+            ).to(get_device())
+        else:
+            self._noise_mixing = None
+
+    @property
+    def modules(self) -> torch.nn.ModuleList:
+        return torch.nn.ModuleList([self.module])
+
+    def _sample_residual_noise(
+        self, like: torch.Tensor, mixing: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """White noise shaped like ``like`` (B, C, T, H, W), temporally correlated
+        with ``mixing`` when given (bridge/OU/RBF kernel, shared or per-channel),
+        else independent.
+
+        ``mixing`` defaults to the full-grid mixing tensor; pass a subset matrix
+        for a subset of frames, or ``None`` stays independent (mixing is ``None``
+        in independent mode regardless). ``mixing`` is either ``(T, T)`` (same
+        kernel for every channel) or ``(C, T, T)`` (per-channel kernels).
+        """
+        noise = randn_like(like)
+        if mixing is None:
+            mixing = self._noise_mixing
+        if mixing is None:
+            return noise
+        mixing = mixing.to(device=noise.device, dtype=noise.dtype)
+        if mixing.ndim == 3:
+            return torch.einsum("cti,bcihw->bcthw", mixing, noise)
+        return torch.einsum("ti,bcihw->bcthw", mixing, noise)
+
+    def _tau_for_indices(self, idx: torch.Tensor | None) -> torch.Tensor | None:
+        """Normalized frame times for a subset of the full grid (``None`` = full
+        grid, where the ``linspace`` default in the baseline already applies).
+        """
+        if idx is None:
+            return None
+        return self._full_tau.to(idx.device).index_select(0, idx)
+
+    def _mixing_for_indices(self, idx: torch.Tensor | None) -> torch.Tensor | None:
+        """Mixing tensor for a subset of frames -- the full-window kernel(s)
+        restricted to ``idx`` (re-derived at just those frame times, which
+        equals the true marginal -- see brownian_bridge_mixing_matrix's
+        docstring). ``None`` for independent noise or the full grid.
+        """
+        if not (self._bridge_noise or self._per_channel_noise):
+            return None
+        if idx is None:
+            return self._noise_mixing
+        tau = self._full_tau.index_select(0, idx.cpu())
+        if self._per_channel_noise:
+            assert self.config.per_channel_noise_kernel is not None
+            return _per_channel_mixing_tensor(
+                tau,
+                self.out_names,
+                self.config.per_channel_noise_kernel,
+                self.config.per_channel_kernel_length_scale,
+            ).to(get_device())
+        return brownian_bridge_mixing_matrix(tau).to(get_device())
+
+    def _synced_generator(self, device: torch.device) -> torch.Generator:
+        """A CPU RNG seeded identically on every rank (drawn on rank 0 and
+        broadcast) so all data-/model-parallel ranks pick the same frame subset
+        and therefore agree on the temporal shape of the batch.
+        """
+        dist = Distributed.get_instance()
+        seed = torch.randint(0, 2**31 - 1, (1,), device=device)
+        if dist.rank != 0:
+            seed.zero_()
+        seed = int(dist.reduce_sum(seed).item())
+        return torch.Generator().manual_seed(seed)
+
+    @staticmethod
+    def _interior_subset_indices(
+        n_keep: int, n_times: int, gen: torch.Generator, device: torch.device
+    ) -> torch.Tensor:
+        """Sorted frame indices keeping both endpoints plus ``n_keep`` random
+        interior frames.
+        """
+        n_interior = n_times - 2
+        interior = torch.sort(torch.randperm(n_interior, generator=gen)[:n_keep]).values
+        idx = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.long),
+                interior + 1,
+                torch.full((1,), n_times - 1, dtype=torch.long),
+            ]
+        )
+        return idx.to(device)
+
+    def _sample_training_subset_indices(
+        self, n_times: int, device: torch.device
+    ) -> torch.Tensor | None:
+        """Randomly pick frame indices (always keeping the two endpoints) for
+        subset-augmented training, or ``None`` to train on the full grid.
+        """
+        if self.config.subset_augmentation_prob <= 0.0:
+            return None
+        gen = self._synced_generator(device)
+        if float(torch.rand((), generator=gen)) >= self.config.subset_augmentation_prob:
+            return None
+        n_interior = n_times - 2
+        n_keep = int(
+            torch.randint(
+                self.config.subset_min_interior, n_interior + 1, (1,), generator=gen
+            )
+        )
+        if n_keep >= n_interior:
+            return None  # kept everything -> full grid
+        return self._interior_subset_indices(n_keep, n_times, gen, device)
+
+    def _sample_consistency_subset_indices(
+        self, n_times: int, device: torch.device
+    ) -> torch.Tensor:
+        """A random *strict* interior subset (endpoints kept, at least one interior
+        frame dropped) for the marginal-consistency second pass.
+        """
+        gen = self._synced_generator(device)
+        n_interior = n_times - 2
+        # keep in [subset_min_interior, n_interior - 1]: never the full interior,
+        # so the two passes always differ in their query set.
+        n_keep = int(
+            torch.randint(
+                self.config.subset_min_interior, n_interior, (1,), generator=gen
+            )
+        )
+        return self._interior_subset_indices(n_keep, n_times, gen, device)
+
+    @staticmethod
+    def _validate_frames(
+        frames: "list[int] | None", n_times: int, device: torch.device
+    ) -> torch.Tensor | None:
+        """Validate a requested frame subset for ``generate`` and return it as a
+        LongTensor of indices into the full grid, or ``None`` for the full grid.
+        """
+        if frames is None:
+            return None
+        idx = torch.as_tensor(list(frames), dtype=torch.long)
+        if idx.ndim != 1 or idx.numel() < 3:
+            raise ValueError(
+                "frames must list at least 3 frame indices (2 endpoints + "
+                f"interior), got {list(frames)}."
+            )
+        if int(idx[0]) != 0 or int(idx[-1]) != n_times - 1:
+            raise ValueError(
+                f"frames must start at 0 and end at {n_times - 1} (the observed "
+                f"endpoints), got {list(frames)}."
+            )
+        if not bool(torch.all(idx[1:] > idx[:-1])):
+            raise ValueError(f"frames must be strictly increasing, got {list(frames)}.")
+        return idx.to(device)
+
+    def _pack_normalized(self, data: TensorMapping) -> torch.Tensor:
+        selected = {
+            k: torch.log1p(data[k].clamp(min=0.0) * scale)
+            if (scale := self.log_transform_channels.get(k))
+            else data[k]
+            for k in self.out_names
+        }
+        normalized = self.normalizer.normalize(selected)
+        return self.packer.pack(normalized, axis=CHANNEL_AXIS)
+
+    def _denormalize_invert(self, packed: torch.Tensor) -> TensorDict:
+        """Denormalize and invert any log1p transform back to physical units."""
+        data = self.normalizer.denormalize(
+            self.packer.unpack(packed, axis=CHANNEL_AXIS)
+        )
+        return {
+            k: (torch.expm1(v) / scale).clamp(min=0.0)
+            if (scale := self.log_transform_channels.get(k))
+            else v
+            for k, v in data.items()
+        }
+
+    def _conditioning(
+        self, clip: torch.Tensor, interior_mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Observed-endpoint values + a binary observed mask channel."""
+        observed = 1.0 - interior_mask
+        observed_values = clip * observed
+        mask_channel = observed.expand(
+            clip.shape[0], 1, -1, clip.shape[-2], clip.shape[-1]
+        )
+        return torch.cat([observed_values, mask_channel], dim=CHANNEL_AXIS)
+
+    def _calendar_inputs(self, batch_fine):
+        lon = batch_fine.latlon_coordinates.lon
+        if lon.dim() == 2:  # all members identical, use first
+            lon = lon[0]
+        return (
+            batch_fine.day_of_year.to(get_device()),
+            batch_fine.second_of_day.to(get_device()),
+            lon.to(get_device()),
+        )
+
+    def train_on_batch(self, batch: PairedVideoBatchData, optimizer) -> ModelOutputs:
+        fine = batch.fine
+        clip = self._pack_normalized(fine.data)
+        day_of_year, second_of_day, lon = self._calendar_inputs(fine)
+
+        # Optionally train on a random subset of interior frames (endpoints kept)
+        # so the model learns to answer variable query sets; the bridge noise and
+        # baseline follow the subset's true times, i.e. the full-window marginal.
+        idx = self._sample_training_subset_indices(clip.shape[2], clip.device)
+        if idx is not None:
+            clip = clip.index_select(2, idx)
+            day_of_year = day_of_year.index_select(1, idx)
+            second_of_day = second_of_day.index_select(1, idx)
+        batch_size, _, n_times, _, _ = clip.shape
+        tau = self._tau_for_indices(idx)
+
+        baseline = _linear_interp_endpoints(clip, tau)
+        residual = clip - baseline  # ~0 at endpoints by construction
+
+        interior = _interior_mask(n_times, clip.device)
+        condition = self._conditioning(clip, interior)
+        mixing = self._mixing_for_indices(idx)
+
+        sigma = self.config.sample_training_noise(batch_size, clip.device)
+        sigma = sigma.reshape(batch_size, -1, 1, 1, 1)
+        # Gaussian noise on interior frames only
+        noise = self._sample_residual_noise(residual, mixing)
+        noised = residual + noise * sigma * interior
+
+        # ``idx`` (or None for the full grid) is exactly the frames' true grid
+        # positions, so the temporal attention's relative bias reflects real
+        # spacing rather than packed-contiguous order.
+        denoised = self.module(
+            noised, condition, sigma, day_of_year, second_of_day, lon, frame_index=idx
+        )
+
+        weight = (
+            (sigma**2 + self.sigma_data**2) / (sigma * self.sigma_data) ** 2
+        ) ** self.config.loss_weight_exponent
+        sq_err = (denoised - residual) ** 2 * interior
+        n_interior_elems = interior.expand_as(sq_err).sum()
+        loss = (weight * sq_err).sum() / n_interior_elems
+
+        # Marginal-consistency loss: a second pass on a random strict subset of
+        # the (full) interior frames, sharing the SAME noised inputs, sigma, and
+        # conditioning on the shared frames (obtained by slicing the full pass, so
+        # the only difference is the query set). We add the subset's own diffusion
+        # loss plus a penalty tying the full-pass prediction, restricted to the
+        # subset, to the subset-native prediction on the shared interior frames.
+        marginal_loss: torch.Tensor | None = None
+        total_loss = loss
+        # A strict interior subset needs at least subset_min_interior + 1 interior
+        # frames; an augmentation-shrunk batch may fall below that, so skip the
+        # consistency pass for it rather than fail.
+        can_subset = n_times - 2 >= self.config.subset_min_interior + 1
+        if self._marginal_consistency_weight > 0.0 and can_subset:
+            sub = self._sample_consistency_subset_indices(n_times, clip.device)
+            interior_s = _interior_mask(int(sub.numel()), clip.device)
+            # True grid positions of the consistency frames: map the subset picks
+            # through the current frames' own grid positions (``idx`` when the
+            # batch was already augmented, else the full grid).
+            base_index = (
+                idx if idx is not None else torch.arange(n_times, device=clip.device)
+            )
+            sub_frame_index = base_index.index_select(0, sub)
+            denoised_s = self.module(
+                noised.index_select(2, sub),
+                condition.index_select(2, sub),
+                sigma,
+                day_of_year.index_select(1, sub),
+                second_of_day.index_select(1, sub),
+                lon,
+                frame_index=sub_frame_index,
+            )
+            residual_s = residual.index_select(2, sub)
+            n_interior_s = interior_s.expand_as(residual_s).sum()
+            sq_err_s = (denoised_s - residual_s) ** 2 * interior_s
+            dsm_sub = (weight * sq_err_s).sum() / n_interior_s
+            # full-pass prediction restricted to the subset vs subset-native one
+            diff = (denoised.index_select(2, sub) - denoised_s) ** 2 * interior_s
+            marginal_loss = diff.sum() / n_interior_s
+            total_loss = (
+                loss + dsm_sub + self._marginal_consistency_weight * marginal_loss
+            )
+
+        optimizer.accumulate_loss(total_loss)
+        optimizer.step_weights()
+
+        with torch.no_grad():
+            weighted_sq_err = sq_err * weight
+            per_sample_denominator = (
+                interior.expand(batch_size, 1, n_times, *clip.shape[-2:])
+                .sum(dim=(-3, -2, -1))
+                .clamp(min=1)
+            )
+            # pin observed endpoints (residual is 0 there)
+            full_norm = baseline + denoised * interior
+            prediction = self._denormalize_invert(full_norm)
+            channel_losses = {
+                name: weighted_sq_err[:, i].sum() / per_sample_denominator.sum()
+                for i, name in enumerate(self.out_names)
+            }
+            per_sample_channel_loss = {
+                name: weighted_sq_err[:, i].sum(dim=(-3, -2, -1))
+                / per_sample_denominator.flatten()
+                for i, name in enumerate(self.out_names)
+            }
+        # keep target aligned with the (possibly subset) prediction frames
+        target = {
+            k: fine.data[k] if idx is None else fine.data[k].index_select(1, idx)
+            for k in self.out_names
+        }
+        return ModelOutputs(
+            prediction=prediction,
+            target=target,
+            loss=total_loss,
+            marginal_consistency_loss=(
+                None if marginal_loss is None else marginal_loss.detach()
+            ),
+            channel_losses=channel_losses,
+            sigma=(
+                sigma.flatten()
+                if sigma.shape[1] == 1
+                else sigma.squeeze(-1).squeeze(-1).squeeze(-1)
+            ),
+            per_sample_channel_loss=per_sample_channel_loss,
+        )
+
+    @torch.no_grad()
+    def generate(
+        self,
+        batch: PairedVideoBatchData,
+        n_samples: int = 1,
+        frames: list[int] | None = None,
+    ) -> TensorDict:
+        """Generate the interior frames conditioned on the observed endpoints.
+
+        ``frames`` optionally restricts generation to a subset of frame indices
+        into the full ``n_timesteps`` grid; it must start at 0 and end at
+        ``n_timesteps - 1`` (the observed endpoints) and be strictly increasing.
+        The returned clips then contain only those frames. The baseline and the
+        bridge noise use the subset's true times, so a subset draws from the
+        exact marginal of the full-window process. Defaults to the full grid.
+        """
+        fine = batch.fine
+        clip = self._pack_normalized(fine.data)
+        day_of_year, second_of_day, lon = self._calendar_inputs(fine)
+        idx = self._validate_frames(frames, clip.shape[2], clip.device)
+        if idx is not None:
+            clip = clip.index_select(2, idx)
+            day_of_year = day_of_year.index_select(1, idx)
+            second_of_day = second_of_day.index_select(1, idx)
+        batch_size, n_channels, n_times, height, width = clip.shape
+        tau = self._tau_for_indices(idx)
+        baseline = _linear_interp_endpoints(clip, tau)
+        interior = _interior_mask(n_times, clip.device)
+        condition = self._conditioning(clip, interior)
+        mixing = self._mixing_for_indices(idx)
+
+        def repeat(t):
+            return t.repeat_interleave(n_samples, dim=0)
+
+        condition = repeat(condition)
+        baseline = repeat(baseline)
+        day_of_year = repeat(day_of_year)
+        second_of_day = repeat(second_of_day)
+        interior_b = interior.expand(batch_size * n_samples, n_channels, n_times, 1, 1)
+
+        latents = self._sample_residual_noise(
+            torch.empty(
+                batch_size * n_samples,
+                n_channels,
+                n_times,
+                height,
+                width,
+                device=clip.device,
+            ),
+            mixing,
+        )
+        sigma_min, sigma_max = self.config.generation_sigma_bounds(clip.device)
+        residual = _video_edm_sample(
+            self.module,
+            latents,
+            condition,
+            interior_b,
+            day_of_year,
+            second_of_day,
+            lon,
+            num_steps=self.config.num_diffusion_generation_steps,
+            sigma_min=sigma_min,
+            sigma_max=sigma_max,
+            s_churn=self.config.churn,
+            noise_mixing=mixing,
+            frame_index=idx,
+        )
+        full_norm = baseline + residual
+        generated = self._denormalize_invert(full_norm)
+        # (B*n, T, H, W) -> (B, n, T, H, W)
+        return {
+            k: v.reshape(batch_size, n_samples, *v.shape[1:])
+            for k, v in generated.items()
+        }
+
+
+def _video_edm_sample(
+    net: torch.nn.Module,
+    latents: torch.Tensor,
+    condition: torch.Tensor,
+    interior_mask: torch.Tensor,
+    day_of_year: torch.Tensor,
+    second_of_day: torch.Tensor,
+    lon: torch.Tensor,
+    num_steps: int,
+    sigma_min: float | torch.Tensor,
+    sigma_max: float | torch.Tensor,
+    rho: float = 7.0,
+    s_churn: float = 0.0,
+    noise_mixing: torch.Tensor | None = None,
+    frame_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """EDM stochastic sampler that keeps the observed endpoints pinned (re-zeroed
+    after every update). When ``noise_mixing`` is given, the stochastic churn noise
+    is temporally correlated with that mixing matrix (matching the training noise).
+    """
+    compute_dtype = torch.float32 if latents.device.type == "mps" else torch.float64
+    sigma_min_t = torch.as_tensor(
+        sigma_min, dtype=compute_dtype, device=latents.device
+    ).reshape(1, -1, 1, 1, 1)
+    sigma_max_t = torch.as_tensor(
+        sigma_max, dtype=compute_dtype, device=latents.device
+    ).reshape(1, -1, 1, 1, 1)
+    step = torch.arange(num_steps, dtype=compute_dtype, device=latents.device).reshape(
+        -1, 1, 1, 1, 1
+    )
+    t = (
+        sigma_max_t ** (1 / rho)
+        + step / (num_steps - 1) * (sigma_min_t ** (1 / rho) - sigma_max_t ** (1 / rho))
+    ) ** rho
+    t = torch.cat([t, torch.zeros_like(t[:1])])
+    mask = interior_mask.to(compute_dtype)
+
+    def denoise(x, sigma):
+        # broadcast per-channel sigma to (B, C) for the precond
+        sigma_bc = sigma.reshape(1, -1).expand(x.shape[0], -1).to(torch.float32)
+        out = net(
+            x.to(torch.float32),
+            condition,
+            sigma_bc,
+            day_of_year,
+            second_of_day,
+            lon,
+            frame_index=frame_index,
+        )
+        return out.to(compute_dtype)
+
+    def churn_noise(x):
+        noise = torch.randn_like(x)
+        if noise_mixing is None:
+            return noise
+        mixing = noise_mixing.to(device=noise.device, dtype=noise.dtype)
+        if mixing.ndim == 3:
+            return torch.einsum("cti,bcihw->bcthw", mixing, noise)
+        return torch.einsum("ti,bcihw->bcthw", mixing, noise)
+
+    x = latents.to(compute_dtype) * t[0] * mask
+    for i, (t_cur, t_next) in enumerate(zip(t[:-1], t[1:])):
+        gamma = s_churn / num_steps
+        t_hat = t_cur + gamma * t_cur
+        x_hat = x + (t_hat**2 - t_cur**2).clamp(min=0).sqrt() * churn_noise(x)
+        x_hat = x_hat * mask
+        d_cur = (x_hat - denoise(x_hat, t_hat)) / t_hat
+        x = (x_hat + (t_next - t_hat) * d_cur) * mask
+        if i < num_steps - 1:
+            d_prime = (x - denoise(x, t_next)) / t_next
+            x = (x_hat + (t_next - t_hat) * (0.5 * d_cur + 0.5 * d_prime)) * mask
+    return x.to(latents.dtype)

--- a/fme/downscaling/video_train.py
+++ b/fme/downscaling/video_train.py
@@ -1,0 +1,524 @@
+"""Training entry point for the endpoint-conditioned video diffusion model."""
+
+import argparse
+import contextlib
+import dataclasses
+import logging
+import os
+import shutil
+import time
+import uuid
+
+import dacite
+import torch
+import yaml
+
+from fme.core.cli import prepare_directory, remove_stale_tmp_checkpoints
+from fme.core.device import get_device
+from fme.core.dicts import to_flat_dict
+from fme.core.distributed import Distributed
+from fme.core.ema import EMAConfig, EMATracker
+from fme.core.generics.trainer import count_parameters
+from fme.core.logging_utils import LoggingConfig
+from fme.core.optimization import NullOptimization, OptimizationConfig
+from fme.core.wandb import WandB
+from fme.downscaling.aggregators.main import LossVsNoiseAggregator
+from fme.downscaling.data import PairedDataLoaderConfig, PairedVideoBatchData
+from fme.downscaling.video_models import (
+    VideoDiffusionModelConfig,
+    _linear_interp_endpoints,
+)
+
+
+def _video_comparison_figure(gt, pred, name: str, example_idx: int):
+    """4-row (GT / Linear / Pred / Pred-GT) x T-frame grid for one var + example."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    n_times = gt.shape[0]
+    lin = _linear_interp_endpoints(gt)
+    diff = pred - gt
+    vmin, vmax = float(gt.min()), float(gt.max())
+    if vmax <= vmin:
+        vmax = vmin + 1e-6
+    dmax = max(float(diff.abs().max()), 1e-6)
+    rows = [
+        ("GT", gt, dict(vmin=vmin, vmax=vmax, cmap="viridis")),
+        ("Linear", lin, dict(vmin=vmin, vmax=vmax, cmap="viridis")),
+        ("Pred", pred, dict(vmin=vmin, vmax=vmax, cmap="viridis")),
+        ("Pred-GT", diff, dict(vmin=-dmax, vmax=dmax, cmap="RdBu_r")),
+    ]
+    fig, axes = plt.subplots(4, n_times, figsize=(1.4 * n_times, 5.8), squeeze=False)
+    for r, (label, data, kw) in enumerate(rows):
+        for t in range(n_times):
+            ax = axes[r][t]
+            ax.imshow(data[t].numpy(), origin="lower", **kw)
+            ax.set_xticks([])
+            ax.set_yticks([])
+            if r == 0:
+                obs = "\n(obs)" if t in (0, n_times - 1) else ""
+                ax.set_title(f"{3 * t}h{obs}", fontsize=7)
+            if t == 0:
+                ax.set_ylabel(label, fontsize=9)
+    fig.suptitle(f"{name} - val example {example_idx}", fontsize=10)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    return fig
+
+
+def _save_checkpoint(trainer: "VideoTrainer", path: str) -> None:
+    temporary_location = os.path.join(os.path.dirname(path), f".{uuid.uuid4()}.tmp")
+    try:
+        torch.save(
+            {
+                "module": trainer.model.module.state_dict(),
+                "ema": trainer.ema.get_state(),
+                "optimization": trainer.optimization.get_state(),
+                "num_batches_seen": trainer.num_batches_seen,
+                "startEpoch": trainer.startEpoch,
+                "best_valid_loss": trainer.best_valid_loss,
+            },
+            temporary_location,
+        )
+        os.replace(temporary_location, path)
+    finally:
+        if os.path.exists(temporary_location):
+            os.remove(temporary_location)
+
+
+def restore_checkpoint(trainer: "VideoTrainer") -> None:
+    checkpoint = torch.load(
+        trainer.epoch_checkpoint_path, map_location="cpu", weights_only=False
+    )
+    trainer.model.module.load_state_dict(checkpoint["module"])
+    trainer.optimization.load_state(checkpoint["optimization"])
+    trainer.num_batches_seen = checkpoint["num_batches_seen"]
+    trainer.startEpoch = checkpoint["startEpoch"]
+    trainer.best_valid_loss = checkpoint["best_valid_loss"]
+    trainer.ema = EMATracker.from_state(checkpoint["ema"], trainer.model.modules)
+
+
+@dataclasses.dataclass
+class VideoTrainerConfig:
+    """Configuration for the video diffusion Trainer."""
+
+    model: VideoDiffusionModelConfig
+    optimization: OptimizationConfig
+    train_data: PairedDataLoaderConfig
+    validation_data: PairedDataLoaderConfig
+    max_epochs: int
+    experiment_dir: str
+    logging: LoggingConfig
+    # Optional held-out test split, evaluated every test_interval epochs.
+    test_data: PairedDataLoaderConfig | None = None
+    test_interval: int = 10
+    save_checkpoints: bool = True
+    ema: EMAConfig = dataclasses.field(default_factory=EMAConfig)
+    validate_using_ema: bool = False
+    generate_n_samples: int = 1
+    # Number of val/test examples to visualize on W&B; 0 disables.
+    num_visualization_examples: int = 3
+    segment_epochs: int | None = None
+    validate_interval: int = 1
+    resume_results_dir: str | None = None
+    # Cap batches per train/val/test pass (None iterates the full loader).
+    max_train_batches: int | None = None
+    max_val_batches: int | None = None
+    max_test_batches: int | None = None
+    log_loss_vs_noise: bool = False
+
+    def __post_init__(self):
+        datasets = [
+            ("train_data", self.train_data),
+            ("validation_data", self.validation_data),
+        ]
+        if self.test_data is not None:
+            datasets.append(("test_data", self.test_data))
+        for name, data in datasets:
+            if data.n_timesteps != self.model.n_timesteps:
+                raise ValueError(
+                    f"{name}.n_timesteps ({data.n_timesteps}) must equal "
+                    f"model.n_timesteps ({self.model.n_timesteps})."
+                )
+
+    @property
+    def checkpoint_dir(self) -> str:
+        return os.path.join(self.experiment_dir, "checkpoints")
+
+    def build(self) -> "VideoTrainer":
+        requirements = self.model.data_requirements
+        train_data = self.train_data.build_video(train=True, requirements=requirements)
+        validation_data = self.validation_data.build_video(
+            train=False, requirements=requirements
+        )
+        test_data = (
+            self.test_data.build_video(train=False, requirements=requirements)
+            if self.test_data is not None
+            else None
+        )
+        model = self.model.build()
+        optimization = self.optimization.build(
+            modules=[model.module], max_epochs=self.max_epochs
+        )
+        return VideoTrainer(
+            model, optimization, train_data, validation_data, self, test_data
+        )
+
+    def configure_logging(self, log_filename: str):
+        config = to_flat_dict(dataclasses.asdict(self))
+        self.logging.configure_logging(
+            self.experiment_dir, log_filename, config=config, resumable=True
+        )
+
+
+class VideoTrainer:
+    def __init__(
+        self, model, optimization, train_data, validation_data, config, test_data=None
+    ):
+        self.model = model
+        self.optimization = optimization
+        self.null_optimization = NullOptimization()
+        self.train_data = train_data
+        self.validation_data = validation_data
+        self.test_data = test_data
+        self.config = config
+        self.ema = config.ema.build(self.model.modules)
+        self.validate_using_ema = config.validate_using_ema
+        self.num_batches_seen = 0
+        self.startEpoch = 0
+        self.segment_epochs = config.segment_epochs
+        self.best_valid_loss = float("inf")
+
+        wandb = WandB.get_instance()
+        wandb.watch(self.model.modules)
+
+        dist = Distributed.get_instance()
+        self.epoch_checkpoint_path: str | None = None
+        self.best_checkpoint_path: str | None = None
+        if config.save_checkpoints:
+            if dist.is_root():
+                os.makedirs(config.checkpoint_dir, exist_ok=True)
+                remove_stale_tmp_checkpoints(config.checkpoint_dir)
+            self.epoch_checkpoint_path = os.path.join(
+                config.checkpoint_dir, "latest.ckpt"
+            )
+            self.best_checkpoint_path = os.path.join(config.checkpoint_dir, "best.ckpt")
+
+    @property
+    def resuming(self) -> bool:
+        return self.epoch_checkpoint_path is not None and os.path.isfile(
+            self.epoch_checkpoint_path
+        )
+
+    @contextlib.contextmanager
+    def _ema_context(self):
+        self.ema.store(parameters=self.model.modules.parameters())
+        self.ema.copy_to(model=self.model.modules)
+        try:
+            yield
+        finally:
+            self.ema.restore(parameters=self.model.modules.parameters())
+
+    @contextlib.contextmanager
+    def _validation_context(self):
+        if self.validate_using_ema:
+            with self._ema_context():
+                yield
+        else:
+            yield
+
+    def train_one_epoch(self) -> None:
+        self.model.module.train()
+        wandb = WandB.get_instance()
+        loss_vs_noise = (
+            LossVsNoiseAggregator() if self.config.log_loss_vs_noise else None
+        )
+        batch: PairedVideoBatchData
+        epoch_loss = 0.0
+        n_batches = 0
+        for i, batch in enumerate(self.train_data.loader):
+            if (
+                self.config.max_train_batches is not None
+                and i >= self.config.max_train_batches
+            ):
+                break
+            self.num_batches_seen += 1
+            outputs = self.model.train_on_batch(batch, self.optimization)
+            self.ema(self.model.modules)
+            if loss_vs_noise is not None:
+                loss_vs_noise.record_batch(outputs)
+            batch_loss = outputs.loss.detach().cpu().item()
+            epoch_loss += batch_loss
+            n_batches += 1
+            if i % 10 == 0:
+                logging.info(f"Training batch {i + 1}, loss {batch_loss:.4f}")
+            batch_logs = {"train/batch_loss": batch_loss}
+            if outputs.marginal_consistency_loss is not None:
+                batch_logs["train/marginal_consistency_loss"] = (
+                    outputs.marginal_consistency_loss.cpu().item()
+                )
+            wandb.log(batch_logs, step=self.num_batches_seen)
+        if n_batches == 0:
+            raise RuntimeError("Empty training batch generator")
+        self.optimization.step_scheduler(epoch_loss / n_batches)
+        logs = {"train/epoch_loss": epoch_loss / n_batches}
+        if loss_vs_noise is not None:
+            logs.update(loss_vs_noise.get_wandb(prefix="train"))
+        wandb.log(logs, step=self.num_batches_seen)
+
+    @torch.no_grad()
+    def valid_one_epoch(self) -> dict[str, float]:
+        self.model.module.eval()
+        total_loss = 0.0
+        total_gen_mae = 0.0
+        loss_vs_noise = (
+            LossVsNoiseAggregator() if self.config.log_loss_vs_noise else None
+        )
+        n_batches = 0
+        with self._validation_context():
+            for j, batch in enumerate(self.validation_data.loader):
+                if (
+                    self.config.max_val_batches is not None
+                    and j >= self.config.max_val_batches
+                ):
+                    break
+                outputs = self.model.train_on_batch(batch, self.null_optimization)
+                if loss_vs_noise is not None:
+                    loss_vs_noise.record_batch(outputs)
+                total_loss += outputs.loss.detach().cpu().item()
+                total_gen_mae += self._interior_generation_mae(batch)
+                n_batches += 1
+        # Reduce across ranks; all ranks must reach this collective (empty check
+        # uses the global count to avoid deadlocking at the WandB.log barrier).
+        stats = torch.tensor(
+            [total_loss, total_gen_mae, float(n_batches)], device=get_device()
+        )
+        Distributed.get_instance().reduce_sum(stats)
+        total_loss, total_gen_mae, n_total = stats.tolist()
+        if n_total == 0:
+            raise RuntimeError("Empty validation batch generator")
+        summary = {
+            "validation/loss": total_loss / n_total,
+            "validation/interior_mae": total_gen_mae / n_total,
+        }
+        logs = dict(summary)
+        if loss_vs_noise is not None:
+            logs.update(loss_vs_noise.get_wandb(prefix="validation"))
+        WandB.get_instance().log(logs, step=self.num_batches_seen)
+        return summary
+
+    def _interior_generation_mae(self, batch: PairedVideoBatchData) -> float:
+        """Ensemble-mean MAE over the generated interior frames."""
+        generated = self.model.generate(batch, n_samples=self.config.generate_n_samples)
+        n_times = self.model.n_timesteps
+        errors = []
+        for name, samples in generated.items():
+            ens_mean = samples.mean(dim=1)
+            truth = batch.fine.data[name].to(ens_mean.device)
+            interior = slice(1, n_times - 1)
+            errors.append(
+                (ens_mean[:, interior] - truth[:, interior]).abs().mean().item()
+            )
+        return sum(errors) / len(errors)
+
+    @torch.no_grad()
+    def log_validation_visualizations(self) -> None:
+        """Log GT-vs-prediction frame grids for a few val examples to W&B.
+
+        Called by all ranks for the WandB.log barrier; only root logs figures.
+        """
+        if self.config.num_visualization_examples <= 0:
+            return
+        dist = Distributed.get_instance()
+        wandb = WandB.get_instance()
+        self.model.module.eval()
+        with self._validation_context():
+            batch = next(iter(self.validation_data.loader))
+            generated = self.model.generate(batch, n_samples=1)
+        logs: dict = {}
+        if dist.is_root() and wandb.enabled:
+            import matplotlib.pyplot as plt
+
+            n = min(self.config.num_visualization_examples, len(batch.fine))
+            for i in range(n):
+                for name in self.model.out_names:
+                    gt = batch.fine.data[name][i].float().cpu()
+                    pred = generated[name][i, 0].float().cpu()
+                    fig = _video_comparison_figure(gt, pred, name, i)
+                    logs[f"val_viz/example_{i}/{name}"] = wandb.Image(fig)
+                    plt.close(fig)
+        wandb.log(logs, step=self.num_batches_seen)
+
+    @torch.no_grad()
+    def evaluate_test(self) -> None:
+        """Evaluate the held-out test set: metrics + visualizations to W&B.
+
+        Per-channel MAE/RMSE, relative error, and improvement over the linear
+        baseline, summed across ranks. Called by all ranks; only root logs.
+        """
+        if self.test_data is None:
+            return
+        dist = Distributed.get_instance()
+        wandb = WandB.get_instance()
+        self.model.module.eval()
+        names = self.model.out_names
+        interior = slice(1, self.model.n_timesteps - 1)
+        # per channel: [sum|err_model|, sum err_model^2, sum|err_linear|, count]
+        acc = torch.zeros(len(names), 4, device=get_device())
+        viz = None
+        with self._validation_context():
+            for b, batch in enumerate(self.test_data.loader):
+                if (
+                    self.config.max_test_batches is not None
+                    and b >= self.config.max_test_batches
+                ):
+                    break
+                generated = self.model.generate(
+                    batch, n_samples=self.config.generate_n_samples
+                )
+                for c, name in enumerate(names):
+                    gt = batch.fine.data[name].float()
+                    pred = generated[name].float().mean(dim=1)
+                    lin = _linear_interp_endpoints(gt)
+                    gi, pi, li = gt[:, interior], pred[:, interior], lin[:, interior]
+                    acc[c, 0] += (pi - gi).abs().sum()
+                    acc[c, 1] += (pi - gi).pow(2).sum()
+                    acc[c, 2] += (li - gi).abs().sum()
+                    acc[c, 3] += gi.numel()
+                if b == 0 and dist.is_root():
+                    viz = (batch, generated)
+        dist.reduce_sum(acc)
+
+        logs: dict = {}
+        for c, name in enumerate(names):
+            s_abs, s_sq, s_abs_lin, count = acc[c].tolist()
+            if count == 0:
+                continue
+            mae = s_abs / count
+            rmse = (s_sq / count) ** 0.5
+            mae_linear = s_abs_lin / count
+            std = float(self.model.normalizer.stds[name].item())
+            logs[f"test/{name}/mae"] = mae
+            logs[f"test/{name}/rmse"] = rmse
+            logs[f"test/{name}/rel_mae_pct"] = 100 * mae / std
+            logs[f"test/{name}/rel_rmse_pct"] = 100 * rmse / std
+            logs[f"test/{name}/linear_mae"] = mae_linear
+            logs[f"test/{name}/mae_improvement_vs_linear_pct"] = (
+                100 * (mae_linear - mae) / mae_linear if mae_linear else 0.0
+            )
+
+        if dist.is_root() and wandb.enabled and viz is not None:
+            import matplotlib.pyplot as plt
+
+            batch, generated = viz
+            n = min(self.config.num_visualization_examples, len(batch.fine))
+            for i in range(n):
+                for name in names:
+                    gt = batch.fine.data[name][i].float().cpu()
+                    pred = generated[name][i].float().mean(dim=0).cpu()
+                    fig = _video_comparison_figure(gt, pred, name, i)
+                    logs[f"test_viz/example_{i}/{name}"] = wandb.Image(fig)
+                    plt.close(fig)
+        wandb.log(logs, step=self.num_batches_seen)
+
+    def save_best_checkpoint(self, summary: dict[str, float]) -> None:
+        if self.best_checkpoint_path is None:
+            return
+        context = (
+            self._ema_context if self.validate_using_ema else contextlib.nullcontext
+        )
+        if summary["validation/loss"] < self.best_valid_loss:
+            logging.info("Saving best checkpoint")
+            self.best_valid_loss = summary["validation/loss"]
+            with context():
+                _save_checkpoint(self, self.best_checkpoint_path)
+
+    def save_epoch_checkpoint(self) -> None:
+        if self.epoch_checkpoint_path is not None:
+            _save_checkpoint(self, self.epoch_checkpoint_path)
+
+    def train(self) -> None:
+        logging.info("Running initial validation.")
+        self.valid_one_epoch()
+        wandb = WandB.get_instance()
+        dist = Distributed.get_instance()
+
+        if self.segment_epochs is None:
+            segment_max_epochs = self.config.max_epochs
+        else:
+            segment_max_epochs = min(
+                self.startEpoch + self.segment_epochs, self.config.max_epochs
+            )
+
+        for epoch in range(self.startEpoch, segment_max_epochs):
+            logging.info(f"Training epoch {epoch + 1}")
+            start = time.time()
+            self.train_one_epoch()
+            self.startEpoch = epoch + 1
+            wandb.log({"epoch": epoch}, step=self.num_batches_seen)
+            if epoch % self.config.validate_interval == 0:
+                summary = self.valid_one_epoch()
+                if dist.is_root() and self.config.save_checkpoints:
+                    self.save_best_checkpoint(summary)
+                self.log_validation_visualizations()  # all ranks (barrier-safe)
+            if epoch % self.config.test_interval == 0:
+                self.evaluate_test()  # all ranks (barrier-safe)
+            if dist.is_root() and self.config.save_checkpoints:
+                self.save_epoch_checkpoint()
+            wandb.log(
+                {"epoch_seconds": time.time() - start}, step=self.num_batches_seen
+            )
+
+
+def _resume_from_results_dir_if_not_preempted(experiment_dir, resume_results_dir):
+    resuming_from_preempt = os.path.isfile(
+        os.path.join(experiment_dir, "checkpoints/latest.ckpt")
+    )
+    if not os.path.isdir(experiment_dir):
+        os.makedirs(experiment_dir, exist_ok=True)
+    if resume_results_dir is not None and not resuming_from_preempt:
+        if not os.path.isdir(resume_results_dir):
+            raise ValueError(
+                f"Existing results directory {resume_results_dir} does not exist."
+            )
+        shutil.copytree(resume_results_dir, experiment_dir, dirs_exist_ok=True)
+        remove_stale_tmp_checkpoints(os.path.join(experiment_dir, "checkpoints"))
+
+
+def main(config_path: str):
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    train_config: VideoTrainerConfig = dacite.from_dict(
+        data_class=VideoTrainerConfig,
+        data=config,
+        config=dacite.Config(strict=True),
+    )
+
+    if train_config.resume_results_dir is not None:
+        _resume_from_results_dir_if_not_preempted(
+            experiment_dir=train_config.experiment_dir,
+            resume_results_dir=train_config.resume_results_dir,
+        )
+    prepare_directory(train_config.experiment_dir, config)
+    train_config.configure_logging(log_filename="out.log")
+    logging.info("Starting video diffusion training")
+    trainer = train_config.build()
+    if trainer.resuming:
+        logging.info(f"Resuming training from {trainer.epoch_checkpoint_path}")
+        restore_checkpoint(trainer)
+    logging.info(f"Number of parameters: {count_parameters(trainer.model.modules)}")
+    trainer.train()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Video downscaling train script")
+    parser.add_argument("config_path", type=str, help="Path to the config file")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    with Distributed.context():
+        main(args.config_path)


### PR DESCRIPTION
Adds an endpoint-conditioned video diffusion model ("video PMD") for temporal
interpolation: given two observed daily snapshots (e.g. 0h/24h), it diffuses
only the residual over a linear-interpolation baseline to infill 3-hourly
interior frames, with endpoints pinned exactly. Includes per-channel temporal
noise kernels (Brownian-bridge/OU/RBF), subset-frame training so the model can
answer variable query sets, and an optional marginal-consistency loss (L_marg)
that penalizes disagreement between full-grid and subset predictions sharing
the same noise. Two interchangeable backbones: a compact periodic VideoUNet,
and a SongUNetv2 wrapper with temporal attention injected via forward hooks.

Changes:
- `fme.downscaling.noise`: Brownian-bridge, OU, and RBF temporal noise-mixing
  kernels, optionally one per channel.
- `fme.downscaling.modules.video_modules.VideoUNet`/`VideoEDMPrecond`: compact
  5-D (B, C, T, H, W) backbone with calendar embedding and temporal attention.
- `fme.downscaling.modules.video_song_unet.VideoSongUNet`: SongUNetv2 wrapped
  for video via forward-hook temporal attention; `physicsnemo_unets_v2.Conv2d`
  gains a `periodic` flag for longitude-circular padding on global fields (and
  a guard against the untested up/down resample-filter case, currently inert).
- `fme.downscaling.video_models.VideoDiffusionModel`/`VideoDiffusionModelConfig`:
  the model itself, including subset-frame generation and the L_marg loss.
- `fme.downscaling.data.config.PairedDataLoaderConfig.build_video`: paired
  fine/coarse video-clip data loading.
- `fme.downscaling.aggregators.main.LossVsNoiseAggregator`: accepts a
  per-channel sigma; the shared-sigma "all_channels" total is now a per-sample
  sum across channels rather than a mean (see class docstring) -- historical
  wandb `loss_vs_noise/all_channels` curves logged before this change are on a
  different scale.
- `fme.downscaling.video_train`: training entry point (checkpointing, EMA,
  wandb visualization panels, optional held-out test split).
- `fme.downscaling.video_inference`: test-set ensemble inference from a
  trained checkpoint, writing a zarr store matching the input format.
- `fme.core.logging_utils.LoggingConfig`: optional `name` field for the wandb
  run display name.
- `configs/experiments/2026-*-video-pmd-*`: dated run configs from the sweep
  that developed this model.
- `configs/baselines/downscaling-temporal/train.yaml`: canonical reference
  config (5-channel, per-channel OU kernel, subset-frame training).

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)
