### PR TITLE
Add video diffusion model backbones and VideoDiffusionModel

### DIFF
--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -47,6 +47,8 @@ class ModelOutputs:
     channel_losses: TensorDict = dataclasses.field(default_factory=dict)
     sigma: torch.Tensor | None = None
     per_sample_channel_loss: TensorDict = dataclasses.field(default_factory=dict)
+    # Optional marginal-consistency term (video PMD), for logging only.
+    marginal_consistency_loss: torch.Tensor | None = None
 
 
 def _rename_normalizer(

--- a/fme/downscaling/models.py
+++ b/fme/downscaling/models.py
@@ -47,8 +47,6 @@ class ModelOutputs:
     channel_losses: TensorDict = dataclasses.field(default_factory=dict)
     sigma: torch.Tensor | None = None
     per_sample_channel_loss: TensorDict = dataclasses.field(default_factory=dict)
-    # Optional marginal-consistency term (video PMD), for logging only.
-    marginal_consistency_loss: torch.Tensor | None = None
 
 
 def _rename_normalizer(

--- a/fme/downscaling/modules/physicsnemo_unets_v2/layers.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v2/layers.py
@@ -181,6 +181,7 @@ class Conv2d(torch.nn.Module):
         init_bias: float = 0.0,
         fused_conv_bias: bool = False,
         amp_mode: bool = False,
+        periodic: bool = False,
     ):
         if up and down:
             raise ValueError("Both 'up' and 'down' cannot be true at the same time.")
@@ -199,6 +200,10 @@ class Conv2d(torch.nn.Module):
         self.fused_resample = fused_resample
         self.fused_conv_bias = fused_conv_bias
         self.amp_mode = amp_mode
+        # When True, the main 3x3 conv pads circularly in W (longitude) and zero
+        # in H (latitude) instead of symmetric zero padding -- for global lat/lon
+        # fields. Off by default, so the standard (image) path is unchanged.
+        self.periodic = periodic
         init_kwargs = dict(
             mode=init_mode,
             fan_in=in_channels * kernel * kernel,
@@ -240,6 +245,18 @@ class Conv2d(torch.nn.Module):
         f = resample_filter if resample_filter is not None else None
         w_pad = w.shape[-1] // 2 if w is not None else 0
         f_pad = (f.shape[-1] - 1) // 2 if f is not None else 0
+        if self.periodic and f_pad > 0:
+            # Only the main (odd-kernel) weight-conv branch below implements
+            # circular padding in W. The up/down resample-filter convs above
+            # still zero-pad, which is silently fine today only because the
+            # default resample_filter=[1, 1] gives f_pad=0 (no padding at
+            # all). Fail loudly rather than silently reintroducing a
+            # longitude discontinuity if a wider resample_filter is ever used
+            # with periodic=True.
+            raise NotImplementedError(
+                "periodic=True is not implemented for up/down-sampling with "
+                f"a resample_filter wider than 2 taps (got f_pad={f_pad})."
+            )
 
         if self.fused_resample and self.up and w is not None:
             x = torch.nn.functional.conv_transpose2d(
@@ -290,10 +307,17 @@ class Conv2d(torch.nn.Module):
                     padding=f_pad,
                 )
             if w is not None:  # ask in corrdiff channel whether w will ever be none
-                if self.fused_conv_bias:
-                    x = torch.nn.functional.conv2d(x, w, padding=w_pad, bias=b)
+                if self.periodic and w_pad > 0:
+                    # circular in longitude (W), zero in latitude (H)
+                    x = torch.cat([x[..., -w_pad:], x, x[..., :w_pad]], dim=-1)
+                    x = torch.nn.functional.pad(x, (0, 0, w_pad, w_pad))
+                    pad = 0
                 else:
-                    x = torch.nn.functional.conv2d(x, w, padding=w_pad)
+                    pad = w_pad
+                if self.fused_conv_bias:
+                    x = torch.nn.functional.conv2d(x, w, padding=pad, bias=b)
+                else:
+                    x = torch.nn.functional.conv2d(x, w, padding=pad)
         if b is not None and not self.fused_conv_bias:
             x = x.add_(b.reshape(1, -1, 1, 1))
         return x

--- a/fme/downscaling/modules/physicsnemo_unets_v2/test_periodic.py
+++ b/fme/downscaling/modules/physicsnemo_unets_v2/test_periodic.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import Conv2d
+from fme.downscaling.modules.physicsnemo_unets_v2.unets import SongUNetv2
+
+
+def test_periodic_conv2d_is_circular_shift_equivariant_in_w():
+    conv = Conv2d(in_channels=2, out_channels=2, kernel=3, periodic=True)
+    x = torch.randn(1, 2, 6, 8)
+    x_rolled = torch.roll(x, shifts=3, dims=-1)
+
+    y = conv(x)
+    y_from_rolled = conv(x_rolled)
+
+    torch.testing.assert_close(y_from_rolled, torch.roll(y, shifts=3, dims=-1))
+
+
+def test_periodic_conv2d_up_down_resample_guard():
+    """The main (odd-kernel) conv branch implements circular padding, but the
+    up/down resample-filter branches do not. With the default 2-tap
+    resample_filter ([1, 1], f_pad=0) that branch never pads, so the gap is
+    inert -- this locks in the guard that fails loudly if a wider filter
+    (f_pad > 0) is ever combined with periodic=True, instead of silently
+    reintroducing a zero-padding discontinuity at the antimeridian.
+    """
+    conv = Conv2d(
+        in_channels=2,
+        out_channels=2,
+        kernel=3,
+        down=True,
+        resample_filter=[1, 3, 3, 1],
+        periodic=True,
+    )
+    with pytest.raises(NotImplementedError):
+        conv(torch.randn(1, 2, 8, 8))
+
+
+def test_periodic_songunet_is_circular_shift_equivariant_in_w():
+    """End-to-end check that setting periodic=True on every Conv2d in a
+    SongUNetv2 (as VideoSongUNet does) makes the whole network -- including
+    its up/down-sampling blocks -- circular-shift equivariant in longitude,
+    not just the main conv branch tested in isolation above.
+    """
+    torch.manual_seed(0)
+    net = SongUNetv2(
+        img_resolution=[16, 16],
+        in_channels=3,
+        out_channels=3,
+        model_channels=8,
+        channel_mult=[1, 2],
+        num_blocks=1,
+        attn_resolutions=[],
+        use_apex_gn=False,
+    )
+    for m in net.modules():
+        if isinstance(m, Conv2d):
+            m.periodic = True
+    net.eval()
+
+    x = torch.randn(1, 3, 16, 16)
+    shift = 4  # multiple of the deepest stride (2) to stay phase-aligned
+    x_rolled = torch.roll(x, shifts=shift, dims=-1)
+
+    with torch.no_grad():
+        y = net(x, noise_labels=torch.zeros(1), class_labels=None)
+        y_from_rolled = net(x_rolled, noise_labels=torch.zeros(1), class_labels=None)
+
+    torch.testing.assert_close(
+        y_from_rolled, torch.roll(y, shifts=shift, dims=-1), atol=1e-5, rtol=1e-5
+    )

--- a/fme/downscaling/modules/video_modules.py
+++ b/fme/downscaling/modules/video_modules.py
@@ -5,6 +5,7 @@ and temporal attention, wrapped in EDM preconditioning (Karras 2022).
 """
 
 import math
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -21,7 +22,9 @@ class NoiseEmbedding(nn.Module):
     mapped through an MLP -- matches HiRO/SongUNet noise conditioning.
     """
 
-    def __init__(self, dim: int, embedding_type: str = "positional"):
+    def __init__(
+        self, dim: int, embedding_type: Literal["positional", "fourier"] = "positional"
+    ):
         super().__init__()
         if dim % 2 != 0:
             raise ValueError("NoiseEmbedding dim must be even.")
@@ -315,7 +318,7 @@ class VideoUNet(nn.Module):
         attention_levels: tuple[int, ...] = (1, 2),
         temporal_attention_levels: tuple[int, ...] | None = None,
         num_freqs: int = 4,
-        noise_embedding_type: str = "positional",
+        noise_embedding_type: Literal["positional", "fourier"] = "positional",
     ):
         super().__init__()
         self.levels = len(channel_mult)

--- a/fme/downscaling/modules/video_modules.py
+++ b/fme/downscaling/modules/video_modules.py
@@ -1,0 +1,477 @@
+"""Network building blocks for video (temporal) diffusion downscaling.
+
+Compact 5-D ``(B, C, T, H, W)`` backbone with cBottle-style calendar embedding
+and temporal attention, wrapped in EDM preconditioning (Karras 2022).
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import (
+    FourierEmbedding,
+    PositionalEmbedding,
+)
+
+
+class NoiseEmbedding(nn.Module):
+    """Positional (DDPM++) or Fourier (NCSN++) embedding of the log-noise level,
+    mapped through an MLP -- matches HiRO/SongUNet noise conditioning.
+    """
+
+    def __init__(self, dim: int, embedding_type: str = "positional"):
+        super().__init__()
+        if dim % 2 != 0:
+            raise ValueError("NoiseEmbedding dim must be even.")
+        if embedding_type == "fourier":
+            self.embed: nn.Module = FourierEmbedding(dim)
+        elif embedding_type == "positional":
+            self.embed = PositionalEmbedding(dim)
+        else:
+            raise ValueError(f"unknown noise embedding_type {embedding_type!r}")
+        self.mlp = nn.Sequential(nn.Linear(dim, dim), nn.SiLU(), nn.Linear(dim, dim))
+
+    def forward(self, c_noise: torch.Tensor) -> torch.Tensor:
+        return self.mlp(self.embed(c_noise.float()))
+
+
+class FrequencyEmbedding(nn.Module):
+    """Periodic sinusoidal encoding on the circle for x in [0, 1)."""
+
+    def __init__(self, num_freqs: int):
+        super().__init__()
+        self.num_freqs = num_freqs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        k = torch.arange(1, self.num_freqs + 1, device=x.device, dtype=x.dtype)
+        ang = 2 * math.pi * x.unsqueeze(-1) * k
+        return torch.cat([ang.cos(), ang.sin()], dim=-1)
+
+
+class CalendarEmbedding(nn.Module):
+    """cBottle-style absolute-time embedding (diurnal + seasonal).
+
+    ``second_of_day`` is shifted by longitude into local solar time so the
+    diurnal phase is correct per pixel.
+    """
+
+    def __init__(self, num_freqs: int = 4):
+        super().__init__()
+        self.embed = FrequencyEmbedding(num_freqs)
+        self.out_channels = 4 * num_freqs
+
+    def forward(
+        self,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        height: int,
+    ) -> torch.Tensor:
+        lon = lon.to(second_of_day.device, second_of_day.dtype)
+        local = second_of_day[:, :, None] + lon[None, None, :] * 86400.0 / 360.0
+        local = local % 86400.0
+        diurnal = self.embed(local / 86400.0)
+        diurnal = diurnal.permute(0, 3, 1, 2)
+        diurnal = diurnal.unsqueeze(3).expand(-1, -1, -1, height, -1)
+
+        seasonal = self.embed((day_of_year / 365.25) % 1.0)
+        seasonal = seasonal.permute(0, 2, 1)[:, :, :, None, None]
+        seasonal = seasonal.expand(-1, -1, -1, height, diurnal.shape[-1])
+        return torch.cat([diurnal, seasonal], dim=1)
+
+
+def _groups(channels: int) -> int:
+    g = min(32, channels)
+    while channels % g != 0:
+        g -= 1
+    return g
+
+
+class PeriodicConv3d(nn.Module):
+    """Per-frame spatial Conv3d, periodic in longitude (W) and zero-padded in
+    latitude (H) for global lat/lon fields.
+    """
+
+    def __init__(self, in_ch, out_ch, kernel=(1, 3, 3), stride=(1, 1, 1)):
+        super().__init__()
+        self.ph = kernel[1] // 2
+        self.pw = kernel[2] // 2
+        self.conv = nn.Conv3d(in_ch, out_ch, kernel, stride=stride, padding=0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.pw:
+            x = torch.cat([x[..., -self.pw :], x, x[..., : self.pw]], dim=-1)
+        if self.ph:
+            x = F.pad(x, (0, 0, self.ph, self.ph))
+        return self.conv(x)
+
+
+class ResBlock(nn.Module):
+    """Per-frame spatial residual block with adaptive GroupNorm (AdaGN)
+    noise-level conditioning and ``1/sqrt(2)`` skip scaling (cBottle/EDM style).
+    """
+
+    def __init__(self, in_ch: int, out_ch: int, emb_dim: int, skip_scale=2**-0.5):
+        super().__init__()
+        self.norm1 = nn.GroupNorm(_groups(in_ch), in_ch)
+        self.conv1 = PeriodicConv3d(in_ch, out_ch)
+        self.emb = nn.Linear(emb_dim, 2 * out_ch)
+        self.norm2 = nn.GroupNorm(_groups(out_ch), out_ch)
+        self.conv2 = PeriodicConv3d(out_ch, out_ch)
+        self.skip = nn.Conv3d(in_ch, out_ch, 1) if in_ch != out_ch else nn.Identity()
+        self.skip_scale = skip_scale
+
+    def forward(self, x: torch.Tensor, emb: torch.Tensor) -> torch.Tensor:
+        h = self.conv1(F.silu(self.norm1(x)))
+        scale, shift = self.emb(emb)[:, :, None, None, None].chunk(2, dim=1)
+        h = self.conv2(F.silu(self.norm2(h) * (1 + scale) + shift))
+        return (self.skip(x) + h) * self.skip_scale
+
+
+class TemporalAttention(nn.Module):
+    """Self-attention along the time axis with learned relative-position bias.
+
+    Each pixel attends across all ``T`` frames; output projection is
+    zero-initialized so the block starts as near-identity.
+    """
+
+    def __init__(self, channels: int, n_heads: int, seq_length: int):
+        super().__init__()
+        if channels % n_heads != 0:
+            raise ValueError("channels must be divisible by n_heads.")
+        self.n_heads = n_heads
+        self.seq_length = seq_length
+        self.norm = nn.GroupNorm(min(32, channels), channels)
+        self.qkv = nn.Conv3d(channels, channels * 3, 1)
+        self.proj = nn.Conv3d(channels, channels, 1)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+        self.relative_embedding = nn.Parameter(torch.zeros(n_heads, 2 * seq_length))
+
+    def forward(
+        self, x: torch.Tensor, frame_index: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        B, C, T, H, W = x.shape
+        if T > self.seq_length:
+            raise ValueError(
+                f"clip length {T} exceeds configured seq_length {self.seq_length}."
+            )
+        cdim = C // self.n_heads
+        qkv = self.qkv(self.norm(x))
+        q, k, v = qkv.chunk(3, dim=1)
+
+        def reshape(t):
+            t = t.reshape(B, self.n_heads, cdim, T, H, W)
+            return t.permute(0, 4, 5, 1, 3, 2).reshape(B * H * W, self.n_heads, T, cdim)
+
+        q, k, v = reshape(q), reshape(k), reshape(v)
+        attn = torch.einsum("nhqc,nhkc->nhqk", q, k) / math.sqrt(cdim)
+        # ``frame_index`` gives each frame's position on the full n_timesteps grid,
+        # so the learned relative bias reflects true frame spacing. For a subset it
+        # is the frames' true grid indices (e.g. [0, 4, 8]); the default arange is
+        # the full grid, identical to the pre-subset behavior.
+        if frame_index is None:
+            i = torch.arange(T, device=x.device)
+        else:
+            if frame_index.numel() != T:
+                raise ValueError(
+                    f"frame_index length {frame_index.numel()} != clip length {T}."
+                )
+            i = frame_index.to(device=x.device, dtype=torch.long)
+        pairwise = (i[:, None] - i[None, :]) + self.seq_length - 1
+        bias = self.relative_embedding[:, pairwise]
+        attn = (attn + bias[None]).softmax(dim=-1)
+        out = torch.einsum("nhqk,nhkc->nhqc", attn, v)
+        out = out.reshape(B, H, W, self.n_heads, T, cdim)
+        out = out.permute(0, 3, 5, 4, 1, 2).reshape(B, C, T, H, W)
+        return x + self.proj(out)
+
+
+class SpatialAttention(nn.Module):
+    """Multi-head self-attention over the spatial (H*W) plane, per frame.
+
+    Cost is O((H*W)^2), so use at coarser levels only; output projection is
+    zero-initialized so the block starts as near-identity.
+    """
+
+    def __init__(self, channels: int, n_heads: int):
+        super().__init__()
+        if channels % n_heads != 0:
+            raise ValueError("channels must be divisible by n_heads.")
+        self.n_heads = n_heads
+        self.norm = nn.GroupNorm(_groups(channels), channels)
+        self.qkv = nn.Conv3d(channels, channels * 3, 1)
+        self.proj = nn.Conv3d(channels, channels, 1)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, C, T, H, W = x.shape
+        cdim = C // self.n_heads
+        qkv = self.qkv(self.norm(x))
+        q, k, v = qkv.chunk(3, dim=1)
+
+        def reshape(t):
+            t = t.reshape(B, self.n_heads, cdim, T, H * W)
+            return t.permute(0, 3, 1, 4, 2).reshape(B * T, self.n_heads, H * W, cdim)
+
+        q, k, v = reshape(q), reshape(k), reshape(v)
+        attn = torch.einsum("nhqc,nhkc->nhqk", q, k) / math.sqrt(cdim)
+        attn = attn.softmax(dim=-1)
+        out = torch.einsum("nhqk,nhkc->nhqc", attn, v)
+        out = out.reshape(B, T, self.n_heads, H, W, cdim)
+        out = out.permute(0, 2, 5, 1, 3, 4).reshape(B, C, T, H, W)
+        return x + self.proj(out)
+
+
+class _BlockAttn(nn.Module):
+    """Optional spatial and/or temporal self-attention for a U-Net block.
+
+    Temporal attention is cheap and runs at every level so time is mixed
+    throughout; spatial attention is restricted to coarse levels.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        n_heads: int,
+        seq_length: int,
+        spatial: bool,
+        temporal: bool,
+    ):
+        super().__init__()
+        self.spatial = SpatialAttention(channels, n_heads) if spatial else None
+        self.temporal = (
+            TemporalAttention(channels, n_heads, seq_length) if temporal else None
+        )
+
+    def forward(
+        self, x: torch.Tensor, frame_index: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        if self.spatial is not None:
+            x = self.spatial(x)
+        if self.temporal is not None:
+            x = self.temporal(x, frame_index)
+        return x
+
+
+class FIRBlur(nn.Module):
+    """Depthwise binomial (FIR) low-pass applied per frame, periodic in longitude.
+
+    Anti-aliases before down-sampling and smooths after up-sampling. The kernel
+    is a fixed constant buffer, so it is identical on every rank (DDP-safe).
+    """
+
+    def __init__(self):
+        super().__init__()
+        f = torch.tensor([1.0, 2.0, 1.0])
+        k = torch.outer(f, f)
+        self.register_buffer("kernel", (k / k.sum())[None, None, None])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        c = x.shape[1]
+        # Materialize the conv weight into its own storage rather than an
+        # ``expand`` view of ``kernel``. Under DDP (broadcast_buffers=True) each
+        # forward re-syncs buffers with an in-place copy_ into ``kernel``; if two
+        # forwards run before one backward (e.g. the marginal-consistency loss),
+        # the second forward's sync would bump the shared buffer's version and
+        # invalidate the first forward's saved-for-backward weight. A copy
+        # decouples each forward's weight from the mutated buffer.
+        w = self.kernel.expand(c, 1, 1, 3, 3).contiguous()
+        x = torch.cat([x[..., -1:], x, x[..., :1]], dim=-1)
+        x = F.pad(x, (0, 0, 1, 1))
+        return F.conv3d(x, w, groups=c)
+
+
+def _resize_spatial(
+    x: torch.Tensor, size, blur: nn.Module | None = None
+) -> torch.Tensor:
+    """Resize the (H, W) of a (B, C, T, H, W) tensor to ``size`` (keeps T),
+    with an optional FIR low-pass applied only when the size actually changes.
+    """
+    if tuple(x.shape[-2:]) == tuple(size):
+        return x
+    x = F.interpolate(x, size=(x.shape[2], size[0], size[1]), mode="nearest")
+    return blur(x) if blur is not None else x
+
+
+class VideoUNet(nn.Module):
+    """Multi-scale video denoiser: per-frame conv U-Net with spatial + temporal
+    self-attention (cBottle-style). Down/up-sampling changes only (H, W); the
+    time axis is preserved and handled by ``TemporalAttention``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        seq_length: int,
+        model_channels: int = 64,
+        channel_mult: tuple[int, ...] = (1, 2, 2),
+        num_blocks: int = 2,
+        n_heads: int = 4,
+        attention_levels: tuple[int, ...] = (1, 2),
+        temporal_attention_levels: tuple[int, ...] | None = None,
+        num_freqs: int = 4,
+        noise_embedding_type: str = "positional",
+    ):
+        super().__init__()
+        self.levels = len(channel_mult)
+        self.num_blocks = num_blocks
+        emb_dim = model_channels
+        self.noise_embed = NoiseEmbedding(model_channels, noise_embedding_type)
+        self.blur = FIRBlur()
+        self.calendar = CalendarEmbedding(num_freqs)
+        chs = [model_channels * m for m in channel_mult]
+        attn_spatial = set(attention_levels)
+        attn_temporal = (
+            set(temporal_attention_levels)
+            if temporal_attention_levels is not None
+            else set(range(self.levels))
+        )
+
+        self.in_conv = PeriodicConv3d(in_channels + self.calendar.out_channels, chs[0])
+
+        self.enc_blocks = nn.ModuleList()
+        self.enc_attn = nn.ModuleList()
+        self.downsamples = nn.ModuleList()
+        skip_ch = [chs[0]]
+        ch = chs[0]
+        for level in range(self.levels):
+            for _ in range(num_blocks):
+                self.enc_blocks.append(ResBlock(ch, chs[level], emb_dim))
+                ch = chs[level]
+                self.enc_attn.append(
+                    _BlockAttn(
+                        ch,
+                        n_heads,
+                        seq_length,
+                        level in attn_spatial,
+                        level in attn_temporal,
+                    )
+                )
+                skip_ch.append(ch)
+            if level < self.levels - 1:
+                self.downsamples.append(
+                    PeriodicConv3d(ch, ch, (1, 3, 3), stride=(1, 2, 2))
+                )
+                skip_ch.append(ch)
+
+        self.mid_block1 = ResBlock(ch, ch, emb_dim)
+        self.mid_attn = _BlockAttn(ch, n_heads, seq_length, True, True)
+        self.mid_block2 = ResBlock(ch, ch, emb_dim)
+
+        self.dec_blocks = nn.ModuleList()
+        self.dec_attn = nn.ModuleList()
+        for level in reversed(range(self.levels)):
+            for _ in range(num_blocks + 1):
+                sch = skip_ch.pop()
+                self.dec_blocks.append(ResBlock(ch + sch, chs[level], emb_dim))
+                ch = chs[level]
+                self.dec_attn.append(
+                    _BlockAttn(
+                        ch,
+                        n_heads,
+                        seq_length,
+                        level in attn_spatial,
+                        level in attn_temporal,
+                    )
+                )
+
+        self.out_norm = nn.GroupNorm(_groups(ch), ch)
+        self.out_conv = PeriodicConv3d(ch, out_channels)
+        nn.init.zeros_(self.out_conv.conv.weight)
+        nn.init.zeros_(self.out_conv.conv.bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        c_noise: torch.Tensor,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        frame_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        cal = self.calendar(day_of_year, second_of_day, lon, x.shape[-2])
+        emb = self.noise_embed(c_noise)
+        h = self.in_conv(torch.cat([x, cal], dim=1))
+
+        skips = [h]
+        idx = 0
+        for level in range(self.levels):
+            for _ in range(self.num_blocks):
+                h = self.enc_attn[idx](self.enc_blocks[idx](h, emb), frame_index)
+                skips.append(h)
+                idx += 1
+            if level < self.levels - 1:
+                h = self.downsamples[level](self.blur(h))
+                skips.append(h)
+
+        h = self.mid_block1(h, emb)
+        h = self.mid_block2(self.mid_attn(h, frame_index), emb)
+
+        for idx in range(len(self.dec_blocks)):
+            skip = skips.pop()
+            h = torch.cat([_resize_spatial(h, skip.shape[-2:], self.blur), skip], dim=1)
+            h = self.dec_attn[idx](self.dec_blocks[idx](h, emb), frame_index)
+
+        return self.out_conv(F.silu(self.out_norm(h)))
+
+
+class VideoEDMPrecond(nn.Module):
+    """EDM preconditioning (Karras 2022) for the 5-D video tensor."""
+
+    def __init__(self, model: VideoUNet, sigma_data: float | torch.Tensor = 1.0):
+        super().__init__()
+        self.model = model
+        # Scalar or per-channel; stored as a (1, C, 1, 1, 1) buffer (constant,
+        # so identical on every rank -> DDP-safe) that broadcasts against sigma.
+        if not isinstance(sigma_data, torch.Tensor):
+            sigma_data = torch.tensor([float(sigma_data)])
+        self.register_buffer("sigma_data", sigma_data.reshape(1, -1, 1, 1, 1))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        condition: torch.Tensor | None,
+        sigma: torch.Tensor,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        frame_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        x = x.to(torch.float32)
+        sigma = sigma.to(torch.float32)
+        if sigma.dim() == 0:
+            sigma = sigma.reshape(1, 1, 1, 1, 1)
+        elif sigma.dim() == 1:
+            if sigma.shape[0] == x.shape[0]:
+                sigma = sigma.reshape(-1, 1, 1, 1, 1)
+            elif sigma.shape[0] == x.shape[1]:
+                sigma = sigma.reshape(1, -1, 1, 1, 1)
+            else:
+                sigma = sigma.reshape(-1, 1, 1, 1, 1)
+        elif sigma.dim() == 2:
+            sigma = sigma.reshape(sigma.shape[0], sigma.shape[1], 1, 1, 1)
+        else:
+            sigma = sigma.reshape(*sigma.shape[:2], 1, 1, 1)
+        c_skip = self.sigma_data**2 / (sigma**2 + self.sigma_data**2)
+        c_out = sigma * self.sigma_data / (sigma**2 + self.sigma_data**2).sqrt()
+        c_in = 1 / (self.sigma_data**2 + sigma**2).sqrt()
+        if sigma.shape[1] == 1:
+            c_noise = (sigma.log() / 4).flatten()
+        else:
+            c_noise = sigma.log().mean(dim=1).flatten() / 4
+
+        arg = c_in * x
+        sigma_features = (sigma.log() / 4).expand(
+            x.shape[0], x.shape[1], x.shape[2], x.shape[3], x.shape[4]
+        )
+        if condition is not None:
+            arg = torch.cat([arg, condition, sigma_features], dim=1)
+        else:
+            arg = torch.cat([arg, sigma_features], dim=1)
+        f_x = self.model(arg, c_noise, day_of_year, second_of_day, lon, frame_index)
+        return c_skip * x + c_out * f_x

--- a/fme/downscaling/modules/video_song_unet.py
+++ b/fme/downscaling/modules/video_song_unet.py
@@ -2,6 +2,8 @@
 attention injected via forward hooks on the attention-resolution ``UNetBlock``s.
 """
 
+from typing import Literal
+
 import torch
 import torch.nn as nn
 
@@ -20,12 +22,26 @@ class VideoSongUNet(nn.Module):
         seq_length: int,
         model_channels: int = 128,
         channel_mult: tuple[int, ...] = (1, 2, 2, 2),
+        channel_mult_emb: int = 4,
+        channel_mult_noise: int = 1,
         num_blocks: int = 2,
         n_heads: int = 8,
         attn_resolutions: tuple[int, ...] = (22,),
         num_freqs: int = 4,
         periodic: bool = True,
+        dropout: float = 0.10,
+        label_dropout: float = 0.0,
+        embedding_type: Literal["fourier", "positional", "zero"] = "positional",
+        encoder_type: Literal["standard", "skip", "residual"] = "standard",
+        decoder_type: Literal["standard", "skip"] = "standard",
+        resample_filter: tuple[int, ...] = (1, 1),
+        checkpoint_level: int = 0,
+        additive_pos_embed: bool = False,
+        bottleneck_attention: bool = True,
         use_apex_gn: bool = False,
+        act: str = "silu",
+        profile_mode: bool = False,
+        amp_mode: bool = True,
     ):
         super().__init__()
         self.seq_length = seq_length
