### PR TITLE
Add video PMD experiment configs

### DIFF
--- a/configs/baselines/downscaling-temporal/train.yaml
+++ b/configs/baselines/downscaling-temporal/train.yaml
@@ -1,0 +1,192 @@
+# Canonical training config for the endpoint-conditioned video-PMD temporal
+# interpolation model (global 1deg, 24h -> 3h). Per-channel Ornstein-Uhlenbeck
+# noise kernels (temporal_noise_correlation: per_channel), plus subset-frame
+# training so the model can answer variable query sets. See
+# fme/downscaling/video_train.py and configs/experiments/2026-*-video-pmd-*
+# for the sweep this was selected from.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20
+max_test_batches: 50
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-per-channel-kernel-subset-cons0-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  # Subset training: half the batches train on a random subset of interior
+  # frames (endpoints always kept), so the model learns to answer variable
+  # query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # No marginal-consistency loss for this config; see
+  # configs/experiments/2026-07-14-video-pmd-bb-subset-cons10 and siblings
+  # for the L_marg sweep this was selected from.
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-06-29-video-pmd-smoke/run.sh
+++ b/configs/experiments/2026-06-29-video-pmd-smoke/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# CPU-only Beaker smoke run for the video PMD trainer, via gantry.
+#
+# Reads data from weka (climate-default), CPU-only (--gpus 0, FME_FORCE_CPU=1),
+# single process. Mirrors the weka pattern used by other ACE experiment runs
+# (e.g. configs/experiments/2025-11-15-ace2s-x-shield/run-ace2s-train.sh).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time):
+#   pip install beaker-gantry            # if gantry isn't installed
+#   beaker secret write --workspace ai2/chloeh CHLOE_WANDB_API_KEY <your-wandb-key>
+#
+# Run:  bash configs/experiments/2026-06-29-video-pmd-smoke/run.sh
+set -e
+
+JOB_NAME="video-pmd-regional-30-60-1degree-24to3-cpu-smoke"
+CONFIG_FILENAME="video_train_smoke.yaml"
+WORKSPACE="ai2/chloeh"
+CLUSTER="ai2/phobos"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name holding your W&B API key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'CPU smoke: endpoint-conditioned video interpolation (PMD), regional 30x60 1deg, 24h->3h' \
+    --workspace "$WORKSPACE" \
+    --priority normal \
+    --preemptible \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus 0 \
+    --shared-memory 10GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env FME_FORCE_CPU=1 \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- python -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-29-video-pmd-smoke/video_train_smoke.yaml
+++ b/configs/experiments/2026-06-29-video-pmd-smoke/video_train_smoke.yaml
@@ -1,0 +1,112 @@
+# Beaker CPU smoke config for the video PMD trainer (tiny + capped). Launch with run.sh.
+experiment_dir: /results
+max_epochs: 1
+max_train_batches: 3
+max_val_batches: 2
+validate_using_ema: true
+validate_interval: 1
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: regional-30-60-1degree-24to3-beaker-smoke
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.99
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 2
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 2
+  num_data_workers: 0
+  strict_ensemble: false
+  lat_extent:
+    start: 0
+    stop: 30
+  lon_extent:
+    start: 0
+    stop: 60
+model:
+  n_timesteps: 9
+  model_channels: 16
+  n_heads: 2
+  num_freqs: 3
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 4
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_min: 0.005
+      p_max: 2000.0
+  sigma_min_by_channel:
+    PRATEsfc: 0.005
+  sigma_max_by_channel:
+    PRATEsfc: 2000.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:
+    means:
+      eastward_wind_at_ten_meters: -0.206107
+      northward_wind_at_ten_meters: 0.133348
+      PRMSL: 1009.104862
+      PRATEsfc: 0.000014
+    stds:
+      eastward_wind_at_ten_meters: 2.845158
+      northward_wind_at_ten_meters: 3.598240
+      PRMSL: 5.558873
+      PRATEsfc: 0.000098