@@ -36,9 +52,23 @@ class VideoSongUNet(nn.Module):
             out_channels=out_channels,
             model_channels=model_channels,
             channel_mult=list(channel_mult),
+            channel_mult_emb=channel_mult_emb,
+            channel_mult_noise=channel_mult_noise,
             num_blocks=num_blocks,
             attn_resolutions=list(attn_resolutions),
+            dropout=dropout,
+            label_dropout=label_dropout,
+            embedding_type=embedding_type,
+            encoder_type=encoder_type,
+            decoder_type=decoder_type,
+            resample_filter=list(resample_filter),
+            checkpoint_level=checkpoint_level,
+            additive_pos_embed=additive_pos_embed,
+            bottleneck_attention=bottleneck_attention,
             use_apex_gn=use_apex_gn,
+            act=act,
+            profile_mode=profile_mode,
+            amp_mode=amp_mode,
         )
         if periodic:
             for m in self.unet.modules():

--- a/fme/downscaling/modules/video_song_unet.py
+++ b/fme/downscaling/modules/video_song_unet.py
@@ -1,0 +1,87 @@
+"""Video backbone: ACE/HiRO's ``SongUNetv2`` with cBottle-style temporal
+attention injected via forward hooks on the attention-resolution ``UNetBlock``s.
+"""
+
+import torch
+import torch.nn as nn
+
+from fme.downscaling.modules.physicsnemo_unets_v2 import SongUNetv2
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import Conv2d as _Conv2d
+from fme.downscaling.modules.physicsnemo_unets_v2.layers import UNetBlock
+from fme.downscaling.modules.video_modules import CalendarEmbedding, TemporalAttention
+
+
+class VideoSongUNet(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        img_resolution: list[int],
+        seq_length: int,
+        model_channels: int = 128,
+        channel_mult: tuple[int, ...] = (1, 2, 2, 2),
+        num_blocks: int = 2,
+        n_heads: int = 8,
+        attn_resolutions: tuple[int, ...] = (22,),
+        num_freqs: int = 4,
+        periodic: bool = True,
+    ):
+        super().__init__()
+        self.seq_length = seq_length
+        self.calendar = CalendarEmbedding(num_freqs)
+        self.unet = SongUNetv2(
+            img_resolution=list(img_resolution),
+            in_channels=in_channels + self.calendar.out_channels,
+            out_channels=out_channels,
+            model_channels=model_channels,
+            channel_mult=list(channel_mult),
+            num_blocks=num_blocks,
+            attn_resolutions=list(attn_resolutions),
+            use_apex_gn=False,
+        )
+        if periodic:
+            for m in self.unet.modules():
+                if isinstance(m, _Conv2d):
+                    m.periodic = True
+
+        self._temporal = nn.ModuleList()
+        self._bt = (1, 1)
+        self._frame_index: torch.Tensor | None = None
+        for name, block in list(self.unet.enc.items()) + list(self.unet.dec.items()):
+            if isinstance(block, UNetBlock) and getattr(block, "attention", False):
+                ta = TemporalAttention(block.out_channels, n_heads, seq_length)
+                self._temporal.append(ta)
+                block.register_forward_hook(self._make_hook(ta))
+
+    def _make_hook(self, temporal: nn.Module):
+        def hook(module, inputs, output):
+            b, t = self._bt
+            bt, c, h, w = output.shape
+            x = output.reshape(b, t, c, h, w).permute(0, 2, 1, 3, 4)
+            x = temporal(x, self._frame_index)
+            return x.permute(0, 2, 1, 3, 4).reshape(bt, c, h, w)
+
+        return hook
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        c_noise: torch.Tensor,
+        day_of_year: torch.Tensor,
+        second_of_day: torch.Tensor,
+        lon: torch.Tensor,
+        frame_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        b, _, t, h, w = x.shape
+        cal = self.calendar(day_of_year, second_of_day, lon, h)
+        inp = torch.cat([x, cal], dim=1)
+        folded = inp.permute(0, 2, 1, 3, 4).reshape(b * t, inp.shape[1], h, w)
+        noise = c_noise.reshape(-1)
+        if noise.shape[0] == b:
+            noise = noise.repeat_interleave(t)
+        self._bt = (b, t)
+        # stashed for the temporal-attention forward hooks (true grid positions of
+        # the frames, so the relative bias reflects real spacing; None = full grid)
+        self._frame_index = frame_index
+        out = self.unet(folded, noise, None)
+        return out.reshape(b, t, -1, h, w).permute(0, 2, 1, 3, 4)

--- a/fme/downscaling/modules/video_song_unet.py
+++ b/fme/downscaling/modules/video_song_unet.py
@@ -25,6 +25,7 @@ class VideoSongUNet(nn.Module):
         attn_resolutions: tuple[int, ...] = (22,),
         num_freqs: int = 4,
         periodic: bool = True,
+        use_apex_gn: bool = False,
     ):
         super().__init__()
         self.seq_length = seq_length
@@ -37,7 +38,7 @@ class VideoSongUNet(nn.Module):
             channel_mult=list(channel_mult),
             num_blocks=num_blocks,
             attn_resolutions=list(attn_resolutions),
-            use_apex_gn=False,
+            use_apex_gn=use_apex_gn,
         )
         if periodic:
             for m in self.unet.modules():

--- a/fme/downscaling/noise.py
+++ b/fme/downscaling/noise.py
@@ -69,13 +69,6 @@ def brownian_bridge_mixing_matrix(tau: torch.Tensor) -> torch.Tensor:
     """Temporal mixing matrix for endpoint-pinned, `Brownian-bridge`_-correlated
     noise.
 
-    Given the normalized frame times ``tau`` (1-D, length ``T``, with
-    ``tau[0] == 0`` and ``tau[-1] == 1`` marking the pinned endpoints and the
-    interior strictly inside ``(0, 1)``), returns a ``(T, T)`` matrix ``M`` such
-    that white noise ``Z ~ N(0, I)`` mixed along the time axis as ``E = M @ Z``
-    has a Brownian-bridge *correlation* structure across the interior frames and
-    is exactly zero on the two endpoint frames.
-
     .. _Brownian-bridge: https://en.wikipedia.org/wiki/Brownian_bridge
 
     Because every entry depends only on its own pair ``(tau_i, tau_j)``, the

--- a/fme/downscaling/noise.py
+++ b/fme/downscaling/noise.py
@@ -66,7 +66,8 @@ def uniform_frame_times(n_timesteps: int) -> torch.Tensor:
 
 
 def brownian_bridge_mixing_matrix(tau: torch.Tensor) -> torch.Tensor:
-    """Temporal mixing matrix for endpoint-pinned, time-correlated noise.
+    """Temporal mixing matrix for endpoint-pinned, `Brownian-bridge`_-correlated
+    noise.
 
     Given the normalized frame times ``tau`` (1-D, length ``T``, with
     ``tau[0] == 0`` and ``tau[-1] == 1`` marking the pinned endpoints and the
@@ -75,14 +76,7 @@ def brownian_bridge_mixing_matrix(tau: torch.Tensor) -> torch.Tensor:
     has a Brownian-bridge *correlation* structure across the interior frames and
     is exactly zero on the two endpoint frames.
 
-    The Brownian-bridge covariance ``k_BB(s, t) = min(s, t) - s * t`` (bridge
-    length 1) vanishes at both endpoints, matching the endpoint-pinned residual
-    the video model diffuses. We normalize it to a *correlation* matrix (unit
-    diagonal on the interior) so that, when scaled by the EDM noise level
-    ``sigma``, each frame's marginal noise std stays ``sigma`` -- only the
-    cross-time correlation is introduced. ``M`` is the Cholesky factor of that
-    correlation matrix placed into the interior block; the endpoint rows/cols are
-    all zero.
+    .. _Brownian-bridge: https://en.wikipedia.org/wiki/Brownian_bridge
 
     Because every entry depends only on its own pair ``(tau_i, tau_j)``, the
     matrix built for any *subset* of frame times equals the full-grid matrix
@@ -97,25 +91,12 @@ def brownian_bridge_mixing_matrix(tau: torch.Tensor) -> torch.Tensor:
     Returns:
         A ``(T, T)`` float32 tensor on ``tau``'s device.
     """