--- a/configs/experiments/2026-06-29-video-pmd-titan/run.sh
+++ b/configs/experiments/2026-06-29-video-pmd-titan/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-29-video-pmd-titan/run.sh
+set -e
+
+JOB_NAME="video-pmd-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video interpolation (PMD), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-29-video-pmd-titan/video_train.yaml
+++ b/configs/experiments/2026-06-29-video-pmd-titan/video_train.yaml
@@ -1,0 +1,141 @@
+# Full GPU training: endpoint-conditioned global video interpolation (PMD), 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_mean: -1.2
+      p_std: 1.8
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/run.sh
+++ b/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (Brownian-bridge + per-channel noise), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/video_train.yaml
+++ b/configs/experiments/2026-06-30-video-pmd-bb-per-channel-noise/video_train.yaml
@@ -1,0 +1,164 @@
+# Global video PMD (independent noise) with PER-CHANNEL noise schedule matched to
+# each channel's residual std. 4x B200 DDP. A/B partner of the bb-per-channel-noise run.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-06-30-video-pmd-bridge-titan/run.sh
+++ b/configs/experiments/2026-06-30-video-pmd-bridge-titan/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Variant of 2026-06-29-video-pmd-titan that uses endpoint-aware Brownian-bridge
+# temporal noise (temporal_noise_correlation: brownian_bridge) instead of the
+# default independent per-frame noise. Same data split and model as that run --
+# a controlled A/B against the independent-noise baseline.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-30-video-pmd-bridge-titan/run.sh
+set -e
+
+JOB_NAME="video-pmd-bridge-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video interpolation (PMD, Brownian-bridge noise), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-30-video-pmd-bridge-titan/video_train.yaml
+++ b/configs/experiments/2026-06-30-video-pmd-bridge-titan/video_train.yaml
@@ -1,0 +1,148 @@
+# Full GPU training: endpoint-conditioned global video interpolation (PMD), 4x B200 DDP.
+# Brownian-bridge temporal-noise variant of 2026-06-29-video-pmd-titan. Identical
+# data split and model to that run; the ONLY change is
+# temporal_noise_correlation: brownian_bridge, so this is a controlled A/B against
+# the independent-noise baseline.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bridge-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). The default
+  # is "independent"; this run uses the Brownian-bridge kernel on interior frames.
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    northward_wind_at_ten_meters:
+      p_mean: -1.2
+      p_std: 1.8
+    PRMSL:
+      p_mean: -1.2
+      p_std: 1.8
+    PRATEsfc:
+      p_mean: -1.2
+      p_std: 1.8
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain (same window as the titan baseline)
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-06-30-video-pmd-per-channel-noise/run.sh
+++ b/configs/experiments/2026-06-30-video-pmd-per-channel-noise/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-06-30-video-pmd-per-channel-noise/run.sh
+set -e
+
+JOB_NAME="video-pmd-pcn-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (independent + per-channel noise), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-06-30-video-pmd-per-channel-noise/video_train.yaml
+++ b/configs/experiments/2026-06-30-video-pmd-per-channel-noise/video_train.yaml
@@ -1,0 +1,162 @@
+# Global video PMD (independent noise) with PER-CHANNEL noise schedule matched to
+# each channel's residual std. 4x B200 DDP. A/B partner of the bb-per-channel-noise run.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-pcn-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/run.sh
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training, NO marginal-consistency loss
+# (weight 0). A/B partner of the ...-subset-cons1 run.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training, no L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/video_train.yaml
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons0/video_train.yaml
@@ -1,0 +1,173 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training but
+# NO marginal-consistency loss (weight 0). A/B partner of the ...-subset-cons1 run:
+# identical in every way (data, normalization, per-channel bridge noise, subset
+# augmentation) EXCEPT marginal_consistency_weight, so the pair isolates L_marg.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons0-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # No marginal-consistency loss for this run (the A/B baseline).
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/run.sh
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training + marginal-consistency loss
+# (weight 1). A/B partner of the ...-subset-cons0 run.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons1-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training + L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/video_train.yaml
+++ b/configs/experiments/2026-07-01-video-pmd-bb-subset-cons1/video_train.yaml
@@ -1,0 +1,175 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 1). A/B partner of the ...-subset-cons0 run:
+# identical in every way (data, normalization, per-channel bridge noise, subset
+# augmentation) EXCEPT marginal_consistency_weight, so the pair isolates L_marg.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons1-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg).
+  marginal_consistency_weight: 1.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/run.sh
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training + marginal-consistency loss
+# (weight 10). Third arm of the cons0 / cons1 / cons10 L_marg sweep.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training + L_marg weight 10), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/video_train.yaml
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset-cons10/video_train.yaml
@@ -1,0 +1,176 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 10). Third arm of the ...-subset-cons0 /
+# ...-subset-cons1 sweep: identical in every way (data, normalization, per-channel
+# bridge noise, subset augmentation) EXCEPT marginal_consistency_weight, so the
+# three runs isolate the strength of L_marg (0 -> 1 -> 10). 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons10-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg). Weight 10
+  # pushes the consistency term hard relative to the two diffusion losses.
+  marginal_consistency_weight: 10.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/run.sh
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training + marginal-consistency loss
+# (weight 1) at the lighter subset rate 0.25. Pairs with ...-subset-cons1 (0.5).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset25-cons1-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training prob 0.25 + L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/video_train.yaml
+++ b/configs/experiments/2026-07-14-video-pmd-bb-subset25-cons1/video_train.yaml
@@ -1,0 +1,178 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 1), at a LIGHTER subset rate (0.25 instead
+# of 0.5). Same as ...-subset-cons1 in every way EXCEPT subset_augmentation_prob,
+# so the pair isolates how much the subset dilution costs the full-set task:
+# at 0.5 only ~57% of batches are full-grid, at 0.25 it is ~79%.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset25-cons1-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training at a lighter rate: a quarter of the batches train on a random
+  # subset of interior frames (endpoints always kept), so the model still learns to
+  # answer variable query sets but the full-grid task keeps ~79% of the batches
+  # (vs ~57% at prob 0.5), halving the dilution of the full-set metric.
+  subset_augmentation_prob: 0.25
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg).
+  marginal_consistency_weight: 1.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/run.sh
+++ b/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Test-set inference for global-1degree-24to3-pcn-v1: 32-member ensemble
+# infilling over the held-out test period, via gantry + torchrun DDP on
+# ai2/titan (4x B200). Reads data from weka (climate-default), reads the
+# trained checkpoint from its Beaker result dataset, writes the output zarr
+# back to weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KWDBK1BTEPRP6K7WRKVD1826
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/global-1degree-24to3-pcn-v1/test-2023-2024-ens32.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Smoke test first (small ensemble, capped batches) before the full run:
+#   Edit video_inference.yaml: n_ensemble: 2, add `max_batches: 4`, then run
+#   this script pointed at a scratch output_path. Confirms the checkpoint
+#   loads and ensemble_chunk_size fits in GPU memory before committing to the
+#   full test period.
+#
+# Run:  bash configs/experiments/2026-07-14-video-pmd-pcn-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-pcn-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBK1BTEPRP6K7WRKVD1826"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-14-video-pmd-pcn-test-inference/video_inference.yaml
@@ -1,0 +1,117 @@
+# Test-set inference for global-1degree-24to3-pcn-v1: 32-member ensemble
+# infilling of the held-out test period (2023-01-01 .. 2024-01-04), using the
+# EMA weights from checkpoints/best.ckpt (Beaker dataset
+# 01KWDBK1BTEPRP6K7WRKVD1826). model:/data: are pasted verbatim from
+# ../2026-06-30-video-pmd-per-channel-noise/video_train.yaml's model:/test_data:
+# blocks -- do not hand-edit them out of sync with that file.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/global-1degree-24to3-pcn-v1/test-2023-2024-ens32.zarr
+# ensemble_chunk_size=8 (B_eff=local_batch_size*chunk=2*8=16) failed on the
+# first real run with `RuntimeError: Input tensor is too large.` -- a hard
+# int32 indexing overflow in the level-0 grouped blur conv (FIRBlur), not an
+# OOM: N*C*T*H*W*kH*kW = 16*128*9*180*360*9 ~= 10.7B elements, over the
+# 2^31-1 cuDNN/PyTorch limit for grouped conv3d. chunk_size=1 (B_eff=2)
+# matches the batch size training's own generate() calls already ran
+# successfully (generate_n_samples: 1, local batch 2) -- known-safe, not a
+# guess. Raise only after confirming a larger value clears the same op.
+n_ensemble: 32
+ensemble_chunk_size: 1
+use_ema: true
+# The first attempt crashed after initialize_store() had already created the
+# zarr, so a retry with the safe default (mode="w-") refuses to touch it.
+# Set back to false once a run is expected to actually complete, so a
+# finished store can't be clobbered by accident.
+overwrite: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-pcn-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/run.sh
+++ b/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training at prob 1.0 (every batch subset,
+# no full-grid batches) + marginal-consistency loss (weight 10). Extends the
+# subset-rate sweep (0.25 -> 0.5 -> 1.0) and the L_marg sweep (0 -> 1 -> 10)
+# to their combined extreme.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset100-cons10-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training prob 1.0 + L_marg weight 10), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/video_train.yaml
+++ b/configs/experiments/2026-07-15-video-pmd-bb-subset100-cons10/video_train.yaml
@@ -1,0 +1,180 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AT
+# THE MAXIMUM RATE (prob 1.0 -- every batch trains on a random subset of interior
+# frames, never the full grid) AND the marginal-consistency loss at weight 10.
+# Extends the subset-rate sweep (0.25 -> 0.5 -> 1.0) and the L_marg sweep
+# (0 -> 1 -> 10) to their combined extreme: maximum variable-query diversity
+# paired with the strongest cross-query consistency penalty.
+# 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset100-cons10-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training at the maximum rate: every batch trains on a random subset
+  # of interior frames (endpoints always kept) -- there is no full-grid batch.
+  # Maximizes variable-query diversity at the cost of the full-set task never
+  # being trained on directly (that cost is what this run measures, paired
+  # with cons10's stronger L_marg to see if it compensates).
+  subset_augmentation_prob: 1.0
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg).
+  marginal_consistency_weight: 10.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/run.sh
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test-set inference for video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1:
+# 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained
+# checkpoint from its Beaker result dataset, writes the output zarr back to
+# weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KXGT4C82YJHGZ8VSHGE99D0N
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect this to take a similar order of magnitude as the first inference run
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture, same
+# ensemble size, same full-year test period.
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KXGT4C82YJHGZ8VSHGE99D0N"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, brownian-bridge + subset + L_marg weight 10), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons10-test-inference/video_inference.yaml
@@ -1,0 +1,128 @@
+# Test-set inference for video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1:
+# 32-member ensemble infilling of the full held-out test period
+# (2023-01-01 .. 2024-01-04), using the EMA weights from checkpoints/best.ckpt
+# (Beaker dataset 01KXGT4C82YJHGZ8VSHGE99D0N). model:/data: are pasted
+# verbatim from ../2026-07-14-video-pmd-bb-subset-cons10/video_train.yaml's
+# model:/test_data: blocks -- do not hand-edit them out of sync with that
+# file. Unlike the first inference target (global-1degree-24to3-pcn-v1), this
+# model uses temporal_noise_correlation: brownian_bridge, which changes how
+# ensemble noise is drawn during generate() -- video_inference.py handles
+# this automatically since it just builds whatever VideoDiffusionModelConfig
+# it's given, but it's the reason this can't just reuse the other model's
+# inference config with the checkpoint path swapped.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Same architecture (model_channels=128, 5-level UNet) as the first
+# checkpoint, which hit an int32 indexing overflow in the level-0 grouped
+# blur conv at ensemble_chunk_size=8 (B_eff=local_batch_size*chunk=2*8=16,
+# ~10.7B elements > 2^31-1). chunk_size=1 (B_eff=2) is the known-safe value
+# from that fix -- see fme/downscaling/video_inference.py's load_video_model
+# docstring and configs/experiments/2026-07-14-video-pmd-pcn-test-inference/.
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-subset-cons10-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). Affects
+  # generate()'s ensemble noise draw (see _sample_residual_noise /
+  # brownian_bridge_mixing_matrix in fme/downscaling/video_models.py) -- this
+  # is the functionally relevant difference from the first inference target.
+  temporal_noise_correlation: brownian_bridge
+  # Training-only fields (subset augmentation, marginal-consistency weight):
+  # generate() always produces the full grid (no frames= subset requested),
+  # so these don't affect inference, but are included verbatim for exact
+  # config fidelity with the training run.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  marginal_consistency_weight: 10.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/run.sh
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# BB + per-channel noise + subset training (prob 0.5, unchanged) +
+# marginal-consistency loss (weight 100). Fourth arm of the cons0 / cons1 /
+# cons10 / cons100 L_marg sweep.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons100-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (BB + per-channel noise + subset training + L_marg weight 100), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/video_train.yaml
+++ b/configs/experiments/2026-07-16-video-pmd-bb-subset-cons100/video_train.yaml
@@ -1,0 +1,179 @@
+# Global video PMD (Brownian-bridge + per-channel noise) WITH subset training AND
+# the marginal-consistency loss (weight 100). Fourth arm of the ...-subset-cons0 /
+# ...-subset-cons1 / ...-subset-cons10 sweep: identical in every way (data,
+# normalization, per-channel bridge noise, subset augmentation prob 0.5) EXCEPT
+# marginal_consistency_weight, so the runs isolate the strength of L_marg
+# (0 -> 1 -> 10 -> 100). 4x B200 DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-bb-pcn-subset-cons100-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion).
+  temporal_noise_correlation: brownian_bridge
+  # Subset training: half the batches train on a random subset of interior frames
+  # (endpoints always kept), so the model learns to answer variable query sets.
+  # Unchanged from the cons10 run.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # Marginal-consistency loss on: each step also runs a second pass on a strict
+  # subset of the interior frames (sharing the first pass's noise on shared
+  # frames) and penalizes cross-query disagreement (video PMD L_marg). Weight
+  # 100 (10x the cons10 run) pushes the consistency term much harder relative
+  # to the two diffusion losses.
+  marginal_consistency_weight: 100.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  # Per-channel noise matched to each channel's measured residual std
+  # (toy/compute_residual_std.py over the TRAIN split): u10=0.354, v10=0.487,
+  # PRMSL=0.200, PRATEsfc=0.782 (log1p space). p_mean=ln(resid_std) centers the
+  # training noise at the residual scale; sigma_data fixes EDM preconditioning;
+  # sigma_max ~= 160 x resid_std (EDM ratio). p_std narrowed 1.8 -> 1.2.
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/run.sh
+++ b/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Test-set inference for video-pmd-bb-pcn-global-1degree-24to3-v1: 32-member
+# ensemble infilling over the full held-out test period (2023-01-01 ..
+# 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x B200). Reads data
+# from weka (climate-default), reads the trained checkpoint from its Beaker
+# result dataset, writes the output zarr back to weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KWDBKFBCWGKCAJD5B49H4TND
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect this to take a similar order of magnitude as the earlier inference
+# runs (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture, same
+# ensemble size, same full-year test period.
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBKFBCWGKCAJD5B49H4TND"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, brownian-bridge, no subset/L_marg), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-17-video-pmd-bb-pcn-test-inference/video_inference.yaml
@@ -1,0 +1,119 @@
+# Test-set inference for video-pmd-bb-pcn-global-1degree-24to3-v1: 32-member
+# ensemble infilling of the held-out test period (2023-01-01 .. 2024-01-04),
+# using the EMA weights from checkpoints/best.ckpt (Beaker dataset
+# 01KWDBKFBCWGKCAJD5B49H4TND, from experiment 01KWDBKF4ST6GH69GHP1Y8MNYK).
+# model:/data: are pasted verbatim from
+# ../2026-06-30-video-pmd-bb-per-channel-noise/video_train.yaml's
+# model:/test_data: blocks -- do not hand-edit them out of sync with that
+# file. This is the brownian-bridge counterpart of
+# ../2026-07-14-video-pmd-pcn-test-inference/ (global-1degree-24to3-pcn-v1):
+# identical architecture, normalization, and per-channel noise, with
+# temporal_noise_correlation: brownian_bridge instead of independent, and NO
+# subset training / L_marg (both default off, same as pcn-v1) -- isolates
+# the effect of the noise correlation scheme alone, independent of the
+# subset/L_marg confounds in the cons0/cons1/cons10/cons100 sweep.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (see
+# ../2026-07-14-video-pmd-pcn-test-inference/video_inference.yaml for the
+# int32 grouped-conv overflow this avoids) -- same architecture here.
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). Affects
+  # generate()'s ensemble noise draw -- the one functional difference from
+  # global-1degree-24to3-pcn-v1.
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/run.sh
+++ b/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test-set inference for video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1:
+# 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained
+# checkpoint from its Beaker result dataset, writes the output zarr back to
+# weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/best.ckpt):
+#   01KWPZJFCNDYEM7266YFQSZXFM
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect this to take a similar order of magnitude as the earlier inference
+# runs (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture, same
+# ensemble size, same full-year test period.
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWPZJFCNDYEM7266YFQSZXFM"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, brownian-bridge + subset, no L_marg / weight 0), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-17-video-pmd-bb-subset-cons0-test-inference/video_inference.yaml
@@ -1,0 +1,128 @@
+# Test-set inference for video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1:
+# 32-member ensemble infilling of the full held-out test period
+# (2023-01-01 .. 2024-01-04), using the EMA weights from checkpoints/best.ckpt
+# (Beaker dataset 01KWPZJFCNDYEM7266YFQSZXFM, from experiment
+# 01KWJC72G9AYF0ZVX8RNT1M24B). model:/data: are pasted verbatim from
+# ../2026-07-01-video-pmd-bb-subset-cons0/video_train.yaml's model:/test_data:
+# blocks -- do not hand-edit them out of sync with that file. This is the A/B
+# baseline (no marginal-consistency loss) for the cons0/cons1/cons10/cons100
+# L_marg sweep -- see ../2026-07-16-video-pmd-bb-subset-cons10-test-inference/
+# for the cons10 counterpart.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Same architecture (model_channels=128, 5-level UNet) as the first
+# checkpoint, which hit an int32 indexing overflow in the level-0 grouped
+# blur conv at ensemble_chunk_size=8 (B_eff=local_batch_size*chunk=2*8=16,
+# ~10.7B elements > 2^31-1). chunk_size=1 (B_eff=2) is the known-safe value
+# from that fix -- see fme/downscaling/video_inference.py's load_video_model
+# docstring and configs/experiments/2026-07-14-video-pmd-pcn-test-inference/.
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-subset-cons0-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Endpoint-aware time-correlated noise (process-matched diffusion). Affects
+  # generate()'s ensemble noise draw (see _sample_residual_noise /
+  # brownian_bridge_mixing_matrix in fme/downscaling/video_models.py) -- this
+  # is the functionally relevant difference from the first inference target
+  # (global-1degree-24to3-pcn-v1).
+  temporal_noise_correlation: brownian_bridge
+  # Training-only fields (subset augmentation, marginal-consistency weight):
+  # generate() always produces the full grid (no frames= subset requested),
+  # so these don't affect inference, but are included verbatim for exact
+  # config fidelity with the training run. weight 0.0 is the A/B baseline
+  # (no L_marg loss).
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-20-video-pmd-5ch-flat/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-flat/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Model 1 of the 5-channel isolation set: flat/independent noise, 5 channels
+# (adds T2m). A/B baseline for models 2/3.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-5ch-flat/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-flat-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (flat/independent noise, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-5ch-flat/video_train.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-flat/video_train.yaml
@@ -1,0 +1,181 @@
+# Model 1 of the 5-channel isolation set: flat/independent noise (no temporal
+# correlation), 5 channels (adds air_temperature_at_two_meters to the
+# existing 4). Baseline for comparing against model 2 (per-channel OU/RBF
+# kernel) and model 3 (model 2 + subset training, L_marg=0) -- all three
+# share identical architecture/data/schedule, differing only in
+# temporal_noise_correlation and subset settings. 4x B200 DDP.
+#
+# T2m normalization/noise-schedule stats derived the same way as the
+# existing 4 channels (toy/compute_norm_stats.py -> global domain, train
+# split only; scripts/video_pmd_eval/compute_residual_std_5ch.py for
+# sigma_data/p_mean/sigma_max): mean=279.3386, std=20.2363,
+# resid_std=0.1403, p_mean=-1.96, sigma_max=22.4. The other 4 channels'
+# recomputed stats matched their existing baked-in values almost exactly,
+# cross-validating the methodology for T2m too.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20   # bound the 50-step generation pass during validation
+max_test_batches: 50  # test eval runs every 10 epochs; 50 batches = stable metrics
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-flat-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  # Flat/independent noise (no temporal correlation) -- this model's whole
+  # point is being the un-correlated baseline for models 2/3.
+  temporal_noise_correlation: independent
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Model 3 of the 5-channel isolation set: model 2's per-channel OU noise
+# kernel PLUS subset training, no marginal-consistency loss (weight 0).
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (per-channel OU noise kernel + subset training, no L_marg, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/video_train.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/video_train.yaml
@@ -1,0 +1,194 @@
+# Model 3 of the 5-channel isolation set: model 2's per-channel noise kernel
+# (../2026-07-20-video-pmd-5ch-per-channel-kernel/) PLUS subset training,
+# with NO marginal-consistency loss (weight 0) -- i.e. the per-channel-kernel
+# analog of bb-subset-cons0 (../2026-07-01-video-pmd-bb-subset-cons0/), which
+# isolates subset training's own effect from L_marg using the OLD uniform
+# bridge kernel. This config does the same isolation but on top of the new
+# per-channel kernel instead. Identical to model 2 in every other way
+# (architecture, per-channel kernel choice/length scales, schedule). 4x B200
+# DDP.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20
+max_test_batches: 50
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-per-channel-kernel-subset-cons0-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  # Subset training: half the batches train on a random subset of interior
+  # frames (endpoints always kept), so the model learns to answer variable
+  # query sets. Matches bb-subset-cons0's values exactly.
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  # No marginal-consistency loss for this run (the A/B baseline, matching
+  # bb-subset-cons0's own role for the bridge-kernel isolation grid).
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Full GPU training run for the video PMD trainer on ai2/titan (4x B200), via
+# gantry + torchrun DDP. Reads data from weka (climate-default).
+#
+# Model 2 of the 5-channel isolation set: per-channel noise kernel (OU for
+# every channel, see the config's own header for why), no subset training.
+# A/B partner of ../2026-07-20-video-pmd-5ch-flat/.
+#
+# Data on weka:
+#   /climate-default/2026-06-25-temporal-diffusion/2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1"
+CONFIG_FILENAME="video_train.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4                              # batch_size in the config must stay divisible by this
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD (per-channel OU noise kernel, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_train "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/video_train.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-5ch-per-channel-kernel/video_train.yaml
@@ -1,0 +1,198 @@
+# Model 2 of the 5-channel isolation set: per-channel noise kernel (each
+# channel gets its own temporal correlation kernel, matched to
+# toy/process_residual_bridge_report.md's empirical fit over the TRAIN
+# split), no subset training / no L_marg. A/B partner of
+# ../2026-07-20-video-pmd-5ch-flat/ (identical except
+# temporal_noise_correlation) and the base model for model 3
+# (.../2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/, which adds
+# subset training on top of this). 4x B200 DDP.
+#
+# Per-channel kernel choice: OU for every channel. u10/v10/PRATEsfc were
+# OU's best fit outright (report's "best kernel" column). PRMSL and T2m's
+# best fit was RBF, but RBF's determinant there is ~1e-16 / ~1e-11 --
+# effectively rank-deficient/numerically degenerate as a mixing matrix (it
+# would collapse those channels' ensemble spread far more severely than
+# even the plain Brownian bridge already does) -- so both fall back to
+# their own second-best fit, OU, which is vastly better conditioned
+# (det ~3.6e-4 / ~4.7e-3) while still beating the bridge's fit error.
+# Length scales are per_channel_kernel_length_scale, in the model's
+# normalized-tau units (hours / 24h window), converted from the report's
+# raw-hour fits: u10 12.9h, v10 13.4h, PRMSL 19.3h, PRATEsfc 7.9h, T2m
+# 11.4h.
+experiment_dir: /results
+max_epochs: 200
+validate_using_ema: true
+validate_interval: 10
+test_interval: 20
+max_val_batches: 20
+max_test_batches: 50
+generate_n_samples: 1
+log_loss_vs_noise: true
+logging:
+  log_to_screen: true
+  log_to_wandb: true
+  log_to_file: true
+  project: ace-temporal-interp
+  name: global-1degree-24to3-5ch-per-channel-kernel-v1
+  entity: ai2cm
+optimization:
+  lr: 0.0001
+ema:
+  decay: 0.9999
+train_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2013-01-02"
+        stop_time: "2021-12-31"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+validation_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2022-01-01"
+        stop_time: "2022-12-31"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+test_data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cheap validation smoke test: does nonzero EDM churn (S_churn=20) restore
+# ensemble spread for the brownian-bridge noise scheme? 10-day window
+# (2023-01-01..2023-01-11), 32-member ensemble, 4x B200 DDP -- should take
+# ~O(30 min), not the ~16.5h a full-year run would.
+#
+# Checkpoint dataset (same as bb-pcn's own inference run):
+#   01KWDBKFBCWGKCAJD5B49H4TND
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn20-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-churn20-smoketest"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBKFBCWGKCAJD5B49H4TND"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Churn=20 smoke test for brownian-bridge video PMD noise (single 3-day window, 32-member ensemble)' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/video_inference.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn20-smoketest/video_inference.yaml
@@ -1,0 +1,144 @@
+# Cheap validation smoke test: does nonzero EDM churn restore ensemble spread
+# for the brownian-bridge noise scheme? Same checkpoint as
+# ../2026-07-17-video-pmd-bb-pcn-test-inference/ (video-pmd-bb-pcn-global-
+# 1degree-24to3-v1, Beaker dataset 01KWDBKFBCWGKCAJD5B49H4TND), with two
+# changes only:
+#   - model.churn: 0.0 -> 20.0 (Karras EDM stochastic sampler S_churn; the
+#     mixing-matrix-aware churn_noise() path in _video_edm_sample already
+#     supports this, it's just never been exercised with churn>0 so far).
+#   - data restricted to a 10-day window (2023-01-01..2023-01-11, covering
+#     crps_eval.py's "winter (Jan)" SAMPLE_WINDOWS 3-day window plus margin)
+#     instead of the full test year, purely to keep this validation run
+#     cheap (~O(30 min) vs. ~16.5h for the full year at 4 GPUs, per the
+#     sibling config's timing note). If this looks promising, follow up
+#     with the full 4-season or full-year run.
+#   - batch_size: 8 -> 4 (global across 4 ranks, so 1 clip/rank/batch
+#     instead of 2) -- with only ~3 total clips in a 3-day window, 2/rank
+#     underflowed drop_last and StopIteration'd every rank on the first
+#     attempt at this run; widening to 10 days (~10 clips) plus a smaller
+#     batch gives comfortable margin.
+# See crps_eval_results_pcn-v1-bb-pcn-bb-subset-cons0-bb-subset-cons10/
+# COMPARISON_REPORT.md ("Why does brownian-bridge noise reduce spread?") for
+# why churn is the theoretically correct lever here: with churn=0, the
+# initial noise draw is the sole source of ensemble stochasticity, and
+# Brownian-bridge-correlated noise has strictly lower joint entropy than
+# independent noise at the same marginal variance.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn20-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+# The two earlier failed attempts (StopIteration, then an NCCL hang) each
+# left partial data at output_path, so the default mode="w-" now refuses to
+# write. True while this run keeps retrying; flip back to False once it's
+# expected to succeed, so a completed store can't be clobbered by accident.
+overwrite: true
+n_ensemble: 32
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-churn20-smoketest
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  # 4 (not 8) so each of the 4 ranks needs only 1 clip/batch -- a 10-day
+  # window gives ~10 tumbling 24h clips, comfortable margin over the
+  # per-rank minimum. The original 3-day window only yielded ~3 total
+  # clips, so with batch_size=8 (2/rank) every rank's DataLoader dropped its
+  # under-full batch and started empty -> StopIteration on all ranks.
+  batch_size: 4  # global across ranks
+  # REQUIRED for small/custom windows: ContiguousDistributedSampler's
+  # drop_last=False path (the default) does NOT pad ranks to equal size
+  # despite what its docstring claims -- it silently dumps the remainder
+  # clips onto the last rank only (datasets.py:919-921). With an uneven
+  # clip count across the 4 ranks, the DDP-wrapped model's per-forward
+  # collective sync falls out of lock-step once the short ranks finish
+  # their loop early, which is what caused the first attempt at this run to
+  # hang for 30 min and die on an NCCL ALLREDUCE watchdog timeout.
+  # drop_last=True takes the correct, actually-even-splitting code path.
+  drop_last: true
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 20.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/run.sh
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cheap validation smoke test, take 2: does churn=5 (gentler than the
+# churn=20 attempt, which made calibration worse) behave differently?
+# 10-day window (2023-01-01..2023-01-11), 32-member ensemble, 4x B200 DDP --
+# should take ~O(30 min), not the ~16.5h a full-year run would.
+#
+# Checkpoint dataset (same as bb-pcn's own inference run):
+#   01KWDBKFBCWGKCAJD5B49H4TND
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn5-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+#
+# Run:  bash configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/run.sh
+set -e
+
+JOB_NAME="video-pmd-bb-pcn-churn5-smoketest"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KWDBKFBCWGKCAJD5B49H4TND"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Churn=5 smoke test for brownian-bridge video PMD noise (10-day window, 32-member ensemble)' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/video_inference.yaml
+++ b/configs/experiments/2026-07-20-video-pmd-bb-pcn-churn5-smoketest/video_inference.yaml
@@ -1,0 +1,108 @@
+# Cheap validation smoke test, take 2: churn=20 (uniform, no S_tmin/S_tmax
+# gating) made calibration *worse* on the same window
+# (../2026-07-20-video-pmd-bb-pcn-churn20-smoketest/,
+# churn_smoketest_results/ -- ratio dropped from ~0.92-0.97 at churn=0 to
+# ~0.84-0.94 at churn=20 across all 4 channels). Testing whether a much
+# gentler kick behaves differently before writing off churn entirely: same
+# checkpoint, same 10-day window/batch/drop_last fixes as the churn=20
+# attempt, only model.churn: 20.0 -> 5.0.
+checkpoint_path: /checkpoint/checkpoints/best.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-bb-pcn-churn5-global-1degree-24to3-v1/smoketest-jan2023-ens32.zarr
+n_ensemble: 32
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-bb-pcn-churn5-smoketest
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2023-01-11"
+  batch_size: 4  # global across ranks (1/rank -- see churn20 config's notes)
+  drop_last: true  # required for small/custom windows -- see churn20 config's notes
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 5.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: brownian_bridge
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331

--- a/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/run.sh
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test-set inference for video-pmd-5ch-flat-global-1degree-24to3-v1:
+# 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained checkpoint
+# from its Beaker result dataset, writes the output zarr back to weka.
+#
+# Checkpoint dataset (result of the SECOND job under this experiment --
+# Beaker auto-retried after the first job was preempted at ~4 min; the
+# second job completed cleanly, exitCode 0, 200 epochs. Contains
+# checkpoints/latest.ckpt, used deliberately over best.ckpt, see
+# video_inference.yaml's header):
+#   01KY0V8ZNN763G59S8QBY4304B
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-flat-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect a similar order of magnitude as the earlier 4-channel inference runs
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture family,
+# same ensemble size, same full-year test period, one extra channel (T2m).
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-flat-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KY0V8ZNN763G59S8QBY4304B"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, flat/independent noise, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-flat-test-inference/video_inference.yaml
@@ -1,0 +1,136 @@
+# Test-set inference for video-pmd-5ch-flat-global-1degree-24to3-v1:
+# 32-member ensemble infilling of the held-out test period (2023-01-01 ..
+# 2024-01-04), using the EMA weights from checkpoints/latest.ckpt (Beaker
+# dataset 01KY0V8ZNN763G59S8QBY4304B, from training experiment
+# 01KY0SQW5SFS5KEYZR94T6WDTZ). Note: this experiment's FIRST job attempt
+# (01KY0SQW9WRDQP4YE5NYD0693A) was preempted after ~4 min and produced no
+# usable checkpoint -- Beaker auto-retried under the same experiment ID, and
+# the SECOND job (01KY0V8ZS0130PRZA0HZQ99H2P) completed cleanly, exitCode 0,
+# 200 epochs, no further preemption. Use the second job's result dataset
+# (above), not the first's (01KY0SQW5YD34ABY98Y74DSVFE, near-empty).
+#
+# Deliberately latest.ckpt, not best.ckpt, for consistency with the
+# per-channel-kernel inference config (see its own header) even though this
+# run's validation kept improving later into training (last "Saving best
+# checkpoint" before epoch 151 of 200, vs. epoch ~92 of 200 for
+# per-channel-kernel) -- latest.ckpt is still the fully-trained final-epoch
+# weights either way. Same _save_checkpoint format for both files (module +
+# ema state dicts), so use_ema: true works identically.
+#
+# model:/data: are pasted verbatim from
+# ../2026-07-20-video-pmd-5ch-flat/video_train.yaml's model:/test_data:
+# blocks -- do not hand-edit them out of sync with that file.
+#
+# 5 channels (adds air_temperature_at_two_meters to the earlier 4-channel
+# models), flat/independent noise (the un-correlated baseline for the
+# per-channel-kernel isolation grid).
+checkpoint_path: /checkpoint/checkpoints/latest.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-flat-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (int32 grouped-conv overflow
+# at higher effective batch -- same architecture family here).
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-5ch-flat-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: independent
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/run.sh
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Test-set inference for video-pmd-5ch-per-channel-kernel-subset-cons0-
+# global-1degree-24to3-v1: 32-member ensemble infilling over the full
+# held-out test period (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP
+# on ai2/titan (4x B200). Reads data from weka (climate-default), reads the
+# trained checkpoint from its Beaker result dataset, writes the output zarr
+# back to weka.
+#
+# Checkpoint dataset (result of the 7th job under this experiment -- the
+# first 6 were each preempted by an urgent-priority job; contains
+# checkpoints/latest.ckpt, used deliberately over best.ckpt, see
+# video_inference.yaml's header. Training completed cleanly, exitCode 0,
+# 200 epochs):
+#   01KY3DB2WP9ME06KQYMVTFBRPY
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Priority is "high" (not "urgent" like the other two 5ch inference configs)
+# per explicit instruction for this run.
+#
+# Expect a similar order of magnitude as the earlier 4-channel inference runs
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture family,
+# same ensemble size, same full-year test period, one extra channel (T2m).
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KY3DB2WP9ME06KQYMVTFBRPY"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, per-channel OU noise kernel + subset training, no L_marg, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority high \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-subset-cons0-test-inference/video_inference.yaml
@@ -1,0 +1,146 @@
+# Test-set inference for video-pmd-5ch-per-channel-kernel-subset-cons0-
+# global-1degree-24to3-v1: 32-member ensemble infilling of the held-out test
+# period (2023-01-01 .. 2024-01-04), using the EMA weights from
+# checkpoints/latest.ckpt (Beaker dataset 01KY3DB2WP9ME06KQYMVTFBRPY, from
+# training experiment 01KY0VVAVTQDKD6NP0MDD8CKQ0). This experiment was
+# preempted SIX times (always a "high"-priority job bumped by an "urgent"
+# one) before the 7th job (01KY3DB2ZXDRXKQGDPZ0648FMD) finally ran
+# uninterrupted and completed cleanly, exitCode 0, 200 epochs.
+#
+# Deliberately latest.ckpt, not best.ckpt, for consistency with the other two
+# 5ch inference configs (see their headers for why) -- same
+# _save_checkpoint format either way, so use_ema: true applies identically.
+#
+# model:/data: are pasted verbatim from
+# ../2026-07-20-video-pmd-5ch-per-channel-kernel-subset-cons0/video_train.yaml's
+# model:/test_data: blocks -- do not hand-edit them out of sync with that
+# file.
+#
+# Model 3 of the 5-channel isolation set: model 2's per-channel OU noise
+# kernel PLUS subset training, L_marg=0 (the per-channel-kernel analog of
+# bb-subset-cons0).
+checkpoint_path: /checkpoint/checkpoints/latest.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (int32 grouped-conv overflow
+# at higher effective batch -- same architecture family here).
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-5ch-per-channel-kernel-subset-cons0-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  subset_augmentation_prob: 0.5
+  subset_min_interior: 1
+  marginal_consistency_weight: 0.0
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/run.sh
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Test-set inference for video-pmd-5ch-per-channel-kernel-global-1degree-
+# 24to3-v1: 32-member ensemble infilling over the full held-out test period
+# (2023-01-01 .. 2024-01-04), via gantry + torchrun DDP on ai2/titan (4x
+# B200). Reads data from weka (climate-default), reads the trained checkpoint
+# from its Beaker result dataset, writes the output zarr back to weka.
+#
+# Checkpoint dataset (result of the training job, contains checkpoints/latest.ckpt
+# -- used deliberately over best.ckpt, see video_inference.yaml's header;
+# training completed cleanly, exitCode 0, 200 epochs, no preemption):
+#   01KY0SRVAY199HM7TM8M9TXEVX
+#
+# Output:
+#   /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+#
+# Expect a similar order of magnitude as the earlier 4-channel inference runs
+# (~16.5h with ensemble_chunk_size=1, 4 GPUs) -- same architecture family,
+# same ensemble size, same full-year test period, one extra channel (T2m).
+#
+# Prereqs (one-time, PER WORKSPACE -- secrets are workspace-scoped):
+#   pip install beaker-gantry
+#   beaker secret write --workspace ai2/climate-titan CHLOE_WANDB_API_KEY <your-wandb-key>
+#   # also commit + push your code: gantry runs your pushed git commit.
+#
+# Run:  bash configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/run.sh
+set -e
+
+JOB_NAME="video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1-test-inference"
+CONFIG_FILENAME="video_inference.yaml"
+WORKSPACE="ai2/climate-titan"
+CLUSTER="ai2/titan"
+N_GPUS=4
+CHECKPOINT_DATASET="01KY0SRVAY199HM7TM8M9TXEVX"
+WANDB_SECRET="CHLOE_WANDB_API_KEY"   # beaker secret name (in WORKSPACE) holding your W&B key
+
+# Resolve the config path relative to the repo root from the script's OWN
+# location, so this works whether invoked from the repo root or the script dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${SCRIPT_DIR#"$REPO_ROOT"/}/$CONFIG_FILENAME"
+cd "$REPO_ROOT"
+
+DEPS_ONLY_IMAGE="$(cat latest_deps_only_image.txt)"
+
+gantry run \
+    --name "$JOB_NAME" \
+    --description 'Video PMD test-set inference (32-member ensemble, per-channel OU noise kernel, 5 channels incl. T2m), global 1deg 24h->3h, 4x B200 DDP' \
+    --workspace "$WORKSPACE" \
+    --priority urgent \
+    --cluster "$CLUSTER" \
+    --beaker-image "$DEPS_ONLY_IMAGE" \
+    --gpus "$N_GPUS" \
+    --shared-memory 64GiB \
+    --budget ai2/atec-climate \
+    --weka climate-default:/climate-default \
+    --dataset "${CHECKPOINT_DATASET}:/checkpoint" \
+    --env-secret WANDB_API_KEY="$WANDB_SECRET" \
+    --system-python \
+    --install "pip install --no-deps ." \
+    -- torchrun --nproc_per_node "$N_GPUS" -m fme.downscaling.video_inference "$CONFIG_PATH"

--- a/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/video_inference.yaml
+++ b/configs/experiments/2026-07-22-video-pmd-5ch-per-channel-kernel-test-inference/video_inference.yaml
@@ -1,0 +1,141 @@
+# Test-set inference for video-pmd-5ch-per-channel-kernel-global-1degree-
+# 24to3-v1: 32-member ensemble infilling of the held-out test period
+# (2023-01-01 .. 2024-01-04), using the EMA weights from
+# checkpoints/latest.ckpt (Beaker dataset 01KY0SRVAY199HM7TM8M9TXEVX, from
+# training experiment 01KY0SRVASWEECEGZHXF67E141, which completed cleanly --
+# exitCode 0, 200 epochs, no preemption). Deliberately latest.ckpt, not
+# best.ckpt: validation/loss stopped improving (no new "Saving best
+# checkpoint") after epoch ~92 and stayed flat through completion at epoch
+# 200, so best.ckpt is a stale ~epoch-92 snapshot -- latest.ckpt is the
+# fully-trained final-epoch weights. Same _save_checkpoint format for both
+# (module + ema state dicts), so use_ema: true works identically either way.
+# model:/data: are pasted verbatim from
+# ../2026-07-20-video-pmd-5ch-per-channel-kernel/video_train.yaml's model:/
+# test_data: blocks -- do not hand-edit them out of sync with that file.
+#
+# 5 channels (adds air_temperature_at_two_meters to the earlier 4-channel
+# models), per-channel OU noise kernel (see the training config's own header
+# for the per-channel kernel-choice rationale and the RBF->OU fallback for
+# PRMSL/T2m).
+checkpoint_path: /checkpoint/checkpoints/latest.ckpt
+experiment_dir: /results
+output_path: /climate-default/2026-06-25-temporal-diffusion/inference/video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1/test-2023-2024-ens32.zarr
+n_ensemble: 32
+# Known-safe value from the pcn-v1 inference run (int32 grouped-conv overflow
+# at higher effective batch -- same architecture family here).
+ensemble_chunk_size: 1
+use_ema: true
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true
+  project: ace-temporal-interp
+  name: video-pmd-5ch-per-channel-kernel-global-1degree-24to3-v1-test-inference
+  entity: ai2cm
+data:
+  n_timesteps: 9
+  fine:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  coarse:
+    - data_path: /climate-default/2026-06-25-temporal-diffusion
+      file_pattern: 2025-07-25-X-SHiELD-AMIP-FME-3h.zarr
+      engine: zarr
+      subset:
+        start_time: "2023-01-01"
+        stop_time: "2024-01-04"
+  batch_size: 8  # global across ranks
+  num_data_workers: 4
+  strict_ensemble: false
+  lat_extent:
+    start: -88
+    stop: 88
+  lon_extent:
+    start: 0
+    stop: 360
+model:
+  n_timesteps: 9
+  model_channels: 128
+  n_heads: 8
+  num_freqs: 4
+  backbone: simple
+  noise_embedding_type: positional
+  channel_mult: [1, 2, 2, 2, 2]
+  num_blocks: 2
+  attention_levels: [3, 4]
+  sigma_min: 0.002
+  sigma_max: 150.0
+  churn: 0.0
+  num_diffusion_generation_steps: 50
+  temporal_noise_correlation: per_channel
+  per_channel_noise_kernel:
+    eastward_wind_at_ten_meters: ou
+    northward_wind_at_ten_meters: ou
+    PRMSL: ou
+    PRATEsfc: ou
+    air_temperature_at_two_meters: ou
+  per_channel_kernel_length_scale:
+    eastward_wind_at_ten_meters: 0.5375      # 12.9h / 24h
+    northward_wind_at_ten_meters: 0.558333   # 13.4h / 24h
+    PRMSL: 0.804167                          # 19.3h / 24h
+    PRATEsfc: 0.329167                       # 7.9h / 24h
+    air_temperature_at_two_meters: 0.475     # 11.4h / 24h
+  log_transform_channels:
+    PRATEsfc: 86400.0  # precip modeled in log1p(mm/day) space
+  training_noise_distributions:
+    eastward_wind_at_ten_meters:
+      p_mean: -1.04
+      p_std: 1.2
+    northward_wind_at_ten_meters:
+      p_mean: -0.72
+      p_std: 1.2
+    PRMSL:
+      p_mean: -1.61
+      p_std: 1.2
+    PRATEsfc:
+      p_mean: -0.25
+      p_std: 1.2
+    air_temperature_at_two_meters:
+      p_mean: -1.96
+      p_std: 1.2
+  sigma_data_by_channel:
+    eastward_wind_at_ten_meters: 0.354
+    northward_wind_at_ten_meters: 0.487
+    PRMSL: 0.200
+    PRATEsfc: 0.782
+    air_temperature_at_two_meters: 0.1403
+  sigma_min_by_channel:
+    eastward_wind_at_ten_meters: 0.002
+    northward_wind_at_ten_meters: 0.002
+    PRMSL: 0.002
+    PRATEsfc: 0.002
+    air_temperature_at_two_meters: 0.002
+  sigma_max_by_channel:
+    eastward_wind_at_ten_meters: 57.0
+    northward_wind_at_ten_meters: 78.0
+    PRMSL: 32.0
+    PRATEsfc: 125.0
+    air_temperature_at_two_meters: 22.4
+  out_names:
+    - eastward_wind_at_ten_meters
+    - northward_wind_at_ten_meters
+    - PRMSL
+    - PRATEsfc
+    - air_temperature_at_two_meters
+  normalization:  # train-only, global domain -- must match training exactly
+    means:
+      eastward_wind_at_ten_meters: -0.036135
+      northward_wind_at_ten_meters: 0.186555
+      PRMSL: 1008.281106
+      PRATEsfc: 0.557112
+      air_temperature_at_two_meters: 279.3386
+    stds:
+      eastward_wind_at_ten_meters: 5.548626
+      northward_wind_at_ten_meters: 4.603089
+      PRMSL: 14.908773
+      PRATEsfc: 0.871331
+      air_temperature_at_two_meters: 20.2363


### PR DESCRIPTION
Adds the experiment configs from the sweep that developed the video PMD
model (#1412 -#1416), plus a canonical baseline config. Final PR in the
stack.

Changes:
- `configs/experiments/2026-*-video-pmd-*`: dated run configs (train +
  test-set inference) from the sweep: Brownian-bridge vs. per-channel noise
  kernels, subset-frame training / marginal-consistency-loss ablations at
  several strengths, and a 5-channel isolation grid comparing flat vs.
  per-channel kernels with and without subset training. See each config's
  header comment for what it isolates relative to its siblings.
- `configs/baselines/downscaling-temporal/train.yaml`: the current
  best/final setup from that sweep (5-channel, per-channel OU noise kernel,
  subset-frame training), following the configs/baselines/<topic>/
  convention used elsewhere (e.g. downscaling-hiro-global) for a maintained
  reference config distinct from the dated one-off experiment snapshots.

- [ ] Tests added (configs only, exercised by earlier PRs' tests)