-    if tau.ndim != 1 or tau.shape[0] < 3:
-        raise ValueError(
-            "Brownian-bridge noise needs at least 3 frames (2 endpoints + 1 "
-            f"interior); got tau with shape {tuple(tau.shape)}."
-        )
-    n_timesteps = tau.shape[0]
-    n_interior = n_timesteps - 2
-    tau_i = tau[1:-1].to(torch.float64)
-    s = tau_i.reshape(-1, 1)
-    t = tau_i.reshape(1, -1)
-    cov = torch.minimum(s, t) - s * t  # interior Brownian-bridge covariance
-    std = cov.diagonal().sqrt()
-    corr = cov / torch.outer(std, std)  # normalize to unit diagonal
-    chol = torch.linalg.cholesky(corr)  # lower-triangular, corr == chol @ chol.T
-    mixing = torch.zeros(
-        n_timesteps, n_timesteps, dtype=torch.float64, device=tau.device
-    )
-    mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = chol
-    return mixing.to(torch.float32)
+
+    def _bridge_corr(s: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        cov = torch.minimum(s, t) - s * t
+        return cov / torch.sqrt((s - s**2) * (t - t**2))
+
+    return _interior_cholesky_mixing_matrix(tau, _bridge_corr)
 
 
 def _interior_cholesky_mixing_matrix(
@@ -151,15 +132,6 @@ def ou_mixing_matrix(tau: torch.Tensor, length_scale: float) -> torch.Tensor:
     """Temporal mixing matrix for endpoint-pinned, Ornstein-Uhlenbeck-
     correlated noise: ``corr(s, t) = exp(-|s - t| / length_scale)``.
 
-    Same endpoint-pinned-interior-Cholesky structure as
-    ``brownian_bridge_mixing_matrix`` (see its docstring for the subset-
-    marginal property, which holds here too since OU correlation is also a
-    pure function of each frame-time pair), but with an OU kernel instead of
-    the Brownian-bridge kernel. Empirically (see
-    ``toy/process_residual_bridge_report.md``), real interior-frame
-    correlations for wind/precipitation channels decay more like OU than
-    like a bridge.
-
     Args:
         tau: Normalized frame times, shape ``(T,)``, as in
             ``brownian_bridge_mixing_matrix``.
@@ -175,13 +147,9 @@ def rbf_mixing_matrix(tau: torch.Tensor, length_scale: float) -> torch.Tensor:
     """Temporal mixing matrix for endpoint-pinned, RBF/squared-exponential-
     correlated noise: ``corr(s, t) = exp(-(s - t)^2 / (2 * length_scale^2))``.
 
-    See ``ou_mixing_matrix`` for the shared structure. **Caution:** RBF
-    kernels become numerically near-singular fast as ``length_scale`` grows
-    relative to the frame spacing -- verify ``det`` isn't degenerate before
-    using this in training (see ``toy/process_residual_bridge_report.md``:
-    RBF was empirically the best-fitting kernel for PRMSL and T2m, but its
-    determinant there is ~1e-16 / ~1e-11, i.e. effectively rank-deficient --
-    OU was used for those channels instead for exactly this reason).
+    **Caution:** RBF kernels become numerically near-singular fast as
+    ``length_scale`` grows relative to the frame spacing -- verify ``det``
+    isn't degenerate before using this in training.
 
     Args:
         tau: Normalized frame times, shape ``(T,)``, as in

--- a/fme/downscaling/noise.py
+++ b/fme/downscaling/noise.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+from collections.abc import Callable
 
 import torch
 
@@ -54,6 +55,142 @@ class LogUniformNoiseDistribution(NoiseDistribution):
             shape=(batch_size, 1, 1, 1),
             dtype=torch.float32,
         ).to(device)
+
+
+def uniform_frame_times(n_timesteps: int) -> torch.Tensor:
+    """Normalized times of ``n_timesteps`` uniformly spaced frames on ``[0, 1]``.
+
+    Endpoints land exactly on 0 and 1; interior frames on ``k / (T - 1)``.
+    """
+    return torch.linspace(0.0, 1.0, n_timesteps, dtype=torch.float64)
+
+
+def brownian_bridge_mixing_matrix(tau: torch.Tensor) -> torch.Tensor:
+    """Temporal mixing matrix for endpoint-pinned, time-correlated noise.
+
+    Given the normalized frame times ``tau`` (1-D, length ``T``, with
+    ``tau[0] == 0`` and ``tau[-1] == 1`` marking the pinned endpoints and the
+    interior strictly inside ``(0, 1)``), returns a ``(T, T)`` matrix ``M`` such
+    that white noise ``Z ~ N(0, I)`` mixed along the time axis as ``E = M @ Z``
+    has a Brownian-bridge *correlation* structure across the interior frames and
+    is exactly zero on the two endpoint frames.
+
+    The Brownian-bridge covariance ``k_BB(s, t) = min(s, t) - s * t`` (bridge
+    length 1) vanishes at both endpoints, matching the endpoint-pinned residual
+    the video model diffuses. We normalize it to a *correlation* matrix (unit
+    diagonal on the interior) so that, when scaled by the EDM noise level
+    ``sigma``, each frame's marginal noise std stays ``sigma`` -- only the
+    cross-time correlation is introduced. ``M`` is the Cholesky factor of that
+    correlation matrix placed into the interior block; the endpoint rows/cols are
+    all zero.
+
+    Because every entry depends only on its own pair ``(tau_i, tau_j)``, the
+    matrix built for any *subset* of frame times equals the full-grid matrix
+    restricted to those frames. Generating a subset of frames therefore draws
+    from the exact *marginal* of the full-window bridge -- the noise obeys the
+    same process whether or not the other frames are requested.
+
+    Args:
+        tau: Normalized frame times, shape ``(T,)`` with ``T >= 3``, sorted with
+            endpoints at 0 and 1 and interior values in ``(0, 1)``.
+
+    Returns:
+        A ``(T, T)`` float32 tensor on ``tau``'s device.
+    """
+    if tau.ndim != 1 or tau.shape[0] < 3:
+        raise ValueError(
+            "Brownian-bridge noise needs at least 3 frames (2 endpoints + 1 "
+            f"interior); got tau with shape {tuple(tau.shape)}."
+        )
+    n_timesteps = tau.shape[0]
+    n_interior = n_timesteps - 2
+    tau_i = tau[1:-1].to(torch.float64)
+    s = tau_i.reshape(-1, 1)
+    t = tau_i.reshape(1, -1)
+    cov = torch.minimum(s, t) - s * t  # interior Brownian-bridge covariance
+    std = cov.diagonal().sqrt()
+    corr = cov / torch.outer(std, std)  # normalize to unit diagonal
+    chol = torch.linalg.cholesky(corr)  # lower-triangular, corr == chol @ chol.T
+    mixing = torch.zeros(
+        n_timesteps, n_timesteps, dtype=torch.float64, device=tau.device
+    )
+    mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = chol
+    return mixing.to(torch.float32)
+
+
+def _interior_cholesky_mixing_matrix(
+    tau: torch.Tensor, corr_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+) -> torch.Tensor:
+    """Shared scaffold for endpoint-pinned mixing matrices: builds the
+    unit-diagonal interior correlation matrix via ``corr_fn(tau_i, tau_j)``,
+    Cholesky-factors it, and embeds it in a zero-padded ``(T, T)`` matrix
+    (endpoint rows/cols zero). Used by ``brownian_bridge_mixing_matrix``,
+    ``ou_mixing_matrix``, and ``rbf_mixing_matrix`` -- they differ only in
+    ``corr_fn``.
+    """
+    if tau.ndim != 1 or tau.shape[0] < 3:
+        raise ValueError(
+            "Endpoint-pinned noise needs at least 3 frames (2 endpoints + 1 "
+            f"interior); got tau with shape {tuple(tau.shape)}."
+        )
+    n_timesteps = tau.shape[0]
+    n_interior = n_timesteps - 2
+    tau_i = tau[1:-1].to(torch.float64)
+    s = tau_i.reshape(-1, 1)
+    t = tau_i.reshape(1, -1)
+    corr = corr_fn(s, t)
+    chol = torch.linalg.cholesky(corr)  # lower-triangular, corr == chol @ chol.T
+    mixing = torch.zeros(
+        n_timesteps, n_timesteps, dtype=torch.float64, device=tau.device
+    )
+    mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = chol
+    return mixing.to(torch.float32)
+
+
+def ou_mixing_matrix(tau: torch.Tensor, length_scale: float) -> torch.Tensor:
+    """Temporal mixing matrix for endpoint-pinned, Ornstein-Uhlenbeck-
+    correlated noise: ``corr(s, t) = exp(-|s - t| / length_scale)``.
+
+    Same endpoint-pinned-interior-Cholesky structure as
+    ``brownian_bridge_mixing_matrix`` (see its docstring for the subset-
+    marginal property, which holds here too since OU correlation is also a
+    pure function of each frame-time pair), but with an OU kernel instead of
+    the Brownian-bridge kernel. Empirically (see
+    ``toy/process_residual_bridge_report.md``), real interior-frame
+    correlations for wind/precipitation channels decay more like OU than
+    like a bridge.
+
+    Args:
+        tau: Normalized frame times, shape ``(T,)``, as in
+            ``brownian_bridge_mixing_matrix``.
+        length_scale: OU decorrelation length, in the same units as ``tau``
+            (hours, for this codebase's frame times).
+    """
+    return _interior_cholesky_mixing_matrix(
+        tau, lambda s, t: torch.exp(-torch.abs(s - t) / length_scale)
+    )
+
+
+def rbf_mixing_matrix(tau: torch.Tensor, length_scale: float) -> torch.Tensor:
+    """Temporal mixing matrix for endpoint-pinned, RBF/squared-exponential-
+    correlated noise: ``corr(s, t) = exp(-(s - t)^2 / (2 * length_scale^2))``.
+
+    See ``ou_mixing_matrix`` for the shared structure. **Caution:** RBF
+    kernels become numerically near-singular fast as ``length_scale`` grows
+    relative to the frame spacing -- verify ``det`` isn't degenerate before
+    using this in training (see ``toy/process_residual_bridge_report.md``:
+    RBF was empirically the best-fitting kernel for PRMSL and T2m, but its
+    determinant there is ~1e-16 / ~1e-11, i.e. effectively rank-deficient --
+    OU was used for those channels instead for exactly this reason).
+
+    Args:
+        tau: Normalized frame times, shape ``(T,)``, as in
+            ``brownian_bridge_mixing_matrix``.
+        length_scale: RBF length scale, in the same units as ``tau``.
+    """
+    return _interior_cholesky_mixing_matrix(
+        tau, lambda s, t: torch.exp(-((s - t) ** 2) / (2 * length_scale**2))
+    )
 
 
 def condition_with_noise_for_training(

--- a/fme/downscaling/test_noise.py
+++ b/fme/downscaling/test_noise.py
@@ -4,6 +4,8 @@ import torch
 from fme.downscaling.noise import (
     LogNormalNoiseDistribution,
     LogUniformNoiseDistribution,
+    brownian_bridge_mixing_matrix,
+    uniform_frame_times,
 )
 
 
@@ -19,3 +21,53 @@ def test_noise_distribution(noise_distribution):
     noise = noise_distribution.sample(batch_size=batch_size, device="cpu")
     assert noise.shape == (batch_size, 1, 1, 1)
     assert noise.dtype == torch.float32
+
+
+def _bridge_corr(tau):
+    """Reference unit-diagonal Brownian-bridge correlation on interior times."""
+    s, t = tau.reshape(-1, 1), tau.reshape(1, -1)
+    bb = torch.minimum(s, t) - s * t
+    std = bb.diagonal().sqrt()
+    return (bb / torch.outer(std, std)).to(torch.float32)
+
+
+@pytest.mark.parametrize("n_timesteps", [3, 5, 9])
+def test_brownian_bridge_mixing_matrix(n_timesteps):
+    tau = uniform_frame_times(n_timesteps)
+    mixing = brownian_bridge_mixing_matrix(tau)
+    assert mixing.shape == (n_timesteps, n_timesteps)
+    assert mixing.dtype == torch.float32
+
+    cov = mixing @ mixing.T  # covariance of M @ Z for white Z
+
+    # Endpoints carry no noise.
+    assert torch.allclose(cov[0], torch.zeros(n_timesteps))
+    assert torch.allclose(cov[-1], torch.zeros(n_timesteps))
+    assert torch.allclose(cov[:, 0], torch.zeros(n_timesteps))
+    assert torch.allclose(cov[:, -1], torch.zeros(n_timesteps))
+
+    # Interior block matches the unit-diagonal (correlation) Brownian bridge.
+    expected_corr = _bridge_corr(tau[1:-1])
+    interior = cov[1:-1, 1:-1]
+    assert torch.allclose(interior.diagonal(), torch.ones(n_timesteps - 2), atol=1e-5)
+    assert torch.allclose(interior, expected_corr, atol=1e-5)
+
+
+def test_brownian_bridge_subset_matches_full_grid_marginal():
+    """A subset's mixing matrix reproduces the full grid's correlations exactly:
+    generating a subset of frames draws from the full-window bridge's marginal."""
+    full_tau = uniform_frame_times(9)
+    full_cov = brownian_bridge_mixing_matrix(full_tau)
+    full_cov = full_cov @ full_cov.T
+
+    # keep endpoints (0, 8) and a non-uniform interior subset (3, 6)
+    idx = torch.tensor([0, 3, 6, 8])
+    subset = brownian_bridge_mixing_matrix(full_tau[idx])
+    subset_cov = subset @ subset.T
+
+    assert torch.allclose(subset_cov, full_cov[idx][:, idx], atol=1e-5)
+
+
+def test_brownian_bridge_mixing_matrix_requires_interior():
+    with pytest.raises(ValueError, match="at least 3 frames"):
+        brownian_bridge_mixing_matrix(uniform_frame_times(2))

--- a/fme/downscaling/test_video_models.py
+++ b/fme/downscaling/test_video_models.py
@@ -112,6 +112,42 @@ def test_train_on_batch_runs_and_backprops_songunet_backbone():
     assert outputs.prediction["var0"].shape == (2, n_times, height, width)
 
 
+def test_attn_resolutions_empty_list_disables_non_bottleneck_attention():
+    """An explicit ``attn_resolutions=[]`` must actually disable songunet
+    attention at the regular resolution levels, not silently fall back to
+    the default (the previous ``self.attn_resolutions or [default_attn]``
+    treated `[]` and `None` the same way). SongUNetv2's bottleneck block
+    always gets attention (``bottleneck_attention`` defaults to ``True``
+    and isn't exposed here), so the empty case still has exactly one
+    temporal-attention module rather than zero.
+    """
+    n_times, height, width = 5, 8, 8
+
+    def n_temporal_blocks(**kwargs):
+        model = _model(
+            n_times, backbone="songunet", img_resolution=[height, width], **kwargs
+        )
+        bare = getattr(model.module, "module", model.module)
+        return len(bare.model._temporal)
+
+    assert n_temporal_blocks(attn_resolutions=[]) == 1
+    assert n_temporal_blocks() > 1
+
+
+def test_use_apex_gn_requires_songunet_backbone():
+    with pytest.raises(ValueError, match="only used with the songunet backbone"):
+        _model(5, use_apex_gn=True)
+
+
+def test_use_apex_gn_requires_gpu():
+    from fme.core.device import using_gpu
+
+    if using_gpu():
+        pytest.skip("use_apex_gn is valid on GPU; nothing to assert here")
+    with pytest.raises(ValueError, match="requires a GPU"):
+        _model(5, backbone="songunet", img_resolution=[8, 8], use_apex_gn=True)
+
+
 def test_train_on_batch_supports_per_channel_noise():
     n_times, height, width = 5, 8, 8
     config = VideoDiffusionModelConfig(
@@ -250,7 +286,7 @@ def test_invalid_temporal_noise_correlation_rejected():
             normalization=NormalizationConfig(
                 means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
             ),
-            temporal_noise_correlation="bridge",
+            temporal_noise_correlation="bridge",  # type: ignore[arg-type]
         )
 
 

--- a/fme/downscaling/test_video_models.py
+++ b/fme/downscaling/test_video_models.py
@@ -148,6 +148,51 @@ def test_use_apex_gn_requires_gpu():
         _model(5, backbone="songunet", img_resolution=[8, 8], use_apex_gn=True)
 
 
+def test_label_dim_rejected():
+    with pytest.raises(ValueError, match="label_dim is not supported"):
+        _model(5, label_dim=2)
+
+
+def test_augment_dim_rejected():
+    with pytest.raises(ValueError, match="augment_dim is not supported"):
+        _model(5, augment_dim=2)
+
+
+def test_train_on_batch_runs_with_non_default_songunet_args():
+    """Smoke-test every SongUNetv2 pass-through arg together (non-default
+    values where possible) so a keyword typo or signature mismatch in the
+    VideoDiffusionModelConfig -> VideoSongUNet -> SongUNetv2 chain isn't silent.
+    """
+    n_times, height, width = 5, 8, 8
+    model = _model(
+        n_times,
+        backbone="songunet",
+        img_resolution=[height, width],
+        channel_mult_emb=2,
+        channel_mult_noise=2,
+        dropout=0.0,
+        label_dropout=0.5,
+        songunet_embedding_type="fourier",
+        encoder_type="residual",
+        decoder_type="skip",
+        checkpoint_level=1,
+        additive_pos_embed=True,
+        bottleneck_attention=False,
+        act="relu",
+        profile_mode=False,
+        amp_mode=False,
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
 def test_train_on_batch_supports_per_channel_noise():
     n_times, height, width = 5, 8, 8
     config = VideoDiffusionModelConfig(

--- a/fme/downscaling/test_video_models.py
+++ b/fme/downscaling/test_video_models.py
@@ -1,0 +1,461 @@
+import datetime
+
+import cftime
+import pytest
+import torch
+import xarray as xr
+
+from fme.core.coordinates import LatLonCoordinates
+from fme.core.device import get_device
+from fme.core.normalizer import NormalizationConfig
+from fme.core.optimization import NullOptimization
+from fme.core.rand import set_seed
+from fme.downscaling.data import (
+    PairedVideoBatchData,
+    VideoBatchData,
+    VideoBatchItem,
+    compute_calendar_features,
+)
+from fme.downscaling.modules.video_modules import FIRBlur, TemporalAttention
+from fme.downscaling.noise import (
+    LogNormalNoiseDistribution,
+    LogUniformNoiseDistribution,
+)
+from fme.downscaling.video_models import VideoDiffusionModelConfig
+
+OUT_NAMES = ["var0", "var1"]
+
+
+def _times(n):
+    base = cftime.DatetimeProlepticGregorian(2013, 1, 2)
+    return xr.DataArray(
+        [base + datetime.timedelta(hours=3 * i) for i in range(n)], dims=["time"]
+    )
+
+
+def _video_item(n_times, height, width):
+    data = {
+        v: torch.rand(n_times, height, width, device=get_device()) for v in OUT_NAMES
+    }
+    time = _times(n_times)
+    coords = LatLonCoordinates(
+        lat=torch.linspace(-10.0, 10.0, height, device=get_device()),
+        lon=torch.linspace(0.0, 30.0, width, device=get_device()),
+    )
+    doy, sod = compute_calendar_features(time)
+    return VideoBatchItem(data, time, coords, doy, sod)
+
+
+def _paired_batch(batch_size, n_times, height, width):
+    items = [_video_item(n_times, height, width) for _ in range(batch_size)]
+    clip = VideoBatchData.from_sequence(items)
+    # coarse is unused by the temporal-only model; reuse the fine clip.
+    return PairedVideoBatchData(fine=clip, coarse=clip)
+
+
+def _model(n_times, temporal_noise_correlation="independent", **config_kwargs):
+    config = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=n_times,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        num_diffusion_generation_steps=4,
+        model_channels=16,
+        n_heads=2,
+        num_freqs=3,
+        temporal_noise_correlation=temporal_noise_correlation,
+        **config_kwargs,
+    )
+    return config.build()
+
+
+def test_train_on_batch_runs_and_backprops():
+    n_times, height, width = 5, 8, 8
+    model = _model(n_times)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    # gradients flow into the network
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+    # prediction is a full clip per variable
+    assert outputs.prediction["var0"].shape == (2, n_times, height, width)
+
+
+def test_train_on_batch_runs_and_backprops_songunet_backbone():
+    """The songunet backbone has its own network construction path (image
+    resolution, attention-level defaults, periodic-conv setup in
+    VideoSongUNet) entirely separate from the default "simple" backbone
+    exercised by every other test in this file -- cover it directly so a
+    break there isn't silent.
+    """
+    n_times, height, width = 5, 8, 8
+    model = _model(
+        n_times,
+        backbone="songunet",
+        img_resolution=[height, width],
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+    assert outputs.prediction["var0"].shape == (2, n_times, height, width)
+
+
+def test_train_on_batch_supports_per_channel_noise():
+    n_times, height, width = 5, 8, 8
+    config = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=n_times,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        num_diffusion_generation_steps=4,
+        model_channels=16,
+        n_heads=2,
+        num_freqs=3,
+        training_noise_distributions={
+            "var0": LogNormalNoiseDistribution(p_mean=-1.2, p_std=1.8),
+            "var1": LogUniformNoiseDistribution(p_min=0.005, p_max=2000.0),
+        },
+        sigma_min=0.002,
+        sigma_max=150.0,
+        sigma_min_by_channel={"var1": 0.005},
+        sigma_max_by_channel={"var1": 2000.0},
+    )
+    model = config.build()
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+
+    assert outputs.sigma is not None
+    assert outputs.sigma.shape == (2, 2)
+    sigma_min, sigma_max = config.generation_sigma_bounds(outputs.sigma.device)
+    assert torch.allclose(
+        sigma_min, torch.tensor([0.002, 0.005], device=sigma_min.device)
+    )
+    assert torch.allclose(
+        sigma_max, torch.tensor([150.0, 2000.0], device=sigma_max.device)
+    )
+
+
+def test_per_channel_sigma_data():
+    n_times, height, width = 5, 8, 8
+    config = VideoDiffusionModelConfig(
+        out_names=OUT_NAMES,
+        n_timesteps=n_times,
+        normalization=NormalizationConfig(
+            means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+        ),
+        num_diffusion_generation_steps=4,
+        model_channels=16,
+        n_heads=2,
+        sigma_min=0.002,
+        sigma_max=150.0,
+        sigma_data_by_channel={"var0": 0.2},  # var1 falls back to 1.0
+    )
+    model = config.build()
+    bare = getattr(model.module, "module", model.module)
+    assert torch.allclose(
+        bare.sigma_data.flatten(),
+        torch.tensor([0.2, 1.0], device=bare.sigma_data.device),
+    )
+    assert model.sigma_data.shape == (1, 2, 1, 1, 1)
+    # train + generate still run end to end with per-channel sigma_data
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+    model.train_on_batch(batch, NullOptimization())
+    generated = model.generate(batch, n_samples=2)
+    assert set(generated) == set(OUT_NAMES)
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_generate_pins_observed_endpoints(temporal_noise_correlation):
+    n_times, height, width = 5, 8, 8
+    model = _model(n_times, temporal_noise_correlation=temporal_noise_correlation)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    generated = model.generate(batch, n_samples=3)
+    out = generated["var0"]
+    assert out.shape == (2, 3, n_times, height, width)
+    assert torch.isfinite(out).all()
+
+    # observed endpoints (t=0 and t=-1) must be reproduced exactly for every
+    # sample; only the interior is generated.
+    truth = batch.fine.data["var0"]  # (B, T, H, W)
+    for s in range(3):
+        assert torch.allclose(out[:, s, 0], truth[:, 0], atol=1e-4)
+        assert torch.allclose(out[:, s, -1], truth[:, -1], atol=1e-4)
+
+
+def test_train_on_batch_runs_with_brownian_bridge_noise():
+    n_times, height, width = 5, 8, 8
+    model = _model(n_times, temporal_noise_correlation="brownian_bridge")
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    assert outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+def test_brownian_bridge_noise_has_expected_temporal_covariance():
+    n_times = 9
+    model = _model(n_times, temporal_noise_correlation="brownian_bridge")
+    set_seed(0)
+    # (samples, C=1, T, H=1, W=1): treat sample dim as the population.
+    like = torch.empty(20000, 1, n_times, 1, 1)
+    noise = model._sample_residual_noise(like)
+    flat = noise[:, 0, :, 0, 0]  # (samples, T)
+
+    emp_cov = (flat.T @ flat) / flat.shape[0]
+    expected = (model._noise_mixing @ model._noise_mixing.T).cpu()
+    assert torch.allclose(emp_cov, expected, atol=0.03)
+    # endpoints are noise-free; interior frames are correlated (off-diagonal != 0)
+    assert torch.allclose(emp_cov[0], torch.zeros(n_times))
+    assert torch.allclose(emp_cov[-1], torch.zeros(n_times))
+    assert emp_cov[1, 2].abs() > 0.1
+
+
+def test_independent_noise_is_uncorrelated_in_time():
+    n_times = 9
+    model = _model(n_times, temporal_noise_correlation="independent")
+    assert model._noise_mixing is None
+    set_seed(0)
+    like = torch.empty(20000, 1, n_times, 1, 1)
+    flat = model._sample_residual_noise(like)[:, 0, :, 0, 0]
+    emp_cov = (flat.T @ flat) / flat.shape[0]
+    assert torch.allclose(emp_cov, torch.eye(n_times), atol=0.05)
+
+
+def test_invalid_temporal_noise_correlation_rejected():
+    with pytest.raises(ValueError, match="temporal_noise_correlation"):
+        VideoDiffusionModelConfig(
+            out_names=OUT_NAMES,
+            n_timesteps=5,
+            normalization=NormalizationConfig(
+                means={"var0": 0.0, "var1": 0.0}, stds={"var0": 1.0, "var1": 1.0}
+            ),
+            temporal_noise_correlation="bridge",
+        )
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_generate_subset_frames(temporal_noise_correlation):
+    # full grid is 9 frames (00..24 at 3h); request a non-uniform subset
+    n_times, height, width = 9, 8, 8
+    model = _model(n_times, temporal_noise_correlation=temporal_noise_correlation)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+
+    frames = [0, 3, 7, 8]  # endpoints + two non-uniformly spaced interior frames
+    generated = model.generate(batch, n_samples=3, frames=frames)
+    out = generated["var0"]
+    assert out.shape == (2, 3, len(frames), height, width)
+    assert torch.isfinite(out).all()
+
+    # observed endpoints (first/last of the subset) reproduced exactly
+    truth = batch.fine.data["var0"]
+    for s in range(3):
+        assert torch.allclose(out[:, s, 0], truth[:, 0], atol=1e-4)
+        assert torch.allclose(out[:, s, -1], truth[:, -1], atol=1e-4)
+
+
+def test_generate_rejects_invalid_frames():
+    n_times = 9
+    model = _model(n_times)
+    batch = _paired_batch(batch_size=1, n_times=n_times, height=8, width=8)
+    # must include both endpoints
+    with pytest.raises(ValueError, match="start at 0 and end at"):
+        model.generate(batch, frames=[0, 3, 6])
+    # must be strictly increasing
+    with pytest.raises(ValueError, match="strictly increasing"):
+        model.generate(batch, frames=[0, 3, 3, 8])
+    # needs at least one interior frame
+    with pytest.raises(ValueError, match="at least 3 frame indices"):
+        model.generate(batch, frames=[0, 8])
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_subset_augmented_training_runs(temporal_noise_correlation):
+    n_times, height, width = 9, 8, 8
+    model = _model(
+        n_times,
+        temporal_noise_correlation=temporal_noise_correlation,
+        subset_augmentation_prob=1.0,  # always subset, to exercise the path
+        subset_min_interior=1,
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+    set_seed(0)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss)
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0 and all(torch.isfinite(g).all() for g in grads)
+    # prediction and target stay aligned on the (subset) frame axis
+    assert outputs.prediction["var0"].shape == outputs.target["var0"].shape
+    assert outputs.prediction["var0"].shape[1] < n_times
+
+
+def test_subset_augmentation_prob_zero_is_full_grid():
+    n_times = 9
+    model = _model(n_times, subset_augmentation_prob=0.0)
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=8, width=8)
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert outputs.prediction["var0"].shape[1] == n_times
+
+
+def test_invalid_subset_config_rejected():
+    with pytest.raises(ValueError, match="subset_augmentation_prob"):
+        _model(5, subset_augmentation_prob=1.5)
+    with pytest.raises(ValueError, match="subset_min_interior"):
+        _model(5, subset_min_interior=4)  # n_timesteps - 2 == 3
+
+
+@pytest.mark.parametrize(
+    "temporal_noise_correlation", ["independent", "brownian_bridge"]
+)
+def test_marginal_consistency_loss_trains(temporal_noise_correlation):
+    n_times, height, width = 9, 8, 8
+    model = _model(
+        n_times,
+        temporal_noise_correlation=temporal_noise_correlation,
+        marginal_consistency_weight=0.5,
+    )
+    batch = _paired_batch(batch_size=2, n_times=n_times, height=height, width=width)
+    set_seed(0)
+
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss) and outputs.loss.requires_grad
+    # the consistency term is surfaced, finite, and non-negative
+    assert outputs.marginal_consistency_loss is not None
+    assert torch.isfinite(outputs.marginal_consistency_loss)
+    assert outputs.marginal_consistency_loss.item() >= 0.0
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0 and all(torch.isfinite(g).all() for g in grads)
+    # ModelOutputs still describes the full-grid pass
+    assert outputs.prediction["var0"].shape == (2, n_times, height, width)
+    assert outputs.target["var0"].shape == (2, n_times, height, width)
+
+
+def test_marginal_consistency_disabled_by_default():
+    model = _model(9)
+    batch = _paired_batch(batch_size=2, n_times=9, height=8, width=8)
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert outputs.marginal_consistency_loss is None
+
+
+def test_consistency_subset_is_strict():
+    model = _model(9, marginal_consistency_weight=1.0)
+    for _ in range(20):
+        idx = model._sample_consistency_subset_indices(9, torch.device("cpu"))
+        # endpoints kept, at least one interior frame kept AND at least one dropped
+        assert int(idx[0]) == 0 and int(idx[-1]) == 8
+        assert 3 <= idx.numel() < 9
+        assert bool(torch.all(idx[1:] > idx[:-1]))
+
+
+def test_marginal_consistency_is_reproducible():
+    # same seed -> same subset choice and same shared noise -> same L_marg
+    model = _model(9, marginal_consistency_weight=1.0)
+    batch = _paired_batch(batch_size=2, n_times=9, height=8, width=8)
+    set_seed(3)
+    a = model.train_on_batch(batch, NullOptimization()).marginal_consistency_loss
+    set_seed(3)
+    b = model.train_on_batch(batch, NullOptimization()).marginal_consistency_loss
+    assert a is not None and b is not None
+    assert a.item() == b.item()
+
+
+def test_marginal_consistency_with_subset_augmentation_compose():
+    # subset augmentation and the consistency loss may be combined: same subset
+    # exposure in the first pass, plus the consistency tie via the second pass.
+    model = _model(
+        9,
+        marginal_consistency_weight=1.0,
+        subset_augmentation_prob=1.0,  # always augment, to exercise the combo
+    )
+    batch = _paired_batch(batch_size=2, n_times=9, height=8, width=8)
+    set_seed(0)
+    outputs = model.train_on_batch(batch, NullOptimization())
+    assert torch.isfinite(outputs.loss) and outputs.loss.requires_grad
+    outputs.loss.backward()
+    grads = [p.grad for p in model.module.parameters() if p.grad is not None]
+    assert len(grads) > 0 and all(torch.isfinite(g).all() for g in grads)
+
+
+def test_marginal_consistency_config_validation():
+    with pytest.raises(ValueError, match="marginal_consistency_weight must be >= 0"):
+        _model(9, marginal_consistency_weight=-0.1)
+    with pytest.raises(ValueError, match="n_timesteps >="):
+        _model(3, marginal_consistency_weight=1.0)  # only 1 interior frame
+
+
+def _temporal_attention(seq_length, channels=8, n_heads=2):
+    attn = TemporalAttention(channels, n_heads, seq_length)
+    # relative_embedding and the output projection are zero-initialized (the block
+    # starts as identity), so the positional bias has no effect until trained;
+    # randomize both so tests can observe the frame_index dependence.
+    with torch.no_grad():
+        attn.relative_embedding.normal_()
+        attn.proj.weight.normal_()
+        attn.proj.bias.normal_()
+    return attn
+
+
+def test_temporal_attention_frame_index_default_matches_arange():
+    # Backward compat: the full-grid default (frame_index=None) must equal passing
+    # the contiguous arange positions, so pre-subset full-set behavior is unchanged.
+    attn = _temporal_attention(seq_length=9)
+    x = torch.randn(2, 8, 9, 4, 4)
+    default = attn(x)
+    explicit = attn(x, torch.arange(9))
+    assert torch.allclose(default, explicit, atol=1e-6)
+
+
+def test_temporal_attention_uses_true_frame_spacing():
+    # A subset packed to contiguous positions [0,1,2] must NOT be treated the same
+    # as its true grid positions [0,4,8]: the relative positional bias should
+    # reflect real spacing. Feeding true grid indices changes the output.
+    attn = _temporal_attention(seq_length=9)
+    x = torch.randn(2, 8, 3, 4, 4)
+    packed = attn(x)  # default arange([0,1,2]) -- the old (buggy) behavior
+    true_grid = attn(x, torch.tensor([0, 4, 8]))
+    assert not torch.allclose(packed, true_grid, atol=1e-5)
+    # ...and a subset's bias equals the full-grid bias restricted to those frames.
+    full = attn(torch.randn(2, 8, 9, 4, 4))  # smoke: full grid still runs
+    assert full.shape == (2, 8, 9, 4, 4)
+
+
+def test_firblur_survives_inplace_kernel_mutation():
+    # Regression: under DDP (broadcast_buffers=True) each forward re-syncs buffers
+    # with an in-place copy_ into the kernel. When two forwards run before one
+    # backward (the marginal-consistency loss), that mutation must not invalidate
+    # the first forward's saved-for-backward conv weight. Simulate the buffer sync
+    # by mutating the kernel in place between forward and backward.
+    blur = FIRBlur()
+    x = torch.randn(2, 8, 3, 8, 8, requires_grad=True)
+    y = blur(x)
+    with torch.no_grad():
+        blur.kernel.copy_(blur.kernel)  # what DDP's buffer broadcast does
+    y.sum().backward()  # must not raise "modified by an inplace operation"
+    assert x.grad is not None and torch.isfinite(x.grad).all()

--- a/fme/downscaling/video_models.py
+++ b/fme/downscaling/video_models.py
@@ -5,10 +5,11 @@ only interior frames are denoised. Operates on the fine clip only.
 """
 
 import dataclasses
+from typing import Literal
 
 import torch
 
-from fme.core.device import get_device
+from fme.core.device import get_device, using_gpu
 from fme.core.distributed import Distributed
 from fme.core.normalizer import NormalizationConfig, StandardNormalizer
 from fme.core.packer import Packer
@@ -86,7 +87,10 @@ class VideoDiffusionModelConfig:
             None applies it everywhere.
         backbone: "simple" (periodic VideoUNet) or "songunet" (SongUNetv2).
         img_resolution: [H, W]; required for the songunet backbone.
-        attn_resolutions: Attention resolutions, for the songunet backbone.
+        attn_resolutions: Attention resolutions, for the songunet backbone. None
+            defaults to the coarsest resolution; pass [] for no attention.
+        use_apex_gn: Use Apex GroupNorm (songunet backbone only); faster on
+            GPUs where Apex is installed (e.g. B200s), but requires a GPU.
         training_noise_distribution: Noise distribution for training.
         training_noise_distributions: Per-channel noise distribution for
             training, keyed by out_names.
@@ -120,14 +124,15 @@ class VideoDiffusionModelConfig:
     model_channels: int = 64
     n_heads: int = 4
     num_freqs: int = 4
-    noise_embedding_type: str = "positional"
+    noise_embedding_type: Literal["positional", "fourier"] = "positional"
     channel_mult: list[int] = dataclasses.field(default_factory=lambda: [1, 2, 2])
     num_blocks: int = 2
     attention_levels: list[int] = dataclasses.field(default_factory=lambda: [1, 2])
     temporal_attention_levels: list[int] | None = None
-    backbone: str = "simple"
+    backbone: Literal["simple", "songunet"] = "simple"
     img_resolution: list[int] | None = None
     attn_resolutions: list[int] | None = None
+    use_apex_gn: bool = False
     training_noise_distribution: (
         LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
     ) = None
@@ -139,8 +144,12 @@ class VideoDiffusionModelConfig:
     sigma_data_by_channel: dict[str, float] | None = None
     loss_weight_exponent: float = 1.0
     log_transform_channels: dict[str, float] | None = None
-    temporal_noise_correlation: str = "independent"
-    per_channel_noise_kernel: dict[str, str] | None = None
+    temporal_noise_correlation: Literal[
+        "independent", "brownian_bridge", "per_channel"
+    ] = "independent"
+    per_channel_noise_kernel: (
+        dict[str, Literal["independent", "brownian_bridge", "ou", "rbf"]] | None
+    ) = None
     per_channel_kernel_length_scale: dict[str, float] | None = None
     subset_augmentation_prob: float = 0.0
     subset_min_interior: int = 1
@@ -300,6 +309,11 @@ class VideoDiffusionModelConfig:
             )
         if self.backbone == "songunet" and self.img_resolution is None:
             raise ValueError("songunet backbone requires img_resolution [H, W].")
+        if self.use_apex_gn:
+            if self.backbone != "songunet":
+                raise ValueError("use_apex_gn is only used with the songunet backbone.")
+            if not using_gpu():
+                raise ValueError("use_apex_gn requires a GPU.")
 
     @property
     def noise_distribution(self) -> NoiseDistribution:
@@ -387,6 +401,11 @@ class VideoDiffusionModelConfig:
                 # unreachable: __post_init__ already enforces this
                 raise ValueError("songunet backbone requires img_resolution [H, W].")
             default_attn = self.img_resolution[0] >> (len(self.channel_mult) - 1)
+            attn_resolutions = (
+                [default_attn]
+                if self.attn_resolutions is None
+                else self.attn_resolutions
+            )
             net = VideoSongUNet(
                 in_channels=in_channels,
                 out_channels=n_channels,
@@ -396,8 +415,9 @@ class VideoDiffusionModelConfig:
                 channel_mult=tuple(self.channel_mult),
                 num_blocks=self.num_blocks,
                 n_heads=self.n_heads,
-                attn_resolutions=tuple(self.attn_resolutions or [default_attn]),
+                attn_resolutions=tuple(attn_resolutions),
                 num_freqs=self.num_freqs,
+                use_apex_gn=self.use_apex_gn,
             )
         else:
             net = VideoUNet(
@@ -422,7 +442,9 @@ class VideoDiffusionModelConfig:
 
 
 def _channel_mixing_matrix(
-    tau: torch.Tensor, kernel: str, length_scale: float | None
+    tau: torch.Tensor,
+    kernel: Literal["independent", "brownian_bridge", "ou", "rbf"],
+    length_scale: float | None,
 ) -> torch.Tensor:
     """``(T, T)`` mixing matrix for one channel's chosen kernel -- the
     per-channel building block for ``temporal_noise_correlation ==
@@ -454,7 +476,7 @@ def _channel_mixing_matrix(
 def _per_channel_mixing_tensor(
     tau: torch.Tensor,
     out_names: list[str],
-    kernel_map: dict[str, str],
+    kernel_map: dict[str, Literal["independent", "brownian_bridge", "ou", "rbf"]],
     length_scale_map: dict[str, float] | None,
 ) -> torch.Tensor:
     """``(C, T, T)`` stacked per-channel mixing matrices, ordered by

--- a/fme/downscaling/video_models.py
+++ b/fme/downscaling/video_models.py
@@ -64,7 +64,51 @@ def _linear_interp_endpoints(
 
 @dataclasses.dataclass
 class VideoDiffusionModelConfig:
-    """Configuration for the temporal-interpolation video diffusion model."""
+    """
+    Configuration for the temporal-interpolation video diffusion model.
+
+    Parameters:
+        out_names: Output (and input) variable names, in channel order.
+        n_timesteps: Number of frames per clip (>= 3: two endpoints + interior).
+        normalization: Per-channel normalization statistics.
+        sigma_min: Min noise level for generation.
+        sigma_max: Max noise level for generation.
+        churn: The amount of stochasticity during generation.
+        num_diffusion_generation_steps: Number of diffusion generation steps.
+        model_channels: Base channel width of the backbone.
+        n_heads: Number of attention heads.
+        num_freqs: Number of Fourier frequencies for the embeddings.
+        noise_embedding_type: "positional" or "fourier" (simple backbone only).
+        channel_mult: Channel multiplier per U-Net resolution level.
+        num_blocks: Number of residual blocks per resolution level.
+        attention_levels: Resolution levels with spatial attention.
+        temporal_attention_levels: Resolution levels with temporal attention;
+            None applies it everywhere.
+        backbone: "simple" (periodic VideoUNet) or "songunet" (SongUNetv2).
+        img_resolution: [H, W]; required for the songunet backbone.
+        attn_resolutions: Attention resolutions, for the songunet backbone.
+        training_noise_distribution: Noise distribution for training.
+        training_noise_distributions: Per-channel noise distribution for
+            training, keyed by out_names.
+        sigma_min_by_channel: Per-channel override of sigma_min.
+        sigma_max_by_channel: Per-channel override of sigma_max.
+        sigma_data_by_channel: Per-channel EDM sigma_data (residual std);
+            unset channels default to 1.0.
+        loss_weight_exponent: Exponent of the EDM noise-level loss weighting.
+        log_transform_channels: Channels modeled via log1p(x * scale), mapped
+            to their scale.
+        temporal_noise_correlation: "independent", "brownian_bridge", or
+            "per_channel" residual noise.
+        per_channel_noise_kernel: Per-channel kernel, for "per_channel"
+            correlation.
+        per_channel_kernel_length_scale: Kernel length scale for "ou"/"rbf"
+            channels, normalized to [0, 1] over the clip window.
+        subset_augmentation_prob: Fraction of batches trained on a random
+            interior subset instead of the full grid.
+        subset_min_interior: Minimum interior frames kept when subsetted.
+        marginal_consistency_weight: Weight of the marginal-consistency loss
+            (video PMD L_marg); 0 disables it.
+    """
 
     out_names: list[str]
     n_timesteps: int
@@ -76,17 +120,13 @@ class VideoDiffusionModelConfig:
     model_channels: int = 64
     n_heads: int = 4
     num_freqs: int = 4
-    # log-noise embedding for the simple backbone: "positional" or "fourier".
     noise_embedding_type: str = "positional"
-    # Multi-scale U-Net: one channel multiplier per resolution level (0 = finest).
     channel_mult: list[int] = dataclasses.field(default_factory=lambda: [1, 2, 2])
     num_blocks: int = 2
-    # spatial attention levels; temporal attention defaults to all levels (None).
     attention_levels: list[int] = dataclasses.field(default_factory=lambda: [1, 2])
     temporal_attention_levels: list[int] | None = None
-    # backbone: "simple" (periodic VideoUNet) or "songunet" (SongUNetv2).
     backbone: str = "simple"
-    img_resolution: list[int] | None = None  # [H, W], required for songunet
+    img_resolution: list[int] | None = None
     attn_resolutions: list[int] | None = None
     training_noise_distribution: (
         LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
@@ -96,44 +136,14 @@ class VideoDiffusionModelConfig:
     ) = None
     sigma_min_by_channel: dict[str, float] | None = None
     sigma_max_by_channel: dict[str, float] | None = None
-    # Per-channel EDM sigma_data (std of the diffused residual). Channels left
-    # unset default to 1.0. Setting it to the measured residual std per channel
-    # fixes the preconditioning/loss weighting for residual diffusion.
     sigma_data_by_channel: dict[str, float] | None = None
     loss_weight_exponent: float = 1.0
-    # Channels modeled in log space via log1p(x*scale); maps channel to scale.
     log_transform_channels: dict[str, float] | None = None
-    # Temporal correlation of the residual noise: "independent" (per-frame white
-    # noise, default), "brownian_bridge" (endpoint-pinned time-correlated noise,
-    # same kernel for every channel), or "per_channel" (a different kernel per
-    # channel, via per_channel_noise_kernel/per_channel_kernel_length_scale below
-    # -- e.g. matching each channel to whichever of bridge/OU/RBF best fits its
-    # real temporal correlation, see toy/process_residual_bridge_report.md).
     temporal_noise_correlation: str = "independent"
-    # Required iff temporal_noise_correlation == "per_channel": maps every
-    # out_names entry to "independent", "brownian_bridge", "ou", or "rbf".
     per_channel_noise_kernel: dict[str, str] | None = None
-    # Required iff per_channel_noise_kernel has any "ou"/"rbf" entries: maps
-    # those channels to their kernel length scale, in the same normalized
-    # [0, 1]-over-the-full-window units as uniform_frame_times (i.e. hours /
-    # total_window_hours, NOT raw hours -- e.g. an empirically-fit 12.9h OU
-    # length scale over a 24h window is 12.9/24 = 0.5375 here).
     per_channel_kernel_length_scale: dict[str, float] | None = None
-    # Fraction of training batches trained on a random subset of interior frames
-    # (the two endpoints are always kept) instead of the full uniform grid, so the
-    # model learns to answer variable query sets and stays consistent across them.
-    # 0.0 (default) trains only on the full grid -- exact prior behavior.
     subset_augmentation_prob: float = 0.0
-    # Minimum number of interior frames to keep when a batch is subsetted.
     subset_min_interior: int = 1
-    # Weight of the marginal-consistency loss (video PMD L_marg). When > 0, each
-    # training step runs a second pass on a random strict subset of the (possibly
-    # augmentation-subset) interior frames -- sharing the first pass's noised
-    # inputs on the shared frames -- and penalizes disagreement between the first
-    # pass's prediction restricted to the subset and the subset-native prediction.
-    # May be combined with subset_augmentation_prob (holds subset exposure fixed
-    # while toggling the loss). 0.0 (default) disables it (single pass, exact
-    # prior behavior).
     marginal_consistency_weight: float = 0.0
 
     def __post_init__(self):
@@ -272,11 +282,7 @@ class VideoDiffusionModelConfig:
                 f"{self.marginal_consistency_weight}."
             )
         if self.marginal_consistency_weight > 0.0:
-            # The full grid must admit a strict interior subset (keep in
-            # [subset_min_interior, n_interior - 1]), so n_interior >=
-            # subset_min_interior + 1. May be combined with subset_augmentation:
-            # when an augmented batch is too small to form a strict subset the
-            # consistency pass is skipped for that batch (see train_on_batch).
+            # requires a strict interior subset: n_interior >= subset_min_interior + 1
             if self.n_timesteps - 2 < self.subset_min_interior + 1:
                 raise ValueError(
                     "marginal_consistency_weight > 0 needs n_timesteps >= "
@@ -463,7 +469,21 @@ def _per_channel_mixing_tensor(
     return torch.stack(mats, dim=0)
 
 
+@dataclasses.dataclass
+class VideoModelOutputs(ModelOutputs):
+    """``ModelOutputs`` plus the video-PMD marginal-consistency loss term
+    (logging only; not part of the optimized loss field).
+    """
+
+    marginal_consistency_loss: torch.Tensor | None = None
+
+
 class VideoDiffusionModel:
+    """Built model wrapping the backbone network, normalizer, and EDM
+    preconditioning for ``VideoDiffusionModelConfig``. Construct via
+    ``VideoDiffusionModelConfig.build()``.
+    """
+
     def __init__(
         self,
         config: VideoDiffusionModelConfig,
@@ -694,14 +714,13 @@ class VideoDiffusionModel:
             lon.to(get_device()),
         )
 
-    def train_on_batch(self, batch: PairedVideoBatchData, optimizer) -> ModelOutputs:
+    def train_on_batch(
+        self, batch: PairedVideoBatchData, optimizer
+    ) -> VideoModelOutputs:
         fine = batch.fine
         clip = self._pack_normalized(fine.data)
         day_of_year, second_of_day, lon = self._calendar_inputs(fine)
 
-        # Optionally train on a random subset of interior frames (endpoints kept)
-        # so the model learns to answer variable query sets; the bridge noise and
-        # baseline follow the subset's true times, i.e. the full-window marginal.
         idx = self._sample_training_subset_indices(clip.shape[2], clip.device)
         if idx is not None:
             clip = clip.index_select(2, idx)
@@ -719,13 +738,9 @@ class VideoDiffusionModel:
 
         sigma = self.config.sample_training_noise(batch_size, clip.device)
         sigma = sigma.reshape(batch_size, -1, 1, 1, 1)
-        # Gaussian noise on interior frames only
         noise = self._sample_residual_noise(residual, mixing)
         noised = residual + noise * sigma * interior
 
-        # ``idx`` (or None for the full grid) is exactly the frames' true grid
-        # positions, so the temporal attention's relative bias reflects real
-        # spacing rather than packed-contiguous order.
         denoised = self.module(
             noised, condition, sigma, day_of_year, second_of_day, lon, frame_index=idx
         )
@@ -737,17 +752,12 @@ class VideoDiffusionModel:
         n_interior_elems = interior.expand_as(sq_err).sum()
         loss = (weight * sq_err).sum() / n_interior_elems
 
-        # Marginal-consistency loss: a second pass on a random strict subset of
-        # the (full) interior frames, sharing the SAME noised inputs, sigma, and
-        # conditioning on the shared frames (obtained by slicing the full pass, so
-        # the only difference is the query set). We add the subset's own diffusion
-        # loss plus a penalty tying the full-pass prediction, restricted to the
-        # subset, to the subset-native prediction on the shared interior frames.
+        # Second pass on a subset sharing the full pass's noised inputs: adds the
+        # subset's own diffusion loss plus a penalty between the two passes'
+        # predictions on the shared frames.
         marginal_loss: torch.Tensor | None = None
         total_loss = loss
-        # A strict interior subset needs at least subset_min_interior + 1 interior
-        # frames; an augmentation-shrunk batch may fall below that, so skip the
-        # consistency pass for it rather than fail.
+        # an augmentation-shrunk batch may already be below the subset floor
         can_subset = n_times - 2 >= self.config.subset_min_interior + 1
         if self._marginal_consistency_weight > 0.0 and can_subset:
             sub = self._sample_consistency_subset_indices(n_times, clip.device)
@@ -806,7 +816,7 @@ class VideoDiffusionModel:
             k: fine.data[k] if idx is None else fine.data[k].index_select(1, idx)
             for k in self.out_names
         }
-        return ModelOutputs(
+        return VideoModelOutputs(
             prediction=prediction,
             target=target,
             loss=total_loss,

--- a/fme/downscaling/video_models.py
+++ b/fme/downscaling/video_models.py
@@ -91,6 +91,15 @@ class VideoDiffusionModelConfig:
             defaults to the coarsest resolution; pass [] for no attention.
         use_apex_gn: Use Apex GroupNorm (songunet backbone only); faster on
             GPUs where Apex is installed (e.g. B200s), but requires a GPU.
+        channel_mult_emb, channel_mult_noise, dropout, songunet_embedding_type,
+            encoder_type, decoder_type, resample_filter, checkpoint_level,
+            additive_pos_embed, bottleneck_attention, act, profile_mode,
+            amp_mode: Songunet-only; passed through to SongUNetv2 (see its
+            docstring).
+        label_dim, augment_dim: Songunet-only; must be 0, since this backbone
+            never supplies class_labels/augment_labels.
+        label_dropout: Songunet-only; passed through, but inert while
+            label_dim is forced to 0.
         training_noise_distribution: Noise distribution for training.
         training_noise_distributions: Per-channel noise distribution for
             training, keyed by out_names.
@@ -133,6 +142,22 @@ class VideoDiffusionModelConfig:
     img_resolution: list[int] | None = None
     attn_resolutions: list[int] | None = None
     use_apex_gn: bool = False
+    channel_mult_emb: int = 4
+    channel_mult_noise: int = 1
+    dropout: float = 0.10
+    songunet_embedding_type: Literal["positional", "fourier", "zero"] = "positional"
+    encoder_type: Literal["standard", "skip", "residual"] = "standard"
+    decoder_type: Literal["standard", "skip"] = "standard"
+    resample_filter: list[int] = dataclasses.field(default_factory=lambda: [1, 1])
+    checkpoint_level: int = 0
+    additive_pos_embed: bool = False
+    bottleneck_attention: bool = True
+    act: str = "silu"
+    profile_mode: bool = False
+    amp_mode: bool = True
+    label_dim: int = 0
+    augment_dim: int = 0
+    label_dropout: float = 0.0
     training_noise_distribution: (
         LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
     ) = None
@@ -314,6 +339,18 @@ class VideoDiffusionModelConfig:
                 raise ValueError("use_apex_gn is only used with the songunet backbone.")
             if not using_gpu():
                 raise ValueError("use_apex_gn requires a GPU.")
+        if self.label_dim != 0:
+            raise ValueError(
+                "label_dim is not supported: VideoDiffusionModel never supplies "
+                "class_labels, so a nonzero label_dim would build an unusable "
+                "class-conditioning layer."
+            )
+        if self.augment_dim != 0:
+            raise ValueError(
+                "augment_dim is not supported: VideoDiffusionModel never supplies "
+                "augment_labels, so a nonzero augment_dim would build an unusable "
+                "augmentation-conditioning layer."
+            )
 
     @property
     def noise_distribution(self) -> NoiseDistribution:
@@ -413,11 +450,25 @@ class VideoDiffusionModelConfig:
                 seq_length=self.n_timesteps,
                 model_channels=self.model_channels,
                 channel_mult=tuple(self.channel_mult),
+                channel_mult_emb=self.channel_mult_emb,
+                channel_mult_noise=self.channel_mult_noise,
                 num_blocks=self.num_blocks,
                 n_heads=self.n_heads,
                 attn_resolutions=tuple(attn_resolutions),
                 num_freqs=self.num_freqs,
+                dropout=self.dropout,
+                label_dropout=self.label_dropout,
+                embedding_type=self.songunet_embedding_type,
+                encoder_type=self.encoder_type,
+                decoder_type=self.decoder_type,
+                resample_filter=tuple(self.resample_filter),
+                checkpoint_level=self.checkpoint_level,
+                additive_pos_embed=self.additive_pos_embed,
+                bottleneck_attention=self.bottleneck_attention,
                 use_apex_gn=self.use_apex_gn,
+                act=self.act,
+                profile_mode=self.profile_mode,
+                amp_mode=self.amp_mode,
             )
         else:
             net = VideoUNet(

--- a/fme/downscaling/video_models.py
+++ b/fme/downscaling/video_models.py
@@ -1,0 +1,972 @@
+"""Endpoint-conditioned video interpolation diffusion (temporal-only).
+
+Diffuses the residual over a temporal linear interpolation of observed endpoints;
+only interior frames are denoised. Operates on the fine clip only.
+"""
+
+import dataclasses
+
+import torch
+
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.normalizer import NormalizationConfig, StandardNormalizer
+from fme.core.packer import Packer
+from fme.core.rand import randn_like
+from fme.core.typing_ import TensorDict, TensorMapping
+from fme.downscaling.data import PairedVideoBatchData
+from fme.downscaling.models import ModelOutputs
+from fme.downscaling.modules.video_modules import VideoEDMPrecond, VideoUNet
+from fme.downscaling.noise import (
+    LogNormalNoiseDistribution,
+    LogUniformNoiseDistribution,
+    NoiseDistribution,
+    brownian_bridge_mixing_matrix,
+    ou_mixing_matrix,
+    rbf_mixing_matrix,
+    uniform_frame_times,
+)
+from fme.downscaling.requirements import DataRequirements
+
+CHANNEL_AXIS = 1
+
+
+def _interior_mask(n_times: int, device: torch.device) -> torch.Tensor:
+    """(1, 1, T, 1, 1) mask: 1 on interior frames, 0 on observed endpoints."""
+    mask = torch.ones(n_times, device=device)
+    mask[0] = 0.0
+    mask[-1] = 0.0
+    return mask.reshape(1, 1, n_times, 1, 1)
+
+
+def _linear_interp_endpoints(
+    field: torch.Tensor, tau: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Temporal linear interpolation of the two endpoints along the time axis.
+
+    ``tau`` gives the normalized time of each frame in ``[0, 1]`` (endpoints at 0
+    and 1). When omitted the frames are assumed uniformly spaced, reproducing the
+    ``linspace`` weights; passing the true ``tau`` lets the baseline stay correct
+    for a non-uniform subset of frames.
+    """
+    n_times = field.shape[-3]
+    shape = [1] * field.dim()
+    shape[-3] = n_times
+    if tau is None:
+        w = torch.linspace(0.0, 1.0, n_times, device=field.device)
+    else:
+        w = tau.to(device=field.device, dtype=field.dtype)
+    w = w.reshape(shape)
+    x0 = field[..., 0:1, :, :]
+    xT = field[..., n_times - 1 : n_times, :, :]
+    return (1 - w) * x0 + w * xT
+
+
+@dataclasses.dataclass
+class VideoDiffusionModelConfig:
+    """Configuration for the temporal-interpolation video diffusion model."""
+
+    out_names: list[str]
+    n_timesteps: int
+    normalization: NormalizationConfig | None = None
+    sigma_min: float = 0.002
+    sigma_max: float = 80.0
+    churn: float = 0.0
+    num_diffusion_generation_steps: int = 18
+    model_channels: int = 64
+    n_heads: int = 4
+    num_freqs: int = 4
+    # log-noise embedding for the simple backbone: "positional" or "fourier".
+    noise_embedding_type: str = "positional"
+    # Multi-scale U-Net: one channel multiplier per resolution level (0 = finest).
+    channel_mult: list[int] = dataclasses.field(default_factory=lambda: [1, 2, 2])
+    num_blocks: int = 2
+    # spatial attention levels; temporal attention defaults to all levels (None).
+    attention_levels: list[int] = dataclasses.field(default_factory=lambda: [1, 2])
+    temporal_attention_levels: list[int] | None = None
+    # backbone: "simple" (periodic VideoUNet) or "songunet" (SongUNetv2).
+    backbone: str = "simple"
+    img_resolution: list[int] | None = None  # [H, W], required for songunet
+    attn_resolutions: list[int] | None = None
+    training_noise_distribution: (
+        LogNormalNoiseDistribution | LogUniformNoiseDistribution | None
+    ) = None
+    training_noise_distributions: (
+        dict[str, LogNormalNoiseDistribution | LogUniformNoiseDistribution] | None
+    ) = None
+    sigma_min_by_channel: dict[str, float] | None = None
+    sigma_max_by_channel: dict[str, float] | None = None
+    # Per-channel EDM sigma_data (std of the diffused residual). Channels left
+    # unset default to 1.0. Setting it to the measured residual std per channel
+    # fixes the preconditioning/loss weighting for residual diffusion.
+    sigma_data_by_channel: dict[str, float] | None = None
+    loss_weight_exponent: float = 1.0
+    # Channels modeled in log space via log1p(x*scale); maps channel to scale.
+    log_transform_channels: dict[str, float] | None = None
+    # Temporal correlation of the residual noise: "independent" (per-frame white
+    # noise, default), "brownian_bridge" (endpoint-pinned time-correlated noise,
+    # same kernel for every channel), or "per_channel" (a different kernel per
+    # channel, via per_channel_noise_kernel/per_channel_kernel_length_scale below
+    # -- e.g. matching each channel to whichever of bridge/OU/RBF best fits its
+    # real temporal correlation, see toy/process_residual_bridge_report.md).
+    temporal_noise_correlation: str = "independent"
+    # Required iff temporal_noise_correlation == "per_channel": maps every
+    # out_names entry to "independent", "brownian_bridge", "ou", or "rbf".
+    per_channel_noise_kernel: dict[str, str] | None = None
+    # Required iff per_channel_noise_kernel has any "ou"/"rbf" entries: maps
+    # those channels to their kernel length scale, in the same normalized
+    # [0, 1]-over-the-full-window units as uniform_frame_times (i.e. hours /
+    # total_window_hours, NOT raw hours -- e.g. an empirically-fit 12.9h OU
+    # length scale over a 24h window is 12.9/24 = 0.5375 here).
+    per_channel_kernel_length_scale: dict[str, float] | None = None
+    # Fraction of training batches trained on a random subset of interior frames
+    # (the two endpoints are always kept) instead of the full uniform grid, so the
+    # model learns to answer variable query sets and stays consistent across them.
+    # 0.0 (default) trains only on the full grid -- exact prior behavior.
+    subset_augmentation_prob: float = 0.0
+    # Minimum number of interior frames to keep when a batch is subsetted.
+    subset_min_interior: int = 1
+    # Weight of the marginal-consistency loss (video PMD L_marg). When > 0, each
+    # training step runs a second pass on a random strict subset of the (possibly
+    # augmentation-subset) interior frames -- sharing the first pass's noised
+    # inputs on the shared frames -- and penalizes disagreement between the first
+    # pass's prediction restricted to the subset and the subset-native prediction.
+    # May be combined with subset_augmentation_prob (holds subset exposure fixed
+    # while toggling the loss). 0.0 (default) disables it (single pass, exact
+    # prior behavior).
+    marginal_consistency_weight: float = 0.0
+
+    def __post_init__(self):
+        if self.n_timesteps < 3:
+            raise ValueError(
+                "Video interpolation needs at least 3 frames (2 endpoints + 1 "
+                f"interior), got n_timesteps={self.n_timesteps}."
+            )
+        for field_name in (
+            "training_noise_distributions",
+            "sigma_min_by_channel",
+            "sigma_max_by_channel",
+            "sigma_data_by_channel",
+        ):
+            values = getattr(self, field_name)
+            if values is None:
+                continue
+            unknown = set(values) - set(self.out_names)
+            if unknown:
+                raise ValueError(
+                    f"{field_name} contains channels not in out_names: "
+                    f"{sorted(unknown)}"
+                )
+        if self.training_noise_distributions is not None:
+            missing = set(self.out_names) - set(self.training_noise_distributions)
+            if missing:
+                raise ValueError(
+                    "training_noise_distributions must specify every output "
+                    f"channel; missing {sorted(missing)}"
+                )
+        if (self.sigma_min_by_channel is None) != (self.sigma_max_by_channel is None):
+            raise ValueError(
+                "sigma_min_by_channel and sigma_max_by_channel must be specified "
+                "together."
+            )
+        if (
+            self.training_noise_distribution is not None
+            and self.training_noise_distributions is not None
+        ):
+            raise ValueError(
+                "Specify only one of training_noise_distribution or "
+                "training_noise_distributions."
+            )
+        unknown_log = set(self.log_transform_channels or {}) - set(self.out_names)
+        if unknown_log:
+            raise ValueError(
+                "log_transform_channels contains channels not in out_names: "
+                f"{sorted(unknown_log)}"
+            )
+        if any(
+            lvl not in range(len(self.channel_mult)) for lvl in self.attention_levels
+        ):
+            raise ValueError(
+                f"attention_levels {self.attention_levels} must index into "
+                f"channel_mult (0..{len(self.channel_mult) - 1})."
+            )
+        for m in self.channel_mult:
+            if (self.model_channels * m) % self.n_heads != 0:
+                raise ValueError(
+                    f"model_channels*{m}={self.model_channels * m} not divisible "
+                    f"by n_heads={self.n_heads}."
+                )
+        if self.temporal_noise_correlation not in (
+            "independent",
+            "brownian_bridge",
+            "per_channel",
+        ):
+            raise ValueError(
+                "temporal_noise_correlation must be 'independent', "
+                f"'brownian_bridge', or 'per_channel', got "
+                f"{self.temporal_noise_correlation}."
+            )
+        if self.temporal_noise_correlation == "per_channel":
+            if self.per_channel_noise_kernel is None:
+                raise ValueError(
+                    "temporal_noise_correlation == 'per_channel' requires "
+                    "per_channel_noise_kernel."
+                )
+            missing = set(self.out_names) - set(self.per_channel_noise_kernel)
+            extra = set(self.per_channel_noise_kernel) - set(self.out_names)
+            if missing or extra:
+                raise ValueError(
+                    "per_channel_noise_kernel must specify exactly out_names: "
+                    f"missing {sorted(missing)}, unexpected {sorted(extra)}."
+                )
+            bad_kernels = {
+                k
+                for k in self.per_channel_noise_kernel.values()
+                if k not in ("independent", "brownian_bridge", "ou", "rbf")
+            }
+            if bad_kernels:
+                raise ValueError(
+                    "per_channel_noise_kernel values must be 'independent', "
+                    f"'brownian_bridge', 'ou', or 'rbf', got {sorted(bad_kernels)}."
+                )
+            needs_length_scale = {
+                name
+                for name, k in self.per_channel_noise_kernel.items()
+                if k in ("ou", "rbf")
+            }
+            have_length_scale = set(self.per_channel_kernel_length_scale or {})
+            missing_ell = needs_length_scale - have_length_scale
+            if missing_ell:
+                raise ValueError(
+                    "per_channel_kernel_length_scale missing entries for "
+                    f"ou/rbf channels: {sorted(missing_ell)}."
+                )
+            bad_ell = {
+                name: ell
+                for name, ell in (self.per_channel_kernel_length_scale or {}).items()
+                if ell <= 0.0
+            }
+            if bad_ell:
+                raise ValueError(
+                    f"per_channel_kernel_length_scale must be > 0, got {bad_ell}."
+                )
+        elif self.per_channel_noise_kernel is not None:
+            raise ValueError(
+                "per_channel_noise_kernel is only used when "
+                "temporal_noise_correlation == 'per_channel'."
+            )
+        if not 0.0 <= self.subset_augmentation_prob <= 1.0:
+            raise ValueError(
+                "subset_augmentation_prob must be in [0, 1], got "
+                f"{self.subset_augmentation_prob}."
+            )
+        max_interior = self.n_timesteps - 2
+        if not 1 <= self.subset_min_interior <= max_interior:
+            raise ValueError(
+                f"subset_min_interior must be in [1, {max_interior}] "
+                f"(n_timesteps - 2), got {self.subset_min_interior}."
+            )
+        if self.marginal_consistency_weight < 0.0:
+            raise ValueError(
+                "marginal_consistency_weight must be >= 0, got "
+                f"{self.marginal_consistency_weight}."
+            )
+        if self.marginal_consistency_weight > 0.0:
+            # The full grid must admit a strict interior subset (keep in
+            # [subset_min_interior, n_interior - 1]), so n_interior >=
+            # subset_min_interior + 1. May be combined with subset_augmentation:
+            # when an augmented batch is too small to form a strict subset the
+            # consistency pass is skipped for that batch (see train_on_batch).
+            if self.n_timesteps - 2 < self.subset_min_interior + 1:
+                raise ValueError(
+                    "marginal_consistency_weight > 0 needs n_timesteps >= "
+                    f"subset_min_interior + 3 (got n_timesteps={self.n_timesteps}, "
+                    f"subset_min_interior={self.subset_min_interior})."
+                )
+        if self.backbone not in ("simple", "songunet"):
+            raise ValueError(
+                f"backbone must be 'simple' or 'songunet', got {self.backbone}."
+            )
+        if self.noise_embedding_type not in ("positional", "fourier"):
+            raise ValueError(
+                "noise_embedding_type must be 'positional' or 'fourier', got "
+                f"{self.noise_embedding_type}."
+            )
+        if self.backbone == "songunet" and self.img_resolution is None:
+            raise ValueError("songunet backbone requires img_resolution [H, W].")
+
+    @property
+    def noise_distribution(self) -> NoiseDistribution:
+        if self.training_noise_distribution is not None:
+            return self.training_noise_distribution
+        return LogNormalNoiseDistribution(p_mean=-1.2, p_std=1.2)
+
+    def sample_training_noise(
+        self, batch_size: int, device: torch.device
+    ) -> torch.Tensor:
+        if self.training_noise_distributions is None:
+            return self.noise_distribution.sample(batch_size, device)
+        sigma_by_channel = [
+            self.training_noise_distributions[name].sample(batch_size, device)
+            for name in self.out_names
+        ]
+        return torch.cat(sigma_by_channel, dim=1)
+
+    def sigma_data_tensor(self, device: torch.device) -> torch.Tensor:
+        """Per-channel sigma_data (default 1.0), ordered by out_names."""
+        return torch.tensor(
+            [
+                1.0
+                if self.sigma_data_by_channel is None
+                else self.sigma_data_by_channel.get(name, 1.0)
+                for name in self.out_names
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+
+    def generation_sigma_bounds(
+        self, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        sigma_min = torch.tensor(
+            [
+                self.sigma_min
+                if self.sigma_min_by_channel is None
+                else self.sigma_min_by_channel.get(name, self.sigma_min)
+                for name in self.out_names
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        sigma_max = torch.tensor(
+            [
+                self.sigma_max
+                if self.sigma_max_by_channel is None
+                else self.sigma_max_by_channel.get(name, self.sigma_max)
+                for name in self.out_names
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        return sigma_min, sigma_max
+
+    @property
+    def data_requirements(self) -> "DataRequirements":
+        # Temporal-only: fine == coarse; clip length comes from the data config.
+        return DataRequirements(
+            fine_names=self.out_names,
+            coarse_names=self.out_names,
+            n_timesteps=1,
+            use_fine_topography=False,
+        )
+
+    def build(
+        self, normalizer: StandardNormalizer | None = None
+    ) -> "VideoDiffusionModel":
+        if normalizer is None:
+            if self.normalization is None:
+                raise ValueError(
+                    "Either `normalization` config or a prebuilt `normalizer` "
+                    "must be provided."
+                )
+            normalizer = self.normalization.build(self.out_names)
+
+        n_channels = len(self.out_names)
+        # noisy residual (C) + endpoint values (C) + mask (1) + log-sigma (C)
+        in_channels = 3 * n_channels + 1
+        if self.backbone == "songunet":
+            from fme.downscaling.modules.video_song_unet import VideoSongUNet
+
+            if self.img_resolution is None:
+                # unreachable: __post_init__ already enforces this
+                raise ValueError("songunet backbone requires img_resolution [H, W].")
+            default_attn = self.img_resolution[0] >> (len(self.channel_mult) - 1)
+            net = VideoSongUNet(
+                in_channels=in_channels,
+                out_channels=n_channels,
+                img_resolution=self.img_resolution,
+                seq_length=self.n_timesteps,
+                model_channels=self.model_channels,
+                channel_mult=tuple(self.channel_mult),
+                num_blocks=self.num_blocks,
+                n_heads=self.n_heads,
+                attn_resolutions=tuple(self.attn_resolutions or [default_attn]),
+                num_freqs=self.num_freqs,
+            )
+        else:
+            net = VideoUNet(
+                in_channels=in_channels,
+                out_channels=n_channels,
+                seq_length=self.n_timesteps,
+                model_channels=self.model_channels,
+                channel_mult=tuple(self.channel_mult),
+                num_blocks=self.num_blocks,
+                n_heads=self.n_heads,
+                attention_levels=tuple(self.attention_levels),
+                temporal_attention_levels=(
+                    None
+                    if self.temporal_attention_levels is None
+                    else tuple(self.temporal_attention_levels)
+                ),
+                num_freqs=self.num_freqs,
+                noise_embedding_type=self.noise_embedding_type,
+            )
+        module = VideoEDMPrecond(net, sigma_data=self.sigma_data_tensor(get_device()))
+        return VideoDiffusionModel(self, module, normalizer, self.out_names)
+
+
+def _channel_mixing_matrix(
+    tau: torch.Tensor, kernel: str, length_scale: float | None
+) -> torch.Tensor:
+    """``(T, T)`` mixing matrix for one channel's chosen kernel -- the
+    per-channel building block for ``temporal_noise_correlation ==
+    'per_channel'``. ``"independent"`` embeds an identity in the interior
+    block (endpoints still zero), giving unmixed white noise for that
+    channel while still stacking cleanly into a per-channel tensor.
+    """
+    if kernel == "independent":
+        n_timesteps = tau.shape[0]
+        n_interior = n_timesteps - 2
+        mixing = torch.zeros(
+            n_timesteps, n_timesteps, dtype=torch.float32, device=tau.device
+        )
+        mixing[1 : 1 + n_interior, 1 : 1 + n_interior] = torch.eye(
+            n_interior, device=tau.device
+        )
+        return mixing
+    if kernel == "brownian_bridge":
+        return brownian_bridge_mixing_matrix(tau)
+    if kernel == "ou":
+        assert length_scale is not None
+        return ou_mixing_matrix(tau, length_scale)
+    if kernel == "rbf":
+        assert length_scale is not None
+        return rbf_mixing_matrix(tau, length_scale)
+    raise ValueError(f"Unknown per-channel noise kernel {kernel!r}")
+
+
+def _per_channel_mixing_tensor(
+    tau: torch.Tensor,
+    out_names: list[str],
+    kernel_map: dict[str, str],
+    length_scale_map: dict[str, float] | None,
+) -> torch.Tensor:
+    """``(C, T, T)`` stacked per-channel mixing matrices, ordered by
+    ``out_names`` -- each channel's own kernel/length-scale choice.
+    """
+    mats = [
+        _channel_mixing_matrix(
+            tau, kernel_map[name], (length_scale_map or {}).get(name)
+        )
+        for name in out_names
+    ]
+    return torch.stack(mats, dim=0)
+
+
+class VideoDiffusionModel:
+    def __init__(
+        self,
+        config: VideoDiffusionModelConfig,
+        module: torch.nn.Module,
+        normalizer: StandardNormalizer,
+        out_names: list[str],
+    ):
+        self.config = config
+        # (1, C, 1, 1, 1) so it broadcasts against the per-channel sigma tensor.
+        self.sigma_data = config.sigma_data_tensor(get_device()).reshape(1, -1, 1, 1, 1)
+        dist = Distributed.get_instance()
+        self.module = dist.wrap_module(module.to(get_device()))
+        self.normalizer = normalizer
+        self.out_names = out_names
+        self.packer = Packer(out_names)
+        self.n_timesteps = config.n_timesteps
+        self.log_transform_channels = dict(config.log_transform_channels or {})
+        # normalized full-grid frame times (endpoints at 0/1) used to derive the
+        # baseline weights and bridge kernel for whatever frame subset is in play.
+        self._full_tau = uniform_frame_times(config.n_timesteps)
+        self._marginal_consistency_weight = config.marginal_consistency_weight
+        self._bridge_noise = config.temporal_noise_correlation == "brownian_bridge"
+        self._per_channel_noise = config.temporal_noise_correlation == "per_channel"
+        if self._bridge_noise:
+            self._noise_mixing: torch.Tensor | None = brownian_bridge_mixing_matrix(
+                self._full_tau
+            ).to(get_device())
+        elif self._per_channel_noise:
+            assert (
+                config.per_channel_noise_kernel is not None
+            )  # validated in __post_init__
+            self._noise_mixing = _per_channel_mixing_tensor(
+                self._full_tau,
+                out_names,
+                config.per_channel_noise_kernel,
+                config.per_channel_kernel_length_scale,
+            ).to(get_device())
+        else:
+            self._noise_mixing = None
+
+    @property
+    def modules(self) -> torch.nn.ModuleList:
+        return torch.nn.ModuleList([self.module])
+
+    def _sample_residual_noise(
+        self, like: torch.Tensor, mixing: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """White noise shaped like ``like`` (B, C, T, H, W), temporally correlated
+        with ``mixing`` when given (bridge/OU/RBF kernel, shared or per-channel),
+        else independent.
+
+        ``mixing`` defaults to the full-grid mixing tensor; pass a subset matrix
+        for a subset of frames, or ``None`` stays independent (mixing is ``None``
+        in independent mode regardless). ``mixing`` is either ``(T, T)`` (same
+        kernel for every channel) or ``(C, T, T)`` (per-channel kernels).
+        """
+        noise = randn_like(like)
+        if mixing is None:
+            mixing = self._noise_mixing
+        if mixing is None:
+            return noise
+        mixing = mixing.to(device=noise.device, dtype=noise.dtype)
+        if mixing.ndim == 3:
+            return torch.einsum("cti,bcihw->bcthw", mixing, noise)
+        return torch.einsum("ti,bcihw->bcthw", mixing, noise)
+
+    def _tau_for_indices(self, idx: torch.Tensor | None) -> torch.Tensor | None:
+        """Normalized frame times for a subset of the full grid (``None`` = full
+        grid, where the ``linspace`` default in the baseline already applies).
+        """
+        if idx is None:
+            return None
+        return self._full_tau.to(idx.device).index_select(0, idx)
+
+    def _mixing_for_indices(self, idx: torch.Tensor | None) -> torch.Tensor | None:
+        """Mixing tensor for a subset of frames -- the full-window kernel(s)
+        restricted to ``idx`` (re-derived at just those frame times, which
+        equals the true marginal -- see brownian_bridge_mixing_matrix's
+        docstring). ``None`` for independent noise or the full grid.
+        """
+        if not (self._bridge_noise or self._per_channel_noise):
+            return None
+        if idx is None:
+            return self._noise_mixing
+        tau = self._full_tau.index_select(0, idx.cpu())
+        if self._per_channel_noise:
+            assert self.config.per_channel_noise_kernel is not None
+            return _per_channel_mixing_tensor(
+                tau,
+                self.out_names,
+                self.config.per_channel_noise_kernel,
+                self.config.per_channel_kernel_length_scale,
+            ).to(get_device())
+        return brownian_bridge_mixing_matrix(tau).to(get_device())
+
+    def _synced_generator(self, device: torch.device) -> torch.Generator:
+        """A CPU RNG seeded identically on every rank (drawn on rank 0 and
+        broadcast) so all data-/model-parallel ranks pick the same frame subset
+        and therefore agree on the temporal shape of the batch.
+        """
+        dist = Distributed.get_instance()
+        seed = torch.randint(0, 2**31 - 1, (1,), device=device)
+        if dist.rank != 0:
+            seed.zero_()
+        seed = int(dist.reduce_sum(seed).item())
+        return torch.Generator().manual_seed(seed)
+
+    @staticmethod
+    def _interior_subset_indices(
+        n_keep: int, n_times: int, gen: torch.Generator, device: torch.device
+    ) -> torch.Tensor:
+        """Sorted frame indices keeping both endpoints plus ``n_keep`` random
+        interior frames.
+        """
+        n_interior = n_times - 2
+        interior = torch.sort(torch.randperm(n_interior, generator=gen)[:n_keep]).values
+        idx = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.long),
+                interior + 1,
+                torch.full((1,), n_times - 1, dtype=torch.long),
+            ]
+        )
+        return idx.to(device)
+
+    def _sample_training_subset_indices(
+        self, n_times: int, device: torch.device
+    ) -> torch.Tensor | None:
+        """Randomly pick frame indices (always keeping the two endpoints) for
+        subset-augmented training, or ``None`` to train on the full grid.
+        """
+        if self.config.subset_augmentation_prob <= 0.0:
+            return None
+        gen = self._synced_generator(device)
+        if float(torch.rand((), generator=gen)) >= self.config.subset_augmentation_prob:
+            return None
+        n_interior = n_times - 2
+        n_keep = int(
+            torch.randint(
+                self.config.subset_min_interior, n_interior + 1, (1,), generator=gen
+            )
+        )
+        if n_keep >= n_interior:
+            return None  # kept everything -> full grid
+        return self._interior_subset_indices(n_keep, n_times, gen, device)
+
+    def _sample_consistency_subset_indices(
+        self, n_times: int, device: torch.device
+    ) -> torch.Tensor:
+        """A random *strict* interior subset (endpoints kept, at least one interior
+        frame dropped) for the marginal-consistency second pass.
+        """
+        gen = self._synced_generator(device)
+        n_interior = n_times - 2
+        # keep in [subset_min_interior, n_interior - 1]: never the full interior,
+        # so the two passes always differ in their query set.
+        n_keep = int(
+            torch.randint(
+                self.config.subset_min_interior, n_interior, (1,), generator=gen
+            )
+        )
+        return self._interior_subset_indices(n_keep, n_times, gen, device)
+
+    @staticmethod
+    def _validate_frames(
+        frames: "list[int] | None", n_times: int, device: torch.device
+    ) -> torch.Tensor | None:
+        """Validate a requested frame subset for ``generate`` and return it as a
+        LongTensor of indices into the full grid, or ``None`` for the full grid.
+        """
+        if frames is None:
+            return None
+        idx = torch.as_tensor(list(frames), dtype=torch.long)
+        if idx.ndim != 1 or idx.numel() < 3:
+            raise ValueError(
+                "frames must list at least 3 frame indices (2 endpoints + "
+                f"interior), got {list(frames)}."
+            )
+        if int(idx[0]) != 0 or int(idx[-1]) != n_times - 1:
+            raise ValueError(
+                f"frames must start at 0 and end at {n_times - 1} (the observed "
+                f"endpoints), got {list(frames)}."
+            )
+        if not bool(torch.all(idx[1:] > idx[:-1])):
+            raise ValueError(f"frames must be strictly increasing, got {list(frames)}.")
+        return idx.to(device)
+
+    def _pack_normalized(self, data: TensorMapping) -> torch.Tensor:
+        selected = {
+            k: torch.log1p(data[k].clamp(min=0.0) * scale)
+            if (scale := self.log_transform_channels.get(k))
+            else data[k]
+            for k in self.out_names
+        }
+        normalized = self.normalizer.normalize(selected)
+        return self.packer.pack(normalized, axis=CHANNEL_AXIS)
+
+    def _denormalize_invert(self, packed: torch.Tensor) -> TensorDict:
+        """Denormalize and invert any log1p transform back to physical units."""
+        data = self.normalizer.denormalize(
+            self.packer.unpack(packed, axis=CHANNEL_AXIS)
+        )
+        return {
+            k: (torch.expm1(v) / scale).clamp(min=0.0)
+            if (scale := self.log_transform_channels.get(k))
+            else v
+            for k, v in data.items()
+        }
+
+    def _conditioning(
+        self, clip: torch.Tensor, interior_mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Observed-endpoint values + a binary observed mask channel."""
+        observed = 1.0 - interior_mask
+        observed_values = clip * observed
+        mask_channel = observed.expand(
+            clip.shape[0], 1, -1, clip.shape[-2], clip.shape[-1]
+        )
+        return torch.cat([observed_values, mask_channel], dim=CHANNEL_AXIS)
+
+    def _calendar_inputs(self, batch_fine):
+        lon = batch_fine.latlon_coordinates.lon
+        if lon.dim() == 2:  # all members identical, use first
+            lon = lon[0]
+        return (
+            batch_fine.day_of_year.to(get_device()),
+            batch_fine.second_of_day.to(get_device()),
+            lon.to(get_device()),
+        )
+
+    def train_on_batch(self, batch: PairedVideoBatchData, optimizer) -> ModelOutputs:
+        fine = batch.fine
+        clip = self._pack_normalized(fine.data)
+        day_of_year, second_of_day, lon = self._calendar_inputs(fine)
+
+        # Optionally train on a random subset of interior frames (endpoints kept)
+        # so the model learns to answer variable query sets; the bridge noise and
+        # baseline follow the subset's true times, i.e. the full-window marginal.
+        idx = self._sample_training_subset_indices(clip.shape[2], clip.device)
+        if idx is not None:
+            clip = clip.index_select(2, idx)
+            day_of_year = day_of_year.index_select(1, idx)
+            second_of_day = second_of_day.index_select(1, idx)
+        batch_size, _, n_times, _, _ = clip.shape
+        tau = self._tau_for_indices(idx)
+
+        baseline = _linear_interp_endpoints(clip, tau)
+        residual = clip - baseline  # ~0 at endpoints by construction
+
+        interior = _interior_mask(n_times, clip.device)
+        condition = self._conditioning(clip, interior)
+        mixing = self._mixing_for_indices(idx)
+
+        sigma = self.config.sample_training_noise(batch_size, clip.device)
+        sigma = sigma.reshape(batch_size, -1, 1, 1, 1)
+        # Gaussian noise on interior frames only
+        noise = self._sample_residual_noise(residual, mixing)
+        noised = residual + noise * sigma * interior
+
+        # ``idx`` (or None for the full grid) is exactly the frames' true grid
+        # positions, so the temporal attention's relative bias reflects real
+        # spacing rather than packed-contiguous order.
+        denoised = self.module(
+            noised, condition, sigma, day_of_year, second_of_day, lon, frame_index=idx
+        )
+
+        weight = (
+            (sigma**2 + self.sigma_data**2) / (sigma * self.sigma_data) ** 2
+        ) ** self.config.loss_weight_exponent
+        sq_err = (denoised - residual) ** 2 * interior
+        n_interior_elems = interior.expand_as(sq_err).sum()
+        loss = (weight * sq_err).sum() / n_interior_elems
+
+        # Marginal-consistency loss: a second pass on a random strict subset of
+        # the (full) interior frames, sharing the SAME noised inputs, sigma, and
+        # conditioning on the shared frames (obtained by slicing the full pass, so
+        # the only difference is the query set). We add the subset's own diffusion
+        # loss plus a penalty tying the full-pass prediction, restricted to the
+        # subset, to the subset-native prediction on the shared interior frames.
+        marginal_loss: torch.Tensor | None = None
+        total_loss = loss
+        # A strict interior subset needs at least subset_min_interior + 1 interior
+        # frames; an augmentation-shrunk batch may fall below that, so skip the
+        # consistency pass for it rather than fail.
+        can_subset = n_times - 2 >= self.config.subset_min_interior + 1
+        if self._marginal_consistency_weight > 0.0 and can_subset:
+            sub = self._sample_consistency_subset_indices(n_times, clip.device)
+            interior_s = _interior_mask(int(sub.numel()), clip.device)
+            # True grid positions of the consistency frames: map the subset picks
+            # through the current frames' own grid positions (``idx`` when the
+            # batch was already augmented, else the full grid).
+            base_index = (
+                idx if idx is not None else torch.arange(n_times, device=clip.device)
+            )
+            sub_frame_index = base_index.index_select(0, sub)
+            denoised_s = self.module(
+                noised.index_select(2, sub),
+                condition.index_select(2, sub),
+                sigma,
+                day_of_year.index_select(1, sub),
+                second_of_day.index_select(1, sub),
+                lon,
+                frame_index=sub_frame_index,
+            )
+            residual_s = residual.index_select(2, sub)
+            n_interior_s = interior_s.expand_as(residual_s).sum()
+            sq_err_s = (denoised_s - residual_s) ** 2 * interior_s
+            dsm_sub = (weight * sq_err_s).sum() / n_interior_s
+            # full-pass prediction restricted to the subset vs subset-native one
+            diff = (denoised.index_select(2, sub) - denoised_s) ** 2 * interior_s
+            marginal_loss = diff.sum() / n_interior_s
+            total_loss = (
+                loss + dsm_sub + self._marginal_consistency_weight * marginal_loss
+            )
+
+        optimizer.accumulate_loss(total_loss)
+        optimizer.step_weights()
+
+        with torch.no_grad():
+            weighted_sq_err = sq_err * weight
+            per_sample_denominator = (
+                interior.expand(batch_size, 1, n_times, *clip.shape[-2:])
+                .sum(dim=(-3, -2, -1))
+                .clamp(min=1)
+            )
+            # pin observed endpoints (residual is 0 there)
+            full_norm = baseline + denoised * interior
+            prediction = self._denormalize_invert(full_norm)
+            channel_losses = {
+                name: weighted_sq_err[:, i].sum() / per_sample_denominator.sum()
+                for i, name in enumerate(self.out_names)
+            }
+            per_sample_channel_loss = {
+                name: weighted_sq_err[:, i].sum(dim=(-3, -2, -1))
+                / per_sample_denominator.flatten()
+                for i, name in enumerate(self.out_names)
+            }
+        # keep target aligned with the (possibly subset) prediction frames
+        target = {
+            k: fine.data[k] if idx is None else fine.data[k].index_select(1, idx)
+            for k in self.out_names
+        }
+        return ModelOutputs(
+            prediction=prediction,
+            target=target,
+            loss=total_loss,
+            marginal_consistency_loss=(
+                None if marginal_loss is None else marginal_loss.detach()
+            ),
+            channel_losses=channel_losses,
+            sigma=(
+                sigma.flatten()
+                if sigma.shape[1] == 1
+                else sigma.squeeze(-1).squeeze(-1).squeeze(-1)
+            ),
+            per_sample_channel_loss=per_sample_channel_loss,
+        )
+
+    @torch.no_grad()
+    def generate(
+        self,
+        batch: PairedVideoBatchData,
+        n_samples: int = 1,
+        frames: list[int] | None = None,
+    ) -> TensorDict:
+        """Generate the interior frames conditioned on the observed endpoints.
+
+        ``frames`` optionally restricts generation to a subset of frame indices
+        into the full ``n_timesteps`` grid; it must start at 0 and end at
+        ``n_timesteps - 1`` (the observed endpoints) and be strictly increasing.
+        The returned clips then contain only those frames. The baseline and the
+        bridge noise use the subset's true times, so a subset draws from the
+        exact marginal of the full-window process. Defaults to the full grid.
+        """
+        fine = batch.fine
+        clip = self._pack_normalized(fine.data)
+        day_of_year, second_of_day, lon = self._calendar_inputs(fine)
+        idx = self._validate_frames(frames, clip.shape[2], clip.device)
+        if idx is not None:
+            clip = clip.index_select(2, idx)
+            day_of_year = day_of_year.index_select(1, idx)
+            second_of_day = second_of_day.index_select(1, idx)
+        batch_size, n_channels, n_times, height, width = clip.shape
+        tau = self._tau_for_indices(idx)
+        baseline = _linear_interp_endpoints(clip, tau)
+        interior = _interior_mask(n_times, clip.device)
+        condition = self._conditioning(clip, interior)
+        mixing = self._mixing_for_indices(idx)
+
+        def repeat(t):
+            return t.repeat_interleave(n_samples, dim=0)
+
+        condition = repeat(condition)
+        baseline = repeat(baseline)
+        day_of_year = repeat(day_of_year)
+        second_of_day = repeat(second_of_day)
+        interior_b = interior.expand(batch_size * n_samples, n_channels, n_times, 1, 1)
+
+        latents = self._sample_residual_noise(
+            torch.empty(
+                batch_size * n_samples,
+                n_channels,
+                n_times,
+                height,
+                width,
+                device=clip.device,
+            ),
+            mixing,
+        )
+        sigma_min, sigma_max = self.config.generation_sigma_bounds(clip.device)
+        residual = _video_edm_sample(
+            self.module,
+            latents,
+            condition,
+            interior_b,
+            day_of_year,
+            second_of_day,
+            lon,
+            num_steps=self.config.num_diffusion_generation_steps,
+            sigma_min=sigma_min,
+            sigma_max=sigma_max,
+            s_churn=self.config.churn,
+            noise_mixing=mixing,
+            frame_index=idx,
+        )
+        full_norm = baseline + residual
+        generated = self._denormalize_invert(full_norm)
+        # (B*n, T, H, W) -> (B, n, T, H, W)
+        return {
+            k: v.reshape(batch_size, n_samples, *v.shape[1:])
+            for k, v in generated.items()
+        }
+
+
+def _video_edm_sample(
+    net: torch.nn.Module,
+    latents: torch.Tensor,
+    condition: torch.Tensor,
+    interior_mask: torch.Tensor,
+    day_of_year: torch.Tensor,
+    second_of_day: torch.Tensor,
+    lon: torch.Tensor,
+    num_steps: int,
+    sigma_min: float | torch.Tensor,
+    sigma_max: float | torch.Tensor,
+    rho: float = 7.0,
+    s_churn: float = 0.0,
+    noise_mixing: torch.Tensor | None = None,
+    frame_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """EDM stochastic sampler that keeps the observed endpoints pinned (re-zeroed
+    after every update). When ``noise_mixing`` is given, the stochastic churn noise
+    is temporally correlated with that mixing matrix (matching the training noise).
+    """
+    compute_dtype = torch.float32 if latents.device.type == "mps" else torch.float64
+    sigma_min_t = torch.as_tensor(
+        sigma_min, dtype=compute_dtype, device=latents.device
+    ).reshape(1, -1, 1, 1, 1)
+    sigma_max_t = torch.as_tensor(
+        sigma_max, dtype=compute_dtype, device=latents.device
+    ).reshape(1, -1, 1, 1, 1)
+    step = torch.arange(num_steps, dtype=compute_dtype, device=latents.device).reshape(
+        -1, 1, 1, 1, 1
+    )
+    t = (
+        sigma_max_t ** (1 / rho)
+        + step / (num_steps - 1) * (sigma_min_t ** (1 / rho) - sigma_max_t ** (1 / rho))
+    ) ** rho
+    t = torch.cat([t, torch.zeros_like(t[:1])])
+    mask = interior_mask.to(compute_dtype)
+
+    def denoise(x, sigma):
+        # broadcast per-channel sigma to (B, C) for the precond
+        sigma_bc = sigma.reshape(1, -1).expand(x.shape[0], -1).to(torch.float32)
+        out = net(
+            x.to(torch.float32),
+            condition,
+            sigma_bc,
+            day_of_year,
+            second_of_day,
+            lon,
+            frame_index=frame_index,
+        )
+        return out.to(compute_dtype)
+
+    def churn_noise(x):
+        noise = torch.randn_like(x)
+        if noise_mixing is None:
+            return noise
+        mixing = noise_mixing.to(device=noise.device, dtype=noise.dtype)
+        if mixing.ndim == 3:
+            return torch.einsum("cti,bcihw->bcthw", mixing, noise)
+        return torch.einsum("ti,bcihw->bcthw", mixing, noise)
+
+    x = latents.to(compute_dtype) * t[0] * mask
+    for i, (t_cur, t_next) in enumerate(zip(t[:-1], t[1:])):
+        gamma = s_churn / num_steps
+        t_hat = t_cur + gamma * t_cur
+        x_hat = x + (t_hat**2 - t_cur**2).clamp(min=0).sqrt() * churn_noise(x)
+        x_hat = x_hat * mask
+        d_cur = (x_hat - denoise(x_hat, t_hat)) / t_hat
+        x = (x_hat + (t_next - t_hat) * d_cur) * mask
+        if i < num_steps - 1:
+            d_prime = (x - denoise(x, t_next)) / t_next
+            x = (x_hat + (t_next - t_hat) * (0.5 * d_cur + 0.5 * d_prime)) * mask
+    return x.to(latents.dtype)


### PR DESCRIPTION
Adds the model layer for video PMD: an endpoint-conditioned diffusion model
that, given two observed daily snapshots (e.g. 0h/24h), diffuses only the
residual over a linear-interpolation baseline to infill 3-hourly interior
frames, with endpoints pinned exactly. Builds on the data loading from #1412.

Changes:
- `fme.downscaling.noise`: Brownian-bridge, OU, and RBF temporal noise-mixing
  kernels that keep noise pinned at clip endpoints, optionally one per
  channel (`per_channel_noise_kernel`/`per_channel_kernel_length_scale`).
- `fme.downscaling.modules.video_modules.VideoUNet`/`VideoEDMPrecond`: a
  compact 5-D (B, C, T, H, W) backbone, periodic in longitude, with
  cBottle-style calendar embedding and temporal attention, wrapped in EDM
  preconditioning (Karras 2022).
- `fme.downscaling.modules.video_song_unet.VideoSongUNet`: wraps the existing
  SongUNetv2 image backbone for video via forward-hook temporal attention on
  its attention-resolution blocks.
- `fme.downscaling.modules.physicsnemo_unets_v2.layers.Conv2d`: new
  `periodic` flag for longitude-circular padding on global lat/lon fields
  (main conv branch only; a guard prevents silently combining it with a
  resample filter wider than the current default, which the up/down branch
  doesn't yet support circularly).
- `fme.downscaling.video_models.VideoDiffusionModel`/`VideoDiffusionModelConfig`:
  the model itself, including subset-frame generation (train on a random
  subset of interior frames so the model can answer variable query sets) and
  an optional marginal-consistency loss (L_marg) tying full-grid and
  subset-native predictions that share the same noise.

- [x] Tests added
