### PR TITLE
Add a Beaker urgent-priority balancer

### DIFF
--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -171,12 +171,19 @@ committed future occupant, not a maybe.
 
 Being charged to a cluster and being balanced against it are the same question,
 so they are answered the same way. A placed job is managed against the single
-cluster it landed on. A queued job targeting multiple clusters is managed
-**pessimistically** against all of them: granting it urgent requires room on
-every cluster, and the grant charges all of them. Demoting it frees all of
-them. This means a multi-cluster grant costs more than a single-cluster one
-when headroom is tight, which is the right tradeoff — the alternative is to
-grant urgent against a budget the job might consume elsewhere.
+cluster it landed on. A queued job targeting multiple budgeted clusters is
+managed **pessimistically** against all of them: granting it urgent requires
+room on every cluster, and the grant charges all of them. Demoting it frees
+all of them. This means a multi-cluster grant costs more than a single-cluster
+one when headroom is tight, which is the right tradeoff — the alternative is
+to grant urgent against a budget the job might consume elsewhere.
+
+A job targeting a mix of budgeted and non-budgeted clusters — e.g. both
+`ai2/jupiter` (budgeted) and `ai2/ceres` (no allocation) — is managed against
+the budgeted ones only. While queued, only the budgeted clusters are checked
+and charged. If it lands on a non-budgeted cluster, its slots stop counting
+against the allocation entirely, since it is not consuming a budgeted cluster's
+slots.
 
 A placed multi-cluster job is different: it is on one cluster and only that
 cluster's budget is affected, whether the job is granted or demoted. It could

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -32,13 +32,18 @@ count per pass:
   to one cluster if you want it balanced. Most `ai2/ace` jobs today target
   `titan+jupiter`, so expect this to be the common case during adoption.
 - **It targets a cluster with no allocation** (`ai2/saturn`, `ai2/ceres`).
-- **It is part of a replica group.** The allocation walk would grant urgent to
-  some ranks and not others, which for a synchronised-start group wastes the
-  slots it did grant. It is also unconfirmed whether `UpdateJobSourcePriority`
-  acts per job or per source; if per source, one call would move every replica.
+- **It is an interactive session.** There is a person attached to it, and
+  taking their priority away mid-session is not the script's call.
+- **It is at `immediate` priority.** Beaker requires a human-supplied reason for
+  `immediate`, so it represents a deliberate decision the balancer should not
+  quietly undo. `immediate` is not an accepted `CM_PRIORITY` value either: it is
+  not something the script may hand out.
 - **It has landed on a node the script cannot resolve to a cluster.** Its slots
   are then charged to every budget as a precaution, which is inconsistent with
   managing it against one.
+
+Sessions and `immediate` jobs still count against the allocation — see
+[Accounting](#accounting).
 
 ### What may surprise you
 
@@ -55,33 +60,61 @@ count per pass:
   a `CM_PRIORITY` level, the job that has held its GPUs longest is the first to
   lose urgent, on the grounds that it has already had its turn.
 
+## Replica groups
+
+Beaker runs a multi-node job as one job per rank. The balancer decides for the
+whole **replica group** at once and grants urgent all-or-nothing. A lone job is
+simply a group of one.
+
+A half-granted group is the worst available outcome: it cannot start until every
+rank is placed, so it waits at the priority of its lowest rank while the granted
+ranks hold slots the allocation has already spent. A four-rank group needing 80
+slots against 72 free therefore gets nothing, rather than stranding 64 slots on
+a job that still cannot run.
+
+A group is managed only if *every* rank is: one unlabelled rank, one session, or
+one at `immediate` makes the whole group untouchable. The same applies if the
+ranks disagree about their `CM_PRIORITY`, or if the group comes back short —
+only unfinished jobs in one workspace are read, so granting the ranks that
+happen to be visible would half-grant the real group. Skipped groups are counted
+in the log.
+
+Splits *below* urgent are left alone deliberately. They cost the allocation
+nothing, and raising a queued rank whose siblings are stuck at a lower priority
+is what gets the group placed.
+
+The grouping is keyed on the replica group rather than the workload, since one
+workload can hold independent tasks that have no reason to move together.
+
 ## What it does
 
 Each pass recomputes the whole allocation from scratch and applies the
 difference:
 
-1. Read every unfinished job in the workspace.
-2. Subtract the slots held at urgent by jobs it cannot modify. Those are a
-   fixed charge; only what is left is available.
-3. Walk the managed jobs in `CM_PRIORITY` order, granting urgent while the
-   job's cluster has room.
-4. Set every managed job to urgent if granted, or to its resting priority if
+1. Read every unfinished job in the workspace and group it with its ranks.
+2. Subtract the slots held at urgent or `immediate` by jobs it cannot modify.
+   Those are a fixed charge; only what is left is available.
+3. Walk the managed groups in `CM_PRIORITY` order, granting urgent while the
+   group's cluster has room for all of it.
+4. Set every managed group to urgent if granted, or to its resting priority if
    not.
 
 Recomputing rather than adjusting incrementally is what makes step 3 work: a
-`high` job is always considered before any `normal` job, so it never has to
-wait for slots a lesser job already took. If `normal` jobs are holding urgent
+`high` group is always considered before any `normal` one, so it never has to
+wait for slots a lesser one already took. If `normal` jobs are holding urgent
 slots that a `high` job needs, they are dropped to make room.
 
-Within one `CM_PRIORITY` level, urgent is granted to running jobs that already
-hold it first — so a queued job always gives up its slot before a running one —
-ordered so the job that has held a GPU longest is the first to lose it. Queued
-jobs follow, longest-waiting first. The two orderings use different clocks:
-time on GPU for running jobs, and time since entering the queue for queued
-ones. The queue clock resets when a job is preempted and requeued, so a job
-that has been bounced does not keep seniority it no longer has.
+Within one `CM_PRIORITY` level, urgent is granted to running groups that already
+hold it first — so a queued group always gives up its slot before a running one
+— ordered so the group that has held its GPUs longest is the first to lose it.
+Queued groups follow, longest-waiting first. The two orderings use different
+clocks: time on GPU for running groups, and time since entering the queue for
+queued ones. A group's queue clock is that of its *latest* rank, because it
+cannot start until the last one is placed; since the clock resets when a rank is
+preempted and requeued, a group that has been bounced does not keep seniority it
+no longer has.
 
-A job too large for the remaining slots is skipped and smaller ones behind it
+A group too large for the remaining slots is skipped and smaller ones behind it
 still get a chance. Nothing is reserved for it, because a level that could not
 fit has already taken everything it was entitled to.
 
@@ -100,13 +133,17 @@ BeakerPermissionsError: cannot increase priority for running job "01K..."
 ```
 
 So a job that starts at `high` stays there for life, even if urgent slots free
-up later. Such a job is also excluded from the allocation walk — granting it
-urgent on paper would displace jobs that *can* be promoted, for no benefit. If
-it is preempted and returns to the queue it becomes eligible again, at its
-proper rank.
+up later. A group with a placed rank below urgent is also excluded from the
+allocation walk — granting it urgent on paper would displace groups that *can*
+be promoted, for no benefit, and it could not be brought wholly to urgent
+anyway. If it is preempted and returns to the queue it becomes eligible again,
+at its proper rank.
 
 The practical consequence: **submit at the priority you want, and let the
 balancer take it away** rather than hoping to be raised later.
+
+**It never touches an interactive session or an `immediate` job**, in either
+direction.
 
 ## Accounting
 
@@ -114,6 +151,14 @@ A job that has landed counts only against the cluster it is on. A *queued*
 urgent job counts at full weight against every cluster it could land on.
 Nothing outranks urgent and nothing can preempt it, so a queued urgent job is a
 committed future occupant, not a maybe.
+
+`immediate` counts the same as urgent: it outranks urgent, so the slot is just
+as occupied. Interactive sessions count too.
+
+Sessions and `immediate` jobs are counted but never reclaimable, so a pass can
+be unable to get within the allocation no matter what it does. Each pass logs
+how many slots per cluster are held that way, so that shows up as a fact rather
+than as a balancer that appears not to be working.
 
 ## Running it
 
@@ -163,8 +208,10 @@ collects cleanly.
 `test_balance.py` covers the decision logic, including randomised populations
 asserting the invariants that matter: a pass never pushes usage above the
 allocation, *any prefix* of a pass stays within it, a second pass is always a
-no-op (so cron cannot flap jobs), and only labelled, manageable jobs are ever
-touched — never raising a placed one. Those tests compute usage with an oracle
+no-op (so cron cannot flap jobs), a replica group is never left holding urgent
+on only some of its ranks, sessions and `immediate` jobs are never touched, and
+only labelled, manageable jobs are ever modified — never raising a placed one.
+Those tests compute usage with an oracle
 written independently of the production accounting, so a bug in the accounting
 cannot hide behind itself; a further test asserts the random populations
 actually reach the states that matter, so the suite cannot quietly go vacuous.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -18,10 +18,10 @@ gantry run --env CM_PRIORITY=high ...
 The balancer only modifies jobs that set it. Jobs that don't are left alone
 entirely, though their urgent slots still count against the allocation.
 
-`CM_PRIORITY` is both a ranking and a resting place. It decides who gets a
-scarce urgent slot first, and what a job falls back to when it doesn't get one.
-A job labelled `urgent` rests at `high`, since resting at urgent would defeat
-the point.
+`CM_PRIORITY` is a ranking, and only a ranking: it decides who gets a scarce
+urgent slot first. It does not say what priority your job runs at. Submit at
+the priority you want; the balancer's only effect is whether you also hold an
+urgent slot, and it puts you back where you were when you don't.
 
 Things that stop a job being managed, each reported in the log as an aggregate
 count per pass:
@@ -52,12 +52,6 @@ Sessions and `immediate` jobs still count against the allocation — see
   eligible. If you label a job `low` to be a good citizen, it may still be made
   unpreemptible and charged to the team allocation. It is simply the first to
   be dropped when the allocation gets tight.
-- **A queued job below its `CM_PRIORITY` is raised to it, grant or no grant.**
-  The resting priority is where the label says the job belongs, so the balancer
-  moves it there in both directions. Submitting at `low` with `CM_PRIORITY=high`
-  therefore gets you `high`, not `low`, once a pass has seen the job. This costs
-  the allocation nothing — only `urgent` is budgeted — but it does change how the
-  job is scheduled against everyone else's.
 - **A demotion is permanent for the life of that run.** Beaker will not raise
   the priority of a job it has already placed, so a job the balancer drops
   during a busy spell stays down even after the spell passes. It becomes
@@ -65,6 +59,36 @@ Sessions and `immediate` jobs still count against the allocation — see
 - **Demotion deliberately targets the job with the most work at risk.** Within
   a `CM_PRIORITY` level, the job that has held its GPUs longest is the first to
   lose urgent, on the grounds that it has already had its turn.
+
+## Where a job goes when it gives up its slot
+
+Back to the priority it was last seen at below urgent — where you submitted it,
+or wherever you last moved it to by hand. The balancer's only lasting effect on
+a job is whether it held an urgent slot.
+
+Beaker keeps no record of that. A job carries one priority, `UpdateJobSourcePriority`
+overwrites it in place, and job events log scheduling rather than priority
+changes, so raising a job destroys the only evidence of where it came from. The
+balancer therefore keeps its own note, in a small JSON file (`--state`, by
+default `~/.cache/beaker_balancer/resting.json`).
+
+Consequences worth knowing:
+
+- **A job that is already resting is never touched.** If it is below urgent, it
+  is where its owner wants it, so the only changes the balancer ever makes are
+  onto an urgent slot and back off again.
+- **Move a job by hand and the balancer adopts it.** Whatever you set it to is
+  what it goes back to next time it gives up a slot. Except at urgent: setting
+  a job to urgent yourself only makes it a candidate, and it is dropped again if
+  the allocation cannot cover it.
+- **Lose the file and jobs currently at urgent fall back to `high`.** That is
+  also where a job goes if it was submitted at urgent and never seen lower.
+  Nothing else degrades: the allocation arithmetic does not depend on it, so a
+  lost, corrupt or unwritable file is logged and the pass carries on.
+- **A preempted job keeps its place.** Beaker requeues it under a new id, at the
+  priority the balancer set rather than the one it was submitted at, so the note
+  follows `retry_ancestor_id`. Without that, every preemption of a granted job
+  would ratchet it up to the `high` fallback.
 
 ## Replica groups
 
@@ -111,8 +135,8 @@ difference:
    Those are a fixed charge; only what is left is available.
 3. Walk the managed groups in `CM_PRIORITY` order, granting urgent while the
    group's cluster has room for all of it.
-4. Set every managed group to urgent if granted, or to its resting priority if
-   not.
+4. Set every managed group to urgent if granted, or back to where its ranks
+   were resting if not.
 
 Recomputing rather than adjusting incrementally is what makes step 3 work: a
 `high` group is always considered before any `normal` one, so it never has to
@@ -187,22 +211,25 @@ python balance.py --interval 180     # keep running, one pass every 3 minutes
 ```
 
 Useful flags: `--workspace` (default `ai2/ace`), `--limit CLUSTER=SLOTS`
-(repeatable; merges into the default allocation rather than replacing it), `-v`
-for debug logging. Cluster names in `--limit` are checked against Beaker at
-startup, since a typo would otherwise manage nothing and look exactly like a
-quiet cluster.
+(repeatable; merges into the default allocation rather than replacing it),
+`--state` (where to keep the remembered resting priorities), `-v` for debug
+logging. Cluster names in `--limit` are checked against Beaker at startup, since
+a typo would otherwise manage nothing and look exactly like a quiet cluster.
 
-A pass is stateless and converges, so it is safe to run from cron. Note that
-cron does not read your shell profile, so `BEAKER_TOKEN` has to be supplied
-explicitly:
+Each pass recomputes what it wants from the live workspace, so it converges and
+is safe to run from cron. Note that cron reads neither your shell profile nor
+necessarily the same `HOME`, so `BEAKER_TOKEN` has to be supplied explicitly and
+`--state` is worth pinning rather than left to default:
 
 ```cron
 BEAKER_TOKEN=...
-*/3 * * * * /path/to/python /path/to/balance.py >> /var/log/beaker_balancer.log 2>&1
+*/3 * * * * /path/to/python /path/to/balance.py --state ~/.cache/beaker_balancer/resting.json >> /var/log/beaker_balancer.log 2>&1
 ```
 
 There is no lockfile, so pick an interval comfortably longer than a pass (a pass
-is a few seconds against the current workspace).
+is a few seconds against the current workspace). Two balancers sharing a state
+file overwrite each other's notes rather than corrupting the file; the loser
+forgets, which costs the `high` fallback and nothing else.
 
 It runs as whoever's token is in the environment and modifies teammates' jobs
 too. A job it lacks permission to change is logged and skipped rather than
@@ -244,6 +271,10 @@ that granted nothing would satisfy every one of them, so one more asserts the
 other half: any candidate group left below urgent was left there because it did
 not fit in what remained, not because the walk overlooked it.
 
+One more says what the balancer is *for*: every change it makes moves a job
+onto an urgent slot or off one, never anywhere else. That is what makes the
+reason each change is logged under readable off the movement alone.
+
 Those invariants are all properties of `decide`, which assumes every call it
 plans succeeds. The ones that only exist once calls can fail belong to
 `run_pass` and are tested there.
@@ -253,6 +284,9 @@ from real protobuf messages, covering environment-variable and
 placement-constraint parsing, org-qualified cluster resolution, the
 scheduled-but-not-started case, slot accounting, dry-run, action ordering,
 fail-soft behaviour, the per-pass reports, and the entrypoint's one-shot and
-`--interval` modes. Its randomised passes make an arbitrary subset of the calls
+`--interval` modes. The resting-priority memory is covered across *pairs* of
+passes, since it only exists to carry something from one to the next: a job is
+put back where it was raised from, a hand-made change is adopted, a preemption
+does not lose the note, and a bad state file is survived. Its randomised passes make an arbitrary subset of the calls
 fail and assert the pass still never ends above the allocation — the property
 that the ordering alone does not buy.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -52,6 +52,12 @@ Sessions and `immediate` jobs still count against the allocation — see
   eligible. If you label a job `low` to be a good citizen, it may still be made
   unpreemptible and charged to the team allocation. It is simply the first to
   be dropped when the allocation gets tight.
+- **A queued job below its `CM_PRIORITY` is raised to it, grant or no grant.**
+  The resting priority is where the label says the job belongs, so the balancer
+  moves it there in both directions. Submitting at `low` with `CM_PRIORITY=high`
+  therefore gets you `high`, not `low`, once a pass has seen the job. This costs
+  the allocation nothing — only `urgent` is budgeted — but it does change how the
+  job is scheduled against everyone else's.
 - **A demotion is permanent for the life of that run.** Beaker will not raise
   the priority of a job it has already placed, so a job the balancer drops
   during a busy spell stays down even after the spell passes. It becomes
@@ -233,6 +239,11 @@ written independently of the production accounting, so a bug in the accounting
 cannot hide behind itself; a further test asserts the random populations
 actually reach the states that matter, so the suite cannot quietly go vacuous.
 
+Those invariants are one-sided — never *above* the allocation — and a balancer
+that granted nothing would satisfy every one of them, so one more asserts the
+other half: any candidate group left below urgent was left there because it did
+not fit in what remained, not because the walk overlooked it.
+
 Those invariants are all properties of `decide`, which assumes every call it
 plans succeeds. The ones that only exist once calls can fail belong to
 `run_pass` and are tested there.
@@ -240,7 +251,8 @@ plans succeeds. The ones that only exist once calls can fail belong to
 `test_beaker_io.py` drives the Beaker-facing layer against a fake client built
 from real protobuf messages, covering environment-variable and
 placement-constraint parsing, org-qualified cluster resolution, the
-scheduled-but-not-started case, slot accounting, dry-run, action ordering, and
-fail-soft behaviour. Its randomised passes make an arbitrary subset of the calls
+scheduled-but-not-started case, slot accounting, dry-run, action ordering,
+fail-soft behaviour, the per-pass reports, and the entrypoint's one-shot and
+`--interval` modes. Its randomised passes make an arbitrary subset of the calls
 fail and assert the pass still never ends above the allocation — the property
 that the ordering alone does not buy.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -23,14 +23,37 @@ scarce urgent slot first, and what a job falls back to when it doesn't get one.
 A job labelled `urgent` rests at `high`, since resting at urgent would defeat
 the point.
 
-Two things stop a job being managed:
+Things that stop a job being managed, each reported in the log as an aggregate
+count per pass:
 
 - **It targets more than one cluster.** Beaker offers no way to pin a queued
   job to a cluster, so a job eligible for both jupiter and titan could consume
   either allocation and there is no way to know which in advance. Pin your job
-  to one cluster if you want it balanced. The script logs a warning for
-  labelled jobs it has to skip for this reason.
+  to one cluster if you want it balanced. Most `ai2/ace` jobs today target
+  `titan+jupiter`, so expect this to be the common case during adoption.
 - **It targets a cluster with no allocation** (`ai2/saturn`, `ai2/ceres`).
+- **It is part of a replica group.** The allocation walk would grant urgent to
+  some ranks and not others, which for a synchronised-start group wastes the
+  slots it did grant. It is also unconfirmed whether `UpdateJobSourcePriority`
+  acts per job or per source; if per source, one call would move every replica.
+- **It has landed on a node the script cannot resolve to a cluster.** Its slots
+  are then charged to every budget as a precaution, which is inconsistent with
+  managing it against one.
+
+### What may surprise you
+
+- **A job labelled `low` can still be promoted to `urgent`.** `CM_PRIORITY` is
+  a ranking, not a ceiling: when the cluster is quiet, any labelled job is
+  eligible. If you label a job `low` to be a good citizen, it may still be made
+  unpreemptible and charged to the team allocation. It is simply the first to
+  be dropped when the allocation gets tight.
+- **A demotion is permanent for the life of that run.** Beaker will not raise
+  the priority of a job it has already placed, so a job the balancer drops
+  during a busy spell stays down even after the spell passes. It becomes
+  eligible again only if it is preempted and returns to the queue.
+- **Demotion deliberately targets the job with the most work at risk.** Within
+  a `CM_PRIORITY` level, the job that has held its GPUs longest is the first to
+  lose urgent, on the grounds that it has already had its turn.
 
 ## What it does
 
@@ -104,18 +127,28 @@ python balance.py --interval 180     # keep running, one pass every 3 minutes
 ```
 
 Useful flags: `--workspace` (default `ai2/ace`), `--limit CLUSTER=SLOTS`
-(repeatable, overrides the allocation), `-v` for debug logging.
+(repeatable; merges into the default allocation rather than replacing it), `-v`
+for debug logging. Cluster names in `--limit` are checked against Beaker at
+startup, since a typo would otherwise manage nothing and look exactly like a
+quiet cluster.
 
-A pass is stateless and converges, so it is safe to run from cron:
+A pass is stateless and converges, so it is safe to run from cron. Note that
+cron does not read your shell profile, so `BEAKER_TOKEN` has to be supplied
+explicitly:
 
 ```cron
+BEAKER_TOKEN=...
 */3 * * * * /path/to/python /path/to/balance.py >> /var/log/beaker_balancer.log 2>&1
 ```
+
+There is no lockfile, so pick an interval comfortably longer than a pass (a pass
+is a few seconds against the current workspace).
 
 It runs as whoever's token is in the environment and modifies teammates' jobs
 too. A job it lacks permission to change is logged and skipped rather than
 failing the pass, so watch the log the first time it runs against jobs it does
-not own.
+not own. Demotions are attempted before promotions, so a pass that dies partway
+through is never left over allocation.
 
 ## Tests
 
@@ -123,9 +156,21 @@ not own.
 python -m pytest
 ```
 
+Requires `beaker-py`, which is not a core `fme` dependency; both test modules
+skip themselves when it is absent so a plain `pytest` at the repo root still
+collects cleanly.
+
 `test_balance.py` covers the decision logic, including randomised populations
 asserting the invariants that matter: a pass never pushes usage above the
-allocation, a second pass is always a no-op (so cron cannot flap jobs), and
-only labelled single-cluster jobs are ever touched — never raising a running
-one. `test_beaker_io.py` drives the Beaker-facing layer against a fake client
-built from real protobuf messages.
+allocation, *any prefix* of a pass stays within it, a second pass is always a
+no-op (so cron cannot flap jobs), and only labelled, manageable jobs are ever
+touched — never raising a placed one. Those tests compute usage with an oracle
+written independently of the production accounting, so a bug in the accounting
+cannot hide behind itself; a further test asserts the random populations
+actually reach the states that matter, so the suite cannot quietly go vacuous.
+
+`test_beaker_io.py` drives the Beaker-facing layer against a fake client built
+from real protobuf messages, covering environment-variable and
+placement-constraint parsing, org-qualified cluster resolution, the
+scheduled-but-not-started case, slot accounting, dry-run, action ordering, and
+fail-soft behaviour.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -86,6 +86,15 @@ is what gets the group placed.
 The grouping is keyed on the replica group rather than the workload, since one
 workload can hold independent tasks that have no reason to move together.
 
+Deciding for the group is only half of it: the ranks are still raised one call
+at a time, so a refusal partway through would split the group anyway. A refused
+rank therefore abandons the rest of the group's grant instead of spending more
+slots on a job that cannot start. Ranks already raised keep urgent — the next
+pass re-decides from what is really there and either finishes the group or takes
+it back, which is cheaper than a rollback that can fail in its own turn. In
+practice permission is per owner and every rank shares one, so the first rank
+fails and nothing is spent.
+
 ## What it does
 
 Each pass recomputes the whole allocation from scratch and applies the
@@ -192,8 +201,16 @@ is a few seconds against the current workspace).
 It runs as whoever's token is in the environment and modifies teammates' jobs
 too. A job it lacks permission to change is logged and skipped rather than
 failing the pass, so watch the log the first time it runs against jobs it does
-not own. Demotions are attempted before promotions, so a pass that dies partway
-through is never left over allocation.
+not own.
+
+Such a refusal is why demotions are attempted before promotions, and why a
+refused demotion also *defers* the grant it was paying for. Ordering alone makes
+any prefix of a pass safe, but a refusal does not end the pass — it skips one
+call and carries on — so what lands is an arbitrary subset. Granting urgent
+after the demotion paying for it was refused would end the pass over the
+allocation. The deferral is per cluster and lasts one pass: the next one
+recomputes from the state that really exists. A group is deferred whole, since
+it is granted whole.
 
 ## Tests
 
@@ -216,8 +233,14 @@ written independently of the production accounting, so a bug in the accounting
 cannot hide behind itself; a further test asserts the random populations
 actually reach the states that matter, so the suite cannot quietly go vacuous.
 
+Those invariants are all properties of `decide`, which assumes every call it
+plans succeeds. The ones that only exist once calls can fail belong to
+`run_pass` and are tested there.
+
 `test_beaker_io.py` drives the Beaker-facing layer against a fake client built
 from real protobuf messages, covering environment-variable and
 placement-constraint parsing, org-qualified cluster resolution, the
 scheduled-but-not-started case, slot accounting, dry-run, action ordering, and
-fail-soft behaviour.
+fail-soft behaviour. Its randomised passes make an arbitrary subset of the calls
+fail and assert the pass still never ends above the allocation — the property
+that the ordering alone does not buy.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -30,13 +30,6 @@ the point.
 Things that stop a job being managed, each reported in the log as an aggregate
 count per pass:
 
-- **It is still queued and targets more than one cluster.** Beaker offers no
-  way to pin a queued job, so a job eligible for both jupiter and titan could
-  consume either allocation and there is no way to know which in advance. This
-  stops applying the moment it lands: a running job occupies one cluster, is
-  charged to that one alone, and is balanced against it whatever it was
-  submitted eligible for. Most `ai2/ace` jobs target `titan+jupiter`, so during
-  adoption expect them to be unmanaged while queued and managed once running.
 - **It targets a cluster with no allocation** (`ai2/saturn`, `ai2/ceres`).
 - **It is an interactive session.** There is a person attached to it, and
   taking their priority away mid-session is not the script's call.
@@ -118,8 +111,8 @@ difference:
    it with its ranks.
 2. Subtract the slots held at urgent or `immediate` by jobs it cannot modify.
    Those are a fixed charge; only what is left is available.
-3. Walk the managed groups in `CM_PRIORITY` order, granting urgent while the
-   group's cluster has room for all of it.
+3. Walk the managed groups in `CM_PRIORITY` order, granting urgent while every
+   cluster the group could land on has room for all of it.
 4. Set every managed group to urgent if granted, or to its resting priority if
    not.
 
@@ -176,13 +169,21 @@ urgent job counts at full weight against every cluster it could land on.
 Nothing outranks urgent and nothing can preempt it, so a queued urgent job is a
 committed future occupant, not a maybe.
 
-Being charged to one cluster and being balanced against it are the same
-question, so they are answered the same way: a placed job is managed against
-the cluster it landed on. It could in principle be preempted and come back
-somewhere else, but then it is queued again and the next pass treats it as
-ambiguous once more. The alternative — leaving a running job unmanaged because
-of a constraint that no longer decides anything — means its slots can be seen
-but never reclaimed.
+Being charged to a cluster and being balanced against it are the same question,
+so they are answered the same way. A placed job is managed against the single
+cluster it landed on. A queued job targeting multiple clusters is managed
+**pessimistically** against all of them: granting it urgent requires room on
+every cluster, and the grant charges all of them. Demoting it frees all of
+them. This means a multi-cluster grant costs more than a single-cluster one
+when headroom is tight, which is the right tradeoff — the alternative is to
+grant urgent against a budget the job might consume elsewhere.
+
+A placed multi-cluster job is different: it is on one cluster and only that
+cluster's budget is affected, whether the job is granted or demoted. It could
+in principle be preempted and come back somewhere else, but then it is queued
+again and the next pass treats it pessimistically once more. The alternative —
+leaving a running job unmanaged because of a constraint that no longer decides
+anything — means its slots can be seen but never reclaimed.
 
 `immediate` counts the same as urgent: it outranks urgent, so the slot is just
 as occupied. Interactive sessions count too.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -4,8 +4,11 @@ Beaker does not enforce our urgent-priority allocation, so queueing urgent jobs
 can quietly put the team over it. This script keeps us within the allocation
 without anyone having to hand-manage priorities.
 
-Our allocation is **72 GPU slots on `ai2/jupiter` and 32 on `ai2/titan`**. A
-Beaker slot is one GPU; a CPU-only job counts as one slot.
+Our allocation is **72 GPU slots on `ai2/jupiter` and 32 on `ai2/titan`**.
+`ai2/ceres` and `ai2/saturn` are tracked at **0** — the balancer knows they
+exist so jobs targeting them alongside a budgeted cluster are managed, but they
+carry no allocation of their own. A Beaker slot is one GPU; a CPU-only job
+counts as one slot.
 
 The allocation is the team's, not one workspace's. The balancer manages
 `ai2/ace` and also counts the urgent slots held in `ai2/climate-titan`, without
@@ -30,7 +33,9 @@ the point.
 Things that stop a job being managed, each reported in the log as an aggregate
 count per pass:
 
-- **It targets a cluster with no allocation** (`ai2/saturn`, `ai2/ceres`).
+- **Every cluster it targets has zero allocation.** A job targeting only
+  `ai2/ceres` (0 slots) has nothing to budget against. A job targeting both
+  `ai2/jupiter` and `ai2/ceres` *is* managed — against jupiter alone.
 - **It is an interactive session.** There is a person attached to it, and
   taking their priority away mid-session is not the script's call.
 - **It is at `immediate` priority.** Beaker requires a human-supplied reason for
@@ -178,12 +183,11 @@ all of them. This means a multi-cluster grant costs more than a single-cluster
 one when headroom is tight, which is the right tradeoff — the alternative is
 to grant urgent against a budget the job might consume elsewhere.
 
-A job targeting a mix of budgeted and non-budgeted clusters — e.g. both
-`ai2/jupiter` (budgeted) and `ai2/ceres` (no allocation) — is managed against
-the budgeted ones only. While queued, only the budgeted clusters are checked
-and charged. If it lands on a non-budgeted cluster, its slots stop counting
-against the allocation entirely, since it is not consuming a budgeted cluster's
-slots.
+A job targeting a mix of budgeted and zero-allocation clusters — e.g. both
+`ai2/jupiter` (72 slots) and `ai2/ceres` (0 slots) — is managed against the
+budgeted ones only. A zero-allocation cluster has no budget to protect, so it
+is transparent: the grant check skips it, the charge skips it, and if the job
+lands there its slots stop counting against the allocation entirely.
 
 A placed multi-cluster job is different: it is on one cluster and only that
 cluster's budget is affected, whether the job is granted or demoted. It could

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -30,11 +30,13 @@ the point.
 Things that stop a job being managed, each reported in the log as an aggregate
 count per pass:
 
-- **It targets more than one cluster.** Beaker offers no way to pin a queued
-  job to a cluster, so a job eligible for both jupiter and titan could consume
-  either allocation and there is no way to know which in advance. Pin your job
-  to one cluster if you want it balanced. Most `ai2/ace` jobs today target
-  `titan+jupiter`, so expect this to be the common case during adoption.
+- **It is still queued and targets more than one cluster.** Beaker offers no
+  way to pin a queued job, so a job eligible for both jupiter and titan could
+  consume either allocation and there is no way to know which in advance. This
+  stops applying the moment it lands: a running job occupies one cluster, is
+  charged to that one alone, and is balanced against it whatever it was
+  submitted eligible for. Most `ai2/ace` jobs target `titan+jupiter`, so during
+  adoption expect them to be unmanaged while queued and managed once running.
 - **It targets a cluster with no allocation** (`ai2/saturn`, `ai2/ceres`).
 - **It is an interactive session.** There is a person attached to it, and
   taking their priority away mid-session is not the script's call.
@@ -84,7 +86,9 @@ a job that still cannot run.
 
 A group is managed only if *every* rank is: one unlabelled rank, one session, or
 one at `immediate` makes the whole group untouchable. The same applies if the
-ranks disagree about their `CM_PRIORITY`, or if the group comes back short —
+ranks disagree about their `CM_PRIORITY` or about the cluster they are charged
+to — a group split across two clusters spends two budgets at once, so it can be
+neither granted nor reclaimed as one — or if the group comes back short —
 only unfinished jobs in one workspace are read, so granting the ranks that
 happen to be visible would half-grant the real group. Skipped groups are counted
 in the log.
@@ -171,6 +175,14 @@ A job that has landed counts only against the cluster it is on. A *queued*
 urgent job counts at full weight against every cluster it could land on.
 Nothing outranks urgent and nothing can preempt it, so a queued urgent job is a
 committed future occupant, not a maybe.
+
+Being charged to one cluster and being balanced against it are the same
+question, so they are answered the same way: a placed job is managed against
+the cluster it landed on. It could in principle be preempted and come back
+somewhere else, but then it is queued again and the next pass treats it as
+ambiguous once more. The alternative — leaving a running job unmanaged because
+of a constraint that no longer decides anything — means its slots can be seen
+but never reclaimed.
 
 `immediate` counts the same as urgent: it outranks urgent, so the slot is just
 as occupied. Interactive sessions count too.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -18,10 +18,10 @@ gantry run --env CM_PRIORITY=high ...
 The balancer only modifies jobs that set it. Jobs that don't are left alone
 entirely, though their urgent slots still count against the allocation.
 
-`CM_PRIORITY` is a ranking, and only a ranking: it decides who gets a scarce
-urgent slot first. It does not say what priority your job runs at. Submit at
-the priority you want; the balancer's only effect is whether you also hold an
-urgent slot, and it puts you back where you were when you don't.
+`CM_PRIORITY` is both a ranking and a resting place. It decides who gets a
+scarce urgent slot first, and what a job falls back to when it doesn't get one.
+A job labelled `urgent` rests at `high`, since resting at urgent would defeat
+the point.
 
 Things that stop a job being managed, each reported in the log as an aggregate
 count per pass:
@@ -52,6 +52,12 @@ Sessions and `immediate` jobs still count against the allocation — see
   eligible. If you label a job `low` to be a good citizen, it may still be made
   unpreemptible and charged to the team allocation. It is simply the first to
   be dropped when the allocation gets tight.
+- **A queued job below its `CM_PRIORITY` is raised to it, grant or no grant.**
+  The resting priority is where the label says the job belongs, so the balancer
+  moves it there in both directions. Submitting at `low` with `CM_PRIORITY=high`
+  therefore gets you `high`, not `low`, once a pass has seen the job. This costs
+  the allocation nothing — only `urgent` is budgeted — but it does change how the
+  job is scheduled against everyone else's.
 - **A demotion is permanent for the life of that run.** Beaker will not raise
   the priority of a job it has already placed, so a job the balancer drops
   during a busy spell stays down even after the spell passes. It becomes
@@ -59,36 +65,6 @@ Sessions and `immediate` jobs still count against the allocation — see
 - **Demotion deliberately targets the job with the most work at risk.** Within
   a `CM_PRIORITY` level, the job that has held its GPUs longest is the first to
   lose urgent, on the grounds that it has already had its turn.
-
-## Where a job goes when it gives up its slot
-
-Back to the priority it was last seen at below urgent — where you submitted it,
-or wherever you last moved it to by hand. The balancer's only lasting effect on
-a job is whether it held an urgent slot.
-
-Beaker keeps no record of that. A job carries one priority, `UpdateJobSourcePriority`
-overwrites it in place, and job events log scheduling rather than priority
-changes, so raising a job destroys the only evidence of where it came from. The
-balancer therefore keeps its own note, in a small JSON file (`--state`, by
-default `~/.cache/beaker_balancer/resting.json`).
-
-Consequences worth knowing:
-
-- **A job that is already resting is never touched.** If it is below urgent, it
-  is where its owner wants it, so the only changes the balancer ever makes are
-  onto an urgent slot and back off again.
-- **Move a job by hand and the balancer adopts it.** Whatever you set it to is
-  what it goes back to next time it gives up a slot. Except at urgent: setting
-  a job to urgent yourself only makes it a candidate, and it is dropped again if
-  the allocation cannot cover it.
-- **Lose the file and jobs currently at urgent fall back to `high`.** That is
-  also where a job goes if it was submitted at urgent and never seen lower.
-  Nothing else degrades: the allocation arithmetic does not depend on it, so a
-  lost, corrupt or unwritable file is logged and the pass carries on.
-- **A preempted job keeps its place.** Beaker requeues it under a new id, at the
-  priority the balancer set rather than the one it was submitted at, so the note
-  follows `retry_ancestor_id`. Without that, every preemption of a granted job
-  would ratchet it up to the `high` fallback.
 
 ## Replica groups
 
@@ -135,8 +111,8 @@ difference:
    Those are a fixed charge; only what is left is available.
 3. Walk the managed groups in `CM_PRIORITY` order, granting urgent while the
    group's cluster has room for all of it.
-4. Set every managed group to urgent if granted, or back to where its ranks
-   were resting if not.
+4. Set every managed group to urgent if granted, or to its resting priority if
+   not.
 
 Recomputing rather than adjusting incrementally is what makes step 3 work: a
 `high` group is always considered before any `normal` one, so it never has to
@@ -211,25 +187,22 @@ python balance.py --interval 180     # keep running, one pass every 3 minutes
 ```
 
 Useful flags: `--workspace` (default `ai2/ace`), `--limit CLUSTER=SLOTS`
-(repeatable; merges into the default allocation rather than replacing it),
-`--state` (where to keep the remembered resting priorities), `-v` for debug
-logging. Cluster names in `--limit` are checked against Beaker at startup, since
-a typo would otherwise manage nothing and look exactly like a quiet cluster.
+(repeatable; merges into the default allocation rather than replacing it), `-v`
+for debug logging. Cluster names in `--limit` are checked against Beaker at
+startup, since a typo would otherwise manage nothing and look exactly like a
+quiet cluster.
 
-Each pass recomputes what it wants from the live workspace, so it converges and
-is safe to run from cron. Note that cron reads neither your shell profile nor
-necessarily the same `HOME`, so `BEAKER_TOKEN` has to be supplied explicitly and
-`--state` is worth pinning rather than left to default:
+A pass is stateless and converges, so it is safe to run from cron. Note that
+cron does not read your shell profile, so `BEAKER_TOKEN` has to be supplied
+explicitly:
 
 ```cron
 BEAKER_TOKEN=...
-*/3 * * * * /path/to/python /path/to/balance.py --state ~/.cache/beaker_balancer/resting.json >> /var/log/beaker_balancer.log 2>&1
+*/3 * * * * /path/to/python /path/to/balance.py >> /var/log/beaker_balancer.log 2>&1
 ```
 
 There is no lockfile, so pick an interval comfortably longer than a pass (a pass
-is a few seconds against the current workspace). Two balancers sharing a state
-file overwrite each other's notes rather than corrupting the file; the loser
-forgets, which costs the `high` fallback and nothing else.
+is a few seconds against the current workspace).
 
 It runs as whoever's token is in the environment and modifies teammates' jobs
 too. A job it lacks permission to change is logged and skipped rather than
@@ -271,10 +244,6 @@ that granted nothing would satisfy every one of them, so one more asserts the
 other half: any candidate group left below urgent was left there because it did
 not fit in what remained, not because the walk overlooked it.
 
-One more says what the balancer is *for*: every change it makes moves a job
-onto an urgent slot or off one, never anywhere else. That is what makes the
-reason each change is logged under readable off the movement alone.
-
 Those invariants are all properties of `decide`, which assumes every call it
 plans succeeds. The ones that only exist once calls can fail belong to
 `run_pass` and are tested there.
@@ -284,9 +253,6 @@ from real protobuf messages, covering environment-variable and
 placement-constraint parsing, org-qualified cluster resolution, the
 scheduled-but-not-started case, slot accounting, dry-run, action ordering,
 fail-soft behaviour, the per-pass reports, and the entrypoint's one-shot and
-`--interval` modes. The resting-priority memory is covered across *pairs* of
-passes, since it only exists to carry something from one to the next: a job is
-put back where it was raised from, a hand-made change is adopted, a preemption
-does not lose the note, and a bad state file is survived. Its randomised passes make an arbitrary subset of the calls
+`--interval` modes. Its randomised passes make an arbitrary subset of the calls
 fail and assert the pass still never ends above the allocation — the property
 that the ordering alone does not buy.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -1,0 +1,131 @@
+# Beaker priority balancer
+
+Beaker does not enforce our urgent-priority allocation, so queueing urgent jobs
+can quietly put the team over it. This script keeps us within the allocation
+without anyone having to hand-manage priorities.
+
+Our allocation is **72 GPU slots on `ai2/jupiter` and 32 on `ai2/titan`**. A
+Beaker slot is one GPU; a CPU-only job counts as one slot.
+
+## Opting a job in
+
+Set `CM_PRIORITY` on the job to `low`, `normal`, `high` or `urgent`:
+
+```bash
+gantry run --env CM_PRIORITY=high ...
+```
+
+The balancer only modifies jobs that set it. Jobs that don't are left alone
+entirely, though their urgent slots still count against the allocation.
+
+`CM_PRIORITY` is both a ranking and a resting place. It decides who gets a
+scarce urgent slot first, and what a job falls back to when it doesn't get one.
+A job labelled `urgent` rests at `high`, since resting at urgent would defeat
+the point.
+
+Two things stop a job being managed:
+
+- **It targets more than one cluster.** Beaker offers no way to pin a queued
+  job to a cluster, so a job eligible for both jupiter and titan could consume
+  either allocation and there is no way to know which in advance. Pin your job
+  to one cluster if you want it balanced. The script logs a warning for
+  labelled jobs it has to skip for this reason.
+- **It targets a cluster with no allocation** (`ai2/saturn`, `ai2/ceres`).
+
+## What it does
+
+Each pass recomputes the whole allocation from scratch and applies the
+difference:
+
+1. Read every unfinished job in the workspace.
+2. Subtract the slots held at urgent by jobs it cannot modify. Those are a
+   fixed charge; only what is left is available.
+3. Walk the managed jobs in `CM_PRIORITY` order, granting urgent while the
+   job's cluster has room.
+4. Set every managed job to urgent if granted, or to its resting priority if
+   not.
+
+Recomputing rather than adjusting incrementally is what makes step 3 work: a
+`high` job is always considered before any `normal` job, so it never has to
+wait for slots a lesser job already took. If `normal` jobs are holding urgent
+slots that a `high` job needs, they are dropped to make room.
+
+Within one `CM_PRIORITY` level, urgent is granted to running jobs that already
+hold it first — so a queued job always gives up its slot before a running one —
+ordered so the job that has held a GPU longest is the first to lose it. Queued
+jobs follow, longest-waiting first. The two orderings use different clocks:
+time on GPU for running jobs, and time since entering the queue for queued
+ones. The queue clock resets when a job is preempted and requeued, so a job
+that has been bounced does not keep seniority it no longer has.
+
+A job too large for the remaining slots is skipped and smaller ones behind it
+still get a chance. Nothing is reserved for it, because a level that could not
+fit has already taken everything it was entitled to.
+
+## What it will not do
+
+**It never stops or preempts a job.** The only call it makes is
+`UpdateJobSourcePriority`. Demoting a running job does not stop it — the job
+keeps running and merely becomes preemptible again, which is the honest
+consequence of being outside the allocation. Whether it is then preempted is
+the cluster scheduler's decision, not ours.
+
+**It never promotes a running job.** Beaker rejects this outright:
+
+```
+BeakerPermissionsError: cannot increase priority for running job "01K..."
+```
+
+So a job that starts at `high` stays there for life, even if urgent slots free
+up later. Such a job is also excluded from the allocation walk — granting it
+urgent on paper would displace jobs that *can* be promoted, for no benefit. If
+it is preempted and returns to the queue it becomes eligible again, at its
+proper rank.
+
+The practical consequence: **submit at the priority you want, and let the
+balancer take it away** rather than hoping to be raised later.
+
+## Accounting
+
+A job that has landed counts only against the cluster it is on. A *queued*
+urgent job counts at full weight against every cluster it could land on.
+Nothing outranks urgent and nothing can preempt it, so a queued urgent job is a
+committed future occupant, not a maybe.
+
+## Running it
+
+Needs `beaker-py` and a Beaker token in the environment:
+
+```bash
+pip install beaker-py
+python balance.py --dry-run          # report what a pass would change
+python balance.py                    # apply one pass
+python balance.py --interval 180     # keep running, one pass every 3 minutes
+```
+
+Useful flags: `--workspace` (default `ai2/ace`), `--limit CLUSTER=SLOTS`
+(repeatable, overrides the allocation), `-v` for debug logging.
+
+A pass is stateless and converges, so it is safe to run from cron:
+
+```cron
+*/3 * * * * /path/to/python /path/to/balance.py >> /var/log/beaker_balancer.log 2>&1
+```
+
+It runs as whoever's token is in the environment and modifies teammates' jobs
+too. A job it lacks permission to change is logged and skipped rather than
+failing the pass, so watch the log the first time it runs against jobs it does
+not own.
+
+## Tests
+
+```bash
+python -m pytest
+```
+
+`test_balance.py` covers the decision logic, including randomised populations
+asserting the invariants that matter: a pass never pushes usage above the
+allocation, a second pass is always a no-op (so cron cannot flap jobs), and
+only labelled single-cluster jobs are ever touched — never raising a running
+one. `test_beaker_io.py` drives the Beaker-facing layer against a fake client
+built from real protobuf messages.

--- a/scripts/beaker_balancer/README.md
+++ b/scripts/beaker_balancer/README.md
@@ -7,6 +7,10 @@ without anyone having to hand-manage priorities.
 Our allocation is **72 GPU slots on `ai2/jupiter` and 32 on `ai2/titan`**. A
 Beaker slot is one GPU; a CPU-only job counts as one slot.
 
+The allocation is the team's, not one workspace's. The balancer manages
+`ai2/ace` and also counts the urgent slots held in `ai2/climate-titan`, without
+ever modifying anything there — see [Other workspaces](#other-workspaces).
+
 ## Opting a job in
 
 Set `CM_PRIORITY` on the job to `low`, `normal`, `high` or `urgent`:
@@ -106,7 +110,8 @@ fails and nothing is spent.
 Each pass recomputes the whole allocation from scratch and applies the
 difference:
 
-1. Read every unfinished job in the workspace and group it with its ranks.
+1. Read every unfinished job in the managed and observed workspaces, and group
+   it with its ranks.
 2. Subtract the slots held at urgent or `immediate` by jobs it cannot modify.
    Those are a fixed charge; only what is left is available.
 3. Walk the managed groups in `CM_PRIORITY` order, granting urgent while the
@@ -170,10 +175,43 @@ committed future occupant, not a maybe.
 `immediate` counts the same as urgent: it outranks urgent, so the slot is just
 as occupied. Interactive sessions count too.
 
-Sessions and `immediate` jobs are counted but never reclaimable, so a pass can
-be unable to get within the allocation no matter what it does. Each pass logs
-how many slots per cluster are held that way, so that shows up as a fact rather
-than as a balancer that appears not to be working.
+Sessions, `immediate` jobs and everything in an observed workspace are counted
+but never reclaimable, so a pass can be unable to get within the allocation no
+matter what it does. Each pass logs how many slots per cluster are held that
+way, broken out by cause, so that shows up as a fact rather than as a balancer
+that appears not to be working:
+
+```
+urgent slots before: ai2/jupiter 12/72, ai2/titan 33/32
+ai2/jupiter: 4 in ai2/climate-titan — counted against the allocation, never reclaimable
+ai2/titan: 33 in ai2/climate-titan — counted against the allocation, never reclaimable
+no changes needed
+```
+
+## Other workspaces
+
+The balancer manages one workspace (`--workspace`, default `ai2/ace`) and
+*observes* others (`--observe`, default `ai2/climate-titan`). An observed
+workspace's jobs are counted against the allocation exactly as our own are, and
+are never modified.
+
+Counting them is the point: the allocation is shared, so slots held elsewhere
+have to be subtracted before any are handed out. Without this the balancer would
+grant urgent against slots that are already occupied — handing out the same
+allocation twice.
+
+`CM_PRIORITY` is not read in an observed workspace. Opting in is what makes a
+job the balancer's to move, and nothing there is, so honouring the label would
+make setting it look like it had done something. Observed jobs are reported as
+held slots rather than as jobs that failed to be managed.
+
+Reading one workspace or several costs the same: Beaker returns the whole org's
+unfinished jobs in one call and the balancer filters them, so observing another
+workspace adds a name lookup, not a second pass.
+
+Use `--no-observe` to count only the managed workspace. Names given to
+`--observe` are checked at startup, since a typo would count nothing and look
+exactly like a workspace holding no urgent slots.
 
 ## Running it
 
@@ -187,10 +225,11 @@ python balance.py --interval 180     # keep running, one pass every 3 minutes
 ```
 
 Useful flags: `--workspace` (default `ai2/ace`), `--limit CLUSTER=SLOTS`
-(repeatable; merges into the default allocation rather than replacing it), `-v`
-for debug logging. Cluster names in `--limit` are checked against Beaker at
-startup, since a typo would otherwise manage nothing and look exactly like a
-quiet cluster.
+(repeatable; merges into the default allocation rather than replacing it),
+`--observe WORKSPACE` / `--no-observe` (see [Other
+workspaces](#other-workspaces)), `-v` for debug logging. Cluster names in
+`--limit` are checked against Beaker at startup, since a typo would otherwise
+manage nothing and look exactly like a quiet cluster.
 
 A pass is stateless and converges, so it is safe to run from cron. Note that
 cron does not read your shell profile, so `BEAKER_TOKEN` has to be supplied
@@ -253,6 +292,9 @@ from real protobuf messages, covering environment-variable and
 placement-constraint parsing, org-qualified cluster resolution, the
 scheduled-but-not-started case, slot accounting, dry-run, action ordering,
 fail-soft behaviour, the per-pass reports, and the entrypoint's one-shot and
-`--interval` modes. Its randomised passes make an arbitrary subset of the calls
+`--interval` modes. Observed workspaces are covered on both halves of what they
+are for: their slots reduce what our own jobs are granted, and no call is ever
+made against them — including when they are holding the whole allocation and we
+are over it. Its randomised passes make an arbitrary subset of the calls
 fail and assert the pass still never ends above the allocation — the property
 that the ordering alone does not buy.

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -15,18 +15,26 @@ Decisions are made per *replica group*, not per job: Beaker runs a multi-node
 job as one job per rank, and a group granted urgent on only some ranks holds
 slots it cannot use.
 
+A job that is not granted an urgent slot is returned to the priority it was
+last seen at before the balancer raised it. Beaker keeps no record of that, so
+the balancer keeps its own -- see ``load_state``.
+
 Run ``python balance.py --dry-run`` to see what a pass would do.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import os
 import sys
+import tempfile
 import time
 from collections import Counter
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
+from pathlib import Path
 
 from beaker import Beaker
 from beaker import beaker_pb2 as pb2
@@ -57,6 +65,18 @@ NAME_BY_PRIORITY[IMMEDIATE] = "immediate"
 #: ``urgent``, so a job holding one is just as much an occupant.
 ALLOCATED_PRIORITIES = (URGENT, IMMEDIATE)
 
+#: Priorities a job may be left resting at. ``urgent`` is excluded because
+#: resting there would defeat the allocation, and ``immediate`` because the
+#: balancer never hands it out.
+RESTABLE_PRIORITIES = (LOW, NORMAL, HIGH)
+
+#: Where the remembered resting priorities are kept between passes.
+DEFAULT_STATE_PATH = Path.home() / ".cache" / "beaker_balancer" / "resting.json"
+
+#: Bumped if the state file's shape ever changes; an unrecognised version is
+#: discarded rather than misread.
+STATE_VERSION = 1
+
 _CLUSTER_CONSTRAINT = pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER
 
 # Why a job may not be modified. Identity-compared, so a caller can tell an
@@ -69,13 +89,64 @@ NO_ALLOCATION = "targets a cluster with no allocation"
 UNRESOLVED_CLUSTER = "landed on a node that cannot be resolved to a cluster"
 
 
-def resting_priority(cm_priority: int) -> int:
-    """Priority a job falls back to when it is not granted an urgent slot.
+def load_state(path: Path) -> dict[str, int]:
+    """Read the remembered resting priorities, or start empty.
 
-    Jobs labelled ``urgent`` rest at ``high``: resting at urgent would defeat
-    the purpose of the allocation.
+    Never raises: a balancer that will not run because its cache is unreadable
+    is worse than one that forgets. Forgetting is bounded -- an unknown job at
+    urgent falls back to ``high`` -- so a corrupt or missing file costs fidelity
+    for the jobs currently at urgent and nothing else.
     """
-    return HIGH if cm_priority == URGENT else cm_priority
+    try:
+        with open(path) as handle:
+            state = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as err:
+        LOGGER.warning("could not read %s, starting with no memory: %s", path, err)
+        return {}
+    if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
+        LOGGER.warning("ignoring %s: not a version %d state file", path, STATE_VERSION)
+        return {}
+    resting = state.get("resting")
+    if not isinstance(resting, dict):
+        LOGGER.warning("ignoring %s: no resting priorities in it", path)
+        return {}
+    return {
+        job_id: priority
+        for job_id, priority in resting.items()
+        if isinstance(job_id, str) and priority in RESTABLE_PRIORITIES
+    }
+
+
+def save_state(path: Path, resting: Mapping[str, int]) -> None:
+    """Write the remembered resting priorities, replacing the file atomically.
+
+    Never raises, for the same reason as ``load_state``: by the time this is
+    called the pass has already decided, and failing here would turn a full
+    disk into a balancer that stops balancing.
+
+    The replace is atomic so that a second balancer, or a process killed
+    mid-write, finds either the old file or the new one and never a half of
+    each. Two balancers still overwrite each other, but the loser only loses
+    memory, which costs the ``high`` fallback rather than correctness: the
+    allocation arithmetic does not depend on where a demoted job lands.
+    """
+    state = {"version": STATE_VERSION, "resting": dict(resting)}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = tempfile.NamedTemporaryFile(
+            "w", dir=path.parent, prefix=path.name, suffix=".tmp", delete=False
+        )
+        try:
+            with handle:
+                json.dump(state, handle)
+            os.replace(handle.name, path)
+        except BaseException:
+            os.unlink(handle.name)
+            raise
+    except OSError as err:
+        LOGGER.warning("could not write %s; the next pass starts fresh: %s", path, err)
 
 
 @dataclass(frozen=True)
@@ -111,6 +182,10 @@ class JobView:
     #: An interactive session has a person attached to it, so its priority is
     #: never ours to change.
     is_session: bool = False
+    #: The job this one was requeued from after a preemption, if any. Beaker
+    #: gives the retry a new id, so this is the only link back to what the
+    #: balancer remembered about the original.
+    retry_ancestor_id: str = ""
 
     @property
     def is_queued(self) -> bool:
@@ -192,6 +267,52 @@ class JobView:
         if self.unmanaged_reason(limits) is not None:
             return None
         return self.clusters[0]
+
+
+def resting_priority(job: JobView, remembered: Mapping[str, int]) -> int:
+    """Priority a job falls back to when it is not granted an urgent slot.
+
+    Where the user last had it, so that the balancer's only lasting effect on a
+    job is whether it held an urgent slot. A job sitting below urgent is already
+    resting: whatever it is at now is what its owner last chose, including a
+    change they made by hand since the previous pass. Only a job at urgent needs
+    memory, since raising it destroyed the record of where it came from.
+
+    ``high`` is the fallback for a job at urgent that has never been seen lower
+    -- submitted at urgent, or first seen there after the memory was lost.
+    Resting at urgent would defeat the purpose of the allocation.
+    """
+    if job.priority in RESTABLE_PRIORITIES:
+        return job.priority
+    return remembered.get(job.id, HIGH)
+
+
+def remember_priorities(
+    jobs: Iterable[JobView], remembered: Mapping[str, int]
+) -> dict[str, int]:
+    """Carry each opted-in job's pre-urgent priority into the next pass.
+
+    Called with what Beaker reports *before* a pass applies anything, so a job
+    the balancer is about to raise is recorded where its owner left it.
+
+    Jobs absent from this pass are dropped, which is how finished jobs are
+    evicted. A preempted job returns under a new id, and the priority Beaker
+    gives it back is the one the balancer set on its source rather than the one
+    it was submitted at, so the memory follows ``retry_ancestor_id``: without
+    that, every preemption of a granted job would ratchet it up to the ``high``
+    fallback.
+    """
+    updated: dict[str, int] = {}
+    for job in jobs:
+        if job.cm_priority is None:
+            continue  # never modified, so never restored
+        if job.priority in RESTABLE_PRIORITIES:
+            updated[job.id] = job.priority
+        elif job.id in remembered:
+            updated[job.id] = remembered[job.id]
+        elif job.retry_ancestor_id in remembered:
+            updated[job.id] = remembered[job.retry_ancestor_id]
+    return updated
 
 
 @dataclass(frozen=True)
@@ -354,22 +475,21 @@ def _eligible_for_urgent(group: ReplicaGroup) -> bool:
     return group.holds_urgent or group.is_queued
 
 
-def _reason(job: JobView, desired: int) -> str:
+def _reason(desired: int) -> str:
     """Why a job is being moved, in terms of the allocation.
 
-    A job that neither takes nor gives up an urgent slot is only being put where
-    its label says it rests -- a queued job submitted below its ``CM_PRIORITY``
-    is raised to it. Describing that as releasing a slot would report a change
-    to the allocation that did not happen.
+    Every change is one or the other: a job resting below urgent is left where
+    it is, so the balancer's only moves are onto an urgent slot and back off
+    again.
     """
-    if desired == URGENT:
-        return "grant urgent slot"
-    if job.priority == URGENT:
-        return "release urgent slot"
-    return "settle at resting priority"
+    return "grant urgent slot" if desired == URGENT else "release urgent slot"
 
 
-def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
+def decide(
+    jobs: Iterable[JobView],
+    limits: dict[str, int],
+    remembered: Mapping[str, int] | None = None,
+) -> list[Action]:
     """Compute the priority changes that bring urgent usage within allocation.
 
     The desired allocation is recomputed from scratch on every pass rather than
@@ -377,7 +497,12 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
     and granted urgent while their cluster has slots left. Because the walk
     starts clean, a high-priority group is always considered before a
     lower-priority one and never has to wait for slots a lesser one took.
+
+    ``remembered`` maps job id to the priority it was last seen at below urgent
+    (see ``remember_priorities``); a job missing from it that is currently at
+    urgent falls back to ``high``.
     """
+    remembered = {} if remembered is None else remembered
     groups, fixed = group_jobs(list(jobs), limits)
 
     # Slots held at urgent or immediate by jobs the balancer will not touch.
@@ -409,8 +534,12 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
 
     actions = []
     for group in groups:
-        desired = URGENT if group.id in granted else resting_priority(group.cm_priority)
+        is_granted = group.id in granted
         for job in group.jobs:
+            # Resting is per job, not per group: each rank goes back to where
+            # its own owner left it. A group is still granted all or nothing,
+            # so this never splits one.
+            desired = URGENT if is_granted else resting_priority(job, remembered)
             if desired == job.priority:
                 continue
             if job.is_placed and desired > job.priority:
@@ -425,7 +554,7 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
                 )
                 continue
             actions.append(
-                Action(job, group.cluster, job.priority, desired, _reason(job, desired))
+                Action(job, group.cluster, job.priority, desired, _reason(desired))
             )
 
     # Demotions first, so that any prefix of a partially applied pass is still
@@ -528,6 +657,7 @@ def fetch_jobs(
                 replica_group_id=job.system_details.replica_group_details.id,
                 # Only an interactive session carries an environment.
                 is_session=bool(job.environment_id),
+                retry_ancestor_id=job.retry_ancestor_id,
             )
         )
     return views
@@ -658,15 +788,25 @@ def run_pass(
     limits: dict[str, int],
     dry_run: bool,
     node_cache: dict[str, str | None] | None = None,
+    state_path: Path | None = None,
 ) -> int:
     """Run one balancing pass. Returns the number of changes applied."""
+    state_path = DEFAULT_STATE_PATH if state_path is None else state_path
     jobs = fetch_jobs(client, workspace, node_cache)
     LOGGER.info("read %d unfinished jobs in %s", len(jobs), workspace)
     report_usage(jobs, limits, "before")
     report_unreclaimable(jobs, limits)
     report_unmanageable(jobs, limits)
 
-    actions = decide(jobs, limits)
+    # Recorded from what Beaker reports now, and written before anything is
+    # applied: a job about to be raised has to be remembered where its owner
+    # left it, and the record has to survive the pass dying halfway through.
+    # A dry run writes nothing, so that reporting a pass cannot change one.
+    remembered = remember_priorities(jobs, load_state(state_path))
+    if not dry_run:
+        save_state(state_path, remembered)
+
+    actions = decide(jobs, limits, remembered)
     if not actions:
         LOGGER.info("no changes needed")
         return 0
@@ -767,6 +907,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="keep running, pausing this long between passes (default: one pass)",
     )
     parser.add_argument(
+        "--state",
+        type=Path,
+        default=DEFAULT_STATE_PATH,
+        help="where to remember the priority each job rests at when it is not "
+        f"granted an urgent slot (default: {DEFAULT_STATE_PATH})",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="include debug logging"
     )
     return parser
@@ -820,7 +967,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     node_cache: dict[str, str | None] = {}
     while True:
         try:
-            run_pass(client, args.workspace, limits, args.dry_run, node_cache)
+            run_pass(
+                client,
+                args.workspace,
+                limits,
+                args.dry_run,
+                node_cache,
+                args.state,
+            )
         except BeakerError:
             if args.interval is None:
                 raise

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -660,6 +660,11 @@ def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None
         if why is None or why is UNLABELLED or why is OBSERVED:
             continue
         if why is NO_ALLOCATION:
+            # A placed job on a non-budgeted cluster that was submitted to at
+            # least one budgeted cluster is a normal outcome: it was managed
+            # while queued and simply landed elsewhere.
+            if job.is_placed and any(c in limits for c in job.clusters):
+                continue
             target = job.assigned_cluster or (job.clusters[0] if job.clusters else None)
             reason = f"targets {target}, which has no allocation" if target else why
         else:

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -1,0 +1,454 @@
+"""Balance Beaker job priorities against the team's urgent slot allocation.
+
+Beaker does not enforce our per-cluster urgent allocation, so queueing urgent
+jobs can silently put the team over it. This script reads the live state of a
+workspace and adjusts the priority of opted-in jobs so that urgent slot usage
+stays within the allocation, favouring the jobs we care about most.
+
+A job opts in by setting the ``CM_PRIORITY`` environment variable to one of
+``low``, ``normal``, ``high`` or ``urgent``. Jobs without it are never
+modified, but their urgent slot usage still counts against the allocation.
+
+Run ``python balance.py --dry-run`` to see what a pass would do.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from beaker import Beaker
+from beaker import beaker_pb2 as pb2
+from beaker._service_client import RpcMethod
+from beaker.exceptions import BeakerError
+
+LOGGER = logging.getLogger("beaker_balancer")
+
+CM_PRIORITY_ENV = "CM_PRIORITY"
+
+#: GPU slots the team may hold at urgent priority, per cluster. Clusters absent
+#: from this mapping have no allocation and are left alone entirely.
+DEFAULT_CLUSTER_LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
+
+LOW = pb2.JOB_PRIORITY_LOW
+NORMAL = pb2.JOB_PRIORITY_NORMAL
+HIGH = pb2.JOB_PRIORITY_HIGH
+URGENT = pb2.JOB_PRIORITY_URGENT
+
+PRIORITY_BY_NAME = {"low": LOW, "normal": NORMAL, "high": HIGH, "urgent": URGENT}
+NAME_BY_PRIORITY = {value: name for name, value in PRIORITY_BY_NAME.items()}
+
+# A job's status is "queued" until Beaker places it on a node. Only queued jobs
+# can have their priority raised; Beaker rejects increases on running jobs with
+# "cannot increase priority for running job".
+_CLUSTER_CONSTRAINT = pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER
+
+
+def resting_priority(cm_priority: int) -> int:
+    """Priority a job falls back to when it is not granted an urgent slot.
+
+    Jobs labelled ``urgent`` rest at ``high``: resting at urgent would defeat
+    the purpose of the allocation.
+    """
+    return HIGH if cm_priority == URGENT else cm_priority
+
+
+@dataclass(frozen=True)
+class JobView:
+    """The parts of a Beaker job the balancer reasons about.
+
+    Kept free of protobuf types so the decision logic can be unit tested with
+    plain constructed values.
+    """
+
+    id: str
+    name: str
+    author: str
+    priority: int
+    slots: int
+    clusters: tuple[str, ...]
+    assigned_cluster: str | None
+    cm_priority: int | None
+    #: When the job entered the queue. Reset when a job is preempted and
+    #: requeued, so this measures the wait of the *current* attempt.
+    queued_at: float
+    #: When the job landed on a GPU, or None if it is still queued.
+    started_at: float | None
+
+    @property
+    def is_queued(self) -> bool:
+        return self.started_at is None
+
+    def budget_clusters(self, limits: dict[str, int]) -> tuple[str, ...]:
+        """Clusters whose allocation this job consumes while it is urgent.
+
+        An assigned job consumes only the cluster it actually landed on. A
+        queued job could land on any cluster it is eligible for, and since
+        nothing can preempt an urgent job it is a committed future occupant of
+        whichever it picks, so it is counted against all of them.
+        """
+        if self.assigned_cluster is not None:
+            candidates: tuple[str, ...] = (self.assigned_cluster,)
+        else:
+            candidates = self.clusters
+        return tuple(cluster for cluster in candidates if cluster in limits)
+
+    def managed_cluster(self, limits: dict[str, int]) -> str | None:
+        """The single budgeted cluster this job may be modified against.
+
+        The balancer only ever changes jobs pinned to exactly one budgeted
+        cluster. A job eligible for several could land on any of them, and
+        Beaker offers no way to pin it, so its effect on a given allocation is
+        not knowable in advance.
+        """
+        if self.cm_priority is None or len(self.clusters) != 1:
+            return None
+        cluster = self.clusters[0]
+        return cluster if cluster in limits else None
+
+
+@dataclass(frozen=True)
+class Action:
+    """A priority change the balancer intends to make."""
+
+    job: JobView
+    from_priority: int
+    to_priority: int
+    reason: str
+
+    def describe(self) -> str:
+        return (
+            f"{self.job.id} {self.job.name!r} ({self.job.author}, "
+            f"{self.job.slots} slots): "
+            f"{NAME_BY_PRIORITY.get(self.from_priority, self.from_priority)} -> "
+            f"{NAME_BY_PRIORITY.get(self.to_priority, self.to_priority)} "
+            f"[{self.reason}]"
+        )
+
+
+def _grant_order(jobs: Sequence[JobView]) -> list[JobView]:
+    """Order jobs within one CM_PRIORITY level by who should keep urgent.
+
+    Running jobs that already hold urgent come first, so a queued job is always
+    given up before a running one at the same level. Among them the job that
+    has held a GPU longest sorts last, so it is the first to lose urgent.
+    Queued jobs follow, longest-waiting first.
+    """
+    running = [job for job in jobs if not job.is_queued]
+    queued = [job for job in jobs if job.is_queued]
+    # started_at descending == shortest time on GPU first.
+    running.sort(key=lambda job: job.started_at or 0.0, reverse=True)
+    # queued_at ascending == longest time waiting first.
+    queued.sort(key=lambda job: job.queued_at)
+    return running + queued
+
+
+def _eligible_for_urgent(job: JobView) -> bool:
+    """Whether a job could hold urgent after this pass.
+
+    Beaker refuses to raise the priority of a running job, so a running job
+    that is not already urgent can never be promoted. Including such a job in
+    the allocation would displace others to no benefit.
+    """
+    return job.priority == URGENT or job.is_queued
+
+
+def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
+    """Compute the priority changes that bring urgent usage within allocation.
+
+    The desired allocation is recomputed from scratch on every pass rather than
+    adjusted incrementally: candidates are walked in CM_PRIORITY order and
+    granted urgent while their cluster has slots left. Because the walk starts
+    clean, a high-priority job is always considered before a lower-priority one
+    and never has to wait for slots a lesser job already took.
+    """
+    all_jobs = list(jobs)
+    # Resolve each managed job's cluster and label once: a job is managed
+    # exactly when both are known.
+    managed: list[tuple[JobView, str, int]] = []
+    for job in all_jobs:
+        cluster = job.managed_cluster(limits)
+        if cluster is not None and job.cm_priority is not None:
+            managed.append((job, cluster, job.cm_priority))
+    managed_ids = {job.id for job, _, _ in managed}
+
+    # Slots held at urgent by jobs the balancer will not touch. These are a
+    # fixed charge against the allocation; only what is left over is ours to
+    # hand out.
+    remaining = dict(limits)
+    for job in all_jobs:
+        if job.id in managed_ids or job.priority != URGENT:
+            continue
+        for charged in job.budget_clusters(limits):
+            remaining[charged] -= job.slots
+
+    granted: set[str] = set()
+    by_level: dict[int, list[tuple[JobView, str]]] = {}
+    for job, cluster, level in managed:
+        by_level.setdefault(level, []).append((job, cluster))
+
+    for level in sorted(by_level, reverse=True):
+        candidates = {job.id: cluster for job, cluster in by_level[level]}
+        for job in _grant_order([job for job, _ in by_level[level]]):
+            if not _eligible_for_urgent(job):
+                continue
+            cluster = candidates[job.id]
+            # First fit: a job too large for what is left is skipped and
+            # smaller ones behind it still get a chance. Nothing is reserved
+            # for it, because a higher level that could not fit has already
+            # taken everything it was entitled to.
+            if job.slots <= remaining[cluster]:
+                granted.add(job.id)
+                remaining[cluster] -= job.slots
+
+    actions = []
+    for job, _, level in managed:
+        desired = URGENT if job.id in granted else resting_priority(level)
+        if desired == job.priority:
+            continue
+        if not job.is_queued and desired > job.priority:
+            # Beaker rejects this; skip rather than log a failure every pass.
+            LOGGER.debug(
+                "%s is running at %s and cannot be raised to %s",
+                job.id,
+                NAME_BY_PRIORITY.get(job.priority),
+                NAME_BY_PRIORITY.get(desired),
+            )
+            continue
+        reason = "grant urgent slot" if desired == URGENT else "release urgent slot"
+        actions.append(Action(job, job.priority, desired, reason))
+    return actions
+
+
+def parse_cm_priority(value: str, job_id: str) -> int | None:
+    """Parse a CM_PRIORITY value, returning None if it is not usable."""
+    priority = PRIORITY_BY_NAME.get(value.strip().lower())
+    if priority is None:
+        LOGGER.warning(
+            "%s sets %s=%r, which is not one of %s; ignoring the job",
+            job_id,
+            CM_PRIORITY_ENV,
+            value,
+            ", ".join(PRIORITY_BY_NAME),
+        )
+    return priority
+
+
+def _cluster_of_node(client: Beaker, node_id: str, cache: dict[str, str]) -> str | None:
+    """Resolve the node's cluster to an org-qualified name, e.g. ``ai2/jupiter``.
+
+    ``Cluster.name`` is bare, but placement constraints and our allocation are
+    written org-qualified, so the two have to be reconciled or assigned jobs
+    match no budget and their slots go uncounted.
+    """
+    if node_id not in cache:
+        try:
+            node = client.node.get(node_id)
+            cluster = client.cluster.get(node.cluster_id)
+            cache[node_id] = f"{cluster.organization_name}/{cluster.name}"
+        except BeakerError as err:
+            LOGGER.warning("could not resolve cluster for node %s: %s", node_id, err)
+            return None
+    return cache[node_id]
+
+
+def fetch_jobs(client: Beaker, workspace_name: str) -> list[JobView]:
+    """Read every unfinished job in a workspace into JobView form."""
+    workspace = client.workspace.get(workspace_name)
+    node_clusters: dict[str, str] = {}
+    views = []
+    for job in client.job.list(finalized=False):
+        if job.workspace_id != workspace.id:
+            continue
+        env = {
+            var.name: var.literal for var in job.container_spec.environment_variables
+        }
+        cm_priority = None
+        if CM_PRIORITY_ENV in env:
+            cm_priority = parse_cm_priority(env[CM_PRIORITY_ENV], job.id)
+
+        clusters = tuple(
+            value
+            for constraint in job.system_details.placement_constraints
+            if constraint.type == _CLUSTER_CONSTRAINT
+            for value in constraint.values
+        )
+        node_id = job.assignment_details.node_id
+        assigned = _cluster_of_node(client, node_id, node_clusters) if node_id else None
+        started = job.status.started.seconds or None
+
+        views.append(
+            JobView(
+                id=job.id,
+                name=job.name,
+                author=job.author_reference,
+                priority=job.system_details.priority,
+                # Beaker counts a CPU-only job as one slot.
+                slots=max(1, job.container_spec.resource_request.gpu_count),
+                clusters=clusters,
+                assigned_cluster=assigned,
+                cm_priority=cm_priority,
+                queued_at=float(job.status.created.seconds),
+                started_at=float(started) if started else None,
+            )
+        )
+    return views
+
+
+def set_priority(client: Beaker, job_id: str, priority: int) -> None:
+    service = client.job
+    service.rpc_request(
+        RpcMethod(service.service.UpdateJobSourcePriority),
+        pb2.UpdateJobSourcePriorityRequest(
+            job_id=job_id, priority=priority, reason="beaker_balancer"
+        ),
+    )
+
+
+def report_usage(jobs: Sequence[JobView], limits: dict[str, int], label: str) -> None:
+    used = dict.fromkeys(limits, 0)
+    for job in jobs:
+        if job.priority != URGENT:
+            continue
+        for cluster in job.budget_clusters(limits):
+            used[cluster] += job.slots
+    summary = ", ".join(
+        f"{cluster} {used[cluster]}/{limit}" for cluster, limit in limits.items()
+    )
+    LOGGER.info("urgent slots %s: %s", label, summary)
+
+
+def warn_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None:
+    """Flag opted-in jobs the balancer cannot act on, so the label isn't silent."""
+    for job in jobs:
+        if job.cm_priority is None or job.managed_cluster(limits) is not None:
+            continue
+        if len(job.clusters) != 1:
+            LOGGER.warning(
+                "%s %r sets %s but targets %d clusters (%s); the balancer only "
+                "manages jobs pinned to one cluster, so it is left alone",
+                job.id,
+                job.name,
+                CM_PRIORITY_ENV,
+                len(job.clusters),
+                ", ".join(job.clusters) or "none",
+            )
+        else:
+            LOGGER.info(
+                "%s %r sets %s but targets %s, which has no allocation; "
+                "leaving it alone",
+                job.id,
+                job.name,
+                CM_PRIORITY_ENV,
+                job.clusters[0],
+            )
+
+
+def run_pass(
+    client: Beaker, workspace: str, limits: dict[str, int], dry_run: bool
+) -> int:
+    """Run one balancing pass. Returns the number of changes applied."""
+    jobs = fetch_jobs(client, workspace)
+    LOGGER.info("read %d unfinished jobs in %s", len(jobs), workspace)
+    report_usage(jobs, limits, "before")
+    warn_unmanageable(jobs, limits)
+
+    actions = decide(jobs, limits)
+    if not actions:
+        LOGGER.info("no changes needed")
+        return 0
+
+    applied = 0
+    for action in actions:
+        if dry_run:
+            LOGGER.info("would change %s", action.describe())
+            continue
+        try:
+            set_priority(client, action.job.id, action.to_priority)
+        except BeakerError as err:
+            # Most likely a job owned by someone whose jobs we cannot modify.
+            # One unreachable job should not stop the rest of the pass.
+            LOGGER.warning(
+                "could not change %s (owner %s): %s",
+                action.job.id,
+                action.job.author,
+                err,
+            )
+            continue
+        applied += 1
+        LOGGER.info("changed %s", action.describe())
+    return applied
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workspace", default="ai2/ace", help="workspace to balance (default: ai2/ace)"
+    )
+    parser.add_argument(
+        "--limit",
+        action="append",
+        metavar="CLUSTER=SLOTS",
+        help="urgent GPU slot allocation for a cluster; repeatable. Defaults to "
+        + ", ".join(f"{k}={v}" for k, v in DEFAULT_CLUSTER_LIMITS.items()),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report the changes a pass would make without making them",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        metavar="SECONDS",
+        help="keep running, pausing this long between passes (default: one pass)",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="include debug logging"
+    )
+    return parser
+
+
+def parse_limits(values: list[str] | None) -> dict[str, int]:
+    if not values:
+        return dict(DEFAULT_CLUSTER_LIMITS)
+    limits = {}
+    for value in values:
+        cluster, _, slots = value.partition("=")
+        if not slots.isdigit():
+            raise ValueError(f"expected CLUSTER=SLOTS, got {value!r}")
+        limits[cluster] = int(slots)
+    return limits
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    limits = parse_limits(args.limit)
+    LOGGER.info(
+        "allocation: %s", ", ".join(f"{k}={v} slots" for k, v in limits.items())
+    )
+
+    client = Beaker.from_env()
+    while True:
+        try:
+            run_pass(client, args.workspace, limits, args.dry_run)
+        except BeakerError:
+            if args.interval is None:
+                raise
+            # A transient Beaker outage should not kill a long-running loop.
+            LOGGER.exception("pass failed; retrying after %s seconds", args.interval)
+        if args.interval is None:
+            return 0
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -73,7 +73,6 @@ UNLABELLED = "does not set CM_PRIORITY"
 OBSERVED = "is in an observed workspace, which is counted but never modified"
 SESSION = "is an interactive session"
 AT_IMMEDIATE = "is at immediate priority, which only a human sets"
-MULTI_CLUSTER = "targets more than one cluster"
 NO_ALLOCATION = "targets a cluster with no allocation"
 UNRESOLVED_CLUSTER = "landed on a node that cannot be resolved to a cluster"
 
@@ -192,26 +191,21 @@ class JobView:
         # cluster while the accounting spent them on all of them.
         if self.is_placed and self.assigned_cluster is None:
             return UNRESOLVED_CLUSTER
-        # A queued job is the ambiguous case: Beaker offers no way to pin one,
-        # so a job eligible for several could consume any of their allocations
-        # and there is no way to know which in advance.
-        if not self.is_placed and len(self.clusters) != 1:
-            return MULTI_CLUSTER
         if not self.budget_clusters(limits):
             return NO_ALLOCATION
         return None
 
-    def managed_cluster(self, limits: dict[str, int]) -> str | None:
-        """The single budgeted cluster this job may be modified against.
+    def managed_clusters(self, limits: dict[str, int]) -> tuple[str, ...] | None:
+        """The budgeted clusters this job is managed against, or None.
 
-        The one its slots are charged to, which for a placed job is the one it
-        landed on. ``unmanaged_reason`` admits a job only when that is exactly
-        one budgeted cluster, so the walk can never hand out slots on one
-        cluster while the accounting spends them on another.
+        For a placed job, a single cluster: the one it landed on. For a queued
+        job, every budgeted cluster it could land on: granting it urgent
+        commits the allocation on each, so the pass must check and charge all
+        of them.
         """
         if self.unmanaged_reason(limits) is not None:
             return None
-        return self.budget_clusters(limits)[0]
+        return self.budget_clusters(limits)
 
 
 @dataclass(frozen=True)
@@ -219,8 +213,8 @@ class Action:
     """A priority change the balancer intends to make."""
 
     job: JobView
-    #: The budgeted cluster this change is accounted against.
-    cluster: str
+    #: The budgeted clusters this change is accounted against.
+    clusters: tuple[str, ...]
     from_priority: int
     to_priority: int
     reason: str
@@ -263,7 +257,7 @@ class ReplicaGroup:
 
     id: str
     jobs: tuple[JobView, ...]
-    cluster: str
+    clusters: tuple[str, ...]
     cm_priority: int
 
     @property
@@ -321,21 +315,21 @@ def group_jobs(
     managed: list[ReplicaGroup] = []
     fixed: list[JobView] = []
     for group_id, members in by_group.items():
-        clusters = {job.managed_cluster(limits) for job in members}
+        cluster_tuples = {job.managed_clusters(limits) for job in members}
         labels = {job.cm_priority for job in members}
         # A single non-None value in each means every rank is manageable and
         # they agree; anything else leaves the group untouched.
-        cluster = clusters.pop() if len(clusters) == 1 else None
+        clusters = cluster_tuples.pop() if len(cluster_tuples) == 1 else None
         label = labels.pop() if len(labels) == 1 else None
         expected = max(job.replica_group_size for job in members)
-        if cluster is None or label is None or len(members) < expected:
+        if clusters is None or label is None or len(members) < expected:
             fixed.extend(members)
             continue
         managed.append(
             ReplicaGroup(
                 id=group_id,
                 jobs=tuple(members),
-                cluster=cluster,
+                clusters=clusters,
                 cm_priority=label,
             )
         )
@@ -422,10 +416,13 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
             # First fit: a group too large for what is left is skipped and
             # smaller ones behind it still get a chance. Nothing is reserved
             # for it, because a higher level that could not fit has already
-            # taken everything it was entitled to.
-            if group.slots <= remaining[group.cluster]:
+            # taken everything it was entitled to. A multi-cluster group must
+            # fit on every cluster it could land on: granting it urgent commits
+            # the allocation on each, and nothing can preempt an urgent job.
+            if all(group.slots <= remaining[c] for c in group.clusters):
                 granted.add(group.id)
-                remaining[group.cluster] -= group.slots
+                for c in group.clusters:
+                    remaining[c] -= group.slots
 
     actions = []
     for group in groups:
@@ -444,9 +441,8 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
                     NAME_BY_PRIORITY.get(desired),
                 )
                 continue
-            actions.append(
-                Action(job, group.cluster, job.priority, desired, _reason(job, desired))
-            )
+            reason = _reason(job, desired)
+            actions.append(Action(job, group.clusters, job.priority, desired, reason))
 
     # Demotions first, so that any prefix of a partially applied pass is still
     # within allocation. A promotion applied before the demotion paying for it
@@ -663,9 +659,7 @@ def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None
         # to be managed: it was never a candidate, and there can be many.
         if why is None or why is UNLABELLED or why is OBSERVED:
             continue
-        if why is MULTI_CLUSTER:
-            reason = f"targets {len(job.clusters)} clusters"
-        elif why is NO_ALLOCATION:
+        if why is NO_ALLOCATION:
             reason = f"targets {job.clusters[0]}, which has no allocation"
         else:
             reason = why
@@ -754,14 +748,16 @@ def run_pass(
         if action.takes_slots:
             if action.job.group_key in abandoned:
                 continue
-            if deficit[action.cluster] > 0:
-                deficit[action.cluster] -= wanted[action.job.group_key]
+            deficient = [c for c in action.clusters if deficit[c] > 0]
+            if deficient:
+                for c in action.clusters:
+                    deficit[c] -= wanted[action.job.group_key]
                 abandoned.add(action.job.group_key)
                 LOGGER.warning(
                     "not granting urgent to %s: a demotion on %s was refused, "
                     "so the slots paying for it are still held",
                     action.job.group_key,
-                    action.cluster,
+                    ", ".join(deficient),
                 )
                 continue
         try:
@@ -770,7 +766,8 @@ def run_pass(
             # Most likely a job owned by someone whose jobs we cannot modify.
             # One unreachable job should not stop the rest of the pass.
             if action.frees_slots:
-                deficit[action.cluster] += action.job.slots
+                for c in action.clusters:
+                    deficit[c] += action.job.slots
             if action.takes_slots:
                 # Stop before splitting the group any further. Permission is
                 # per owner and every rank shares one, so in practice this

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -184,30 +184,34 @@ class JobView:
             return SESSION
         if self.priority == IMMEDIATE:
             return AT_IMMEDIATE
-        if len(self.clusters) != 1:
-            return MULTI_CLUSTER
-        if self.clusters[0] not in limits:
-            return NO_ALLOCATION
-        # A job is only managed when its slots are charged to exactly the
-        # cluster it is pinned to. A placed job whose node could not be
-        # resolved is charged to every budget as a precaution, and managing it
-        # would let the walk hand out slots on one cluster while the accounting
-        # spent them on all of them.
-        if self.budget_clusters(limits) != (self.clusters[0],):
+        # A placed job is pinned in fact. It occupies one cluster and is
+        # charged to that one alone, whatever it was submitted eligible for, so
+        # what it was eligible for stops being a reason not to touch it. Only a
+        # placed job whose node cannot be resolved is still charged to every
+        # budget, and managing that would let the walk hand out slots on one
+        # cluster while the accounting spent them on all of them.
+        if self.is_placed and self.assigned_cluster is None:
             return UNRESOLVED_CLUSTER
+        # A queued job is the ambiguous case: Beaker offers no way to pin one,
+        # so a job eligible for several could consume any of their allocations
+        # and there is no way to know which in advance.
+        if not self.is_placed and len(self.clusters) != 1:
+            return MULTI_CLUSTER
+        if not self.budget_clusters(limits):
+            return NO_ALLOCATION
         return None
 
     def managed_cluster(self, limits: dict[str, int]) -> str | None:
         """The single budgeted cluster this job may be modified against.
 
-        The balancer only ever changes jobs pinned to exactly one budgeted
-        cluster. A job eligible for several could land on any of them, and
-        Beaker offers no way to pin it, so its effect on a given allocation is
-        not knowable in advance.
+        The one its slots are charged to, which for a placed job is the one it
+        landed on. ``unmanaged_reason`` admits a job only when that is exactly
+        one budgeted cluster, so the walk can never hand out slots on one
+        cluster while the accounting spends them on another.
         """
         if self.unmanaged_reason(limits) is not None:
             return None
-        return self.clusters[0]
+        return self.budget_clusters(limits)[0]
 
 
 @dataclass(frozen=True)

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -199,6 +199,8 @@ class Action:
     """A priority change the balancer intends to make."""
 
     job: JobView
+    #: The budgeted cluster this change is accounted against.
+    cluster: str
     from_priority: int
     to_priority: int
     reason: str
@@ -206,6 +208,16 @@ class Action:
     @property
     def is_demotion(self) -> bool:
         return self.to_priority < self.from_priority
+
+    @property
+    def frees_slots(self) -> bool:
+        """Whether applying this change returns slots to the allocation."""
+        return self.from_priority == URGENT and self.to_priority != URGENT
+
+    @property
+    def takes_slots(self) -> bool:
+        """Whether applying this change spends slots from the allocation."""
+        return self.to_priority == URGENT and self.from_priority != URGENT
 
     def describe(self) -> str:
         return (
@@ -398,7 +410,7 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
                 )
                 continue
             reason = "grant urgent slot" if desired == URGENT else "release urgent slot"
-            actions.append(Action(job, job.priority, desired, reason))
+            actions.append(Action(job, group.cluster, job.priority, desired, reason))
 
     # Demotions first, so that any prefix of a partially applied pass is still
     # within allocation. A promotion applied before the demotion paying for it
@@ -430,8 +442,8 @@ def _cluster_of_node(
     written org-qualified, so the two have to be reconciled or placed jobs match
     no budget and their slots go uncounted.
 
-    Failures are cached too: a node that cannot be resolved would otherwise be
-    retried on every job in every pass.
+    Failures are cached too, so one unresolvable node is not retried for every
+    job sitting on it. ``fetch_jobs`` drops them between passes.
     """
     if node_id not in cache:
         try:
@@ -450,6 +462,14 @@ def fetch_jobs(
     """Read every unfinished job in a workspace into JobView form."""
     workspace = client.workspace.get(workspace_name)
     node_clusters: dict[str, str | None] = {} if node_cache is None else node_cache
+    # Failures are cached within a pass so one bad node is not retried for every
+    # job on it, but they are dropped between passes. A job whose node cannot be
+    # resolved is charged to every budget, so a single transient Beaker error
+    # would otherwise hold it there for the life of an --interval process --
+    # under-granting the allocation, and silently, since the warning is logged
+    # only the first time.
+    for stale in [node for node, cluster in node_clusters.items() if cluster is None]:
+        del node_clusters[stale]
     views = []
     for job in client.job.list(finalized=False):
         if job.workspace_id != workspace.id:
@@ -630,15 +650,55 @@ def run_pass(
 
     applied = 0
     changed: dict[str, int] = {}
+    # Slots a refused demotion failed to free, per cluster. Ordering demotions
+    # first makes any *prefix* of a pass safe, but a failure does not stop the
+    # pass -- it skips one action and carries on -- so what lands is an
+    # arbitrary subset, and the subset that matters is exactly the documented
+    # fail-soft case. Granting urgent after the demotion paying for it was
+    # refused ends the pass over allocation. Such a grant is deferred to the
+    # next pass, which recomputes from the state that really exists. The
+    # deficit is per cluster, so a stuck job on one does not stall the other.
+    deficit: Counter[str] = Counter()
+    # What each replica group is waiting to be granted. A group is granted all
+    # or nothing, so it has to be deferred all or nothing too.
+    wanted: Counter[str] = Counter()
+    for action in actions:
+        if action.takes_slots:
+            wanted[action.job.group_key] += action.job.slots
+    # Groups whose grant this pass has given up on.
+    abandoned: set[str] = set()
+
     for action in actions:
         if dry_run:
             LOGGER.info("would change %s", action.describe())
             continue
+        if action.takes_slots:
+            if action.job.group_key in abandoned:
+                continue
+            if deficit[action.cluster] > 0:
+                deficit[action.cluster] -= wanted[action.job.group_key]
+                abandoned.add(action.job.group_key)
+                LOGGER.warning(
+                    "not granting urgent to %s: a demotion on %s was refused, "
+                    "so the slots paying for it are still held",
+                    action.job.group_key,
+                    action.cluster,
+                )
+                continue
         try:
             set_priority(client, action.job.id, action.to_priority)
         except BeakerError as err:
             # Most likely a job owned by someone whose jobs we cannot modify.
             # One unreachable job should not stop the rest of the pass.
+            if action.frees_slots:
+                deficit[action.cluster] += action.job.slots
+            if action.takes_slots:
+                # Stop before splitting the group any further. Permission is
+                # per owner and every rank shares one, so in practice this
+                # fires on the first rank and spends nothing. A rank already
+                # granted is left for the next pass to finish or undo, rather
+                # than adding a rollback path that can fail in its turn.
+                abandoned.add(action.job.group_key)
             LOGGER.warning(
                 "could not change %s (owner %s): %s",
                 action.job.id,

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -354,6 +354,21 @@ def _eligible_for_urgent(group: ReplicaGroup) -> bool:
     return group.holds_urgent or group.is_queued
 
 
+def _reason(job: JobView, desired: int) -> str:
+    """Why a job is being moved, in terms of the allocation.
+
+    A job that neither takes nor gives up an urgent slot is only being put where
+    its label says it rests -- a queued job submitted below its ``CM_PRIORITY``
+    is raised to it. Describing that as releasing a slot would report a change
+    to the allocation that did not happen.
+    """
+    if desired == URGENT:
+        return "grant urgent slot"
+    if job.priority == URGENT:
+        return "release urgent slot"
+    return "settle at resting priority"
+
+
 def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
     """Compute the priority changes that bring urgent usage within allocation.
 
@@ -409,8 +424,9 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
                     NAME_BY_PRIORITY.get(desired),
                 )
                 continue
-            reason = "grant urgent slot" if desired == URGENT else "release urgent slot"
-            actions.append(Action(job, group.cluster, job.priority, desired, reason))
+            actions.append(
+                Action(job, group.cluster, job.priority, desired, _reason(job, desired))
+            )
 
     # Demotions first, so that any prefix of a partially applied pass is still
     # within allocation. A promotion applied before the demotion paying for it
@@ -518,6 +534,13 @@ def fetch_jobs(
 
 
 def set_priority(client: Beaker, job_id: str, priority: int) -> None:
+    """Change one job's priority. The only call the balancer makes that mutates.
+
+    ``beaker-py`` exposes no wrapper for ``UpdateJobSourcePriority``, so the rpc
+    is issued directly through the private ``RpcMethod``. A beaker-py upgrade
+    can therefore break this import, and CI will not notice: it does not install
+    beaker-py, so both test modules skip. Run the tests locally after upgrading.
+    """
     service = client.job
     service.rpc_request(
         RpcMethod(service.service.UpdateJobSourcePriority),

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -41,6 +41,14 @@ CM_PRIORITY_ENV = "CM_PRIORITY"
 #: from this mapping have no allocation and are left alone entirely.
 DEFAULT_CLUSTER_LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
 
+#: Workspaces whose jobs spend the same allocation but are never modified. The
+#: allocation is the team's, not one workspace's, so slots held here have to be
+#: subtracted before any are handed out -- otherwise the balancer grants urgent
+#: against slots that are already occupied. ``CM_PRIORITY`` is not read in
+#: these: opting in is what makes a job the balancer's to move, and nothing
+#: here is.
+DEFAULT_OBSERVED_WORKSPACES = ("ai2/climate-titan",)
+
 LOW = pb2.JOB_PRIORITY_LOW
 NORMAL = pb2.JOB_PRIORITY_NORMAL
 HIGH = pb2.JOB_PRIORITY_HIGH
@@ -62,6 +70,7 @@ _CLUSTER_CONSTRAINT = pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER
 # Why a job may not be modified. Identity-compared, so a caller can tell an
 # expected state apart from one worth warning about.
 UNLABELLED = "does not set CM_PRIORITY"
+OBSERVED = "is in an observed workspace, which is counted but never modified"
 SESSION = "is an interactive session"
 AT_IMMEDIATE = "is at immediate priority, which only a human sets"
 MULTI_CLUSTER = "targets more than one cluster"
@@ -111,6 +120,11 @@ class JobView:
     #: An interactive session has a person attached to it, so its priority is
     #: never ours to change.
     is_session: bool = False
+    #: The workspace the job is in, for reporting.
+    workspace: str = ""
+    #: Whether the job is only being watched: its slots are counted against the
+    #: allocation, but it is never modified and its CM_PRIORITY is not read.
+    is_observed: bool = False
 
     @property
     def is_queued(self) -> bool:
@@ -162,6 +176,8 @@ class JobView:
         group rather than individually, which is what stops the walk granting
         urgent to some ranks and not others; see ``ReplicaGroup``.
         """
+        if self.is_observed:
+            return OBSERVED
         if self.cm_priority is None:
             return UNLABELLED
         if self.is_session:
@@ -473,10 +489,24 @@ def _cluster_of_node(
 
 
 def fetch_jobs(
-    client: Beaker, workspace_name: str, node_cache: dict[str, str | None] | None = None
+    client: Beaker,
+    workspace_name: str,
+    node_cache: dict[str, str | None] | None = None,
+    observed: Sequence[str] = (),
 ) -> list[JobView]:
-    """Read every unfinished job in a workspace into JobView form."""
+    """Read every unfinished job in the managed and observed workspaces.
+
+    Jobs from an observed workspace are marked ``is_observed``: their slots are
+    counted against the allocation but they are never modified, and their
+    ``CM_PRIORITY`` is not read -- setting it in a workspace the balancer does
+    not manage would otherwise look like it did something.
+    """
     workspace = client.workspace.get(workspace_name)
+    # One listing covers the whole org, so watching another workspace costs a
+    # name lookup rather than a second pass over the jobs.
+    names = {workspace.id: workspace_name}
+    for name in observed or ():
+        names.setdefault(client.workspace.get(name).id, name)
     node_clusters: dict[str, str | None] = {} if node_cache is None else node_cache
     # Failures are cached within a pass so one bad node is not retried for every
     # job on it, but they are dropped between passes. A job whose node cannot be
@@ -488,14 +518,17 @@ def fetch_jobs(
         del node_clusters[stale]
     views = []
     for job in client.job.list(finalized=False):
-        if job.workspace_id != workspace.id:
+        if job.workspace_id not in names:
             continue
-        env = {
-            var.name: var.literal for var in job.container_spec.environment_variables
-        }
+        is_observed = job.workspace_id != workspace.id
         cm_priority = None
-        if CM_PRIORITY_ENV in env:
-            cm_priority = parse_cm_priority(env[CM_PRIORITY_ENV], job.id)
+        if not is_observed:
+            env = {
+                var.name: var.literal
+                for var in job.container_spec.environment_variables
+            }
+            if CM_PRIORITY_ENV in env:
+                cm_priority = parse_cm_priority(env[CM_PRIORITY_ENV], job.id)
 
         clusters = tuple(
             value
@@ -528,6 +561,8 @@ def fetch_jobs(
                 replica_group_id=job.system_details.replica_group_details.id,
                 # Only an interactive session carries an environment.
                 is_session=bool(job.environment_id),
+                workspace=names[job.workspace_id],
+                is_observed=is_observed,
             )
         )
     return views
@@ -572,18 +607,24 @@ def report_usage(jobs: Sequence[JobView], limits: dict[str, int], label: str) ->
 def report_unreclaimable(jobs: Sequence[JobView], limits: dict[str, int]) -> None:
     """Break out allocated slots the balancer can never reclaim.
 
-    Sessions and immediate-priority jobs count against the allocation but are
-    never demoted, so a pass can be unable to get within the allocation no
-    matter what it does. Reporting them makes that a visible fact rather than a
-    balancer that appears not to be working.
+    Sessions, immediate-priority jobs and jobs in an observed workspace count
+    against the allocation but are never demoted, so a pass can be unable to get
+    within the allocation no matter what it does. Reporting them makes that a
+    visible fact rather than a balancer that appears not to be working.
     """
     sessions = dict.fromkeys(limits, 0)
     immediate = dict.fromkeys(limits, 0)
+    elsewhere: dict[str, Counter[str]] = {cluster: Counter() for cluster in limits}
     for job in jobs:
         if not job.holds_allocation:
             continue
         for cluster in job.budget_clusters(limits):
-            if job.is_session:
+            # Checked first: a session or immediate job in an observed
+            # workspace is unreclaimable because of where it is, and reporting
+            # it under its own workspace is what makes the number add up.
+            if job.is_observed:
+                elsewhere[cluster][job.workspace] += job.slots
+            elif job.is_session:
                 sessions[cluster] += job.slots
             elif job.priority == IMMEDIATE:
                 immediate[cluster] += job.slots
@@ -593,6 +634,8 @@ def report_unreclaimable(jobs: Sequence[JobView], limits: dict[str, int]) -> Non
             notes.append(f"{sessions[cluster]} in interactive sessions")
         if immediate[cluster]:
             notes.append(f"{immediate[cluster]} at immediate priority")
+        for workspace, slots in sorted(elsewhere[cluster].items()):
+            notes.append(f"{slots} in {workspace}")
         if notes:
             LOGGER.info(
                 "%s: %s — counted against the allocation, never reclaimable",
@@ -612,7 +655,9 @@ def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None
     examples: dict[str, str] = {}
     for job in jobs:
         why = job.unmanaged_reason(limits)
-        if why is None or why is UNLABELLED:
+        # An observed job is reported as held slots, not as a job that failed
+        # to be managed: it was never a candidate, and there can be many.
+        if why is None or why is UNLABELLED or why is OBSERVED:
             continue
         if why is MULTI_CLUSTER:
             reason = f"targets {len(job.clusters)} clusters"
@@ -658,10 +703,17 @@ def run_pass(
     limits: dict[str, int],
     dry_run: bool,
     node_cache: dict[str, str | None] | None = None,
+    observed: Sequence[str] = (),
 ) -> int:
     """Run one balancing pass. Returns the number of changes applied."""
-    jobs = fetch_jobs(client, workspace, node_cache)
-    LOGGER.info("read %d unfinished jobs in %s", len(jobs), workspace)
+    jobs = fetch_jobs(client, workspace, node_cache, observed)
+    watched = sum(1 for job in jobs if job.is_observed)
+    LOGGER.info(
+        "read %d unfinished jobs in %s%s",
+        len(jobs) - watched,
+        workspace,
+        f", and {watched} watched in {', '.join(observed)}" if watched else "",
+    )
     report_usage(jobs, limits, "before")
     report_unreclaimable(jobs, limits)
     report_unmanageable(jobs, limits)
@@ -767,6 +819,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="keep running, pausing this long between passes (default: one pass)",
     )
     parser.add_argument(
+        "--observe",
+        action="append",
+        metavar="WORKSPACE",
+        help="also count this workspace's urgent slots against the allocation, "
+        "without ever modifying its jobs; repeatable. Replaces the default: "
+        + ", ".join(DEFAULT_OBSERVED_WORKSPACES),
+    )
+    parser.add_argument(
+        "--no-observe",
+        action="store_true",
+        help="count only the managed workspace's slots",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="include debug logging"
     )
     return parser
@@ -800,6 +865,20 @@ def validate_limits(client: Beaker, limits: dict[str, int]) -> None:
             raise SystemExit(f"unknown cluster {cluster!r} in allocation: {err}")
 
 
+def validate_workspaces(client: Beaker, workspaces: Sequence[str]) -> None:
+    """Check every workspace name resolves.
+
+    A typo in an observed workspace counts nothing and looks exactly like a
+    workspace holding no urgent slots, so the balancer would quietly hand out
+    the allocation twice.
+    """
+    for workspace in workspaces:
+        try:
+            client.workspace.get(workspace)
+        except BeakerError as err:
+            raise SystemExit(f"unknown workspace {workspace!r}: {err}")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -814,13 +893,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     LOGGER.info(
         "allocation: %s", ", ".join(f"{k}={v} slots" for k, v in limits.items())
     )
+    observed: tuple[str, ...] = ()
+    if not args.no_observe:
+        observed = tuple(args.observe or DEFAULT_OBSERVED_WORKSPACES)
+    if observed:
+        LOGGER.info("also counting, but never modifying: %s", ", ".join(observed))
 
     client = Beaker.from_env()
     validate_limits(client, limits)
+    validate_workspaces(client, [args.workspace, *observed])
     node_cache: dict[str, str | None] = {}
     while True:
         try:
-            run_pass(client, args.workspace, limits, args.dry_run, node_cache)
+            run_pass(client, args.workspace, limits, args.dry_run, node_cache, observed)
         except BeakerError:
             if args.interval is None:
                 raise

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -7,7 +7,13 @@ the allocation, favouring the jobs we care about most.
 
 A job opts in by setting the ``CM_PRIORITY`` environment variable to one of
 ``low``, ``normal``, ``high`` or ``urgent``. Jobs without it are never modified,
-but their urgent slot usage still counts against the allocation.
+but their urgent slot usage still counts against the allocation. So do
+interactive sessions and jobs at ``immediate`` priority, neither of which the
+balancer will touch.
+
+Decisions are made per *replica group*, not per job: Beaker runs a multi-node
+job as one job per rank, and a group granted urgent on only some ranks holds
+slots it cannot use.
 
 Run ``python balance.py --dry-run`` to see what a pass would do.
 """
@@ -39,11 +45,28 @@ LOW = pb2.JOB_PRIORITY_LOW
 NORMAL = pb2.JOB_PRIORITY_NORMAL
 HIGH = pb2.JOB_PRIORITY_HIGH
 URGENT = pb2.JOB_PRIORITY_URGENT
+IMMEDIATE = pb2.JOB_PRIORITY_IMMEDIATE
 
+#: ``immediate`` is deliberately absent: Beaker requires a human-supplied
+#: reason for it, so it is not something the balancer may hand out.
 PRIORITY_BY_NAME = {"low": LOW, "normal": NORMAL, "high": HIGH, "urgent": URGENT}
 NAME_BY_PRIORITY = {value: name for name, value in PRIORITY_BY_NAME.items()}
+NAME_BY_PRIORITY[IMMEDIATE] = "immediate"
+
+#: Priorities that occupy a slot in the allocation. ``immediate`` outranks
+#: ``urgent``, so a job holding one is just as much an occupant.
+ALLOCATED_PRIORITIES = (URGENT, IMMEDIATE)
 
 _CLUSTER_CONSTRAINT = pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER
+
+# Why a job may not be modified. Identity-compared, so a caller can tell an
+# expected state apart from one worth warning about.
+UNLABELLED = "does not set CM_PRIORITY"
+SESSION = "is an interactive session"
+AT_IMMEDIATE = "is at immediate priority, which only a human sets"
+MULTI_CLUSTER = "targets more than one cluster"
+NO_ALLOCATION = "targets a cluster with no allocation"
+UNRESOLVED_CLUSTER = "landed on a node that cannot be resolved to a cluster"
 
 
 def resting_priority(cm_priority: int) -> int:
@@ -83,11 +106,28 @@ class JobView:
     placed_at: float | None
     #: Size of the job's replica group, or 0 when it is a lone job.
     replica_group_size: int = 0
+    #: Identifies the replicas that must start together. Empty for a lone job.
+    replica_group_id: str = ""
+    #: An interactive session has a person attached to it, so its priority is
+    #: never ours to change.
+    is_session: bool = False
 
     @property
     def is_queued(self) -> bool:
         """Whether the job is still waiting, and so may have its priority raised."""
         return not self.is_placed
+
+    @property
+    def holds_allocation(self) -> bool:
+        """Whether this job currently occupies a slot in the allocation."""
+        return self.priority in ALLOCATED_PRIORITIES
+
+    @property
+    def group_key(self) -> str:
+        """What this job is decided along with: its replica group, or itself."""
+        if self.replica_group_size > 1 and self.replica_group_id:
+            return self.replica_group_id
+        return self.id
 
     def budget_clusters(self, limits: dict[str, int]) -> tuple[str, ...]:
         """Clusters whose allocation this job consumes while it is urgent.
@@ -112,6 +152,35 @@ class JobView:
             candidates = self.clusters
         return tuple(cluster for cluster in candidates if cluster in limits)
 
+    def unmanaged_reason(self, limits: dict[str, int]) -> str | None:
+        """Why the balancer may not change this job, or None if it may.
+
+        Returns one of the module-level reason constants, so a caller can tell
+        an expected state apart from one worth warning about.
+
+        Replica group members are *not* excluded here. They are decided as a
+        group rather than individually, which is what stops the walk granting
+        urgent to some ranks and not others; see ``ReplicaGroup``.
+        """
+        if self.cm_priority is None:
+            return UNLABELLED
+        if self.is_session:
+            return SESSION
+        if self.priority == IMMEDIATE:
+            return AT_IMMEDIATE
+        if len(self.clusters) != 1:
+            return MULTI_CLUSTER
+        if self.clusters[0] not in limits:
+            return NO_ALLOCATION
+        # A job is only managed when its slots are charged to exactly the
+        # cluster it is pinned to. A placed job whose node could not be
+        # resolved is charged to every budget as a precaution, and managing it
+        # would let the walk hand out slots on one cluster while the accounting
+        # spent them on all of them.
+        if self.budget_clusters(limits) != (self.clusters[0],):
+            return UNRESOLVED_CLUSTER
+        return None
+
     def managed_cluster(self, limits: dict[str, int]) -> str | None:
         """The single budgeted cluster this job may be modified against.
 
@@ -119,22 +188,8 @@ class JobView:
         cluster. A job eligible for several could land on any of them, and
         Beaker offers no way to pin it, so its effect on a given allocation is
         not knowable in advance.
-
-        Replica group members are excluded: the walk would happily grant urgent
-        to some ranks and not others, which for a synchronised-start group
-        wastes the slots it did grant.
-
-        A job is also only managed when its slots are charged to exactly the
-        cluster it is pinned to. A placed job whose node could not be resolved
-        is charged to every budget as a precaution, and managing it would let
-        the walk hand out slots on one cluster while the accounting spent them
-        on all of them.
         """
-        if self.cm_priority is None or self.replica_group_size > 1:
-            return None
-        if len(self.clusters) != 1 or self.clusters[0] not in limits:
-            return None
-        if self.budget_clusters(limits) != (self.clusters[0],):
+        if self.unmanaged_reason(limits) is not None:
             return None
         return self.clusters[0]
 
@@ -162,101 +217,188 @@ class Action:
         )
 
 
-def _grant_order(jobs: Sequence[JobView]) -> list[JobView]:
-    """Order jobs within one CM_PRIORITY level by who should keep urgent.
+@dataclass(frozen=True)
+class ReplicaGroup:
+    """Jobs that must start together, granted or denied urgent as a unit.
 
-    Placed jobs that already hold urgent come first, so a queued job is always
-    given up before a running one at the same level. Among them the job that has
-    held its slots longest sorts last, so it is the first to lose urgent. Queued
-    jobs follow, longest-waiting first.
+    Beaker runs a multi-node job as one job per replica. Granting urgent to
+    some ranks and not others is the worst available outcome: the group cannot
+    start until every rank is placed, so it waits at the priority of its lowest
+    rank while the granted ranks hold slots the allocation has already spent.
 
-    Both clocks are whole seconds and a launch wave shares one, so the job id
+    A lone job is a group of one, so the walk has a single kind of candidate.
+    """
+
+    id: str
+    jobs: tuple[JobView, ...]
+    cluster: str
+    cm_priority: int
+
+    @property
+    def slots(self) -> int:
+        return sum(job.slots for job in self.jobs)
+
+    @property
+    def is_queued(self) -> bool:
+        return all(job.is_queued for job in self.jobs)
+
+    @property
+    def is_placed(self) -> bool:
+        return not self.is_queued
+
+    @property
+    def holds_urgent(self) -> bool:
+        return all(job.priority == URGENT for job in self.jobs)
+
+    @property
+    def placed_at(self) -> float:
+        """When the group first took slots."""
+        return min((job.placed_at or 0.0) for job in self.jobs)
+
+    @property
+    def queued_at(self) -> float:
+        """When the group last became wholly queued.
+
+        The latest of its ranks, not the earliest: the group cannot start until
+        the last one is placed. Since the clock resets when a rank is preempted
+        and requeued, a group that has been bounced does not keep seniority it
+        no longer has.
+        """
+        return max(job.queued_at for job in self.jobs)
+
+
+def group_jobs(
+    jobs: Sequence[JobView], limits: dict[str, int]
+) -> tuple[list[ReplicaGroup], list[JobView]]:
+    """Split jobs into manageable groups and jobs charged but left alone.
+
+    A group is manageable only if *every* rank is individually manageable and
+    they agree on their label and cluster. One rank the balancer may not touch
+    would otherwise leave the group at mixed priorities, which is exactly what
+    deciding as a group is meant to prevent.
+
+    A group is also left alone unless every rank is present. ``fetch_jobs``
+    reads only unfinished jobs in one workspace, so a group can come back
+    partial; granting urgent to the ranks that happen to be visible would
+    half-grant the real group.
+    """
+    by_group: dict[str, list[JobView]] = {}
+    for job in jobs:
+        by_group.setdefault(job.group_key, []).append(job)
+
+    managed: list[ReplicaGroup] = []
+    fixed: list[JobView] = []
+    for group_id, members in by_group.items():
+        clusters = {job.managed_cluster(limits) for job in members}
+        labels = {job.cm_priority for job in members}
+        # A single non-None value in each means every rank is manageable and
+        # they agree; anything else leaves the group untouched.
+        cluster = clusters.pop() if len(clusters) == 1 else None
+        label = labels.pop() if len(labels) == 1 else None
+        expected = max(job.replica_group_size for job in members)
+        if cluster is None or label is None or len(members) < expected:
+            fixed.extend(members)
+            continue
+        managed.append(
+            ReplicaGroup(
+                id=group_id,
+                jobs=tuple(members),
+                cluster=cluster,
+                cm_priority=label,
+            )
+        )
+    return managed, fixed
+
+
+def _grant_order(groups: Sequence[ReplicaGroup]) -> list[ReplicaGroup]:
+    """Order groups within one CM_PRIORITY level by who should keep urgent.
+
+    Placed groups that already hold urgent come first, so a queued group is
+    always given up before a running one at the same level. Among them the
+    group that has held its slots longest sorts last, so it is the first to
+    lose urgent. Queued groups follow, longest-waiting first.
+
+    Both clocks are whole seconds and a launch wave shares one, so the group id
     breaks ties: without it the order would fall through to whatever sequence
     Beaker happened to list the jobs in, and the pass would not be reproducible.
     """
-    placed = [job for job in jobs if job.is_placed]
-    queued = [job for job in jobs if job.is_queued]
+    placed = [group for group in groups if group.is_placed]
+    queued = [group for group in groups if group.is_queued]
     # placed_at descending == shortest time holding slots first.
-    placed.sort(key=lambda job: (-(job.placed_at or 0.0), job.id))
+    placed.sort(key=lambda group: (-group.placed_at, group.id))
     # queued_at ascending == longest time waiting first.
-    queued.sort(key=lambda job: (job.queued_at, job.id))
+    queued.sort(key=lambda group: (group.queued_at, group.id))
     return placed + queued
 
 
-def _eligible_for_urgent(job: JobView) -> bool:
-    """Whether a job could hold urgent after this pass.
+def _eligible_for_urgent(group: ReplicaGroup) -> bool:
+    """Whether a group could hold urgent after this pass.
 
-    Beaker refuses to raise the priority of a job it has already placed, so such
-    a job can never be promoted unless it is already urgent. Including one in
-    the allocation would displace jobs that can actually be promoted.
+    Beaker refuses to raise the priority of a job it has already placed, so a
+    group with a placed rank below urgent can never be brought wholly to
+    urgent. Including one in the allocation would displace groups that can
+    actually be promoted.
     """
-    return job.priority == URGENT or job.is_queued
+    return group.holds_urgent or group.is_queued
 
 
 def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
     """Compute the priority changes that bring urgent usage within allocation.
 
     The desired allocation is recomputed from scratch on every pass rather than
-    adjusted incrementally: candidates are walked in CM_PRIORITY order and
-    granted urgent while their cluster has slots left. Because the walk starts
-    clean, a high-priority job is always considered before a lower-priority one
-    and never has to wait for slots a lesser job already took.
+    adjusted incrementally: candidate groups are walked in CM_PRIORITY order
+    and granted urgent while their cluster has slots left. Because the walk
+    starts clean, a high-priority group is always considered before a
+    lower-priority one and never has to wait for slots a lesser one took.
     """
-    all_jobs = list(jobs)
-    # Resolve each managed job's cluster and label once. managed_cluster only
-    # returns a cluster when cm_priority is set, so the label is known here.
-    managed: list[tuple[JobView, str, int]] = []
-    for job in all_jobs:
-        cluster = job.managed_cluster(limits)
-        if cluster is not None and job.cm_priority is not None:
-            managed.append((job, cluster, job.cm_priority))
-    managed_ids = {job.id for job, _, _ in managed}
+    groups, fixed = group_jobs(list(jobs), limits)
 
-    # Slots held at urgent by jobs the balancer will not touch. These are a
-    # fixed charge against the allocation; only what is left over is ours to
-    # hand out.
+    # Slots held at urgent or immediate by jobs the balancer will not touch.
+    # These are a fixed charge against the allocation; only what is left over
+    # is ours to hand out.
     remaining = dict(limits)
-    for job in all_jobs:
-        if job.id in managed_ids or job.priority != URGENT:
+    for job in fixed:
+        if not job.holds_allocation:
             continue
         for charged in job.budget_clusters(limits):
             remaining[charged] -= job.slots
 
     granted: set[str] = set()
-    by_level: dict[int, list[tuple[JobView, str]]] = {}
-    for job, cluster, level in managed:
-        by_level.setdefault(level, []).append((job, cluster))
+    by_level: dict[int, list[ReplicaGroup]] = {}
+    for group in groups:
+        by_level.setdefault(group.cm_priority, []).append(group)
 
     for level in sorted(by_level, reverse=True):
-        candidates = {job.id: cluster for job, cluster in by_level[level]}
-        for job in _grant_order([job for job, _ in by_level[level]]):
-            if not _eligible_for_urgent(job):
+        for group in _grant_order(by_level[level]):
+            if not _eligible_for_urgent(group):
                 continue
-            cluster = candidates[job.id]
-            # First fit: a job too large for what is left is skipped and smaller
-            # ones behind it still get a chance. Nothing is reserved for it,
-            # because a higher level that could not fit has already taken
-            # everything it was entitled to.
-            if job.slots <= remaining[cluster]:
-                granted.add(job.id)
-                remaining[cluster] -= job.slots
+            # First fit: a group too large for what is left is skipped and
+            # smaller ones behind it still get a chance. Nothing is reserved
+            # for it, because a higher level that could not fit has already
+            # taken everything it was entitled to.
+            if group.slots <= remaining[group.cluster]:
+                granted.add(group.id)
+                remaining[group.cluster] -= group.slots
 
     actions = []
-    for job, _, level in managed:
-        desired = URGENT if job.id in granted else resting_priority(level)
-        if desired == job.priority:
-            continue
-        if job.is_placed and desired > job.priority:
-            # Beaker rejects this; skip rather than log a failure every pass.
-            LOGGER.debug(
-                "%s is placed at %s and cannot be raised to %s",
-                job.id,
-                NAME_BY_PRIORITY.get(job.priority),
-                NAME_BY_PRIORITY.get(desired),
-            )
-            continue
-        reason = "grant urgent slot" if desired == URGENT else "release urgent slot"
-        actions.append(Action(job, job.priority, desired, reason))
+    for group in groups:
+        desired = URGENT if group.id in granted else resting_priority(group.cm_priority)
+        for job in group.jobs:
+            if desired == job.priority:
+                continue
+            if job.is_placed and desired > job.priority:
+                # Beaker rejects this; skip rather than log a failure every
+                # pass. A group is only granted urgent when every rank can get
+                # there, so this never splits a granted group.
+                LOGGER.debug(
+                    "%s is placed at %s and cannot be raised to %s",
+                    job.id,
+                    NAME_BY_PRIORITY.get(job.priority),
+                    NAME_BY_PRIORITY.get(desired),
+                )
+                continue
+            reason = "grant urgent slot" if desired == URGENT else "release urgent slot"
+            actions.append(Action(job, job.priority, desired, reason))
 
     # Demotions first, so that any prefix of a partially applied pass is still
     # within allocation. A promotion applied before the demotion paying for it
@@ -347,6 +489,9 @@ def fetch_jobs(
                 queued_at=float(job.status.created.seconds),
                 placed_at=float(placed_at) if is_placed and placed_at else None,
                 replica_group_size=job.system_details.replica_group_details.size,
+                replica_group_id=job.system_details.replica_group_details.id,
+                # Only an interactive session carries an environment.
+                is_session=bool(job.environment_id),
             )
         )
     return views
@@ -363,9 +508,10 @@ def set_priority(client: Beaker, job_id: str, priority: int) -> None:
 
 
 def urgent_usage(jobs: Sequence[JobView], limits: dict[str, int]) -> dict[str, int]:
+    """Slots occupied per cluster, counting immediate alongside urgent."""
     used = dict.fromkeys(limits, 0)
     for job in jobs:
-        if job.priority != URGENT:
+        if not job.holds_allocation:
             continue
         for cluster in job.budget_clusters(limits):
             used[cluster] += job.slots
@@ -380,6 +526,38 @@ def report_usage(jobs: Sequence[JobView], limits: dict[str, int], label: str) ->
     LOGGER.info("urgent slots %s: %s", label, summary)
 
 
+def report_unreclaimable(jobs: Sequence[JobView], limits: dict[str, int]) -> None:
+    """Break out allocated slots the balancer can never reclaim.
+
+    Sessions and immediate-priority jobs count against the allocation but are
+    never demoted, so a pass can be unable to get within the allocation no
+    matter what it does. Reporting them makes that a visible fact rather than a
+    balancer that appears not to be working.
+    """
+    sessions = dict.fromkeys(limits, 0)
+    immediate = dict.fromkeys(limits, 0)
+    for job in jobs:
+        if not job.holds_allocation:
+            continue
+        for cluster in job.budget_clusters(limits):
+            if job.is_session:
+                sessions[cluster] += job.slots
+            elif job.priority == IMMEDIATE:
+                immediate[cluster] += job.slots
+    for cluster in limits:
+        notes = []
+        if sessions[cluster]:
+            notes.append(f"{sessions[cluster]} in interactive sessions")
+        if immediate[cluster]:
+            notes.append(f"{immediate[cluster]} at immediate priority")
+        if notes:
+            LOGGER.info(
+                "%s: %s — counted against the allocation, never reclaimable",
+                cluster,
+                "; ".join(notes),
+            )
+
+
 def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None:
     """Summarise opted-in jobs the balancer cannot act on.
 
@@ -390,16 +568,37 @@ def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None
     reasons: Counter[str] = Counter()
     examples: dict[str, str] = {}
     for job in jobs:
-        if job.cm_priority is None or job.managed_cluster(limits) is not None:
+        why = job.unmanaged_reason(limits)
+        if why is None or why is UNLABELLED:
             continue
-        if job.replica_group_size > 1:
-            reason = "in a replica group"
-        elif len(job.clusters) != 1:
+        if why is MULTI_CLUSTER:
             reason = f"targets {len(job.clusters)} clusters"
-        else:
+        elif why is NO_ALLOCATION:
             reason = f"targets {job.clusters[0]}, which has no allocation"
+        else:
+            reason = why
         reasons[reason] += 1
         examples.setdefault(reason, job.id)
+
+    # A group left alone as a whole is not visible per job, since each rank may
+    # be individually fine.
+    managed_ids = {
+        job.id for group in group_jobs(jobs, limits)[0] for job in group.jobs
+    }
+    skipped_groups = {
+        job.group_key
+        for job in jobs
+        if job.replica_group_size > 1
+        and job.id not in managed_ids
+        and job.unmanaged_reason(limits) is None
+    }
+    if skipped_groups:
+        LOGGER.warning(
+            "%d replica group(s) left alone because their ranks are not "
+            "uniformly manageable (e.g. %s)",
+            len(skipped_groups),
+            sorted(skipped_groups)[0],
+        )
     for reason, count in sorted(reasons.items()):
         LOGGER.warning(
             "%d job(s) set %s but cannot be managed: %s (e.g. %s)",
@@ -421,6 +620,7 @@ def run_pass(
     jobs = fetch_jobs(client, workspace, node_cache)
     LOGGER.info("read %d unfinished jobs in %s", len(jobs), workspace)
     report_usage(jobs, limits, "before")
+    report_unreclaimable(jobs, limits)
     report_unmanageable(jobs, limits)
 
     actions = decide(jobs, limits)

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -39,7 +39,12 @@ CM_PRIORITY_ENV = "CM_PRIORITY"
 
 #: GPU slots the team may hold at urgent priority, per cluster. Clusters absent
 #: from this mapping have no allocation and are left alone entirely.
-DEFAULT_CLUSTER_LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
+DEFAULT_CLUSTER_LIMITS = {
+    "ai2/jupiter": 72,
+    "ai2/titan": 32,
+    "ai2/ceres": 0,
+    "ai2/saturn": 0,
+}
 
 #: Workspaces whose jobs spend the same allocation but are never modified. The
 #: allocation is the team's, not one workspace's, so slots held here have to be
@@ -405,6 +410,7 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
             remaining[charged] -= job.slots
 
     granted: set[str] = set()
+    grant_clusters: dict[str, tuple[str, ...]] = {}
     by_level: dict[int, list[ReplicaGroup]] = {}
     for group in groups:
         by_level.setdefault(group.cm_priority, []).append(group)
@@ -419,14 +425,20 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
             # taken everything it was entitled to. A multi-cluster group must
             # fit on every cluster it could land on: granting it urgent commits
             # the allocation on each, and nothing can preempt an urgent job.
-            if all(group.slots <= remaining[c] for c in group.clusters):
+            # Zero-allocation clusters are transparent: they have no budget to
+            # protect, so including them would block grants that are valid on
+            # the clusters that matter.
+            eligible = tuple(c for c in group.clusters if limits[c] > 0)
+            if eligible and all(group.slots <= remaining[c] for c in eligible):
                 granted.add(group.id)
-                for c in group.clusters:
+                grant_clusters[group.id] = eligible
+                for c in eligible:
                     remaining[c] -= group.slots
 
     actions = []
     for group in groups:
         desired = URGENT if group.id in granted else resting_priority(group.cm_priority)
+        clusters = grant_clusters.get(group.id, group.clusters)
         for job in group.jobs:
             if desired == job.priority:
                 continue
@@ -442,7 +454,7 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
                 )
                 continue
             reason = _reason(job, desired)
-            actions.append(Action(job, group.clusters, job.priority, desired, reason))
+            actions.append(Action(job, clusters, job.priority, desired, reason))
 
     # Demotions first, so that any prefix of a partially applied pass is still
     # within allocation. A promotion applied before the demotion paying for it
@@ -660,10 +672,10 @@ def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None
         if why is None or why is UNLABELLED or why is OBSERVED:
             continue
         if why is NO_ALLOCATION:
-            # A placed job on a non-budgeted cluster that was submitted to at
-            # least one budgeted cluster is a normal outcome: it was managed
-            # while queued and simply landed elsewhere.
-            if job.is_placed and any(c in limits for c in job.clusters):
+            # A placed job on a zero-allocation cluster that was submitted to
+            # at least one positively-budgeted cluster is a normal outcome: it
+            # was managed while queued and simply landed elsewhere.
+            if job.is_placed and any(limits.get(c, 0) > 0 for c in job.clusters):
                 continue
             target = job.assigned_cluster or (job.clusters[0] if job.clusters else None)
             reason = f"targets {target}, which has no allocation" if target else why

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -15,26 +15,18 @@ Decisions are made per *replica group*, not per job: Beaker runs a multi-node
 job as one job per rank, and a group granted urgent on only some ranks holds
 slots it cannot use.
 
-A job that is not granted an urgent slot is returned to the priority it was
-last seen at before the balancer raised it. Beaker keeps no record of that, so
-the balancer keeps its own -- see ``load_state``.
-
 Run ``python balance.py --dry-run`` to see what a pass would do.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import logging
-import os
 import sys
-import tempfile
 import time
 from collections import Counter
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
-from pathlib import Path
 
 from beaker import Beaker
 from beaker import beaker_pb2 as pb2
@@ -65,18 +57,6 @@ NAME_BY_PRIORITY[IMMEDIATE] = "immediate"
 #: ``urgent``, so a job holding one is just as much an occupant.
 ALLOCATED_PRIORITIES = (URGENT, IMMEDIATE)
 
-#: Priorities a job may be left resting at. ``urgent`` is excluded because
-#: resting there would defeat the allocation, and ``immediate`` because the
-#: balancer never hands it out.
-RESTABLE_PRIORITIES = (LOW, NORMAL, HIGH)
-
-#: Where the remembered resting priorities are kept between passes.
-DEFAULT_STATE_PATH = Path.home() / ".cache" / "beaker_balancer" / "resting.json"
-
-#: Bumped if the state file's shape ever changes; an unrecognised version is
-#: discarded rather than misread.
-STATE_VERSION = 1
-
 _CLUSTER_CONSTRAINT = pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER
 
 # Why a job may not be modified. Identity-compared, so a caller can tell an
@@ -89,64 +69,13 @@ NO_ALLOCATION = "targets a cluster with no allocation"
 UNRESOLVED_CLUSTER = "landed on a node that cannot be resolved to a cluster"
 
 
-def load_state(path: Path) -> dict[str, int]:
-    """Read the remembered resting priorities, or start empty.
+def resting_priority(cm_priority: int) -> int:
+    """Priority a job falls back to when it is not granted an urgent slot.
 
-    Never raises: a balancer that will not run because its cache is unreadable
-    is worse than one that forgets. Forgetting is bounded -- an unknown job at
-    urgent falls back to ``high`` -- so a corrupt or missing file costs fidelity
-    for the jobs currently at urgent and nothing else.
+    Jobs labelled ``urgent`` rest at ``high``: resting at urgent would defeat
+    the purpose of the allocation.
     """
-    try:
-        with open(path) as handle:
-            state = json.load(handle)
-    except FileNotFoundError:
-        return {}
-    except (OSError, ValueError) as err:
-        LOGGER.warning("could not read %s, starting with no memory: %s", path, err)
-        return {}
-    if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
-        LOGGER.warning("ignoring %s: not a version %d state file", path, STATE_VERSION)
-        return {}
-    resting = state.get("resting")
-    if not isinstance(resting, dict):
-        LOGGER.warning("ignoring %s: no resting priorities in it", path)
-        return {}
-    return {
-        job_id: priority
-        for job_id, priority in resting.items()
-        if isinstance(job_id, str) and priority in RESTABLE_PRIORITIES
-    }
-
-
-def save_state(path: Path, resting: Mapping[str, int]) -> None:
-    """Write the remembered resting priorities, replacing the file atomically.
-
-    Never raises, for the same reason as ``load_state``: by the time this is
-    called the pass has already decided, and failing here would turn a full
-    disk into a balancer that stops balancing.
-
-    The replace is atomic so that a second balancer, or a process killed
-    mid-write, finds either the old file or the new one and never a half of
-    each. Two balancers still overwrite each other, but the loser only loses
-    memory, which costs the ``high`` fallback rather than correctness: the
-    allocation arithmetic does not depend on where a demoted job lands.
-    """
-    state = {"version": STATE_VERSION, "resting": dict(resting)}
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        handle = tempfile.NamedTemporaryFile(
-            "w", dir=path.parent, prefix=path.name, suffix=".tmp", delete=False
-        )
-        try:
-            with handle:
-                json.dump(state, handle)
-            os.replace(handle.name, path)
-        except BaseException:
-            os.unlink(handle.name)
-            raise
-    except OSError as err:
-        LOGGER.warning("could not write %s; the next pass starts fresh: %s", path, err)
+    return HIGH if cm_priority == URGENT else cm_priority
 
 
 @dataclass(frozen=True)
@@ -182,10 +111,6 @@ class JobView:
     #: An interactive session has a person attached to it, so its priority is
     #: never ours to change.
     is_session: bool = False
-    #: The job this one was requeued from after a preemption, if any. Beaker
-    #: gives the retry a new id, so this is the only link back to what the
-    #: balancer remembered about the original.
-    retry_ancestor_id: str = ""
 
     @property
     def is_queued(self) -> bool:
@@ -267,52 +192,6 @@ class JobView:
         if self.unmanaged_reason(limits) is not None:
             return None
         return self.clusters[0]
-
-
-def resting_priority(job: JobView, remembered: Mapping[str, int]) -> int:
-    """Priority a job falls back to when it is not granted an urgent slot.
-
-    Where the user last had it, so that the balancer's only lasting effect on a
-    job is whether it held an urgent slot. A job sitting below urgent is already
-    resting: whatever it is at now is what its owner last chose, including a
-    change they made by hand since the previous pass. Only a job at urgent needs
-    memory, since raising it destroyed the record of where it came from.
-
-    ``high`` is the fallback for a job at urgent that has never been seen lower
-    -- submitted at urgent, or first seen there after the memory was lost.
-    Resting at urgent would defeat the purpose of the allocation.
-    """
-    if job.priority in RESTABLE_PRIORITIES:
-        return job.priority
-    return remembered.get(job.id, HIGH)
-
-
-def remember_priorities(
-    jobs: Iterable[JobView], remembered: Mapping[str, int]
-) -> dict[str, int]:
-    """Carry each opted-in job's pre-urgent priority into the next pass.
-
-    Called with what Beaker reports *before* a pass applies anything, so a job
-    the balancer is about to raise is recorded where its owner left it.
-
-    Jobs absent from this pass are dropped, which is how finished jobs are
-    evicted. A preempted job returns under a new id, and the priority Beaker
-    gives it back is the one the balancer set on its source rather than the one
-    it was submitted at, so the memory follows ``retry_ancestor_id``: without
-    that, every preemption of a granted job would ratchet it up to the ``high``
-    fallback.
-    """
-    updated: dict[str, int] = {}
-    for job in jobs:
-        if job.cm_priority is None:
-            continue  # never modified, so never restored
-        if job.priority in RESTABLE_PRIORITIES:
-            updated[job.id] = job.priority
-        elif job.id in remembered:
-            updated[job.id] = remembered[job.id]
-        elif job.retry_ancestor_id in remembered:
-            updated[job.id] = remembered[job.retry_ancestor_id]
-    return updated
 
 
 @dataclass(frozen=True)
@@ -475,21 +354,22 @@ def _eligible_for_urgent(group: ReplicaGroup) -> bool:
     return group.holds_urgent or group.is_queued
 
 
-def _reason(desired: int) -> str:
+def _reason(job: JobView, desired: int) -> str:
     """Why a job is being moved, in terms of the allocation.
 
-    Every change is one or the other: a job resting below urgent is left where
-    it is, so the balancer's only moves are onto an urgent slot and back off
-    again.
+    A job that neither takes nor gives up an urgent slot is only being put where
+    its label says it rests -- a queued job submitted below its ``CM_PRIORITY``
+    is raised to it. Describing that as releasing a slot would report a change
+    to the allocation that did not happen.
     """
-    return "grant urgent slot" if desired == URGENT else "release urgent slot"
+    if desired == URGENT:
+        return "grant urgent slot"
+    if job.priority == URGENT:
+        return "release urgent slot"
+    return "settle at resting priority"
 
 
-def decide(
-    jobs: Iterable[JobView],
-    limits: dict[str, int],
-    remembered: Mapping[str, int] | None = None,
-) -> list[Action]:
+def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
     """Compute the priority changes that bring urgent usage within allocation.
 
     The desired allocation is recomputed from scratch on every pass rather than
@@ -497,12 +377,7 @@ def decide(
     and granted urgent while their cluster has slots left. Because the walk
     starts clean, a high-priority group is always considered before a
     lower-priority one and never has to wait for slots a lesser one took.
-
-    ``remembered`` maps job id to the priority it was last seen at below urgent
-    (see ``remember_priorities``); a job missing from it that is currently at
-    urgent falls back to ``high``.
     """
-    remembered = {} if remembered is None else remembered
     groups, fixed = group_jobs(list(jobs), limits)
 
     # Slots held at urgent or immediate by jobs the balancer will not touch.
@@ -534,12 +409,8 @@ def decide(
 
     actions = []
     for group in groups:
-        is_granted = group.id in granted
+        desired = URGENT if group.id in granted else resting_priority(group.cm_priority)
         for job in group.jobs:
-            # Resting is per job, not per group: each rank goes back to where
-            # its own owner left it. A group is still granted all or nothing,
-            # so this never splits one.
-            desired = URGENT if is_granted else resting_priority(job, remembered)
             if desired == job.priority:
                 continue
             if job.is_placed and desired > job.priority:
@@ -554,7 +425,7 @@ def decide(
                 )
                 continue
             actions.append(
-                Action(job, group.cluster, job.priority, desired, _reason(desired))
+                Action(job, group.cluster, job.priority, desired, _reason(job, desired))
             )
 
     # Demotions first, so that any prefix of a partially applied pass is still
@@ -657,7 +528,6 @@ def fetch_jobs(
                 replica_group_id=job.system_details.replica_group_details.id,
                 # Only an interactive session carries an environment.
                 is_session=bool(job.environment_id),
-                retry_ancestor_id=job.retry_ancestor_id,
             )
         )
     return views
@@ -788,25 +658,15 @@ def run_pass(
     limits: dict[str, int],
     dry_run: bool,
     node_cache: dict[str, str | None] | None = None,
-    state_path: Path | None = None,
 ) -> int:
     """Run one balancing pass. Returns the number of changes applied."""
-    state_path = DEFAULT_STATE_PATH if state_path is None else state_path
     jobs = fetch_jobs(client, workspace, node_cache)
     LOGGER.info("read %d unfinished jobs in %s", len(jobs), workspace)
     report_usage(jobs, limits, "before")
     report_unreclaimable(jobs, limits)
     report_unmanageable(jobs, limits)
 
-    # Recorded from what Beaker reports now, and written before anything is
-    # applied: a job about to be raised has to be remembered where its owner
-    # left it, and the record has to survive the pass dying halfway through.
-    # A dry run writes nothing, so that reporting a pass cannot change one.
-    remembered = remember_priorities(jobs, load_state(state_path))
-    if not dry_run:
-        save_state(state_path, remembered)
-
-    actions = decide(jobs, limits, remembered)
+    actions = decide(jobs, limits)
     if not actions:
         LOGGER.info("no changes needed")
         return 0
@@ -907,13 +767,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="keep running, pausing this long between passes (default: one pass)",
     )
     parser.add_argument(
-        "--state",
-        type=Path,
-        default=DEFAULT_STATE_PATH,
-        help="where to remember the priority each job rests at when it is not "
-        f"granted an urgent slot (default: {DEFAULT_STATE_PATH})",
-    )
-    parser.add_argument(
         "-v", "--verbose", action="store_true", help="include debug logging"
     )
     return parser
@@ -967,14 +820,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     node_cache: dict[str, str | None] = {}
     while True:
         try:
-            run_pass(
-                client,
-                args.workspace,
-                limits,
-                args.dry_run,
-                node_cache,
-                args.state,
-            )
+            run_pass(client, args.workspace, limits, args.dry_run, node_cache)
         except BeakerError:
             if args.interval is None:
                 raise

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -660,7 +660,8 @@ def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None
         if why is None or why is UNLABELLED or why is OBSERVED:
             continue
         if why is NO_ALLOCATION:
-            reason = f"targets {job.clusters[0]}, which has no allocation"
+            target = job.assigned_cluster or (job.clusters[0] if job.clusters else None)
+            reason = f"targets {target}, which has no allocation" if target else why
         else:
             reason = why
         reasons[reason] += 1

--- a/scripts/beaker_balancer/balance.py
+++ b/scripts/beaker_balancer/balance.py
@@ -1,13 +1,13 @@
 """Balance Beaker job priorities against the team's urgent slot allocation.
 
-Beaker does not enforce our per-cluster urgent allocation, so queueing urgent
-jobs can silently put the team over it. This script reads the live state of a
-workspace and adjusts the priority of opted-in jobs so that urgent slot usage
-stays within the allocation, favouring the jobs we care about most.
+Beaker does not enforce our urgent slot allocation, so queueing urgent jobs can
+silently put the team over it. This script reads the live state of a workspace
+and adjusts the priority of opted-in jobs so that urgent slot usage stays within
+the allocation, favouring the jobs we care about most.
 
 A job opts in by setting the ``CM_PRIORITY`` environment variable to one of
-``low``, ``normal``, ``high`` or ``urgent``. Jobs without it are never
-modified, but their urgent slot usage still counts against the allocation.
+``low``, ``normal``, ``high`` or ``urgent``. Jobs without it are never modified,
+but their urgent slot usage still counts against the allocation.
 
 Run ``python balance.py --dry-run`` to see what a pass would do.
 """
@@ -18,8 +18,9 @@ import argparse
 import logging
 import sys
 import time
+from collections import Counter
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from beaker import Beaker
 from beaker import beaker_pb2 as pb2
@@ -42,9 +43,6 @@ URGENT = pb2.JOB_PRIORITY_URGENT
 PRIORITY_BY_NAME = {"low": LOW, "normal": NORMAL, "high": HIGH, "urgent": URGENT}
 NAME_BY_PRIORITY = {value: name for name, value in PRIORITY_BY_NAME.items()}
 
-# A job's status is "queued" until Beaker places it on a node. Only queued jobs
-# can have their priority raised; Beaker rejects increases on running jobs with
-# "cannot increase priority for running job".
 _CLUSTER_CONSTRAINT = pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER
 
 
@@ -73,26 +71,43 @@ class JobView:
     clusters: tuple[str, ...]
     assigned_cluster: str | None
     cm_priority: int | None
+    #: Whether Beaker has placed this job on a node. True from the moment it is
+    #: scheduled, which is before it starts running -- an initializing job is
+    #: already occupying its slots, and Beaker already refuses to raise its
+    #: priority, so it must not be treated as queued.
+    is_placed: bool
     #: When the job entered the queue. Reset when a job is preempted and
     #: requeued, so this measures the wait of the *current* attempt.
     queued_at: float
-    #: When the job landed on a GPU, or None if it is still queued.
-    started_at: float | None
+    #: When the job took its slots, or None if it is still queued.
+    placed_at: float | None
+    #: Size of the job's replica group, or 0 when it is a lone job.
+    replica_group_size: int = 0
 
     @property
     def is_queued(self) -> bool:
-        return self.started_at is None
+        """Whether the job is still waiting, and so may have its priority raised."""
+        return not self.is_placed
 
     def budget_clusters(self, limits: dict[str, int]) -> tuple[str, ...]:
         """Clusters whose allocation this job consumes while it is urgent.
 
-        An assigned job consumes only the cluster it actually landed on. A
-        queued job could land on any cluster it is eligible for, and since
-        nothing can preempt an urgent job it is a committed future occupant of
-        whichever it picks, so it is counted against all of them.
+        A placed job consumes only the cluster it landed on. A queued job could
+        land on any cluster it is eligible for, and since nothing can preempt an
+        urgent job it is a committed future occupant of whichever it picks, so
+        it is counted against all of them.
+
+        A job whose landing cluster cannot be narrowed -- placed but
+        unresolvable, or queued with no cluster constraint at all -- is charged
+        to every budgeted cluster. Charging it to none would let the balancer
+        hand out slots that are already spoken for.
         """
-        if self.assigned_cluster is not None:
+        if self.is_placed:
+            if self.assigned_cluster is None:
+                return tuple(limits)
             candidates: tuple[str, ...] = (self.assigned_cluster,)
+        elif not self.clusters:
+            return tuple(limits)
         else:
             candidates = self.clusters
         return tuple(cluster for cluster in candidates if cluster in limits)
@@ -104,11 +119,24 @@ class JobView:
         cluster. A job eligible for several could land on any of them, and
         Beaker offers no way to pin it, so its effect on a given allocation is
         not knowable in advance.
+
+        Replica group members are excluded: the walk would happily grant urgent
+        to some ranks and not others, which for a synchronised-start group
+        wastes the slots it did grant.
+
+        A job is also only managed when its slots are charged to exactly the
+        cluster it is pinned to. A placed job whose node could not be resolved
+        is charged to every budget as a precaution, and managing it would let
+        the walk hand out slots on one cluster while the accounting spent them
+        on all of them.
         """
-        if self.cm_priority is None or len(self.clusters) != 1:
+        if self.cm_priority is None or self.replica_group_size > 1:
             return None
-        cluster = self.clusters[0]
-        return cluster if cluster in limits else None
+        if len(self.clusters) != 1 or self.clusters[0] not in limits:
+            return None
+        if self.budget_clusters(limits) != (self.clusters[0],):
+            return None
+        return self.clusters[0]
 
 
 @dataclass(frozen=True)
@@ -119,6 +147,10 @@ class Action:
     from_priority: int
     to_priority: int
     reason: str
+
+    @property
+    def is_demotion(self) -> bool:
+        return self.to_priority < self.from_priority
 
     def describe(self) -> str:
         return (
@@ -133,26 +165,30 @@ class Action:
 def _grant_order(jobs: Sequence[JobView]) -> list[JobView]:
     """Order jobs within one CM_PRIORITY level by who should keep urgent.
 
-    Running jobs that already hold urgent come first, so a queued job is always
-    given up before a running one at the same level. Among them the job that
-    has held a GPU longest sorts last, so it is the first to lose urgent.
-    Queued jobs follow, longest-waiting first.
+    Placed jobs that already hold urgent come first, so a queued job is always
+    given up before a running one at the same level. Among them the job that has
+    held its slots longest sorts last, so it is the first to lose urgent. Queued
+    jobs follow, longest-waiting first.
+
+    Both clocks are whole seconds and a launch wave shares one, so the job id
+    breaks ties: without it the order would fall through to whatever sequence
+    Beaker happened to list the jobs in, and the pass would not be reproducible.
     """
-    running = [job for job in jobs if not job.is_queued]
+    placed = [job for job in jobs if job.is_placed]
     queued = [job for job in jobs if job.is_queued]
-    # started_at descending == shortest time on GPU first.
-    running.sort(key=lambda job: job.started_at or 0.0, reverse=True)
+    # placed_at descending == shortest time holding slots first.
+    placed.sort(key=lambda job: (-(job.placed_at or 0.0), job.id))
     # queued_at ascending == longest time waiting first.
-    queued.sort(key=lambda job: job.queued_at)
-    return running + queued
+    queued.sort(key=lambda job: (job.queued_at, job.id))
+    return placed + queued
 
 
 def _eligible_for_urgent(job: JobView) -> bool:
     """Whether a job could hold urgent after this pass.
 
-    Beaker refuses to raise the priority of a running job, so a running job
-    that is not already urgent can never be promoted. Including such a job in
-    the allocation would displace others to no benefit.
+    Beaker refuses to raise the priority of a job it has already placed, so such
+    a job can never be promoted unless it is already urgent. Including one in
+    the allocation would displace jobs that can actually be promoted.
     """
     return job.priority == URGENT or job.is_queued
 
@@ -167,8 +203,8 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
     and never has to wait for slots a lesser job already took.
     """
     all_jobs = list(jobs)
-    # Resolve each managed job's cluster and label once: a job is managed
-    # exactly when both are known.
+    # Resolve each managed job's cluster and label once. managed_cluster only
+    # returns a cluster when cm_priority is set, so the label is known here.
     managed: list[tuple[JobView, str, int]] = []
     for job in all_jobs:
         cluster = job.managed_cluster(limits)
@@ -197,10 +233,10 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
             if not _eligible_for_urgent(job):
                 continue
             cluster = candidates[job.id]
-            # First fit: a job too large for what is left is skipped and
-            # smaller ones behind it still get a chance. Nothing is reserved
-            # for it, because a higher level that could not fit has already
-            # taken everything it was entitled to.
+            # First fit: a job too large for what is left is skipped and smaller
+            # ones behind it still get a chance. Nothing is reserved for it,
+            # because a higher level that could not fit has already taken
+            # everything it was entitled to.
             if job.slots <= remaining[cluster]:
                 granted.add(job.id)
                 remaining[cluster] -= job.slots
@@ -210,10 +246,10 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
         desired = URGENT if job.id in granted else resting_priority(level)
         if desired == job.priority:
             continue
-        if not job.is_queued and desired > job.priority:
+        if job.is_placed and desired > job.priority:
             # Beaker rejects this; skip rather than log a failure every pass.
             LOGGER.debug(
-                "%s is running at %s and cannot be raised to %s",
+                "%s is placed at %s and cannot be raised to %s",
                 job.id,
                 NAME_BY_PRIORITY.get(job.priority),
                 NAME_BY_PRIORITY.get(desired),
@@ -221,6 +257,11 @@ def decide(jobs: Iterable[JobView], limits: dict[str, int]) -> list[Action]:
             continue
         reason = "grant urgent slot" if desired == URGENT else "release urgent slot"
         actions.append(Action(job, job.priority, desired, reason))
+
+    # Demotions first, so that any prefix of a partially applied pass is still
+    # within allocation. A promotion applied before the demotion paying for it
+    # would leave us over if that demotion then failed.
+    actions.sort(key=lambda action: not action.is_demotion)
     return actions
 
 
@@ -238,12 +279,17 @@ def parse_cm_priority(value: str, job_id: str) -> int | None:
     return priority
 
 
-def _cluster_of_node(client: Beaker, node_id: str, cache: dict[str, str]) -> str | None:
+def _cluster_of_node(
+    client: Beaker, node_id: str, cache: dict[str, str | None]
+) -> str | None:
     """Resolve the node's cluster to an org-qualified name, e.g. ``ai2/jupiter``.
 
     ``Cluster.name`` is bare, but placement constraints and our allocation are
-    written org-qualified, so the two have to be reconciled or assigned jobs
-    match no budget and their slots go uncounted.
+    written org-qualified, so the two have to be reconciled or placed jobs match
+    no budget and their slots go uncounted.
+
+    Failures are cached too: a node that cannot be resolved would otherwise be
+    retried on every job in every pass.
     """
     if node_id not in cache:
         try:
@@ -252,14 +298,16 @@ def _cluster_of_node(client: Beaker, node_id: str, cache: dict[str, str]) -> str
             cache[node_id] = f"{cluster.organization_name}/{cluster.name}"
         except BeakerError as err:
             LOGGER.warning("could not resolve cluster for node %s: %s", node_id, err)
-            return None
+            cache[node_id] = None
     return cache[node_id]
 
 
-def fetch_jobs(client: Beaker, workspace_name: str) -> list[JobView]:
+def fetch_jobs(
+    client: Beaker, workspace_name: str, node_cache: dict[str, str | None] | None = None
+) -> list[JobView]:
     """Read every unfinished job in a workspace into JobView form."""
     workspace = client.workspace.get(workspace_name)
-    node_clusters: dict[str, str] = {}
+    node_clusters: dict[str, str | None] = {} if node_cache is None else node_cache
     views = []
     for job in client.job.list(finalized=False):
         if job.workspace_id != workspace.id:
@@ -278,8 +326,11 @@ def fetch_jobs(client: Beaker, workspace_name: str) -> list[JobView]:
             for value in constraint.values
         )
         node_id = job.assignment_details.node_id
+        is_placed = bool(node_id)
         assigned = _cluster_of_node(client, node_id, node_clusters) if node_id else None
-        started = job.status.started.seconds or None
+        # A scheduled job holds its slots before it starts running, so fall back
+        # to the scheduling time rather than treating it as never placed.
+        placed_at = job.status.started.seconds or job.status.scheduled.seconds or None
 
         views.append(
             JobView(
@@ -292,8 +343,10 @@ def fetch_jobs(client: Beaker, workspace_name: str) -> list[JobView]:
                 clusters=clusters,
                 assigned_cluster=assigned,
                 cm_priority=cm_priority,
+                is_placed=is_placed,
                 queued_at=float(job.status.created.seconds),
-                started_at=float(started) if started else None,
+                placed_at=float(placed_at) if is_placed and placed_at else None,
+                replica_group_size=job.system_details.replica_group_details.size,
             )
         )
     return views
@@ -309,53 +362,66 @@ def set_priority(client: Beaker, job_id: str, priority: int) -> None:
     )
 
 
-def report_usage(jobs: Sequence[JobView], limits: dict[str, int], label: str) -> None:
+def urgent_usage(jobs: Sequence[JobView], limits: dict[str, int]) -> dict[str, int]:
     used = dict.fromkeys(limits, 0)
     for job in jobs:
         if job.priority != URGENT:
             continue
         for cluster in job.budget_clusters(limits):
             used[cluster] += job.slots
+    return used
+
+
+def report_usage(jobs: Sequence[JobView], limits: dict[str, int], label: str) -> None:
+    used = urgent_usage(jobs, limits)
     summary = ", ".join(
         f"{cluster} {used[cluster]}/{limit}" for cluster, limit in limits.items()
     )
     LOGGER.info("urgent slots %s: %s", label, summary)
 
 
-def warn_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None:
-    """Flag opted-in jobs the balancer cannot act on, so the label isn't silent."""
+def report_unmanageable(jobs: Sequence[JobView], limits: dict[str, int]) -> None:
+    """Summarise opted-in jobs the balancer cannot act on.
+
+    Reported as one aggregate line rather than one per job: most jobs in the
+    workspace target several clusters, so per-job warnings would drown the log
+    during adoption.
+    """
+    reasons: Counter[str] = Counter()
+    examples: dict[str, str] = {}
     for job in jobs:
         if job.cm_priority is None or job.managed_cluster(limits) is not None:
             continue
-        if len(job.clusters) != 1:
-            LOGGER.warning(
-                "%s %r sets %s but targets %d clusters (%s); the balancer only "
-                "manages jobs pinned to one cluster, so it is left alone",
-                job.id,
-                job.name,
-                CM_PRIORITY_ENV,
-                len(job.clusters),
-                ", ".join(job.clusters) or "none",
-            )
+        if job.replica_group_size > 1:
+            reason = "in a replica group"
+        elif len(job.clusters) != 1:
+            reason = f"targets {len(job.clusters)} clusters"
         else:
-            LOGGER.info(
-                "%s %r sets %s but targets %s, which has no allocation; "
-                "leaving it alone",
-                job.id,
-                job.name,
-                CM_PRIORITY_ENV,
-                job.clusters[0],
-            )
+            reason = f"targets {job.clusters[0]}, which has no allocation"
+        reasons[reason] += 1
+        examples.setdefault(reason, job.id)
+    for reason, count in sorted(reasons.items()):
+        LOGGER.warning(
+            "%d job(s) set %s but cannot be managed: %s (e.g. %s)",
+            count,
+            CM_PRIORITY_ENV,
+            reason,
+            examples[reason],
+        )
 
 
 def run_pass(
-    client: Beaker, workspace: str, limits: dict[str, int], dry_run: bool
+    client: Beaker,
+    workspace: str,
+    limits: dict[str, int],
+    dry_run: bool,
+    node_cache: dict[str, str | None] | None = None,
 ) -> int:
     """Run one balancing pass. Returns the number of changes applied."""
-    jobs = fetch_jobs(client, workspace)
+    jobs = fetch_jobs(client, workspace, node_cache)
     LOGGER.info("read %d unfinished jobs in %s", len(jobs), workspace)
     report_usage(jobs, limits, "before")
-    warn_unmanageable(jobs, limits)
+    report_unmanageable(jobs, limits)
 
     actions = decide(jobs, limits)
     if not actions:
@@ -363,6 +429,7 @@ def run_pass(
         return 0
 
     applied = 0
+    changed: dict[str, int] = {}
     for action in actions:
         if dry_run:
             LOGGER.info("would change %s", action.describe())
@@ -380,7 +447,15 @@ def run_pass(
             )
             continue
         applied += 1
+        changed[action.job.id] = action.to_priority
         LOGGER.info("changed %s", action.describe())
+
+    if not dry_run:
+        settled = [
+            replace(job, priority=changed[job.id]) if job.id in changed else job
+            for job in jobs
+        ]
+        report_usage(settled, limits, "after")
     return applied
 
 
@@ -393,7 +468,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit",
         action="append",
         metavar="CLUSTER=SLOTS",
-        help="urgent GPU slot allocation for a cluster; repeatable. Defaults to "
+        help="override one cluster's urgent GPU slot allocation; repeatable. "
+        "Other clusters keep their defaults: "
         + ", ".join(f"{k}={v}" for k, v in DEFAULT_CLUSTER_LIMITS.items()),
     )
     parser.add_argument(
@@ -414,32 +490,54 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def parse_limits(values: list[str] | None) -> dict[str, int]:
-    if not values:
-        return dict(DEFAULT_CLUSTER_LIMITS)
-    limits = {}
-    for value in values:
-        cluster, _, slots = value.partition("=")
-        if not slots.isdigit():
+    """Apply CLUSTER=SLOTS overrides on top of the default allocation.
+
+    Overrides merge rather than replace: naming one cluster must not silently
+    drop the allocation of another and leave its jobs unmanaged.
+    """
+    limits = dict(DEFAULT_CLUSTER_LIMITS)
+    for value in values or []:
+        cluster, sep, slots = value.partition("=")
+        if not sep or not cluster or not slots.isdigit():
             raise ValueError(f"expected CLUSTER=SLOTS, got {value!r}")
         limits[cluster] = int(slots)
     return limits
 
 
+def validate_limits(client: Beaker, limits: dict[str, int]) -> None:
+    """Check every budgeted cluster name resolves.
+
+    A typo here manages nothing at all and looks exactly like a quiet cluster,
+    so fail loudly at startup instead.
+    """
+    for cluster in limits:
+        try:
+            client.cluster.get(cluster)
+        except BeakerError as err:
+            raise SystemExit(f"unknown cluster {cluster!r} in allocation: {err}")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
     )
-    limits = parse_limits(args.limit)
+    try:
+        limits = parse_limits(args.limit)
+    except ValueError as err:
+        parser.error(str(err))
     LOGGER.info(
         "allocation: %s", ", ".join(f"{k}={v} slots" for k, v in limits.items())
     )
 
     client = Beaker.from_env()
+    validate_limits(client, limits)
+    node_cache: dict[str, str | None] = {}
     while True:
         try:
-            run_pass(client, args.workspace, limits, args.dry_run)
+            run_pass(client, args.workspace, limits, args.dry_run, node_cache)
         except BeakerError:
             if args.interval is None:
                 raise

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -412,6 +412,40 @@ def test_jobs_on_unbudgeted_clusters_are_left_alone():
     assert decide([saturn], LIMITS) == []
 
 
+# --- mixed budgeted and non-budgeted clusters --------------------------------
+
+
+def test_a_queued_job_targeting_budgeted_and_non_budgeted_clusters_is_managed():
+    mixed = job(clusters=("ai2/jupiter", "ai2/ceres"), cm_priority=HIGH)
+    assert mixed.budget_clusters(LIMITS) == ("ai2/jupiter",)
+    assert mixed.managed_clusters(LIMITS) == ("ai2/jupiter",)
+    result = changes(decide([mixed], LIMITS))
+    assert result == {mixed.id: URGENT}
+
+
+def test_promoting_a_queued_mixed_cluster_job_charges_only_the_budgeted_cluster():
+    mixed = job(cm_priority=HIGH, slots=72, clusters=("ai2/jupiter", "ai2/ceres"))
+    on_titan = job(cm_priority=HIGH, slots=32, clusters=("ai2/titan",))
+    result = changes(decide([mixed, on_titan], LIMITS))
+    # mixed takes 72 from jupiter (fills it), but titan is independent.
+    assert result == {mixed.id: URGENT, on_titan.id: URGENT}
+
+
+def test_a_placed_job_on_a_non_budgeted_cluster_is_not_counted():
+    on_ceres = placed(
+        priority=URGENT,
+        cm_priority=HIGH,
+        clusters=("ai2/jupiter", "ai2/ceres"),
+        assigned_cluster="ai2/ceres",
+    )
+    assert on_ceres.budget_clusters(LIMITS) == ()
+    assert on_ceres.managed_clusters(LIMITS) is None
+    # The urgent slots on ceres do not reduce what is available on jupiter.
+    contender = job(cm_priority=HIGH, slots=72, clusters=("ai2/jupiter",))
+    result = changes(decide([on_ceres, contender], LIMITS))
+    assert result == {contender.id: URGENT}
+
+
 # --- replica groups ---------------------------------------------------------
 
 
@@ -658,6 +692,7 @@ def random_population(rng: random.Random) -> list[JobView]:
                 ("ai2/jupiter",),
                 ("ai2/titan",),
                 ("ai2/titan", "ai2/jupiter"),
+                ("ai2/jupiter", "ai2/ceres"),
                 ("ai2/saturn",),
                 (),  # unconstrained: could land anywhere
             ]
@@ -876,6 +911,7 @@ def test_random_population_reaches_the_states_that_matter():
         "replica": 0,
         "replica_managed": 0,
         "multi_cluster_managed": 0,
+        "mixed_budget_non_budget": 0,
         "session": 0,
         "immediate": 0,
         "demotion": 0,
@@ -895,6 +931,12 @@ def test_random_population_reaches_the_states_that_matter():
         )
         seen["multi_cluster_managed"] += sum(
             1 for j in jobs if len(j.clusters) > 1 and j.id in allowed
+        )
+        seen["mixed_budget_non_budget"] += sum(
+            1
+            for j in jobs
+            if any(c in LIMITS for c in j.clusters)
+            and any(c not in LIMITS for c in j.clusters)
         )
         seen["session"] += sum(1 for j in jobs if j.is_session)
         seen["immediate"] += sum(1 for j in jobs if j.priority == IMMEDIATE)

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -4,6 +4,7 @@ These exercise ``decide`` against constructed job lists, so no Beaker calls are
 made. The Beaker-facing layer is covered in ``test_beaker_io.py``.
 """
 
+import copy
 import itertools
 import random
 from dataclasses import replace
@@ -599,16 +600,18 @@ def test_a_pass_always_converges(seed):
 
 
 @pytest.mark.parametrize("seed", range(300))
-def test_converges_even_when_every_action_fails(seed):
-    """A pass whose calls all fail must not change what the next pass decides.
+def test_decide_does_not_mutate_the_jobs_it_is_given(seed):
+    """decide reads the world; run_pass is what changes it.
 
-    The permission fail-soft path means actions can silently not happen; the
-    balancer must simply retry the same thing rather than escalate.
+    This is what makes a pass whose calls all fail decide the same thing again
+    rather than escalate. The failure behaviour itself is tested against
+    run_pass, where the applying actually happens.
     """
     rng = random.Random(seed)
     jobs = random_population(rng)
-    first = decide(jobs, LIMITS)
-    assert decide(jobs, LIMITS) == first
+    before = copy.deepcopy(jobs)
+    decide(jobs, LIMITS)
+    assert jobs == before
 
 
 @pytest.mark.parametrize("seed", range(300))

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -14,6 +14,7 @@ pytest.importorskip("beaker", reason="beaker-py is not a core fme dependency")
 
 from balance import (  # noqa: E402
     HIGH,
+    IMMEDIATE,
     LOW,
     NORMAL,
     URGENT,
@@ -39,6 +40,8 @@ def job(
     queued_at=0.0,
     placed_at=None,
     replica_group_size=0,
+    replica_group_id="",
+    is_session=False,
     name="job",
     author="jeremym",
 ):
@@ -56,7 +59,17 @@ def job(
         queued_at=queued_at,
         placed_at=placed_at,
         replica_group_size=replica_group_size,
+        replica_group_id=replica_group_id,
+        is_session=is_session,
     )
+
+
+def group(count=4, group_id="rg-1", **kwargs):
+    """Build the ranks of one replica group, all sharing a spec."""
+    return [
+        job(replica_group_size=count, replica_group_id=group_id, **kwargs)
+        for _ in range(count)
+    ]
 
 
 def placed(**kwargs):
@@ -95,15 +108,42 @@ def charged_clusters(job_view: JobView) -> tuple[str, ...]:
 def usage(jobs, limits=LIMITS) -> dict[str, int]:
     used = dict.fromkeys(limits, 0)
     for job_view in jobs:
-        if job_view.priority == URGENT:
+        # immediate outranks urgent, so it occupies a slot just the same.
+        if job_view.priority in (URGENT, IMMEDIATE):
             for cluster in charged_clusters(job_view):
                 used[cluster] += job_view.slots
     return used
 
 
+def modifiable(jobs, limits=LIMITS) -> set[str]:
+    """Ids of jobs the balancer may change, restated from the rules.
+
+    A rank of a replica group is modifiable only as part of a whole group that
+    is uniformly manageable and entirely present, since the group is granted
+    urgent all-or-nothing.
+    """
+    groups: dict[str, list[JobView]] = {}
+    for j in jobs:
+        key = j.replica_group_id if j.replica_group_size > 1 else j.id
+        groups.setdefault(key or j.id, []).append(j)
+    allowed: set[str] = set()
+    for members in groups.values():
+        if any(m.managed_cluster(limits) is None for m in members):
+            continue
+        if len({m.cm_priority for m in members}) != 1:
+            continue
+        if len({m.clusters[0] for m in members}) != 1:
+            continue
+        if len(members) < max(m.replica_group_size for m in members):
+            continue
+        allowed.update(m.id for m in members)
+    return allowed
+
+
 def unmanaged_charge(jobs, limits=LIMITS) -> dict[str, int]:
-    """Urgent slots held by jobs the balancer cannot modify."""
-    return usage([j for j in jobs if j.managed_cluster(limits) is None], limits)
+    """Allocated slots held by jobs the balancer cannot modify."""
+    allowed = modifiable(jobs, limits)
+    return usage([j for j in jobs if j.id not in allowed], limits)
 
 
 def apply(jobs: list[JobView], actions: list[Action]) -> list[JobView]:
@@ -335,11 +375,96 @@ def test_jobs_on_unbudgeted_clusters_are_left_alone():
     assert decide([saturn], LIMITS) == []
 
 
-def test_replica_group_members_are_not_managed():
-    # Granting urgent to some ranks and not others wastes the slots granted,
-    # and it is unconfirmed whether the priority RPC is per-job or per-source.
-    ranks = [job(cm_priority=HIGH, slots=8, replica_group_size=4) for _ in range(4)]
+# --- replica groups ---------------------------------------------------------
+
+
+def test_replica_group_ranks_are_granted_together():
+    ranks = group(4, cm_priority=HIGH, slots=8)
+    assert changes(decide(ranks, LIMITS)) == {rank.id: URGENT for rank in ranks}
+
+
+def test_a_replica_group_is_granted_all_or_nothing():
+    # 5 x 16 = 80 against 72: four ranks would fit, but a group cannot be split
+    # to fit, so every rank gives up urgent rather than stranding 64 slots on a
+    # job that still cannot start.
+    ranks = group(5, priority=URGENT, cm_priority=HIGH, slots=16)
+    assert changes(decide(ranks, LIMITS)) == {rank.id: HIGH for rank in ranks}
+
+
+def test_a_replica_group_is_charged_as_the_sum_of_its_ranks():
+    big = group(4, group_id="big", cm_priority=HIGH, slots=16)
+    small = job(cm_priority=NORMAL, slots=16)
+    # The 64-slot group wins its level first, leaving 8 — too few for the
+    # 16-slot normal job behind it.
+    result = changes(decide([*big, small], LIMITS))
+    assert result == {**{rank.id: URGENT for rank in big}, small.id: NORMAL}
+
+
+def test_a_replica_group_with_an_unlabelled_rank_is_left_alone():
+    ranks = group(3, cm_priority=HIGH)
+    ranks.append(job(cm_priority=None, replica_group_size=4, replica_group_id="rg-1"))
     assert decide(ranks, LIMITS) == []
+
+
+def test_a_replica_group_whose_ranks_disagree_on_their_label_is_left_alone():
+    ranks = group(3, cm_priority=HIGH)
+    ranks.append(job(cm_priority=LOW, replica_group_size=4, replica_group_id="rg-1"))
+    assert decide(ranks, LIMITS) == []
+
+
+def test_a_partially_visible_replica_group_is_left_alone():
+    # fetch_jobs reads only unfinished jobs in one workspace, so a group can
+    # come back short. Granting the visible ranks would half-grant the real one.
+    assert decide(group(4, group_id="rg-1")[:3], LIMITS) == []
+
+
+def test_a_replica_group_with_a_placed_rank_below_urgent_is_not_promoted():
+    # Beaker cannot raise the placed rank, so granting urgent would split the
+    # group. It is excluded from the walk instead.
+    ranks = [
+        placed(
+            priority=HIGH,
+            cm_priority=URGENT,
+            replica_group_size=2,
+            replica_group_id="rg-1",
+            slots=8,
+        ),
+        job(
+            priority=HIGH,
+            cm_priority=URGENT,
+            replica_group_size=2,
+            replica_group_id="rg-1",
+            slots=8,
+        ),
+    ]
+    contender = job(cm_priority=NORMAL, slots=8)
+    result = changes(decide([*ranks, contender], {"ai2/jupiter": 8}))
+    assert result == {contender.id: URGENT}
+
+
+# --- sessions and immediate priority ----------------------------------------
+
+
+def test_an_interactive_session_is_never_modified():
+    session = job(priority=URGENT, cm_priority=LOW, is_session=True, slots=8)
+    assert decide([session], {"ai2/jupiter": 0}) == []
+
+
+def test_an_interactive_session_still_consumes_the_allocation():
+    session = job(priority=URGENT, cm_priority=None, is_session=True, slots=72)
+    contender = job(priority=URGENT, cm_priority=HIGH, slots=8)
+    assert changes(decide([session, contender], LIMITS)) == {contender.id: HIGH}
+
+
+def test_an_immediate_job_is_never_demoted():
+    urgent_now = job(priority=IMMEDIATE, cm_priority=LOW, slots=8)
+    assert decide([urgent_now], {"ai2/jupiter": 0}) == []
+
+
+def test_an_immediate_job_consumes_the_allocation():
+    urgent_now = job(priority=IMMEDIATE, cm_priority=None, slots=72)
+    contender = job(priority=URGENT, cm_priority=HIGH, slots=8)
+    assert changes(decide([urgent_now, contender], LIMITS)) == {contender.id: HIGH}
 
 
 # --- fitting ----------------------------------------------------------------
@@ -390,9 +515,14 @@ def test_tied_jobs_are_broken_deterministically_by_id():
 
 
 def random_population(rng: random.Random) -> list[JobView]:
+    """Build a random workspace of lone jobs, replica groups and sessions.
+
+    Ranks of a group share a spec but vary in placement, and a group is
+    occasionally emitted short a rank or with one rank's label perturbed, so
+    the uniformly-manageable check is genuinely exercised.
+    """
     jobs = []
-    for _ in range(rng.randint(0, 40)):
-        is_placed = rng.random() < 0.5
+    for index in range(rng.randint(0, 25)):
         clusters = rng.choice(
             [
                 ("ai2/jupiter",),
@@ -402,23 +532,42 @@ def random_population(rng: random.Random) -> list[JobView]:
                 (),  # unconstrained: could land anywhere
             ]
         )
-        # A placed job may be running, or scheduled and still initializing.
-        assigned = None
-        if is_placed and clusters and rng.random() < 0.9:
-            assigned = rng.choice(clusters)
-        jobs.append(
-            job(
-                priority=rng.choice([LOW, NORMAL, HIGH, URGENT]),
-                cm_priority=rng.choice([None, LOW, NORMAL, HIGH, URGENT]),
-                slots=rng.choice([1, 2, 4, 8, 16, 40]),
-                clusters=clusters,
-                is_placed=is_placed,
-                assigned_cluster=assigned,
-                placed_at=float(rng.randint(1, 10_000)) if is_placed else None,
-                queued_at=float(rng.randint(1, 100)),  # ties are common
-                replica_group_size=rng.choice([0, 0, 0, 4]),
+        size = rng.choice([0, 0, 0, 4])
+        shared = {
+            "cm_priority": rng.choice([None, LOW, NORMAL, HIGH, URGENT]),
+            "slots": rng.choice([1, 2, 4, 8, 16, 40]),
+            "clusters": clusters,
+            "replica_group_size": size,
+            "replica_group_id": f"rg-{index}" if size else "",
+            "is_session": rng.random() < 0.1,
+        }
+        priority = rng.choice([LOW, NORMAL, HIGH, URGENT, IMMEDIATE])
+        ranks = max(1, size)
+        if size and rng.random() < 0.2:
+            ranks -= 1  # a group we can only partly see
+        for rank in range(ranks):
+            is_placed = rng.random() < 0.5
+            # A placed job may be running, or scheduled and still initializing.
+            assigned = None
+            if is_placed and clusters and rng.random() < 0.9:
+                assigned = rng.choice(clusters)
+            overrides = {}
+            if size and rank == 0 and rng.random() < 0.15:
+                overrides["cm_priority"] = rng.choice([None, LOW, URGENT])
+            jobs.append(
+                job(
+                    **{**shared, **overrides},
+                    priority=(
+                        rng.choice([LOW, NORMAL, HIGH, URGENT, IMMEDIATE])
+                        if rng.random() < 0.15
+                        else priority
+                    ),
+                    is_placed=is_placed,
+                    assigned_cluster=assigned,
+                    placed_at=float(rng.randint(1, 10_000)) if is_placed else None,
+                    queued_at=float(rng.randint(1, 100)),  # ties are common
+                )
             )
-        )
     return jobs
 
 
@@ -487,10 +636,44 @@ def test_only_labelled_manageable_jobs_are_ever_modified(seed):
     for action in decide(jobs, LIMITS):
         assert action.job.cm_priority is not None
         assert action.job.managed_cluster(LIMITS) is not None
-        assert action.job.replica_group_size <= 1
+        assert action.job.id in modifiable(jobs)
+        assert not action.job.is_session
+        assert action.from_priority != IMMEDIATE
+        assert action.to_priority != IMMEDIATE
         # Beaker refuses to raise a placed job; we must never try.
         if action.job.is_placed:
             assert action.to_priority < action.from_priority
+
+
+def half_urgent(members) -> bool:
+    holders = sum(1 for member in members if member.priority == URGENT)
+    return 0 < holders < len(members)
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_a_replica_group_never_half_holds_urgent(seed):
+    """The guarantee group granularity exists for.
+
+    A group holding urgent on only some ranks cannot start until every rank is
+    placed, so it waits at the priority of its lowest rank while the granted
+    ranks hold slots the allocation has already spent.
+
+    Splits *below* urgent are left alone deliberately: they cost the allocation
+    nothing, and raising a queued rank whose siblings are stuck at a lower
+    priority is what gets the group placed.
+    """
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    after = {j.id: j for j in apply(jobs, decide(jobs, LIMITS))}
+    groups: dict[str, list[JobView]] = {}
+    for j in jobs:
+        if j.replica_group_size > 1 and j.replica_group_id:
+            groups.setdefault(j.replica_group_id, []).append(j)
+    for group_id, members in groups.items():
+        if half_urgent(members):
+            continue  # the balancer did not create this, and may not own it
+        settled = [after[m.id] for m in members]
+        assert not half_urgent(settled), f"{group_id} was left half-urgent"
 
 
 @pytest.mark.parametrize("seed", range(300))
@@ -509,17 +692,26 @@ def test_random_population_reaches_the_states_that_matter():
         "unconstrained": 0,
         "initializing": 0,
         "replica": 0,
+        "replica_managed": 0,
+        "session": 0,
+        "immediate": 0,
         "demotion": 0,
         "promotion": 0,
         "over_before": 0,
     }
     for seed in range(300):
         jobs = random_population(random.Random(seed))
+        allowed = modifiable(jobs)
         seen["unconstrained"] += sum(1 for j in jobs if not j.clusters)
         seen["initializing"] += sum(
             1 for j in jobs if j.is_placed and j.assigned_cluster is None
         )
         seen["replica"] += sum(1 for j in jobs if j.replica_group_size > 1)
+        seen["replica_managed"] += sum(
+            1 for j in jobs if j.replica_group_size > 1 and j.id in allowed
+        )
+        seen["session"] += sum(1 for j in jobs if j.is_session)
+        seen["immediate"] += sum(1 for j in jobs if j.priority == IMMEDIATE)
         actions = decide(jobs, LIMITS)
         seen["demotion"] += sum(1 for a in actions if a.is_demotion)
         seen["promotion"] += sum(1 for a in actions if not a.is_demotion)

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -129,11 +129,11 @@ def modifiable(jobs, limits=LIMITS) -> set[str]:
         groups.setdefault(key or j.id, []).append(j)
     allowed: set[str] = set()
     for members in groups.values():
-        if any(m.managed_cluster(limits) is None for m in members):
+        if any(m.unmanaged_reason(limits) is not None for m in members):
             continue
         if len({m.cm_priority for m in members}) != 1:
             continue
-        # Ranks must agree on the cluster their slots are charged to -- which
+        # Ranks must agree on the clusters their slots are charged to -- which
         # for a placed rank is the one it landed on, not what it was submitted
         # eligible for. A group split across clusters cannot be granted
         # coherently: its slots come out of two different budgets.
@@ -290,9 +290,41 @@ def test_placed_non_urgent_job_does_not_displace_others():
 # --- accounting -------------------------------------------------------------
 
 
-def test_multi_cluster_jobs_are_never_modified():
-    both = job(clusters=("ai2/titan", "ai2/jupiter"), cm_priority=URGENT)
-    assert decide([both], LIMITS) == []
+def test_a_queued_multi_cluster_job_is_promoted_when_both_clusters_have_room():
+    both = job(clusters=("ai2/titan", "ai2/jupiter"), cm_priority=HIGH)
+    result = changes(decide([both], LIMITS))
+    assert result == {both.id: URGENT}
+
+
+def test_a_queued_multi_cluster_job_is_not_promoted_when_one_cluster_is_full():
+    both = job(clusters=("ai2/titan", "ai2/jupiter"), cm_priority=HIGH, slots=8)
+    hog = job(priority=URGENT, cm_priority=None, slots=32, clusters=("ai2/titan",))
+    result = decide([both, hog], LIMITS)
+    assert result == []
+
+
+def test_a_queued_multi_cluster_urgent_job_is_demoted_from_both_clusters():
+    both = job(
+        priority=URGENT,
+        cm_priority=LOW,
+        slots=8,
+        clusters=("ai2/titan", "ai2/jupiter"),
+    )
+    result = changes(decide([both], {"ai2/jupiter": 0, "ai2/titan": 0}))
+    assert result == {both.id: LOW}
+
+
+def test_promoting_a_queued_multi_cluster_job_charges_both_clusters():
+    both = job(
+        cm_priority=HIGH,
+        slots=32,
+        clusters=("ai2/titan", "ai2/jupiter"),
+    )
+    on_titan = job(cm_priority=NORMAL, slots=8, clusters=("ai2/titan",))
+    result = changes(decide([both, on_titan], LIMITS))
+    # both takes 32 from titan (fills it) and 32 from jupiter; on_titan doesn't
+    # fit on titan anymore.
+    assert result == {both.id: URGENT, on_titan.id: NORMAL}
 
 
 def test_queued_multi_cluster_urgent_job_counts_against_every_cluster():
@@ -334,7 +366,7 @@ def test_placed_job_with_unresolvable_cluster_is_not_managed():
         placed_at=100.0,
         slots=8,
     )
-    assert unknown.managed_cluster(LIMITS) is None
+    assert unknown.managed_clusters(LIMITS) is None
     assert decide([unknown], LIMITS) == []
 
 
@@ -347,7 +379,7 @@ def test_placed_job_on_its_pinned_cluster_is_managed():
         placed_at=100.0,
         slots=8,
     )
-    assert on_titan.managed_cluster(LIMITS) == "ai2/titan"
+    assert on_titan.managed_clusters(LIMITS) == ("ai2/titan",)
 
 
 def test_assigned_multi_cluster_job_counts_only_where_it_landed():
@@ -735,7 +767,7 @@ def test_only_labelled_manageable_jobs_are_ever_modified(seed):
     jobs = random_population(rng)
     for action in decide(jobs, LIMITS):
         assert action.job.cm_priority is not None
-        assert action.job.managed_cluster(LIMITS) is not None
+        assert action.job.managed_clusters(LIMITS) is not None
         assert action.job.id in modifiable(jobs)
         assert not action.job.is_session
         assert action.from_priority != IMMEDIATE
@@ -816,6 +848,10 @@ def test_the_allocation_is_not_left_unspent(seed):
     balancer that granted nothing at all would satisfy them. This asserts the
     walk is maximal: any candidate group left below urgent was left there
     because it did not fit in what remained, not because it was overlooked.
+
+    A multi-cluster group must fit on *every* cluster it could land on: the
+    pessimistic grant commits the allocation on each. So a group left out needs
+    only one cluster too tight to justify it.
     """
     rng = random.Random(seed)
     jobs = random_population(rng)
@@ -824,12 +860,12 @@ def test_the_allocation_is_not_left_unspent(seed):
     for key, members in grantable_groups(jobs).items():
         if all(after[m.id].priority == URGENT for m in members):
             continue
-        cluster = members[0].clusters[0]
+        clusters = charged_clusters(members[0])
         slots = sum(m.slots for m in members)
-        headroom = LIMITS[cluster] - used[cluster]
-        assert (
-            slots > headroom
-        ), f"{key} needed {slots} on {cluster} and {headroom} were left unspent"
+        assert any(slots > LIMITS[c] - used[c] for c in clusters), (
+            f"{key} needed {slots} on {clusters} and all had room: "
+            + ", ".join(f"{c}={LIMITS[c] - used[c]}" for c in clusters)
+        )
 
 
 def test_random_population_reaches_the_states_that_matter():
@@ -839,6 +875,7 @@ def test_random_population_reaches_the_states_that_matter():
         "initializing": 0,
         "replica": 0,
         "replica_managed": 0,
+        "multi_cluster_managed": 0,
         "session": 0,
         "immediate": 0,
         "demotion": 0,
@@ -855,6 +892,9 @@ def test_random_population_reaches_the_states_that_matter():
         seen["replica"] += sum(1 for j in jobs if j.replica_group_size > 1)
         seen["replica_managed"] += sum(
             1 for j in jobs if j.replica_group_size > 1 and j.id in allowed
+        )
+        seen["multi_cluster_managed"] += sum(
+            1 for j in jobs if len(j.clusters) > 1 and j.id in allowed
         )
         seen["session"] += sum(1 for j in jobs if j.is_session)
         seen["immediate"] += sum(1 for j in jobs if j.priority == IMMEDIATE)
@@ -881,7 +921,7 @@ def test_a_placed_job_is_managed_against_the_cluster_it_landed_on():
         assigned_cluster="ai2/jupiter",
     )
     assert running.budget_clusters(LIMITS) == ("ai2/jupiter",)
-    assert running.managed_cluster(LIMITS) == "ai2/jupiter"
+    assert running.managed_clusters(LIMITS) == ("ai2/jupiter",)
     assert changes(decide([running], {"ai2/jupiter": 0, "ai2/titan": 32})) == {
         running.id: NORMAL
     }
@@ -902,14 +942,13 @@ def test_a_placed_multi_cluster_job_can_be_displaced_by_a_queued_one():
     assert result == {holder.id: NORMAL, contender.id: URGENT}
 
 
-def test_a_queued_multi_cluster_job_is_still_left_alone():
-    # Beaker offers no way to pin a queued job, so which allocation it will
-    # consume is genuinely unknowable.
+def test_a_queued_multi_cluster_job_is_managed_pessimistically():
     queued = job(
         priority=URGENT, cm_priority=LOW, clusters=("ai2/titan", "ai2/jupiter")
     )
-    assert queued.managed_cluster(LIMITS) is None
-    assert decide([queued], {"ai2/jupiter": 0, "ai2/titan": 0}) == []
+    assert queued.managed_clusters(LIMITS) == ("ai2/titan", "ai2/jupiter")
+    result = changes(decide([queued], {"ai2/jupiter": 0, "ai2/titan": 0}))
+    assert result == {queued.id: LOW}
 
 
 def test_a_placed_job_on_an_unbudgeted_cluster_is_left_alone():
@@ -919,7 +958,7 @@ def test_a_placed_job_on_an_unbudgeted_cluster_is_left_alone():
         clusters=("ai2/saturn", "ai2/jupiter"),
         assigned_cluster="ai2/saturn",
     )
-    assert stray.managed_cluster(LIMITS) is None
+    assert stray.managed_clusters(LIMITS) is None
     assert decide([stray], LIMITS) == []
 
 
@@ -935,7 +974,7 @@ def test_a_placed_job_whose_node_is_unresolved_is_still_left_alone():
         placed_at=100.0,
     )
     assert unresolved.budget_clusters(LIMITS) == BUDGETED
-    assert unresolved.managed_cluster(LIMITS) is None
+    assert unresolved.managed_clusters(LIMITS) is None
     assert decide([unresolved], {"ai2/jupiter": 0, "ai2/titan": 0}) == []
 
 

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -22,7 +22,6 @@ from balance import (  # noqa: E402
     Action,
     JobView,
     decide,
-    remember_priorities,
     resting_priority,
 )
 
@@ -160,70 +159,10 @@ def apply(jobs: list[JobView], actions: list[Action]) -> list[JobView]:
 # --- resting priority -------------------------------------------------------
 
 
-def test_a_job_below_urgent_is_already_resting():
-    # Whatever it is at now is what its owner last chose, so there is nothing
-    # to remember and nothing to restore.
-    for priority in (LOW, NORMAL, HIGH):
-        assert resting_priority(job(priority=priority), {}) == priority
-
-
-def test_a_job_at_urgent_rests_where_it_was_last_seen():
-    raised = job(priority=URGENT)
-    assert resting_priority(raised, {raised.id: NORMAL}) == NORMAL
-
-
-def test_an_unremembered_urgent_job_falls_back_to_high():
-    # Submitted at urgent, or first seen there after the memory was lost.
-    # Resting at urgent would defeat the allocation.
-    assert resting_priority(job(priority=URGENT), {}) == HIGH
-
-
-def test_a_manual_change_becomes_the_new_resting_priority():
-    # The owner moved the job by hand since the last pass. It is below urgent,
-    # so what they chose wins over anything remembered from before.
-    edited = job(priority=LOW)
-    assert resting_priority(edited, {edited.id: HIGH}) == LOW
-
-
-# --- what is carried between passes -----------------------------------------
-
-
-def test_only_jobs_at_urgent_need_remembering():
-    resting = job(priority=NORMAL)
-    raised = job(priority=URGENT)
-    assert remember_priorities([resting, raised], {raised.id: LOW}) == {
-        resting.id: NORMAL,
-        raised.id: LOW,
-    }
-
-
-def test_an_unlabelled_job_is_not_remembered():
-    # The balancer never modifies it, so it never has to restore it either.
-    assert remember_priorities([job(priority=NORMAL, cm_priority=None)], {}) == {}
-
-
-def test_a_finished_job_is_forgotten():
-    # Jobs are evicted by simply not appearing in the pass that carries them.
-    gone = job(priority=URGENT)
-    assert remember_priorities([], {gone.id: LOW}) == {}
-
-
-def test_a_requeued_job_inherits_what_its_ancestor_rested_at():
-    # Preemption gives the job a new id, and Beaker hands it back at the
-    # priority the balancer set on its source rather than the submitted one.
-    # Without this the job would ratchet up to the high fallback every time it
-    # was preempted.
-    original = job(priority=URGENT)
-    requeued = replace(job(priority=URGENT), retry_ancestor_id=original.id)
-    carried = remember_priorities([requeued], {original.id: LOW})
-    assert carried == {requeued.id: LOW}
-
-
-def test_a_remembered_job_is_not_overwritten_by_its_ancestor():
-    original = job(priority=URGENT)
-    requeued = replace(job(priority=URGENT), retry_ancestor_id=original.id)
-    carried = remember_priorities([requeued], {original.id: LOW, requeued.id: NORMAL})
-    assert carried == {requeued.id: NORMAL}
+def test_resting_priority_drops_urgent_to_high():
+    assert resting_priority(URGENT) == HIGH
+    assert resting_priority(HIGH) == HIGH
+    assert resting_priority(LOW) == LOW
 
 
 # --- promotion --------------------------------------------------------------
@@ -252,18 +191,9 @@ def test_higher_cm_priority_is_granted_first():
 
 
 def test_job_is_moved_to_its_resting_priority_when_not_granted():
-    raised = job(priority=URGENT, cm_priority=LOW, slots=8)
+    mislabelled = job(priority=HIGH, cm_priority=LOW, slots=8)
     hog = job(priority=URGENT, cm_priority=None, slots=72)
-    result = changes(decide([hog, raised], LIMITS, {raised.id: LOW}))
-    assert result == {raised.id: LOW}
-
-
-def test_a_job_that_is_not_granted_and_not_at_urgent_is_left_alone():
-    # It is already resting. Under a label-derived resting priority this job
-    # would be dragged to NORMAL for no gain to the allocation.
-    settled = job(priority=HIGH, cm_priority=NORMAL, slots=8)
-    hog = job(priority=URGENT, cm_priority=None, slots=72)
-    assert decide([hog, settled], LIMITS) == []
+    assert changes(decide([hog, mislabelled], LIMITS)) == {mislabelled.id: LOW}
 
 
 @pytest.mark.parametrize("cm_priority", [LOW, NORMAL, HIGH, URGENT])
@@ -278,7 +208,7 @@ def test_any_labelled_job_can_be_granted_an_urgent_slot(cm_priority):
 def test_over_allocation_demotes_lowest_cm_priority_first():
     keep = placed(priority=URGENT, cm_priority=HIGH, slots=64)
     drop = placed(priority=URGENT, cm_priority=LOW, slots=8)
-    result = changes(decide([keep, drop], {"ai2/jupiter": 64}, {drop.id: LOW}))
+    result = changes(decide([keep, drop], {"ai2/jupiter": 64}))
     assert result == {drop.id: LOW}
 
 
@@ -303,17 +233,9 @@ def test_longest_queued_job_is_promoted_first():
     assert result == {old.id: URGENT}
 
 
-def test_a_demoted_job_returns_to_where_it_was_raised_from():
-    over = placed(priority=URGENT, cm_priority=HIGH, slots=8)
-    result = changes(decide([over], {"ai2/jupiter": 0}, {over.id: LOW}))
-    assert result == {over.id: LOW}
-
-
-def test_a_demoted_job_with_nothing_remembered_falls_back_to_high():
-    # Either submitted at urgent, or first seen there after the memory was
-    # lost. Its owner never chose anything lower for us to put it back to.
+def test_demoted_job_returns_to_its_own_label_not_to_high():
     over = placed(priority=URGENT, cm_priority=LOW, slots=8)
-    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: HIGH}
+    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: LOW}
 
 
 def test_demotions_are_ordered_before_promotions():
@@ -476,8 +398,7 @@ def test_a_replica_group_is_charged_as_the_sum_of_its_ranks():
     # The 64-slot group wins its level first, leaving 8 — too few for the
     # 16-slot normal job behind it.
     result = changes(decide([*big, small], LIMITS))
-    # The normal job is left where it is: it is already resting below urgent.
-    assert result == {rank.id: URGENT for rank in big}
+    assert result == {**{rank.id: URGENT for rank in big}, small.id: NORMAL}
 
 
 def test_a_replica_group_with_an_unlabelled_rank_is_left_alone():
@@ -595,21 +516,15 @@ def test_a_group_holds_its_slots_from_its_earliest_rank():
 # --- what a change is reported as -------------------------------------------
 
 
-@pytest.mark.parametrize("seed", range(300))
-def test_every_change_moves_a_job_onto_or_off_an_urgent_slot(seed):
-    # The balancer's whole remit. A job resting below urgent is left where its
-    # owner put it, so there is no third kind of change -- which is also why
-    # the reason a change is logged under can be read off the movement alone.
-    rng = random.Random(seed)
-    jobs = random_population(rng)
-    remembered = {
-        j.id: rng.choice([LOW, NORMAL, HIGH]) for j in jobs if rng.random() < 0.5
-    }
-    for action in decide(jobs, LIMITS, remembered):
-        assert action.takes_slots != action.frees_slots
-        assert action.reason == (
-            "grant urgent slot" if action.takes_slots else "release urgent slot"
-        )
+def test_a_job_raised_to_its_label_is_not_reported_as_releasing_a_slot():
+    # A queued job submitted below its CM_PRIORITY is raised to it even when it
+    # is granted nothing. The log is the only window on a cron process, so it
+    # must not claim an urgent slot changed hands.
+    hog = job(priority=URGENT, cm_priority=None, slots=72)
+    below = job(priority=LOW, cm_priority=HIGH, slots=8)
+    (action,) = decide([hog, below], LIMITS)
+    assert (action.from_priority, action.to_priority) == (LOW, HIGH)
+    assert action.reason == "settle at resting priority"
 
 
 def test_granting_and_releasing_are_reported_as_such():
@@ -666,8 +581,7 @@ def test_a_blocked_level_does_not_reserve_slots_for_itself():
 def test_higher_level_job_displaces_lower_level_urgent_jobs():
     holders = [placed(priority=URGENT, cm_priority=NORMAL, slots=4) for _ in range(2)]
     contender = job(cm_priority=HIGH, slots=8)
-    remembered = {holder.id: NORMAL for holder in holders}
-    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}, remembered))
+    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}))
     assert result == {
         holders[0].id: NORMAL,
         holders[1].id: NORMAL,
@@ -859,17 +773,13 @@ def test_a_replica_group_never_half_holds_urgent(seed):
 
 
 @pytest.mark.parametrize("seed", range(300))
-def test_a_job_is_only_ever_left_at_urgent_or_where_it_was_resting(seed):
+def test_a_job_is_never_left_above_urgent_or_below_its_label(seed):
     rng = random.Random(seed)
     jobs = random_population(rng)
-    remembered = {
-        j.id: rng.choice([LOW, NORMAL, HIGH]) for j in jobs if rng.random() < 0.5
-    }
-    for action in decide(jobs, LIMITS, remembered):
-        assert action.job.cm_priority is not None
-        assert action.to_priority in (URGENT, resting_priority(action.job, remembered))
-        # Nothing is ever left at immediate, which only a human hands out.
-        assert action.to_priority != IMMEDIATE
+    for action in decide(jobs, LIMITS):
+        cm_priority = action.job.cm_priority
+        assert cm_priority is not None
+        assert action.to_priority in (URGENT, resting_priority(cm_priority))
 
 
 def grantable_groups(jobs, limits=LIMITS) -> dict[str, list[JobView]]:

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -133,7 +133,11 @@ def modifiable(jobs, limits=LIMITS) -> set[str]:
             continue
         if len({m.cm_priority for m in members}) != 1:
             continue
-        if len({m.clusters[0] for m in members}) != 1:
+        # Ranks must agree on the cluster their slots are charged to -- which
+        # for a placed rank is the one it landed on, not what it was submitted
+        # eligible for. A group split across clusters cannot be granted
+        # coherently: its slots come out of two different budgets.
+        if len({charged_clusters(m) for m in members}) != 1:
             continue
         if len(members) < max(m.replica_group_size for m in members):
             continue
@@ -861,3 +865,102 @@ def test_random_population_reaches_the_states_that_matter():
         seen["over_before"] += any(before[c] > LIMITS[c] for c in LIMITS)
     for state, count in seen.items():
         assert count > 10, f"{state} only reached {count} times"
+
+
+# --- a placed job is pinned to the cluster it landed on ----------------------
+
+
+def test_a_placed_job_is_managed_against_the_cluster_it_landed_on():
+    # Submitted eligible for both, now running on jupiter. It is charged to
+    # jupiter alone, so it is jupiter's to reclaim.
+    running = placed(
+        priority=URGENT,
+        cm_priority=NORMAL,
+        slots=8,
+        clusters=("ai2/titan", "ai2/jupiter"),
+        assigned_cluster="ai2/jupiter",
+    )
+    assert running.budget_clusters(LIMITS) == ("ai2/jupiter",)
+    assert running.managed_cluster(LIMITS) == "ai2/jupiter"
+    assert changes(decide([running], {"ai2/jupiter": 0, "ai2/titan": 32})) == {
+        running.id: NORMAL
+    }
+
+
+def test_a_placed_multi_cluster_job_can_be_displaced_by_a_queued_one():
+    # The reclaim path this unlocks: without it the queued job waits forever
+    # behind slots the balancer could see but not take back.
+    holder = placed(
+        priority=URGENT,
+        cm_priority=NORMAL,
+        slots=8,
+        clusters=("ai2/titan", "ai2/jupiter"),
+        assigned_cluster="ai2/jupiter",
+    )
+    contender = job(cm_priority=HIGH, slots=8, clusters=("ai2/jupiter",))
+    result = changes(decide([holder, contender], {"ai2/jupiter": 8}))
+    assert result == {holder.id: NORMAL, contender.id: URGENT}
+
+
+def test_a_queued_multi_cluster_job_is_still_left_alone():
+    # Beaker offers no way to pin a queued job, so which allocation it will
+    # consume is genuinely unknowable.
+    queued = job(
+        priority=URGENT, cm_priority=LOW, clusters=("ai2/titan", "ai2/jupiter")
+    )
+    assert queued.managed_cluster(LIMITS) is None
+    assert decide([queued], {"ai2/jupiter": 0, "ai2/titan": 0}) == []
+
+
+def test_a_placed_job_on_an_unbudgeted_cluster_is_left_alone():
+    stray = placed(
+        priority=URGENT,
+        cm_priority=HIGH,
+        clusters=("ai2/saturn", "ai2/jupiter"),
+        assigned_cluster="ai2/saturn",
+    )
+    assert stray.managed_cluster(LIMITS) is None
+    assert decide([stray], LIMITS) == []
+
+
+def test_a_placed_job_whose_node_is_unresolved_is_still_left_alone():
+    # Charged to every budget as a precaution, so managing it against one would
+    # hand out slots the accounting had spent on both.
+    unresolved = job(
+        priority=URGENT,
+        cm_priority=HIGH,
+        clusters=("ai2/titan", "ai2/jupiter"),
+        is_placed=True,
+        assigned_cluster=None,
+        placed_at=100.0,
+    )
+    assert unresolved.budget_clusters(LIMITS) == BUDGETED
+    assert unresolved.managed_cluster(LIMITS) is None
+    assert decide([unresolved], {"ai2/jupiter": 0, "ai2/titan": 0}) == []
+
+
+def test_a_replica_group_split_across_clusters_is_left_alone():
+    # Its slots come out of two budgets at once, so it cannot be granted or
+    # reclaimed coherently as one group.
+    ranks = group(2, group_id="split", cm_priority=HIGH, slots=8, priority=URGENT)
+    ranks = [
+        replace(rank, is_placed=True, placed_at=100.0, assigned_cluster=cluster)
+        for rank, cluster in zip(ranks, ("ai2/jupiter", "ai2/titan"))
+    ]
+    assert decide(ranks, {"ai2/jupiter": 0, "ai2/titan": 0}) == []
+
+
+def test_a_replica_group_placed_on_one_cluster_is_managed():
+    ranks = group(
+        2,
+        group_id="together",
+        cm_priority=NORMAL,
+        slots=8,
+        priority=URGENT,
+        clusters=("ai2/titan", "ai2/jupiter"),
+    )
+    ranks = [
+        replace(rank, is_placed=True, placed_at=100.0, assigned_cluster="ai2/jupiter")
+        for rank in ranks
+    ]
+    assert changes(decide(ranks, {"ai2/jupiter": 0})) == {r.id: NORMAL for r in ranks}

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -1,28 +1,30 @@
 """Tests for the balancer's decision logic.
 
 These exercise ``decide`` against constructed job lists, so no Beaker calls are
-made.
+made. The Beaker-facing layer is covered in ``test_beaker_io.py``.
 """
 
 import itertools
 import random
 from dataclasses import replace
-from types import SimpleNamespace
 
 import pytest
-from balance import (
+
+pytest.importorskip("beaker", reason="beaker-py is not a core fme dependency")
+
+from balance import (  # noqa: E402
     HIGH,
     LOW,
     NORMAL,
     URGENT,
     Action,
     JobView,
-    _cluster_of_node,
     decide,
     resting_priority,
 )
 
 LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
+BUDGETED = tuple(LIMITS)
 
 _ids = itertools.count()
 
@@ -33,14 +35,16 @@ def job(
     slots=8,
     clusters=("ai2/jupiter",),
     assigned_cluster=None,
+    is_placed=False,
     queued_at=0.0,
-    started_at=None,
+    placed_at=None,
+    replica_group_size=0,
     name="job",
     author="jeremym",
 ):
     """Build a JobView, defaulting to a queued 8-GPU jupiter job."""
     return JobView(
-        id=f"job-{next(_ids)}",
+        id=f"job-{next(_ids):04d}",
         name=name,
         author=author,
         priority=priority,
@@ -48,15 +52,18 @@ def job(
         clusters=clusters,
         assigned_cluster=assigned_cluster,
         cm_priority=cm_priority,
+        is_placed=is_placed,
         queued_at=queued_at,
-        started_at=started_at,
+        placed_at=placed_at,
+        replica_group_size=replica_group_size,
     )
 
 
-def running(**kwargs):
-    """A job that has landed on a node, and so cannot be promoted."""
-    kwargs.setdefault("started_at", 100.0)
+def placed(**kwargs):
+    """A job Beaker has put on a node, and so will not raise the priority of."""
+    kwargs.setdefault("placed_at", 100.0)
     kwargs.setdefault("assigned_cluster", kwargs.get("clusters", ("ai2/jupiter",))[0])
+    kwargs["is_placed"] = True
     return job(**kwargs)
 
 
@@ -64,10 +71,60 @@ def changes(actions: list[Action]) -> dict[str, int]:
     return {action.job.id: action.to_priority for action in actions}
 
 
+# --- an oracle written independently of the production accounting ------------
+
+
+def charged_clusters(job_view: JobView) -> tuple[str, ...]:
+    """Which budgets a job's urgent slots land on, derived from first principles.
+
+    Deliberately does not call ``JobView.budget_clusters``: an oracle that reuses
+    the code under test cannot catch a bug in that code.
+    """
+    if job_view.is_placed:
+        if job_view.assigned_cluster is None:
+            return BUDGETED  # landed somewhere we could not identify
+        if job_view.assigned_cluster in LIMITS:
+            return (job_view.assigned_cluster,)
+        return ()  # landed on a cluster we have no allocation on
+    eligible = tuple(c for c in job_view.clusters if c in LIMITS)
+    if not job_view.clusters:
+        return BUDGETED  # unconstrained: could land anywhere
+    return eligible
+
+
+def usage(jobs, limits=LIMITS) -> dict[str, int]:
+    used = dict.fromkeys(limits, 0)
+    for job_view in jobs:
+        if job_view.priority == URGENT:
+            for cluster in charged_clusters(job_view):
+                used[cluster] += job_view.slots
+    return used
+
+
+def unmanaged_charge(jobs, limits=LIMITS) -> dict[str, int]:
+    """Urgent slots held by jobs the balancer cannot modify."""
+    return usage([j for j in jobs if j.managed_cluster(limits) is None], limits)
+
+
+def apply(jobs: list[JobView], actions: list[Action]) -> list[JobView]:
+    """Return the job list as it would be after the actions are applied."""
+    new_priority = {action.job.id: action.to_priority for action in actions}
+    return [
+        replace(j, priority=new_priority[j.id]) if j.id in new_priority else j
+        for j in jobs
+    ]
+
+
+# --- resting priority -------------------------------------------------------
+
+
 def test_resting_priority_drops_urgent_to_high():
     assert resting_priority(URGENT) == HIGH
     assert resting_priority(HIGH) == HIGH
     assert resting_priority(LOW) == LOW
+
+
+# --- promotion --------------------------------------------------------------
 
 
 def test_queued_jobs_are_promoted_to_fill_the_allocation():
@@ -93,30 +150,37 @@ def test_higher_cm_priority_is_granted_first():
 
 
 def test_job_is_moved_to_its_resting_priority_when_not_granted():
-    # "own it fully": a labelled job sits at its own label, whatever it was
-    # submitted at, once it is clear it will not get an urgent slot.
     mislabelled = job(priority=HIGH, cm_priority=LOW, slots=8)
     hog = job(priority=URGENT, cm_priority=None, slots=72)
     assert changes(decide([hog, mislabelled], LIMITS)) == {mislabelled.id: LOW}
 
 
+@pytest.mark.parametrize("cm_priority", [LOW, NORMAL, HIGH, URGENT])
+def test_any_labelled_job_can_be_granted_an_urgent_slot(cm_priority):
+    queued = job(cm_priority=cm_priority)
+    assert changes(decide([queued], LIMITS)) == {queued.id: URGENT}
+
+
+# --- demotion ---------------------------------------------------------------
+
+
 def test_over_allocation_demotes_lowest_cm_priority_first():
-    keep = running(priority=URGENT, cm_priority=HIGH, slots=64)
-    drop = running(priority=URGENT, cm_priority=LOW, slots=8)
+    keep = placed(priority=URGENT, cm_priority=HIGH, slots=64)
+    drop = placed(priority=URGENT, cm_priority=LOW, slots=8)
     result = changes(decide([keep, drop], {"ai2/jupiter": 64}))
     assert result == {drop.id: LOW}
 
 
-def test_queued_jobs_are_demoted_before_running_ones_at_the_same_level():
+def test_queued_jobs_are_demoted_before_placed_ones_at_the_same_level():
     still_queued = job(priority=URGENT, cm_priority=HIGH, slots=8)
-    on_gpu = running(priority=URGENT, cm_priority=HIGH, slots=8)
+    on_gpu = placed(priority=URGENT, cm_priority=HIGH, slots=8)
     result = changes(decide([still_queued, on_gpu], {"ai2/jupiter": 8}))
     assert result == {still_queued.id: HIGH}
 
 
-def test_longest_running_job_is_demoted_first():
-    old = running(priority=URGENT, cm_priority=HIGH, slots=8, started_at=100.0)
-    new = running(priority=URGENT, cm_priority=HIGH, slots=8, started_at=900.0)
+def test_longest_placed_job_is_demoted_first():
+    old = placed(priority=URGENT, cm_priority=HIGH, slots=8, placed_at=100.0)
+    new = placed(priority=URGENT, cm_priority=HIGH, slots=8, placed_at=900.0)
     result = changes(decide([old, new], {"ai2/jupiter": 8}))
     assert result == {old.id: HIGH}
 
@@ -128,24 +192,57 @@ def test_longest_queued_job_is_promoted_first():
     assert result == {old.id: URGENT}
 
 
-def test_running_job_is_never_promoted():
-    # Beaker rejects raising the priority of a running job.
-    on_gpu = running(priority=HIGH, cm_priority=URGENT)
+def test_demoted_job_returns_to_its_own_label_not_to_high():
+    over = placed(priority=URGENT, cm_priority=LOW, slots=8)
+    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: LOW}
+
+
+def test_demotions_are_ordered_before_promotions():
+    # A partially applied pass must never sit over allocation, so the demotion
+    # paying for a promotion has to be attempted first.
+    holder = placed(priority=URGENT, cm_priority=NORMAL, slots=8)
+    contender = job(cm_priority=HIGH, slots=8)
+    actions = decide([contender, holder], {"ai2/jupiter": 8})
+    assert [a.is_demotion for a in actions] == [True, False]
+
+
+# --- placement and promotability --------------------------------------------
+
+
+def test_placed_job_is_never_promoted():
+    # Beaker rejects raising the priority of a job it has already placed.
+    on_gpu = placed(priority=HIGH, cm_priority=URGENT)
     assert decide([on_gpu], LIMITS) == []
 
 
-def test_running_job_below_its_resting_priority_is_left_alone():
-    on_gpu = running(priority=NORMAL, cm_priority=HIGH)
+def test_placed_job_below_its_resting_priority_is_left_alone():
+    on_gpu = placed(priority=NORMAL, cm_priority=HIGH)
     assert decide([on_gpu], LIMITS) == []
 
 
-def test_running_non_urgent_job_does_not_displace_others():
-    # The urgent-labelled running job cannot be promoted, so it must not push
-    # the queued job out of the allocation.
-    blocked = running(priority=HIGH, cm_priority=URGENT, slots=8)
+def test_scheduled_but_not_started_job_is_not_treated_as_queued():
+    # A job Beaker has scheduled is initializing: it already holds its slots and
+    # Beaker already refuses to raise it, so promoting it would both double-count
+    # the slots and emit a call that fails on every pass.
+    initializing = job(
+        priority=HIGH,
+        cm_priority=URGENT,
+        is_placed=True,
+        assigned_cluster="ai2/jupiter",
+        placed_at=500.0,
+    )
+    assert initializing.is_queued is False
+    assert decide([initializing], LIMITS) == []
+
+
+def test_placed_non_urgent_job_does_not_displace_others():
+    blocked = placed(priority=HIGH, cm_priority=URGENT, slots=8)
     queued = job(cm_priority=NORMAL, slots=8)
     result = changes(decide([blocked, queued], {"ai2/jupiter": 8}))
     assert result == {queued.id: URGENT}
+
+
+# --- accounting -------------------------------------------------------------
 
 
 def test_multi_cluster_jobs_are_never_modified():
@@ -157,13 +254,59 @@ def test_queued_multi_cluster_urgent_job_counts_against_every_cluster():
     both = job(priority=URGENT, cm_priority=None, clusters=("ai2/titan", "ai2/jupiter"))
     on_jupiter = job(cm_priority=HIGH, slots=72, clusters=("ai2/jupiter",))
     on_titan = job(cm_priority=HIGH, slots=32, clusters=("ai2/titan",))
-    # The multi-cluster job takes 8 slots from both budgets, so neither of the
-    # exactly-sized jobs fits any more.
     assert decide([both, on_jupiter, on_titan], LIMITS) == []
 
 
+def test_queued_job_with_no_cluster_constraint_is_charged_everywhere():
+    # It could land anywhere, so charging it to nothing would let the balancer
+    # hand out slots that are already spoken for.
+    ghost = job(priority=URGENT, cm_priority=None, clusters=(), slots=72)
+    assert ghost.budget_clusters(LIMITS) == BUDGETED
+    on_jupiter = job(cm_priority=HIGH, slots=8, clusters=("ai2/jupiter",))
+    assert decide([ghost, on_jupiter], LIMITS) == []
+
+
+def test_placed_job_with_unresolvable_cluster_is_charged_everywhere():
+    unknown = job(
+        priority=URGENT,
+        cm_priority=None,
+        is_placed=True,
+        assigned_cluster=None,
+        slots=72,
+    )
+    assert unknown.budget_clusters(LIMITS) == BUDGETED
+
+
+def test_placed_job_with_unresolvable_cluster_is_not_managed():
+    # It is charged to every budget as a precaution, so managing it would let
+    # the walk spend slots on one cluster while the accounting spent them on
+    # all of them -- and the pass would end over allocation.
+    unknown = job(
+        cm_priority=HIGH,
+        clusters=("ai2/titan",),
+        is_placed=True,
+        assigned_cluster=None,
+        placed_at=100.0,
+        slots=8,
+    )
+    assert unknown.managed_cluster(LIMITS) is None
+    assert decide([unknown], LIMITS) == []
+
+
+def test_placed_job_on_its_pinned_cluster_is_managed():
+    on_titan = job(
+        cm_priority=HIGH,
+        clusters=("ai2/titan",),
+        is_placed=True,
+        assigned_cluster="ai2/titan",
+        placed_at=100.0,
+        slots=8,
+    )
+    assert on_titan.managed_cluster(LIMITS) == "ai2/titan"
+
+
 def test_assigned_multi_cluster_job_counts_only_where_it_landed():
-    landed = running(
+    landed = placed(
         priority=URGENT,
         cm_priority=None,
         clusters=("ai2/titan", "ai2/jupiter"),
@@ -177,36 +320,7 @@ def test_assigned_multi_cluster_job_counts_only_where_it_landed():
 def test_jobs_without_cm_priority_count_but_are_not_modified():
     unlabelled = job(priority=URGENT, cm_priority=None, slots=72)
     labelled = job(cm_priority=HIGH, slots=8)
-    # The whole allocation is spoken for by a job we may not touch.
     assert decide([unlabelled, labelled], LIMITS) == []
-
-
-def test_first_fit_skips_a_job_that_does_not_fit():
-    big = job(cm_priority=HIGH, slots=16, queued_at=0.0)
-    small = job(cm_priority=HIGH, slots=8, queued_at=10.0)
-    result = changes(decide([big, small], {"ai2/jupiter": 8}))
-    assert result == {small.id: URGENT}
-
-
-def test_a_blocked_level_does_not_reserve_slots_for_itself():
-    # The high job cannot fit, so normal jobs behind it still get the slots.
-    big = job(cm_priority=HIGH, slots=16)
-    small = job(cm_priority=NORMAL, slots=8)
-    result = changes(decide([big, small], {"ai2/jupiter": 8}))
-    assert result == {small.id: URGENT}
-
-
-def test_higher_level_job_displaces_lower_level_urgent_jobs():
-    # The rebalancing case: normal-priority jobs holding urgent are dropped so
-    # a high-priority job can take the slots.
-    holders = [running(priority=URGENT, cm_priority=NORMAL, slots=4) for _ in range(2)]
-    contender = job(cm_priority=HIGH, slots=8)
-    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}))
-    assert result == {
-        holders[0].id: NORMAL,
-        holders[1].id: NORMAL,
-        contender.id: URGENT,
-    }
 
 
 def test_cluster_allocations_are_independent():
@@ -221,56 +335,88 @@ def test_jobs_on_unbudgeted_clusters_are_left_alone():
     assert decide([saturn], LIMITS) == []
 
 
-@pytest.mark.parametrize("cm_priority", [LOW, NORMAL, HIGH, URGENT])
-def test_any_labelled_job_can_be_granted_an_urgent_slot(cm_priority):
-    queued = job(cm_priority=cm_priority)
-    assert changes(decide([queued], LIMITS)) == {queued.id: URGENT}
+def test_replica_group_members_are_not_managed():
+    # Granting urgent to some ranks and not others wastes the slots granted,
+    # and it is unconfirmed whether the priority RPC is per-job or per-source.
+    ranks = [job(cm_priority=HIGH, slots=8, replica_group_size=4) for _ in range(4)]
+    assert decide(ranks, LIMITS) == []
 
 
-def test_demoted_job_returns_to_its_own_label_not_to_high():
-    over = running(priority=URGENT, cm_priority=LOW, slots=8)
-    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: LOW}
+# --- fitting ----------------------------------------------------------------
 
 
-def apply(jobs: list[JobView], actions: list[Action]) -> list[JobView]:
-    """Return the job list as it would be after the actions are applied."""
-    new_priority = {action.job.id: action.to_priority for action in actions}
-    return [
-        replace(j, priority=new_priority[j.id]) if j.id in new_priority else j
-        for j in jobs
-    ]
+def test_first_fit_skips_a_job_that_does_not_fit():
+    big = job(cm_priority=HIGH, slots=16, queued_at=0.0)
+    small = job(cm_priority=HIGH, slots=8, queued_at=10.0)
+    result = changes(decide([big, small], {"ai2/jupiter": 8}))
+    assert result == {small.id: URGENT}
 
 
-def usage(jobs: list[JobView], limits: dict[str, int]) -> dict[str, int]:
-    used = dict.fromkeys(limits, 0)
-    for job in jobs:
-        if job.priority == URGENT:
-            for cluster in job.budget_clusters(limits):
-                used[cluster] += job.slots
-    return used
+def test_a_blocked_level_does_not_reserve_slots_for_itself():
+    big = job(cm_priority=HIGH, slots=16)
+    small = job(cm_priority=NORMAL, slots=8)
+    result = changes(decide([big, small], {"ai2/jupiter": 8}))
+    assert result == {small.id: URGENT}
+
+
+def test_higher_level_job_displaces_lower_level_urgent_jobs():
+    holders = [placed(priority=URGENT, cm_priority=NORMAL, slots=4) for _ in range(2)]
+    contender = job(cm_priority=HIGH, slots=8)
+    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}))
+    assert result == {
+        holders[0].id: NORMAL,
+        holders[1].id: NORMAL,
+        contender.id: URGENT,
+    }
+
+
+# --- determinism ------------------------------------------------------------
+
+
+def test_tied_jobs_are_broken_deterministically_by_id():
+    # Whole-second clocks mean a launch wave ties; without an explicit
+    # tie-break the outcome would depend on Beaker's listing order.
+    def build():
+        return [job(cm_priority=HIGH, slots=8, queued_at=500.0) for _ in range(4)]
+
+    jobs = build()
+    forward = changes(decide(jobs, {"ai2/jupiter": 16}))
+    backward = changes(decide(list(reversed(jobs)), {"ai2/jupiter": 16}))
+    assert forward == backward
+    assert len(forward) == 2
+
+
+# --- invariants over randomised populations ---------------------------------
 
 
 def random_population(rng: random.Random) -> list[JobView]:
     jobs = []
     for _ in range(rng.randint(0, 40)):
-        is_running = rng.random() < 0.5
+        is_placed = rng.random() < 0.5
         clusters = rng.choice(
             [
                 ("ai2/jupiter",),
                 ("ai2/titan",),
                 ("ai2/titan", "ai2/jupiter"),
                 ("ai2/saturn",),
+                (),  # unconstrained: could land anywhere
             ]
         )
+        # A placed job may be running, or scheduled and still initializing.
+        assigned = None
+        if is_placed and clusters and rng.random() < 0.9:
+            assigned = rng.choice(clusters)
         jobs.append(
             job(
                 priority=rng.choice([LOW, NORMAL, HIGH, URGENT]),
                 cm_priority=rng.choice([None, LOW, NORMAL, HIGH, URGENT]),
                 slots=rng.choice([1, 2, 4, 8, 16, 40]),
                 clusters=clusters,
-                assigned_cluster=rng.choice(clusters) if is_running else None,
-                started_at=float(rng.randint(1, 10_000)) if is_running else None,
-                queued_at=float(rng.randint(1, 10_000)),
+                is_placed=is_placed,
+                assigned_cluster=assigned,
+                placed_at=float(rng.randint(1, 10_000)) if is_placed else None,
+                queued_at=float(rng.randint(1, 100)),  # ties are common
+                replica_group_size=rng.choice([0, 0, 0, 4]),
             )
         )
     return jobs
@@ -280,22 +426,23 @@ def random_population(rng: random.Random) -> list[JobView]:
 def test_allocation_is_never_exceeded_by_our_own_doing(seed):
     """The core guarantee: a pass never pushes usage above the allocation.
 
-    Usage may start over the limit because of jobs the balancer cannot modify.
-    In that case it must not make matters worse.
+    Usage may legitimately start above a limit because of jobs the balancer
+    cannot modify. The claim is that it never ends above the limit *or* above
+    that unmodifiable charge, whichever is higher.
     """
     rng = random.Random(seed)
     jobs = random_population(rng)
-    before = usage(jobs, LIMITS)
-    after = usage(apply(jobs, decide(jobs, LIMITS)), LIMITS)
+    floor = unmanaged_charge(jobs)
+    after = usage(apply(jobs, decide(jobs, LIMITS)))
     for cluster, limit in LIMITS.items():
         assert after[cluster] <= max(
-            limit, before[cluster]
-        ), f"{cluster}: {before[cluster]} -> {after[cluster]}, limit {limit}"
+            limit, floor[cluster]
+        ), f"{cluster}: -> {after[cluster]}, limit {limit}, floor {floor[cluster]}"
 
 
 @pytest.mark.parametrize("seed", range(300))
 def test_a_pass_always_converges(seed):
-    """A second pass must be a no-op, or the cron would flap jobs forever."""
+    """A second pass must be a no-op, or the cron would flap jobs."""
     rng = random.Random(seed)
     jobs = random_population(rng)
     settled = apply(jobs, decide(jobs, LIMITS))
@@ -303,14 +450,46 @@ def test_a_pass_always_converges(seed):
 
 
 @pytest.mark.parametrize("seed", range(300))
-def test_only_labelled_single_cluster_jobs_are_ever_modified(seed):
+def test_converges_even_when_every_action_fails(seed):
+    """A pass whose calls all fail must not change what the next pass decides.
+
+    The permission fail-soft path means actions can silently not happen; the
+    balancer must simply retry the same thing rather than escalate.
+    """
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    first = decide(jobs, LIMITS)
+    assert decide(jobs, LIMITS) == first
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_any_prefix_of_a_pass_stays_within_allocation(seed):
+    """Actions are applied one at a time and any of them can fail.
+
+    Every prefix must therefore be safe, which is what ordering demotions first
+    buys us.
+    """
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    actions = decide(jobs, LIMITS)
+    floor = unmanaged_charge(jobs)
+    start = usage(jobs)
+    for i in range(len(actions) + 1):
+        after = usage(apply(jobs, actions[:i]))
+        for cluster, limit in LIMITS.items():
+            assert after[cluster] <= max(limit, floor[cluster], start[cluster])
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_only_labelled_manageable_jobs_are_ever_modified(seed):
     rng = random.Random(seed)
     jobs = random_population(rng)
     for action in decide(jobs, LIMITS):
         assert action.job.cm_priority is not None
         assert action.job.managed_cluster(LIMITS) is not None
-        # Beaker refuses to raise a running job; we must never try.
-        if not action.job.is_queued:
+        assert action.job.replica_group_size <= 1
+        # Beaker refuses to raise a placed job; we must never try.
+        if action.job.is_placed:
             assert action.to_priority < action.from_priority
 
 
@@ -324,16 +503,27 @@ def test_a_job_is_never_left_above_urgent_or_below_its_label(seed):
         assert action.to_priority in (URGENT, resting_priority(cm_priority))
 
 
-def test_node_cluster_is_org_qualified():
-    # Cluster.name is bare ("jupiter") but placement constraints and our
-    # allocation are qualified ("ai2/jupiter"). If these are not reconciled,
-    # assigned jobs match no budget and their urgent slots go uncounted.
-    client = SimpleNamespace(
-        node=SimpleNamespace(get=lambda _: SimpleNamespace(cluster_id="c1")),
-        cluster=SimpleNamespace(
-            get=lambda _: SimpleNamespace(name="jupiter", organization_name="ai2")
-        ),
-    )
-    cache: dict[str, str] = {}
-    assert _cluster_of_node(client, "node-1", cache) == "ai2/jupiter"
-    assert cache == {"node-1": "ai2/jupiter"}
+def test_random_population_reaches_the_states_that_matter():
+    """Guard against the property tests quietly becoming vacuous."""
+    seen = {
+        "unconstrained": 0,
+        "initializing": 0,
+        "replica": 0,
+        "demotion": 0,
+        "promotion": 0,
+        "over_before": 0,
+    }
+    for seed in range(300):
+        jobs = random_population(random.Random(seed))
+        seen["unconstrained"] += sum(1 for j in jobs if not j.clusters)
+        seen["initializing"] += sum(
+            1 for j in jobs if j.is_placed and j.assigned_cluster is None
+        )
+        seen["replica"] += sum(1 for j in jobs if j.replica_group_size > 1)
+        actions = decide(jobs, LIMITS)
+        seen["demotion"] += sum(1 for a in actions if a.is_demotion)
+        seen["promotion"] += sum(1 for a in actions if not a.is_demotion)
+        before = usage(jobs)
+        seen["over_before"] += any(before[c] > LIMITS[c] for c in LIMITS)
+    for state, count in seen.items():
+        assert count > 10, f"{state} only reached {count} times"

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -443,6 +443,99 @@ def test_a_replica_group_with_a_placed_rank_below_urgent_is_not_promoted():
     assert result == {contender.id: URGENT}
 
 
+# --- resolving a group that is already half-urgent ---------------------------
+#
+# run_pass leaves this state behind deliberately: a rank refused partway through
+# a grant abandons the rest of the group, and the ranks already raised keep
+# urgent for the next pass to "finish or take back". These pin that next pass.
+
+
+def test_an_inherited_half_urgent_group_is_completed_when_it_fits():
+    ranks = group(4, cm_priority=HIGH, slots=8)
+    ranks[0] = replace(ranks[0], priority=URGENT)
+    ranks[1] = replace(ranks[1], priority=URGENT)
+    result = changes(decide(ranks, LIMITS))
+    assert result == {ranks[2].id: URGENT, ranks[3].id: URGENT}
+
+
+def test_an_inherited_half_urgent_group_is_taken_back_when_it_no_longer_fits():
+    ranks = group(4, cm_priority=HIGH, slots=8)
+    ranks[0] = replace(ranks[0], priority=URGENT)
+    ranks[1] = replace(ranks[1], priority=URGENT)
+    result = changes(decide(ranks, {"ai2/jupiter": 16}))
+    assert result == {ranks[0].id: HIGH, ranks[1].id: HIGH}
+
+
+def test_an_inherited_half_urgent_group_with_a_placed_rank_is_taken_back():
+    # The placed rank can never be raised, so the group can never be completed.
+    # It must lose the urgent it holds rather than keep it indefinitely.
+    ranks = group(4, cm_priority=HIGH, slots=8)
+    ranks[0] = replace(ranks[0], priority=URGENT)
+    ranks[1] = replace(ranks[1], priority=URGENT)
+    ranks[2] = replace(
+        ranks[2], is_placed=True, placed_at=100.0, assigned_cluster="ai2/jupiter"
+    )
+    result = changes(decide(ranks, LIMITS))
+    assert result == {ranks[0].id: HIGH, ranks[1].id: HIGH}
+
+
+# --- group clocks -----------------------------------------------------------
+
+
+def test_a_group_waits_from_its_latest_rank():
+    # A group cannot start until its last rank is placed, and the clock resets
+    # when a rank is preempted, so a bounced group must not keep seniority it no
+    # longer has: the rank that was requeued sets the whole group's wait.
+    bounced = group(2, group_id="bounced", cm_priority=HIGH, slots=8)
+    bounced[0] = replace(bounced[0], queued_at=100.0)
+    bounced[1] = replace(bounced[1], queued_at=900.0)
+    steady = group(2, group_id="steady", cm_priority=HIGH, slots=8, queued_at=500.0)
+    result = changes(decide([*bounced, *steady], {"ai2/jupiter": 16}))
+    assert result == {rank.id: URGENT for rank in steady}
+
+
+def test_a_group_holds_its_slots_from_its_earliest_rank():
+    # Longest-held loses urgent first, and a group has held slots since its
+    # first rank landed, not its last.
+    early = group(2, group_id="early", priority=URGENT, cm_priority=HIGH, slots=8)
+    early[0] = replace(
+        early[0], is_placed=True, placed_at=100.0, assigned_cluster="ai2/jupiter"
+    )
+    early[1] = replace(
+        early[1], is_placed=True, placed_at=900.0, assigned_cluster="ai2/jupiter"
+    )
+    late = group(2, group_id="late", priority=URGENT, cm_priority=HIGH, slots=8)
+    late = [
+        replace(rank, is_placed=True, placed_at=500.0, assigned_cluster="ai2/jupiter")
+        for rank in late
+    ]
+    result = changes(decide([*early, *late], {"ai2/jupiter": 16}))
+    assert result == {rank.id: HIGH for rank in early}
+
+
+# --- what a change is reported as -------------------------------------------
+
+
+def test_a_job_raised_to_its_label_is_not_reported_as_releasing_a_slot():
+    # A queued job submitted below its CM_PRIORITY is raised to it even when it
+    # is granted nothing. The log is the only window on a cron process, so it
+    # must not claim an urgent slot changed hands.
+    hog = job(priority=URGENT, cm_priority=None, slots=72)
+    below = job(priority=LOW, cm_priority=HIGH, slots=8)
+    (action,) = decide([hog, below], LIMITS)
+    assert (action.from_priority, action.to_priority) == (LOW, HIGH)
+    assert action.reason == "settle at resting priority"
+
+
+def test_granting_and_releasing_are_reported_as_such():
+    granted = job(priority=HIGH, cm_priority=HIGH, slots=8)
+    (grant,) = decide([granted], LIMITS)
+    assert grant.reason == "grant urgent slot"
+    released = placed(priority=URGENT, cm_priority=HIGH, slots=8)
+    (release,) = decide([released], {"ai2/jupiter": 0})
+    assert release.reason == "release urgent slot"
+
+
 # --- sessions and immediate priority ----------------------------------------
 
 
@@ -687,6 +780,52 @@ def test_a_job_is_never_left_above_urgent_or_below_its_label(seed):
         cm_priority = action.job.cm_priority
         assert cm_priority is not None
         assert action.to_priority in (URGENT, resting_priority(cm_priority))
+
+
+def grantable_groups(jobs, limits=LIMITS) -> dict[str, list[JobView]]:
+    """Groups that could hold urgent after a pass, restated from the rules.
+
+    A group is a candidate only if the balancer may move it at all, and only if
+    every rank could reach urgent: Beaker will not raise a job it has placed, so
+    a group with a placed rank below urgent is out.
+    """
+    allowed = modifiable(jobs, limits)
+    groups: dict[str, list[JobView]] = {}
+    for j in jobs:
+        if j.id not in allowed:
+            continue
+        key = j.replica_group_id if j.replica_group_size > 1 else j.id
+        groups.setdefault(key or j.id, []).append(j)
+    return {
+        key: members
+        for key, members in groups.items()
+        if all(m.priority == URGENT for m in members)
+        or all(not m.is_placed for m in members)
+    }
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_the_allocation_is_not_left_unspent(seed):
+    """The other half of the guarantee: a pass must also *use* the allocation.
+
+    Every other property here is one-sided -- never above the limit -- so a
+    balancer that granted nothing at all would satisfy them. This asserts the
+    walk is maximal: any candidate group left below urgent was left there
+    because it did not fit in what remained, not because it was overlooked.
+    """
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    after = {j.id: j for j in apply(jobs, decide(jobs, LIMITS))}
+    used = usage(list(after.values()))
+    for key, members in grantable_groups(jobs).items():
+        if all(after[m.id].priority == URGENT for m in members):
+            continue
+        cluster = members[0].clusters[0]
+        slots = sum(m.slots for m in members)
+        headroom = LIMITS[cluster] - used[cluster]
+        assert (
+            slots > headroom
+        ), f"{key} needed {slots} on {cluster} and {headroom} were left unspent"
 
 
 def test_random_population_reaches_the_states_that_matter():

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -1,0 +1,339 @@
+"""Tests for the balancer's decision logic.
+
+These exercise ``decide`` against constructed job lists, so no Beaker calls are
+made.
+"""
+
+import itertools
+import random
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from balance import (
+    HIGH,
+    LOW,
+    NORMAL,
+    URGENT,
+    Action,
+    JobView,
+    _cluster_of_node,
+    decide,
+    resting_priority,
+)
+
+LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
+
+_ids = itertools.count()
+
+
+def job(
+    priority=HIGH,
+    cm_priority=HIGH,
+    slots=8,
+    clusters=("ai2/jupiter",),
+    assigned_cluster=None,
+    queued_at=0.0,
+    started_at=None,
+    name="job",
+    author="jeremym",
+):
+    """Build a JobView, defaulting to a queued 8-GPU jupiter job."""
+    return JobView(
+        id=f"job-{next(_ids)}",
+        name=name,
+        author=author,
+        priority=priority,
+        slots=slots,
+        clusters=clusters,
+        assigned_cluster=assigned_cluster,
+        cm_priority=cm_priority,
+        queued_at=queued_at,
+        started_at=started_at,
+    )
+
+
+def running(**kwargs):
+    """A job that has landed on a node, and so cannot be promoted."""
+    kwargs.setdefault("started_at", 100.0)
+    kwargs.setdefault("assigned_cluster", kwargs.get("clusters", ("ai2/jupiter",))[0])
+    return job(**kwargs)
+
+
+def changes(actions: list[Action]) -> dict[str, int]:
+    return {action.job.id: action.to_priority for action in actions}
+
+
+def test_resting_priority_drops_urgent_to_high():
+    assert resting_priority(URGENT) == HIGH
+    assert resting_priority(HIGH) == HIGH
+    assert resting_priority(LOW) == LOW
+
+
+def test_queued_jobs_are_promoted_to_fill_the_allocation():
+    jobs = [job(priority=HIGH, cm_priority=HIGH) for _ in range(3)]
+    assert changes(decide(jobs, LIMITS)) == {j.id: URGENT for j in jobs}
+
+
+def test_promotion_stops_at_the_allocation():
+    # 10 x 8 slots = 80, against a 72 slot allocation.
+    jobs = [job(queued_at=float(i)) for i in range(10)]
+    promoted = changes(decide(jobs, LIMITS))
+    assert len(promoted) == 9
+    # The longest-waiting jobs are promoted first, so the newest misses out.
+    assert jobs[-1].id not in promoted
+
+
+def test_higher_cm_priority_is_granted_first():
+    low = job(priority=LOW, cm_priority=LOW, slots=72, queued_at=0.0)
+    high = job(cm_priority=HIGH, slots=72, queued_at=10.0)
+    result = changes(decide([low, high], LIMITS))
+    # Only one fits. The high-priority job wins despite waiting less.
+    assert result == {high.id: URGENT}
+
+
+def test_job_is_moved_to_its_resting_priority_when_not_granted():
+    # "own it fully": a labelled job sits at its own label, whatever it was
+    # submitted at, once it is clear it will not get an urgent slot.
+    mislabelled = job(priority=HIGH, cm_priority=LOW, slots=8)
+    hog = job(priority=URGENT, cm_priority=None, slots=72)
+    assert changes(decide([hog, mislabelled], LIMITS)) == {mislabelled.id: LOW}
+
+
+def test_over_allocation_demotes_lowest_cm_priority_first():
+    keep = running(priority=URGENT, cm_priority=HIGH, slots=64)
+    drop = running(priority=URGENT, cm_priority=LOW, slots=8)
+    result = changes(decide([keep, drop], {"ai2/jupiter": 64}))
+    assert result == {drop.id: LOW}
+
+
+def test_queued_jobs_are_demoted_before_running_ones_at_the_same_level():
+    still_queued = job(priority=URGENT, cm_priority=HIGH, slots=8)
+    on_gpu = running(priority=URGENT, cm_priority=HIGH, slots=8)
+    result = changes(decide([still_queued, on_gpu], {"ai2/jupiter": 8}))
+    assert result == {still_queued.id: HIGH}
+
+
+def test_longest_running_job_is_demoted_first():
+    old = running(priority=URGENT, cm_priority=HIGH, slots=8, started_at=100.0)
+    new = running(priority=URGENT, cm_priority=HIGH, slots=8, started_at=900.0)
+    result = changes(decide([old, new], {"ai2/jupiter": 8}))
+    assert result == {old.id: HIGH}
+
+
+def test_longest_queued_job_is_promoted_first():
+    old = job(cm_priority=HIGH, slots=8, queued_at=100.0)
+    new = job(cm_priority=HIGH, slots=8, queued_at=900.0)
+    result = changes(decide([old, new], {"ai2/jupiter": 8}))
+    assert result == {old.id: URGENT}
+
+
+def test_running_job_is_never_promoted():
+    # Beaker rejects raising the priority of a running job.
+    on_gpu = running(priority=HIGH, cm_priority=URGENT)
+    assert decide([on_gpu], LIMITS) == []
+
+
+def test_running_job_below_its_resting_priority_is_left_alone():
+    on_gpu = running(priority=NORMAL, cm_priority=HIGH)
+    assert decide([on_gpu], LIMITS) == []
+
+
+def test_running_non_urgent_job_does_not_displace_others():
+    # The urgent-labelled running job cannot be promoted, so it must not push
+    # the queued job out of the allocation.
+    blocked = running(priority=HIGH, cm_priority=URGENT, slots=8)
+    queued = job(cm_priority=NORMAL, slots=8)
+    result = changes(decide([blocked, queued], {"ai2/jupiter": 8}))
+    assert result == {queued.id: URGENT}
+
+
+def test_multi_cluster_jobs_are_never_modified():
+    both = job(clusters=("ai2/titan", "ai2/jupiter"), cm_priority=URGENT)
+    assert decide([both], LIMITS) == []
+
+
+def test_queued_multi_cluster_urgent_job_counts_against_every_cluster():
+    both = job(priority=URGENT, cm_priority=None, clusters=("ai2/titan", "ai2/jupiter"))
+    on_jupiter = job(cm_priority=HIGH, slots=72, clusters=("ai2/jupiter",))
+    on_titan = job(cm_priority=HIGH, slots=32, clusters=("ai2/titan",))
+    # The multi-cluster job takes 8 slots from both budgets, so neither of the
+    # exactly-sized jobs fits any more.
+    assert decide([both, on_jupiter, on_titan], LIMITS) == []
+
+
+def test_assigned_multi_cluster_job_counts_only_where_it_landed():
+    landed = running(
+        priority=URGENT,
+        cm_priority=None,
+        clusters=("ai2/titan", "ai2/jupiter"),
+        assigned_cluster="ai2/titan",
+    )
+    on_jupiter = job(cm_priority=HIGH, slots=72, clusters=("ai2/jupiter",))
+    result = changes(decide([landed, on_jupiter], LIMITS))
+    assert result == {on_jupiter.id: URGENT}
+
+
+def test_jobs_without_cm_priority_count_but_are_not_modified():
+    unlabelled = job(priority=URGENT, cm_priority=None, slots=72)
+    labelled = job(cm_priority=HIGH, slots=8)
+    # The whole allocation is spoken for by a job we may not touch.
+    assert decide([unlabelled, labelled], LIMITS) == []
+
+
+def test_first_fit_skips_a_job_that_does_not_fit():
+    big = job(cm_priority=HIGH, slots=16, queued_at=0.0)
+    small = job(cm_priority=HIGH, slots=8, queued_at=10.0)
+    result = changes(decide([big, small], {"ai2/jupiter": 8}))
+    assert result == {small.id: URGENT}
+
+
+def test_a_blocked_level_does_not_reserve_slots_for_itself():
+    # The high job cannot fit, so normal jobs behind it still get the slots.
+    big = job(cm_priority=HIGH, slots=16)
+    small = job(cm_priority=NORMAL, slots=8)
+    result = changes(decide([big, small], {"ai2/jupiter": 8}))
+    assert result == {small.id: URGENT}
+
+
+def test_higher_level_job_displaces_lower_level_urgent_jobs():
+    # The rebalancing case: normal-priority jobs holding urgent are dropped so
+    # a high-priority job can take the slots.
+    holders = [running(priority=URGENT, cm_priority=NORMAL, slots=4) for _ in range(2)]
+    contender = job(cm_priority=HIGH, slots=8)
+    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}))
+    assert result == {
+        holders[0].id: NORMAL,
+        holders[1].id: NORMAL,
+        contender.id: URGENT,
+    }
+
+
+def test_cluster_allocations_are_independent():
+    jupiter = job(clusters=("ai2/jupiter",), cm_priority=HIGH, slots=72)
+    titan = job(clusters=("ai2/titan",), cm_priority=HIGH, slots=32)
+    result = changes(decide([jupiter, titan], LIMITS))
+    assert result == {jupiter.id: URGENT, titan.id: URGENT}
+
+
+def test_jobs_on_unbudgeted_clusters_are_left_alone():
+    saturn = job(clusters=("ai2/saturn",), cm_priority=URGENT, priority=URGENT)
+    assert decide([saturn], LIMITS) == []
+
+
+@pytest.mark.parametrize("cm_priority", [LOW, NORMAL, HIGH, URGENT])
+def test_any_labelled_job_can_be_granted_an_urgent_slot(cm_priority):
+    queued = job(cm_priority=cm_priority)
+    assert changes(decide([queued], LIMITS)) == {queued.id: URGENT}
+
+
+def test_demoted_job_returns_to_its_own_label_not_to_high():
+    over = running(priority=URGENT, cm_priority=LOW, slots=8)
+    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: LOW}
+
+
+def apply(jobs: list[JobView], actions: list[Action]) -> list[JobView]:
+    """Return the job list as it would be after the actions are applied."""
+    new_priority = {action.job.id: action.to_priority for action in actions}
+    return [
+        replace(j, priority=new_priority[j.id]) if j.id in new_priority else j
+        for j in jobs
+    ]
+
+
+def usage(jobs: list[JobView], limits: dict[str, int]) -> dict[str, int]:
+    used = dict.fromkeys(limits, 0)
+    for job in jobs:
+        if job.priority == URGENT:
+            for cluster in job.budget_clusters(limits):
+                used[cluster] += job.slots
+    return used
+
+
+def random_population(rng: random.Random) -> list[JobView]:
+    jobs = []
+    for _ in range(rng.randint(0, 40)):
+        is_running = rng.random() < 0.5
+        clusters = rng.choice(
+            [
+                ("ai2/jupiter",),
+                ("ai2/titan",),
+                ("ai2/titan", "ai2/jupiter"),
+                ("ai2/saturn",),
+            ]
+        )
+        jobs.append(
+            job(
+                priority=rng.choice([LOW, NORMAL, HIGH, URGENT]),
+                cm_priority=rng.choice([None, LOW, NORMAL, HIGH, URGENT]),
+                slots=rng.choice([1, 2, 4, 8, 16, 40]),
+                clusters=clusters,
+                assigned_cluster=rng.choice(clusters) if is_running else None,
+                started_at=float(rng.randint(1, 10_000)) if is_running else None,
+                queued_at=float(rng.randint(1, 10_000)),
+            )
+        )
+    return jobs
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_allocation_is_never_exceeded_by_our_own_doing(seed):
+    """The core guarantee: a pass never pushes usage above the allocation.
+
+    Usage may start over the limit because of jobs the balancer cannot modify.
+    In that case it must not make matters worse.
+    """
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    before = usage(jobs, LIMITS)
+    after = usage(apply(jobs, decide(jobs, LIMITS)), LIMITS)
+    for cluster, limit in LIMITS.items():
+        assert after[cluster] <= max(
+            limit, before[cluster]
+        ), f"{cluster}: {before[cluster]} -> {after[cluster]}, limit {limit}"
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_a_pass_always_converges(seed):
+    """A second pass must be a no-op, or the cron would flap jobs forever."""
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    settled = apply(jobs, decide(jobs, LIMITS))
+    assert decide(settled, LIMITS) == []
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_only_labelled_single_cluster_jobs_are_ever_modified(seed):
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    for action in decide(jobs, LIMITS):
+        assert action.job.cm_priority is not None
+        assert action.job.managed_cluster(LIMITS) is not None
+        # Beaker refuses to raise a running job; we must never try.
+        if not action.job.is_queued:
+            assert action.to_priority < action.from_priority
+
+
+@pytest.mark.parametrize("seed", range(300))
+def test_a_job_is_never_left_above_urgent_or_below_its_label(seed):
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    for action in decide(jobs, LIMITS):
+        cm_priority = action.job.cm_priority
+        assert cm_priority is not None
+        assert action.to_priority in (URGENT, resting_priority(cm_priority))
+
+
+def test_node_cluster_is_org_qualified():
+    # Cluster.name is bare ("jupiter") but placement constraints and our
+    # allocation are qualified ("ai2/jupiter"). If these are not reconciled,
+    # assigned jobs match no budget and their urgent slots go uncounted.
+    client = SimpleNamespace(
+        node=SimpleNamespace(get=lambda _: SimpleNamespace(cluster_id="c1")),
+        cluster=SimpleNamespace(
+            get=lambda _: SimpleNamespace(name="jupiter", organization_name="ai2")
+        ),
+    )
+    cache: dict[str, str] = {}
+    assert _cluster_of_node(client, "node-1", cache) == "ai2/jupiter"
+    assert cache == {"node-1": "ai2/jupiter"}

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -22,6 +22,7 @@ from balance import (  # noqa: E402
     Action,
     JobView,
     decide,
+    remember_priorities,
     resting_priority,
 )
 
@@ -159,10 +160,70 @@ def apply(jobs: list[JobView], actions: list[Action]) -> list[JobView]:
 # --- resting priority -------------------------------------------------------
 
 
-def test_resting_priority_drops_urgent_to_high():
-    assert resting_priority(URGENT) == HIGH
-    assert resting_priority(HIGH) == HIGH
-    assert resting_priority(LOW) == LOW
+def test_a_job_below_urgent_is_already_resting():
+    # Whatever it is at now is what its owner last chose, so there is nothing
+    # to remember and nothing to restore.
+    for priority in (LOW, NORMAL, HIGH):
+        assert resting_priority(job(priority=priority), {}) == priority
+
+
+def test_a_job_at_urgent_rests_where_it_was_last_seen():
+    raised = job(priority=URGENT)
+    assert resting_priority(raised, {raised.id: NORMAL}) == NORMAL
+
+
+def test_an_unremembered_urgent_job_falls_back_to_high():
+    # Submitted at urgent, or first seen there after the memory was lost.
+    # Resting at urgent would defeat the allocation.
+    assert resting_priority(job(priority=URGENT), {}) == HIGH
+
+
+def test_a_manual_change_becomes_the_new_resting_priority():
+    # The owner moved the job by hand since the last pass. It is below urgent,
+    # so what they chose wins over anything remembered from before.
+    edited = job(priority=LOW)
+    assert resting_priority(edited, {edited.id: HIGH}) == LOW
+
+
+# --- what is carried between passes -----------------------------------------
+
+
+def test_only_jobs_at_urgent_need_remembering():
+    resting = job(priority=NORMAL)
+    raised = job(priority=URGENT)
+    assert remember_priorities([resting, raised], {raised.id: LOW}) == {
+        resting.id: NORMAL,
+        raised.id: LOW,
+    }
+
+
+def test_an_unlabelled_job_is_not_remembered():
+    # The balancer never modifies it, so it never has to restore it either.
+    assert remember_priorities([job(priority=NORMAL, cm_priority=None)], {}) == {}
+
+
+def test_a_finished_job_is_forgotten():
+    # Jobs are evicted by simply not appearing in the pass that carries them.
+    gone = job(priority=URGENT)
+    assert remember_priorities([], {gone.id: LOW}) == {}
+
+
+def test_a_requeued_job_inherits_what_its_ancestor_rested_at():
+    # Preemption gives the job a new id, and Beaker hands it back at the
+    # priority the balancer set on its source rather than the submitted one.
+    # Without this the job would ratchet up to the high fallback every time it
+    # was preempted.
+    original = job(priority=URGENT)
+    requeued = replace(job(priority=URGENT), retry_ancestor_id=original.id)
+    carried = remember_priorities([requeued], {original.id: LOW})
+    assert carried == {requeued.id: LOW}
+
+
+def test_a_remembered_job_is_not_overwritten_by_its_ancestor():
+    original = job(priority=URGENT)
+    requeued = replace(job(priority=URGENT), retry_ancestor_id=original.id)
+    carried = remember_priorities([requeued], {original.id: LOW, requeued.id: NORMAL})
+    assert carried == {requeued.id: NORMAL}
 
 
 # --- promotion --------------------------------------------------------------
@@ -191,9 +252,18 @@ def test_higher_cm_priority_is_granted_first():
 
 
 def test_job_is_moved_to_its_resting_priority_when_not_granted():
-    mislabelled = job(priority=HIGH, cm_priority=LOW, slots=8)
+    raised = job(priority=URGENT, cm_priority=LOW, slots=8)
     hog = job(priority=URGENT, cm_priority=None, slots=72)
-    assert changes(decide([hog, mislabelled], LIMITS)) == {mislabelled.id: LOW}
+    result = changes(decide([hog, raised], LIMITS, {raised.id: LOW}))
+    assert result == {raised.id: LOW}
+
+
+def test_a_job_that_is_not_granted_and_not_at_urgent_is_left_alone():
+    # It is already resting. Under a label-derived resting priority this job
+    # would be dragged to NORMAL for no gain to the allocation.
+    settled = job(priority=HIGH, cm_priority=NORMAL, slots=8)
+    hog = job(priority=URGENT, cm_priority=None, slots=72)
+    assert decide([hog, settled], LIMITS) == []
 
 
 @pytest.mark.parametrize("cm_priority", [LOW, NORMAL, HIGH, URGENT])
@@ -208,7 +278,7 @@ def test_any_labelled_job_can_be_granted_an_urgent_slot(cm_priority):
 def test_over_allocation_demotes_lowest_cm_priority_first():
     keep = placed(priority=URGENT, cm_priority=HIGH, slots=64)
     drop = placed(priority=URGENT, cm_priority=LOW, slots=8)
-    result = changes(decide([keep, drop], {"ai2/jupiter": 64}))
+    result = changes(decide([keep, drop], {"ai2/jupiter": 64}, {drop.id: LOW}))
     assert result == {drop.id: LOW}
 
 
@@ -233,9 +303,17 @@ def test_longest_queued_job_is_promoted_first():
     assert result == {old.id: URGENT}
 
 
-def test_demoted_job_returns_to_its_own_label_not_to_high():
+def test_a_demoted_job_returns_to_where_it_was_raised_from():
+    over = placed(priority=URGENT, cm_priority=HIGH, slots=8)
+    result = changes(decide([over], {"ai2/jupiter": 0}, {over.id: LOW}))
+    assert result == {over.id: LOW}
+
+
+def test_a_demoted_job_with_nothing_remembered_falls_back_to_high():
+    # Either submitted at urgent, or first seen there after the memory was
+    # lost. Its owner never chose anything lower for us to put it back to.
     over = placed(priority=URGENT, cm_priority=LOW, slots=8)
-    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: LOW}
+    assert changes(decide([over], {"ai2/jupiter": 0})) == {over.id: HIGH}
 
 
 def test_demotions_are_ordered_before_promotions():
@@ -398,7 +476,8 @@ def test_a_replica_group_is_charged_as_the_sum_of_its_ranks():
     # The 64-slot group wins its level first, leaving 8 — too few for the
     # 16-slot normal job behind it.
     result = changes(decide([*big, small], LIMITS))
-    assert result == {**{rank.id: URGENT for rank in big}, small.id: NORMAL}
+    # The normal job is left where it is: it is already resting below urgent.
+    assert result == {rank.id: URGENT for rank in big}
 
 
 def test_a_replica_group_with_an_unlabelled_rank_is_left_alone():
@@ -516,15 +595,21 @@ def test_a_group_holds_its_slots_from_its_earliest_rank():
 # --- what a change is reported as -------------------------------------------
 
 
-def test_a_job_raised_to_its_label_is_not_reported_as_releasing_a_slot():
-    # A queued job submitted below its CM_PRIORITY is raised to it even when it
-    # is granted nothing. The log is the only window on a cron process, so it
-    # must not claim an urgent slot changed hands.
-    hog = job(priority=URGENT, cm_priority=None, slots=72)
-    below = job(priority=LOW, cm_priority=HIGH, slots=8)
-    (action,) = decide([hog, below], LIMITS)
-    assert (action.from_priority, action.to_priority) == (LOW, HIGH)
-    assert action.reason == "settle at resting priority"
+@pytest.mark.parametrize("seed", range(300))
+def test_every_change_moves_a_job_onto_or_off_an_urgent_slot(seed):
+    # The balancer's whole remit. A job resting below urgent is left where its
+    # owner put it, so there is no third kind of change -- which is also why
+    # the reason a change is logged under can be read off the movement alone.
+    rng = random.Random(seed)
+    jobs = random_population(rng)
+    remembered = {
+        j.id: rng.choice([LOW, NORMAL, HIGH]) for j in jobs if rng.random() < 0.5
+    }
+    for action in decide(jobs, LIMITS, remembered):
+        assert action.takes_slots != action.frees_slots
+        assert action.reason == (
+            "grant urgent slot" if action.takes_slots else "release urgent slot"
+        )
 
 
 def test_granting_and_releasing_are_reported_as_such():
@@ -581,7 +666,8 @@ def test_a_blocked_level_does_not_reserve_slots_for_itself():
 def test_higher_level_job_displaces_lower_level_urgent_jobs():
     holders = [placed(priority=URGENT, cm_priority=NORMAL, slots=4) for _ in range(2)]
     contender = job(cm_priority=HIGH, slots=8)
-    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}))
+    remembered = {holder.id: NORMAL for holder in holders}
+    result = changes(decide([*holders, contender], {"ai2/jupiter": 8}, remembered))
     assert result == {
         holders[0].id: NORMAL,
         holders[1].id: NORMAL,
@@ -773,13 +859,17 @@ def test_a_replica_group_never_half_holds_urgent(seed):
 
 
 @pytest.mark.parametrize("seed", range(300))
-def test_a_job_is_never_left_above_urgent_or_below_its_label(seed):
+def test_a_job_is_only_ever_left_at_urgent_or_where_it_was_resting(seed):
     rng = random.Random(seed)
     jobs = random_population(rng)
-    for action in decide(jobs, LIMITS):
-        cm_priority = action.job.cm_priority
-        assert cm_priority is not None
-        assert action.to_priority in (URGENT, resting_priority(cm_priority))
+    remembered = {
+        j.id: rng.choice([LOW, NORMAL, HIGH]) for j in jobs if rng.random() < 0.5
+    }
+    for action in decide(jobs, LIMITS, remembered):
+        assert action.job.cm_priority is not None
+        assert action.to_priority in (URGENT, resting_priority(action.job, remembered))
+        # Nothing is ever left at immediate, which only a human hands out.
+        assert action.to_priority != IMMEDIATE
 
 
 def grantable_groups(jobs, limits=LIMITS) -> dict[str, list[JobView]]:

--- a/scripts/beaker_balancer/test_balance.py
+++ b/scripts/beaker_balancer/test_balance.py
@@ -446,6 +446,59 @@ def test_a_placed_job_on_a_non_budgeted_cluster_is_not_counted():
     assert result == {contender.id: URGENT}
 
 
+def test_zero_allocation_cluster_is_transparent_for_grants():
+    # A cluster at limit 0 is tracked (jobs targeting it are managed) but
+    # transparent for grants: the grant check and charge skip it, so a job
+    # targeting both jupiter and ceres is granted against jupiter alone.
+    limits = {"ai2/jupiter": 72, "ai2/titan": 32, "ai2/ceres": 0}
+    mixed = job(clusters=("ai2/jupiter", "ai2/ceres"), cm_priority=HIGH)
+    assert mixed.budget_clusters(limits) == ("ai2/jupiter", "ai2/ceres")
+    assert mixed.managed_clusters(limits) == ("ai2/jupiter", "ai2/ceres")
+    result = changes(decide([mixed], limits))
+    assert result == {mixed.id: URGENT}
+
+
+def test_zero_allocation_cluster_does_not_block_pessimistic_grant():
+    limits = {"ai2/jupiter": 72, "ai2/titan": 32, "ai2/ceres": 0}
+    mixed = job(clusters=("ai2/jupiter", "ai2/ceres"), cm_priority=HIGH, slots=72)
+    result = changes(decide([mixed], limits))
+    assert result == {mixed.id: URGENT}
+
+
+def test_job_targeting_only_zero_allocation_cluster_is_managed_but_never_granted():
+    # The job is managed (ceres is in limits), so it can be demoted. But the
+    # grant check has no positive-allocation cluster to check, so it is never
+    # granted urgent.
+    limits = {"ai2/jupiter": 72, "ai2/titan": 32, "ai2/ceres": 0}
+    only_ceres = job(clusters=("ai2/ceres",), cm_priority=HIGH)
+    assert only_ceres.budget_clusters(limits) == ("ai2/ceres",)
+    assert only_ceres.managed_clusters(limits) == ("ai2/ceres",)
+    assert decide([only_ceres], limits) == []
+
+
+def test_urgent_job_on_zero_allocation_cluster_is_demoted():
+    limits = {"ai2/jupiter": 72, "ai2/titan": 32, "ai2/ceres": 0}
+    on_ceres = job(priority=URGENT, cm_priority=HIGH, clusters=("ai2/ceres",))
+    result = changes(decide([on_ceres], limits))
+    assert result == {on_ceres.id: HIGH}
+
+
+def test_placed_on_zero_allocation_cluster_does_not_block_jupiter():
+    limits = {"ai2/jupiter": 72, "ai2/titan": 32, "ai2/ceres": 0}
+    on_ceres = placed(
+        priority=URGENT,
+        cm_priority=HIGH,
+        clusters=("ai2/jupiter", "ai2/ceres"),
+        assigned_cluster="ai2/ceres",
+    )
+    # Placed on ceres, charged to ceres only (limit 0). Does not consume
+    # jupiter's budget, so the contender fits.
+    assert on_ceres.budget_clusters(limits) == ("ai2/ceres",)
+    contender = job(cm_priority=HIGH, slots=72, clusters=("ai2/jupiter",))
+    result = changes(decide([on_ceres, contender], limits))
+    assert contender.id in result and result[contender.id] == URGENT
+
+
 # --- replica groups ---------------------------------------------------------
 
 

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -33,6 +33,8 @@ from beaker import beaker_pb2 as pb2  # noqa: E402
 from beaker.exceptions import BeakerError  # noqa: E402
 
 WORKSPACE_ID = "ws-ace"
+OBSERVED_ID = "ws-climate-titan"
+WORKSPACE_IDS = {"ai2/ace": WORKSPACE_ID, "ai2/climate-titan": OBSERVED_ID}
 LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
 
 
@@ -100,7 +102,14 @@ def make_job(
 class FakeClient:
     """Stands in for beaker.Beaker over the surface the balancer uses."""
 
-    def __init__(self, jobs, node_clusters=None, fail_on=(), unknown_clusters=()):
+    def __init__(
+        self,
+        jobs,
+        node_clusters=None,
+        fail_on=(),
+        unknown_clusters=(),
+        unknown_workspaces=(),
+    ):
         self._jobs = list(jobs)
         # node id -> (bare cluster name, org name)
         self._node_clusters = node_clusters or {"node-jup": ("jupiter", "ai2")}
@@ -126,12 +135,17 @@ class FakeClient:
                 assert request.reason, "a reason should be recorded on every change"
                 return pb2.UpdateJobSourcePriorityResponse()
 
+        self._unknown_workspaces = set(unknown_workspaces)
         self.job = _JobService()
-        self.workspace = SimpleNamespace(
-            get=lambda name: SimpleNamespace(id=WORKSPACE_ID, name=name)
-        )
+        self.workspace = SimpleNamespace(get=self._get_workspace)
         self.node = SimpleNamespace(get=self._get_node)
         self.cluster = SimpleNamespace(get=self._get_cluster)
+
+    def _get_workspace(self, name):
+        if name in self._unknown_workspaces:
+            raise BeakerError(f"no such workspace {name}")
+        # Every workspace gets its own id, so a job can be attributed to one.
+        return SimpleNamespace(id=WORKSPACE_IDS.get(name, name), name=name)
 
     def _get_node(self, node_id):
         self.node_lookups.append(node_id)
@@ -825,3 +839,164 @@ def test_a_transient_beaker_error_does_not_kill_an_interval_loop(monkeypatch, ca
         balance.main(["--interval", "5"])
     assert len(passes) == 2
     assert "pass failed" in caplog.text
+
+
+# --- workspaces that are counted but never modified -------------------------
+
+OBSERVE = ("ai2/climate-titan",)
+
+
+def _elsewhere(job_id, **kwargs):
+    """A job in the observed workspace."""
+    kwargs.setdefault("workspace_id", OBSERVED_ID)
+    return make_job(job_id=job_id, **kwargs)
+
+
+def test_an_observed_workspaces_jobs_are_read_and_marked():
+    client = FakeClient([_labelled("mine", "high"), _elsewhere("theirs")])
+    mine, theirs = fetch_jobs(client, "ai2/ace", observed=OBSERVE)
+    assert (mine.workspace, mine.is_observed) == ("ai2/ace", False)
+    assert (theirs.workspace, theirs.is_observed) == ("ai2/climate-titan", True)
+
+
+def test_an_observed_job_is_not_read_for_cm_priority():
+    # Opting in is what makes a job ours to move, and nothing there is. Reading
+    # the label would make setting it look like it did something.
+    client = FakeClient([_elsewhere("theirs", env={"CM_PRIORITY": "urgent"})])
+    (view,) = fetch_jobs(client, "ai2/ace", observed=OBSERVE)
+    assert view.cm_priority is None
+    assert view.unmanaged_reason(LIMITS) is balance.OBSERVED
+
+
+def test_a_third_workspace_is_still_ignored_entirely():
+    client = FakeClient(
+        [_labelled("mine", "high"), make_job(job_id="other", workspace_id="ws-other")]
+    )
+    views = fetch_jobs(client, "ai2/ace", observed=OBSERVE)
+    assert [view.id for view in views] == ["mine"]
+
+
+def test_an_observed_jobs_urgent_slots_count_against_the_allocation():
+    client = FakeClient(
+        [_elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8)]
+    )
+    views = fetch_jobs(client, "ai2/ace", observed=OBSERVE)
+    assert urgent_usage(views, LIMITS)["ai2/jupiter"] == 8
+
+
+def test_an_observed_job_takes_slots_away_from_ours():
+    # The whole point: the allocation is the team's, not one workspace's.
+    client = FakeClient(
+        [
+            _elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8),
+            _labelled("mine", "high", gpu_count=8),
+        ]
+    )
+    applied = run_pass(
+        client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False, observed=OBSERVE
+    )
+    assert applied == 0
+    assert client.priority_calls == []
+
+
+def test_an_observed_job_is_never_modified_even_when_over_allocation():
+    # It is holding the entire allocation and we are over it; it is still not
+    # ours to touch.
+    client = FakeClient(
+        [_elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8)]
+    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False, observed=OBSERVE)
+    assert client.priority_calls == []
+
+
+def test_ours_is_still_balanced_around_an_observed_job():
+    client = FakeClient(
+        [
+            _elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8),
+            _labelled("mine", "high", gpu_count=8),
+        ]
+    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 16}, dry_run=False, observed=OBSERVE)
+    assert client.priority_calls == [("mine", URGENT)]
+
+
+def test_observed_slots_are_reported_under_their_workspace(caplog):
+    # Otherwise the log reads "8/8, no changes needed" with nothing saying why.
+    client = FakeClient(
+        [_elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8)]
+    )
+    with caplog.at_level(logging.INFO):
+        run_pass(client, "ai2/ace", LIMITS, dry_run=False, observed=OBSERVE)
+    assert "8 in ai2/climate-titan" in caplog.text
+    assert "never reclaimable" in caplog.text
+
+
+def test_observed_jobs_are_not_reported_as_failures_to_manage(caplog):
+    client = FakeClient([_elsewhere("theirs", clusters=("ai2/jupiter", "ai2/titan"))])
+    with caplog.at_level(logging.WARNING):
+        run_pass(client, "ai2/ace", LIMITS, dry_run=False, observed=OBSERVE)
+    assert "cannot be managed" not in caplog.text
+
+
+def test_the_pass_says_how_many_jobs_it_is_only_watching(caplog):
+    client = FakeClient([_labelled("mine", "high"), _elsewhere("theirs")])
+    with caplog.at_level(logging.INFO):
+        run_pass(client, "ai2/ace", LIMITS, dry_run=False, observed=OBSERVE)
+    assert "read 1 unfinished jobs in ai2/ace" in caplog.text
+    assert "1 watched in ai2/climate-titan" in caplog.text
+
+
+def test_an_observed_replica_group_is_counted_but_left_alone():
+    ranks = [
+        _elsewhere(
+            f"rank-{i}",
+            priority=pb2.JOB_PRIORITY_URGENT,
+            gpu_count=8,
+            replica_size=2,
+            replica_group_id="rg-theirs",
+        )
+        for i in range(2)
+    ]
+    client = FakeClient(ranks)
+    views = fetch_jobs(client, "ai2/ace", observed=OBSERVE)
+    assert urgent_usage(views, LIMITS)["ai2/jupiter"] == 16
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False, observed=OBSERVE)
+    assert client.priority_calls == []
+
+
+def test_a_misspelled_observed_workspace_fails_at_startup(monkeypatch):
+    # Counting nothing looks exactly like a workspace holding no urgent slots,
+    # so the allocation would quietly be handed out twice.
+    client = FakeClient([], unknown_workspaces={"ai2/climat-titan"})
+    _with_client(monkeypatch, client)
+    with pytest.raises(SystemExit, match="unknown workspace 'ai2/climat-titan'"):
+        balance.main(["--observe", "ai2/climat-titan"])
+
+
+def test_climate_titan_is_observed_by_default(monkeypatch):
+    # With no flag at all. If observing had to be asked for, the allocation
+    # would be handed out twice until someone remembered to ask.
+    client = FakeClient(
+        [
+            _elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8),
+            _labelled("mine", "high", gpu_count=8),
+        ]
+    )
+    _with_client(monkeypatch, client)
+    assert balance.main(["--limit", "ai2/jupiter=8"]) == 0
+    # Theirs holds the whole allocation, so ours is not granted anything.
+    assert client.priority_calls == []
+    assert balance.DEFAULT_OBSERVED_WORKSPACES == ("ai2/climate-titan",)
+
+
+def test_no_observe_counts_only_our_own_workspace(monkeypatch):
+    client = FakeClient(
+        [
+            _elsewhere("theirs", priority=pb2.JOB_PRIORITY_URGENT, gpu_count=8),
+            _labelled("mine", "high", gpu_count=8),
+        ]
+    )
+    _with_client(monkeypatch, client)
+    # Without the observed workspace's 8 slots counted, ours fits.
+    assert balance.main(["--limit", "ai2/jupiter=8", "--no-observe"]) == 0
+    assert client.priority_calls == [("mine", URGENT)]

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -1,0 +1,305 @@
+"""Integration tests for the balancer's Beaker-facing layer.
+
+These build real protobuf messages of the shapes Beaker returns and drive
+``fetch_jobs``, ``set_priority`` and ``run_pass`` against a fake client, so the
+parsing and mutation paths are covered without touching a live workspace.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+from balance import (
+    HIGH,
+    LOW,
+    NORMAL,
+    URGENT,
+    fetch_jobs,
+    parse_cm_priority,
+    parse_limits,
+    run_pass,
+    set_priority,
+)
+from beaker import beaker_pb2 as pb2
+from beaker.exceptions import BeakerError
+
+WORKSPACE_ID = "ws-ace"
+LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
+
+
+def make_job(
+    job_id="job-1",
+    name="train",
+    author="jeremym",
+    priority=pb2.JOB_PRIORITY_HIGH,
+    gpu_count=8,
+    clusters=("ai2/jupiter",),
+    hostnames=(),
+    env=None,
+    node_id="",
+    created=1000,
+    started=0,
+    workspace_id=WORKSPACE_ID,
+):
+    """Build a pb2.Job mirroring the shape Beaker returns for a live job."""
+    job = pb2.Job(
+        id=job_id,
+        name=name,
+        author_reference=author,
+        workspace_id=workspace_id,
+        task_id="task-1",
+        workload_id="workload-1",
+    )
+    job.container_spec.resource_request.gpu_count = gpu_count
+    for key, value in (env or {}).items():
+        job.container_spec.environment_variables.add(name=key, literal=value)
+
+    job.system_details.priority = priority
+    if clusters:
+        job.system_details.placement_constraints.add(
+            type=pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_CLUSTER, values=list(clusters)
+        )
+    if hostnames:
+        job.system_details.placement_constraints.add(
+            type=pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_HOSTNAME, values=list(hostnames)
+        )
+
+    job.status.created.seconds = created
+    if started:
+        job.status.started.seconds = started
+        job.status.status = pb2.STATUS_RUNNING
+    else:
+        job.status.status = pb2.STATUS_QUEUED
+    if node_id:
+        job.assignment_details.node_id = node_id
+    return job
+
+
+class FakeClient:
+    """Stands in for beaker.Beaker over the surface the balancer uses."""
+
+    def __init__(self, jobs, node_clusters=None, fail_on=()):
+        self._jobs = list(jobs)
+        # node id -> (bare cluster name, org name)
+        self._node_clusters = node_clusters or {"node-jup": ("jupiter", "ai2")}
+        self._fail_on = set(fail_on)
+        self.priority_calls: list[tuple[str, int]] = []
+
+        outer = self
+
+        class _JobService:
+            service = SimpleNamespace(UpdateJobSourcePriority=object())
+
+            def list(self, *, finalized=None, **kwargs):
+                return iter(outer._jobs)
+
+            def rpc_request(self, method, request, **kwargs):
+                if request.job_id in outer._fail_on:
+                    raise BeakerError(f"cannot modify {request.job_id}")
+                outer.priority_calls.append((request.job_id, request.priority))
+                assert request.reason, "a reason should be recorded on every change"
+                return pb2.UpdateJobSourcePriorityResponse()
+
+        self.job = _JobService()
+        self.workspace = SimpleNamespace(
+            get=lambda name: SimpleNamespace(id=WORKSPACE_ID, name=name)
+        )
+        self.node = SimpleNamespace(
+            get=lambda node_id: SimpleNamespace(cluster_id=node_id)
+        )
+        self.cluster = SimpleNamespace(
+            get=lambda cluster_id: SimpleNamespace(
+                name=outer._node_clusters[cluster_id][0],
+                organization_name=outer._node_clusters[cluster_id][1],
+            )
+        )
+
+
+# --- fetch_jobs -------------------------------------------------------------
+
+
+def test_fetch_reads_a_queued_job():
+    client = FakeClient([make_job(env={"CM_PRIORITY": "high"}, created=1234)])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.id == "job-1"
+    assert view.author == "jeremym"
+    assert view.priority == HIGH
+    assert view.cm_priority == HIGH
+    assert view.slots == 8
+    assert view.clusters == ("ai2/jupiter",)
+    assert view.assigned_cluster is None
+    assert view.is_queued
+    assert view.queued_at == 1234.0
+    assert view.started_at is None
+
+
+def test_fetch_qualifies_the_assigned_cluster_with_its_org():
+    # Regression: Cluster.name is bare, so an unqualified value would match no
+    # budget and the job's urgent slots would go uncounted.
+    client = FakeClient(
+        [make_job(node_id="node-jup", started=5000)],
+        node_clusters={"node-jup": ("jupiter", "ai2")},
+    )
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.assigned_cluster == "ai2/jupiter"
+    assert view.budget_clusters(LIMITS) == ("ai2/jupiter",)
+    assert not view.is_queued
+    assert view.started_at == 5000.0
+
+
+def test_fetch_ignores_jobs_in_other_workspaces():
+    client = FakeClient(
+        [make_job(job_id="mine"), make_job(job_id="theirs", workspace_id="ws-other")]
+    )
+    assert [view.id for view in fetch_jobs(client, "ai2/ace")] == ["mine"]
+
+
+def test_fetch_only_reads_cluster_placement_constraints():
+    # A hostname constraint must not be mistaken for a cluster, or a
+    # single-cluster job would look multi-cluster and never be managed.
+    client = FakeClient(
+        [make_job(clusters=("ai2/jupiter",), hostnames=("jupiter-cs-aus-241",))]
+    )
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.clusters == ("ai2/jupiter",)
+    assert view.managed_cluster(LIMITS) is None  # no CM_PRIORITY set
+
+
+def test_fetch_counts_a_cpu_only_job_as_one_slot():
+    client = FakeClient([make_job(gpu_count=0)])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.slots == 1
+
+
+def test_fetch_leaves_cm_priority_unset_when_absent():
+    client = FakeClient([make_job(env={"WANDB_NAME": "x"})])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.cm_priority is None
+    assert view.managed_cluster(LIMITS) is None
+
+
+def test_fetch_reads_multi_cluster_constraints_in_order():
+    client = FakeClient([make_job(clusters=("ai2/titan", "ai2/jupiter"))])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.clusters == ("ai2/titan", "ai2/jupiter")
+
+
+# --- CM_PRIORITY parsing ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("low", LOW),
+        ("normal", NORMAL),
+        ("high", HIGH),
+        ("urgent", URGENT),
+        ("URGENT", URGENT),
+        ("  high  ", HIGH),
+    ],
+)
+def test_cm_priority_values_are_parsed(raw, expected):
+    assert parse_cm_priority(raw, "job-1") == expected
+
+
+@pytest.mark.parametrize("raw", ["", "immediate", "highest", "3", "hgih"])
+def test_unusable_cm_priority_is_ignored_with_a_warning(raw, caplog):
+    with caplog.at_level(logging.WARNING):
+        assert parse_cm_priority(raw, "job-1") is None
+    assert "job-1" in caplog.text
+
+
+def test_a_job_with_an_unusable_cm_priority_is_not_managed():
+    client = FakeClient([make_job(env={"CM_PRIORITY": "highest"})])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.cm_priority is None
+    assert view.managed_cluster(LIMITS) is None
+
+
+# --- mutation ---------------------------------------------------------------
+
+
+def test_set_priority_sends_the_job_id_and_priority():
+    client = FakeClient([])
+    set_priority(client, "job-7", URGENT)
+    assert client.priority_calls == [("job-7", URGENT)]
+
+
+# --- run_pass ---------------------------------------------------------------
+
+
+def _labelled(job_id, cm, **kwargs):
+    return make_job(job_id=job_id, env={"CM_PRIORITY": cm}, **kwargs)
+
+
+def test_dry_run_changes_nothing():
+    client = FakeClient([_labelled("a", "high"), _labelled("b", "high")])
+    applied = run_pass(client, "ai2/ace", LIMITS, dry_run=True)
+    assert applied == 0
+    assert client.priority_calls == []
+
+
+def test_run_pass_applies_promotions():
+    client = FakeClient([_labelled("a", "high"), _labelled("b", "urgent")])
+    applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert applied == 2
+    assert sorted(client.priority_calls) == [("a", URGENT), ("b", URGENT)]
+
+
+def test_a_job_we_cannot_modify_does_not_stop_the_pass(caplog):
+    # Fail-soft: a teammate's job we lack permission on must not block ours.
+    client = FakeClient(
+        [_labelled("theirs", "high", author="yyexela"), _labelled("mine", "high")],
+        fail_on={"theirs"},
+    )
+    with caplog.at_level(logging.WARNING):
+        applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert applied == 1
+    assert client.priority_calls == [("mine", URGENT)]
+    assert "theirs" in caplog.text and "yyexela" in caplog.text
+
+
+def test_run_pass_is_idempotent():
+    # A second pass over the resulting state must be a no-op, or the balancer
+    # would flap jobs between priorities on every cron tick.
+    jobs = [_labelled("a", "high"), _labelled("b", "normal")]
+    client = FakeClient(jobs)
+    assert run_pass(client, "ai2/ace", LIMITS, dry_run=False) == 2
+
+    for job in jobs:
+        job.system_details.priority = URGENT
+    client = FakeClient(jobs)
+    assert run_pass(client, "ai2/ace", LIMITS, dry_run=False) == 0
+    assert client.priority_calls == []
+
+
+def test_multi_cluster_labelled_job_is_reported_but_untouched(caplog):
+    client = FakeClient(
+        [_labelled("both", "urgent", clusters=("ai2/titan", "ai2/jupiter"))]
+    )
+    with caplog.at_level(logging.WARNING):
+        applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert applied == 0
+    assert client.priority_calls == []
+    assert "both" in caplog.text
+
+
+# --- configuration ----------------------------------------------------------
+
+
+def test_limits_default_to_the_team_allocation():
+    assert parse_limits(None) == {"ai2/jupiter": 72, "ai2/titan": 32}
+
+
+def test_limits_can_be_overridden():
+    assert parse_limits(["ai2/jupiter=8", "ai2/titan=4"]) == {
+        "ai2/jupiter": 8,
+        "ai2/titan": 4,
+    }
+
+
+@pytest.mark.parametrize("bad", ["ai2/jupiter", "ai2/jupiter=", "ai2/jupiter=lots"])
+def test_a_malformed_limit_is_rejected(bad):
+    # Silently ignoring this would run the balancer against a wrong allocation.
+    with pytest.raises(ValueError):
+        parse_limits([bad])

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -46,6 +46,8 @@ def make_job(
     scheduled=0,
     started=0,
     replica_size=0,
+    replica_group_id="",
+    environment_id="",
     workspace_id=WORKSPACE_ID,
 ):
     """Build a pb2.Job mirroring the shape Beaker returns for a live job."""
@@ -56,6 +58,7 @@ def make_job(
         workspace_id=workspace_id,
         task_id="task-1",
         workload_id="workload-1",
+        environment_id=environment_id,
     )
     job.container_spec.resource_request.gpu_count = gpu_count
     for key, value in (env or {}).items():
@@ -72,6 +75,8 @@ def make_job(
         )
     if replica_size:
         job.system_details.replica_group_details.size = replica_size
+    if replica_group_id:
+        job.system_details.replica_group_details.id = replica_group_id
 
     job.status.created.seconds = created
     if scheduled:
@@ -223,11 +228,38 @@ def test_fetch_reads_a_job_with_no_cluster_constraint():
     assert view.budget_clusters(LIMITS) == tuple(LIMITS)
 
 
-def test_fetch_reads_replica_group_size():
-    client = FakeClient([make_job(replica_size=4, env={"CM_PRIORITY": "high"})])
+def test_fetch_reads_the_replica_group_so_ranks_group_together():
+    client = FakeClient(
+        [
+            make_job(
+                job_id=f"rank-{rank}",
+                replica_size=4,
+                replica_group_id="rg-1",
+                env={"CM_PRIORITY": "high"},
+            )
+            for rank in range(4)
+        ]
+    )
+    views = fetch_jobs(client, "ai2/ace")
+    assert {view.replica_group_size for view in views} == {4}
+    assert {view.group_key for view in views} == {"rg-1"}
+    # A rank is individually manageable; the group decides whether it moves.
+    assert all(view.managed_cluster(LIMITS) == "ai2/jupiter" for view in views)
+
+
+def test_a_lone_job_is_its_own_group():
+    client = FakeClient([make_job(job_id="solo", env={"CM_PRIORITY": "high"})])
     (view,) = fetch_jobs(client, "ai2/ace")
-    assert view.replica_group_size == 4
-    assert view.managed_cluster(LIMITS) is None
+    assert view.group_key == "solo"
+
+
+def test_fetch_marks_an_interactive_session():
+    # A session carries an environment id; a batch job does not.
+    client = FakeClient(
+        [make_job(job_id="session", environment_id="env-1"), make_job(job_id="batch")]
+    )
+    sessions = {view.id: view.is_session for view in fetch_jobs(client, "ai2/ace")}
+    assert sessions == {"session": True, "batch": False}
 
 
 def test_fetch_counts_a_cpu_only_job_as_one_slot():

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -14,6 +14,7 @@ import pytest
 
 pytest.importorskip("beaker", reason="beaker-py is not a core fme dependency")
 
+import balance  # noqa: E402
 from balance import (  # noqa: E402
     HIGH,
     LOW,
@@ -442,6 +443,55 @@ def test_multi_cluster_labelled_jobs_are_reported_once_in_aggregate(caplog):
     assert "5 job(s)" in warnings[0].getMessage()
 
 
+def test_unreclaimable_slots_are_broken_out_per_cluster(caplog):
+    # A pass can be stuck above the allocation through no fault of its own. The
+    # log has to say so, or it reads as a balancer that is not working.
+    client = FakeClient(
+        [
+            make_job(
+                job_id="session",
+                environment_id="env-1",
+                priority=pb2.JOB_PRIORITY_URGENT,
+                gpu_count=8,
+                node_id="node-jup",
+                started=100,
+            ),
+            make_job(
+                job_id="immediate",
+                priority=pb2.JOB_PRIORITY_IMMEDIATE,
+                gpu_count=16,
+                node_id="node-jup",
+                started=100,
+            ),
+        ],
+        node_clusters=NODES,
+    )
+    with caplog.at_level(logging.INFO):
+        run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "ai2/jupiter: 8 in interactive sessions; 16 at immediate priority" in m
+        for m in messages
+    )
+    assert client.priority_calls == []
+
+
+def test_a_replica_group_left_alone_is_reported(caplog):
+    # Each rank is individually fine, so this is invisible in the per-job
+    # counts: without its own line the group would be skipped silently.
+    ranks = [
+        _labelled(f"rank-{i}", "high", replica_size=4, replica_group_id="rg-1")
+        for i in range(3)
+    ]
+    ranks.append(make_job(job_id="rank-3", replica_size=4, replica_group_id="rg-1"))
+    client = FakeClient(ranks)
+    with caplog.at_level(logging.WARNING):
+        run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert client.priority_calls == []
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("1 replica group(s) left alone" in m and "rg-1" in m for m in warnings)
+
+
 def test_run_pass_reports_usage_after_applying(caplog):
     client = FakeClient([_labelled("a", "high", gpu_count=8)])
     with caplog.at_level(logging.INFO):
@@ -578,6 +628,37 @@ def test_a_replica_group_grant_is_deferred_as_a_unit():
     assert client.priority_calls == []
 
 
+def test_a_deferred_group_repays_the_deficit_with_all_of_its_slots():
+    # A group is deferred whole, so it stops spending everything it was going to
+    # spend -- not just the one rank that reached the check. Deferring further
+    # grants after that would strand slots the refusal did not actually hold.
+    client = FakeClient(
+        [
+            _holder("theirs", "normal", author="yyexela", gpu_count=16),
+            *[
+                _labelled(
+                    f"rank-{i}",
+                    "high",
+                    gpu_count=8,
+                    replica_size=4,
+                    replica_group_id="rg-1",
+                    created=100,
+                )
+                for i in range(4)
+            ],
+            _labelled("lone", "high", gpu_count=8, created=200),
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    # 32 for the group and 8 for the lone job fill the 40, so the 16-slot holder
+    # must be demoted to pay for them -- and that is the call that is refused.
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 40}, dry_run=False)
+    # Abandoning the group frees 32 against a 16-slot deficit, so the lone job
+    # still fits and must not be deferred with it.
+    assert client.priority_calls == [("lone", URGENT)]
+
+
 def test_negative_node_cache_is_dropped_between_passes():
     # A transient error must not charge a job to every budget indefinitely.
     jobs = [make_job(node_id="flaky", started=5000)]
@@ -664,7 +745,7 @@ def test_limits_can_add_a_new_cluster():
 
 
 @pytest.mark.parametrize(
-    "bad", ["ai2/jupiter", "ai2/jupiter=", "ai2/jupiter=lots", "=8"]
+    "bad", ["ai2/jupiter", "ai2/jupiter=", "ai2/jupiter=lots", "=8", "ai2/jupiter=-8"]
 )
 def test_a_malformed_limit_is_rejected(bad):
     # Silently ignoring this would run the balancer against a wrong allocation.
@@ -681,3 +762,66 @@ def test_an_unknown_cluster_name_is_rejected_at_startup():
 
 def test_valid_cluster_names_pass_validation():
     validate_limits(FakeClient([]), LIMITS)
+
+
+# --- the entrypoint ---------------------------------------------------------
+
+
+class _Stop(Exception):
+    """Breaks out of the --interval loop, which otherwise never returns."""
+
+
+def _with_client(monkeypatch, client):
+    monkeypatch.setattr(balance, "Beaker", SimpleNamespace(from_env=lambda: client))
+
+
+def test_one_pass_is_run_and_returned_from_by_default(monkeypatch):
+    client = FakeClient([_labelled("a", "high")])
+    _with_client(monkeypatch, client)
+    monkeypatch.setattr(balance.time, "sleep", lambda seconds: pytest.fail("looped"))
+    assert balance.main(["--dry-run"]) == 0
+    assert client.priority_calls == []
+
+
+def test_a_malformed_limit_exits_before_touching_beaker(monkeypatch):
+    monkeypatch.setattr(
+        balance, "Beaker", SimpleNamespace(from_env=lambda: pytest.fail("connected"))
+    )
+    with pytest.raises(SystemExit):
+        balance.main(["--limit", "ai2/jupiter"])
+
+
+def test_a_failed_pass_is_not_swallowed_without_an_interval(monkeypatch):
+    # A one-shot run must report failure rather than exit 0 having done nothing.
+    _with_client(monkeypatch, FakeClient([]))
+    monkeypatch.setattr(
+        balance, "run_pass", lambda *a, **k: (_ for _ in ()).throw(BeakerError("down"))
+    )
+    with pytest.raises(BeakerError):
+        balance.main([])
+
+
+def test_a_transient_beaker_error_does_not_kill_an_interval_loop(monkeypatch, caplog):
+    # The failure mode this guards is a cron balancer that quietly stops
+    # balancing after one bad poll.
+    _with_client(monkeypatch, FakeClient([]))
+    passes = []
+
+    def flaky(*args, **kwargs):
+        passes.append(1)
+        if len(passes) == 1:
+            raise BeakerError("beaker is down")
+        return 0
+
+    monkeypatch.setattr(balance, "run_pass", flaky)
+
+    def sleeper(seconds):
+        assert seconds == 5.0
+        if len(passes) >= 2:
+            raise _Stop
+
+    monkeypatch.setattr(balance.time, "sleep", sleeper)
+    with caplog.at_level(logging.ERROR), pytest.raises(_Stop):
+        balance.main(["--interval", "5"])
+    assert len(passes) == 2
+    assert "pass failed" in caplog.text

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -5,6 +5,7 @@ These build real protobuf messages of the shapes Beaker returns and drive
 parsing and mutation paths are covered without touching a live workspace.
 """
 
+import json
 import logging
 import random
 from dataclasses import replace
@@ -36,6 +37,19 @@ WORKSPACE_ID = "ws-ace"
 LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
 
 
+@pytest.fixture(autouse=True)
+def state_in_tmp_path(tmp_path, monkeypatch):
+    """Keep every pass's remembered resting priorities inside the test.
+
+    ``run_pass`` defaults to a real path under the user's home directory, so
+    without this the suite would read and overwrite the memory of a balancer
+    actually running on this machine -- and leak state between tests.
+    """
+    path = tmp_path / "resting.json"
+    monkeypatch.setattr(balance, "DEFAULT_STATE_PATH", path)
+    return path
+
+
 def make_job(
     job_id="job-1",
     name="train",
@@ -53,6 +67,7 @@ def make_job(
     replica_group_id="",
     environment_id="",
     workspace_id=WORKSPACE_ID,
+    retry_ancestor_id="",
 ):
     """Build a pb2.Job mirroring the shape Beaker returns for a live job."""
     job = pb2.Job(
@@ -63,6 +78,7 @@ def make_job(
         task_id="task-1",
         workload_id="workload-1",
         environment_id=environment_id,
+        retry_ancestor_id=retry_ancestor_id,
     )
     job.container_spec.resource_request.gpu_count = gpu_count
     for key, value in (env or {}).items():
@@ -411,7 +427,9 @@ def test_demotions_are_attempted_before_promotions():
         ]
     )
     run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    assert client.priority_calls == [("holder", NORMAL), ("contender", URGENT)]
+    # The holder was already at urgent when this balancer first saw it, so
+    # there is nothing remembered to put it back to and it falls back to high.
+    assert client.priority_calls == [("holder", HIGH), ("contender", URGENT)]
 
 
 def test_run_pass_is_idempotent():
@@ -567,7 +585,7 @@ def test_a_deferred_grant_is_retried_once_the_demotion_lands():
     # Next pass, with permission no longer refused: both halves go through.
     client = FakeClient(jobs, node_clusters=NODES)
     run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    assert client.priority_calls == [("theirs", NORMAL), ("mine", URGENT)]
+    assert client.priority_calls == [("theirs", HIGH), ("mine", URGENT)]
 
 
 def test_only_the_grant_the_deficit_pays_for_is_deferred():
@@ -825,3 +843,147 @@ def test_a_transient_beaker_error_does_not_kill_an_interval_loop(monkeypatch, ca
         balance.main(["--interval", "5"])
     assert len(passes) == 2
     assert "pass failed" in caplog.text
+
+
+# --- remembering where a job rests, across passes ---------------------------
+
+
+def test_a_job_is_returned_to_the_priority_it_was_raised_from(state_in_tmp_path):
+    """The point of the memory: give the slot back, leave everything else.
+
+    The first pass raises a ``normal`` job to urgent. By the second the
+    allocation has gone, and the job must land back on ``normal`` -- where its
+    owner submitted it -- rather than on the ``high`` fallback.
+    """
+    submitted = _labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)
+    client = FakeClient([submitted])
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert client.priority_calls == [("mine", URGENT)]
+
+    raised = _labelled(
+        "mine",
+        "high",
+        priority=pb2.JOB_PRIORITY_URGENT,
+        node_id="node-jup",
+        started=100,
+    )
+    client = FakeClient([raised])
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
+    assert client.priority_calls == [("mine", NORMAL)]
+
+
+def test_a_manual_change_is_adopted_as_the_new_resting_priority(state_in_tmp_path):
+    # The owner dropped the job to low between passes. That is now where it
+    # belongs, overriding the normal recorded when the balancer first saw it.
+    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+
+    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_LOW)])
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert client.priority_calls == [("mine", URGENT)]
+
+    raised = _holder("mine", "high")
+    client = FakeClient([raised], node_clusters=NODES)
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
+    assert client.priority_calls == [("mine", LOW)]
+
+
+def test_a_requeued_job_is_not_ratcheted_up_by_preemption(state_in_tmp_path):
+    """A preempted job comes back at the priority the balancer set, not its own.
+
+    Beaker gives the retry a new id, so without following ``retry_ancestor_id``
+    every preemption would lose the submitted priority and leave the job at the
+    ``high`` fallback -- ratcheting the whole workspace up over time.
+    """
+    client = FakeClient([_labelled("first", "high", priority=pb2.JOB_PRIORITY_LOW)])
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert client.priority_calls == [("first", URGENT)]
+
+    # Preempted, requeued under a new id, handed back at urgent by the source.
+    retry = _labelled(
+        "second", "high", priority=pb2.JOB_PRIORITY_URGENT, retry_ancestor_id="first"
+    )
+    client = FakeClient([retry])
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
+    assert client.priority_calls == [("second", LOW)]
+
+
+def test_a_finished_job_is_dropped_from_the_state_file(state_in_tmp_path):
+    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
+    run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert "mine" in json.loads(state_in_tmp_path.read_text())["resting"]
+
+    run_pass(FakeClient([]), "ai2/ace", LIMITS, dry_run=False)
+    assert json.loads(state_in_tmp_path.read_text())["resting"] == {}
+
+
+def test_a_dry_run_does_not_write_the_state_file(state_in_tmp_path):
+    # Reporting a pass must not change what a real one would then do.
+    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
+    run_pass(client, "ai2/ace", LIMITS, dry_run=True)
+    assert not state_in_tmp_path.exists()
+
+
+def test_an_unreadable_state_file_does_not_stop_a_pass(state_in_tmp_path, caplog):
+    # Forgetting costs the high fallback; refusing to run costs the allocation.
+    state_in_tmp_path.write_text("{not json")
+    client = FakeClient([_holder("mine", "high")], node_clusters=NODES)
+    with caplog.at_level(logging.WARNING):
+        run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
+    assert client.priority_calls == [("mine", HIGH)]
+    assert "could not read" in caplog.text
+
+
+def test_an_unwritable_state_file_does_not_stop_a_pass(state_in_tmp_path, caplog):
+    state_in_tmp_path.parent.joinpath("resting.json").mkdir()
+    client = FakeClient([_labelled("mine", "high")])
+    with caplog.at_level(logging.WARNING):
+        applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert applied == 1
+    assert "could not write" in caplog.text
+
+
+def test_state_from_a_future_version_is_ignored(state_in_tmp_path, caplog):
+    state_in_tmp_path.write_text(json.dumps({"version": 99, "resting": {"mine": LOW}}))
+    client = FakeClient([_holder("mine", "high")], node_clusters=NODES)
+    with caplog.at_level(logging.WARNING):
+        run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
+    assert client.priority_calls == [("mine", HIGH)]
+
+
+def test_a_nonsense_priority_in_the_state_file_is_ignored(state_in_tmp_path):
+    # Never restore a job to urgent or immediate, whatever the file claims.
+    state_in_tmp_path.write_text(
+        json.dumps({"version": 1, "resting": {"mine": URGENT, "other": 99}})
+    )
+    client = FakeClient([_holder("mine", "high")], node_clusters=NODES)
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
+    assert client.priority_calls == [("mine", HIGH)]
+
+
+def test_the_state_is_written_before_any_change_is_applied(
+    state_in_tmp_path, monkeypatch
+):
+    """A pass that dies midway must still have recorded what it saw.
+
+    The record is what lets the next pass put the job back; taking it after the
+    fact would read the priority this pass had just imposed.
+    """
+    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
+    seen = {}
+
+    def crash(*args, **kwargs):
+        seen.update(json.loads(state_in_tmp_path.read_text())["resting"])
+        raise BeakerError("died midway")
+
+    monkeypatch.setattr(client.job, "rpc_request", crash)
+    run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert seen == {"mine": NORMAL}
+
+
+def test_the_state_path_is_taken_from_the_command_line(tmp_path, monkeypatch):
+    chosen = tmp_path / "elsewhere" / "resting.json"
+    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
+    _with_client(monkeypatch, client)
+    assert balance.main(["--state", str(chosen)]) == 0
+    assert json.loads(chosen.read_text())["resting"] == {"mine": NORMAL}

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -9,19 +9,24 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-from balance import (
+
+pytest.importorskip("beaker", reason="beaker-py is not a core fme dependency")
+
+from balance import (  # noqa: E402
     HIGH,
     LOW,
     NORMAL,
     URGENT,
+    _cluster_of_node,
     fetch_jobs,
     parse_cm_priority,
     parse_limits,
     run_pass,
     set_priority,
+    validate_limits,
 )
-from beaker import beaker_pb2 as pb2
-from beaker.exceptions import BeakerError
+from beaker import beaker_pb2 as pb2  # noqa: E402
+from beaker.exceptions import BeakerError  # noqa: E402
 
 WORKSPACE_ID = "ws-ace"
 LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
@@ -38,7 +43,9 @@ def make_job(
     env=None,
     node_id="",
     created=1000,
+    scheduled=0,
     started=0,
+    replica_size=0,
     workspace_id=WORKSPACE_ID,
 ):
     """Build a pb2.Job mirroring the shape Beaker returns for a live job."""
@@ -63,11 +70,17 @@ def make_job(
         job.system_details.placement_constraints.add(
             type=pb2.JOB_PLACEMENT_CONSTRAINT_TYPE_HOSTNAME, values=list(hostnames)
         )
+    if replica_size:
+        job.system_details.replica_group_details.size = replica_size
 
     job.status.created.seconds = created
+    if scheduled:
+        job.status.scheduled.seconds = scheduled
     if started:
         job.status.started.seconds = started
         job.status.status = pb2.STATUS_RUNNING
+    elif scheduled:
+        job.status.status = pb2.STATUS_INITIALIZING
     else:
         job.status.status = pb2.STATUS_QUEUED
     if node_id:
@@ -78,19 +91,23 @@ def make_job(
 class FakeClient:
     """Stands in for beaker.Beaker over the surface the balancer uses."""
 
-    def __init__(self, jobs, node_clusters=None, fail_on=()):
+    def __init__(self, jobs, node_clusters=None, fail_on=(), unknown_clusters=()):
         self._jobs = list(jobs)
         # node id -> (bare cluster name, org name)
         self._node_clusters = node_clusters or {"node-jup": ("jupiter", "ai2")}
         self._fail_on = set(fail_on)
+        self._unknown_clusters = set(unknown_clusters)
         self.priority_calls: list[tuple[str, int]] = []
+        self.list_kwargs: list[dict] = []
+        self.node_lookups: list[str] = []
 
         outer = self
 
         class _JobService:
             service = SimpleNamespace(UpdateJobSourcePriority=object())
 
-            def list(self, *, finalized=None, **kwargs):
+            def list(self, **kwargs):
+                outer.list_kwargs.append(kwargs)
                 return iter(outer._jobs)
 
             def rpc_request(self, method, request, **kwargs):
@@ -104,15 +121,23 @@ class FakeClient:
         self.workspace = SimpleNamespace(
             get=lambda name: SimpleNamespace(id=WORKSPACE_ID, name=name)
         )
-        self.node = SimpleNamespace(
-            get=lambda node_id: SimpleNamespace(cluster_id=node_id)
-        )
-        self.cluster = SimpleNamespace(
-            get=lambda cluster_id: SimpleNamespace(
-                name=outer._node_clusters[cluster_id][0],
-                organization_name=outer._node_clusters[cluster_id][1],
-            )
-        )
+        self.node = SimpleNamespace(get=self._get_node)
+        self.cluster = SimpleNamespace(get=self._get_cluster)
+
+    def _get_node(self, node_id):
+        self.node_lookups.append(node_id)
+        if node_id not in self._node_clusters:
+            raise BeakerError(f"no such node {node_id}")
+        return SimpleNamespace(cluster_id=node_id)
+
+    def _get_cluster(self, cluster_id):
+        if cluster_id in self._unknown_clusters:
+            raise BeakerError(f"no such cluster {cluster_id}")
+        if cluster_id in self._node_clusters:
+            name, org = self._node_clusters[cluster_id]
+            return SimpleNamespace(name=name, organization_name=org)
+        org, _, name = cluster_id.partition("/")
+        return SimpleNamespace(name=name, organization_name=org)
 
 
 # --- fetch_jobs -------------------------------------------------------------
@@ -130,21 +155,40 @@ def test_fetch_reads_a_queued_job():
     assert view.assigned_cluster is None
     assert view.is_queued
     assert view.queued_at == 1234.0
-    assert view.started_at is None
+    assert view.placed_at is None
+
+
+def test_fetch_only_reads_unfinished_jobs():
+    # Dropping this filter would start charging finished jobs' slots against
+    # the allocation.
+    client = FakeClient([make_job()])
+    fetch_jobs(client, "ai2/ace")
+    assert client.list_kwargs == [{"finalized": False}]
 
 
 def test_fetch_qualifies_the_assigned_cluster_with_its_org():
     # Regression: Cluster.name is bare, so an unqualified value would match no
     # budget and the job's urgent slots would go uncounted.
     client = FakeClient(
-        [make_job(node_id="node-jup", started=5000)],
+        [make_job(node_id="node-jup", scheduled=4000, started=5000)],
         node_clusters={"node-jup": ("jupiter", "ai2")},
     )
     (view,) = fetch_jobs(client, "ai2/ace")
     assert view.assigned_cluster == "ai2/jupiter"
     assert view.budget_clusters(LIMITS) == ("ai2/jupiter",)
+    assert view.is_placed
+    assert view.placed_at == 5000.0
+
+
+def test_scheduled_but_not_started_job_is_placed_not_queued():
+    # A job Beaker has scheduled is initializing: it holds its slots already and
+    # Beaker refuses to raise its priority, so treating it as queued would both
+    # double-count the slots and emit a call that fails every pass.
+    client = FakeClient([make_job(node_id="node-jup", scheduled=4000, started=0)])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.is_placed
     assert not view.is_queued
-    assert view.started_at == 5000.0
+    assert view.placed_at == 4000.0
 
 
 def test_fetch_ignores_jobs_in_other_workspaces():
@@ -158,11 +202,32 @@ def test_fetch_only_reads_cluster_placement_constraints():
     # A hostname constraint must not be mistaken for a cluster, or a
     # single-cluster job would look multi-cluster and never be managed.
     client = FakeClient(
-        [make_job(clusters=("ai2/jupiter",), hostnames=("jupiter-cs-aus-241",))]
+        [
+            make_job(
+                clusters=("ai2/jupiter",),
+                hostnames=("jupiter-cs-aus-241",),
+                env={"CM_PRIORITY": "high"},
+            )
+        ]
     )
     (view,) = fetch_jobs(client, "ai2/ace")
     assert view.clusters == ("ai2/jupiter",)
-    assert view.managed_cluster(LIMITS) is None  # no CM_PRIORITY set
+    assert view.managed_cluster(LIMITS) == "ai2/jupiter"
+
+
+def test_fetch_reads_a_job_with_no_cluster_constraint():
+    client = FakeClient([make_job(clusters=())])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.clusters == ()
+    # It could land anywhere, so it is charged to every budget.
+    assert view.budget_clusters(LIMITS) == tuple(LIMITS)
+
+
+def test_fetch_reads_replica_group_size():
+    client = FakeClient([make_job(replica_size=4, env={"CM_PRIORITY": "high"})])
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.replica_group_size == 4
+    assert view.managed_cluster(LIMITS) is None
 
 
 def test_fetch_counts_a_cpu_only_job_as_one_slot():
@@ -182,6 +247,42 @@ def test_fetch_reads_multi_cluster_constraints_in_order():
     client = FakeClient([make_job(clusters=("ai2/titan", "ai2/jupiter"))])
     (view,) = fetch_jobs(client, "ai2/ace")
     assert view.clusters == ("ai2/titan", "ai2/jupiter")
+
+
+# --- node/cluster resolution ------------------------------------------------
+
+
+def test_node_cluster_is_org_qualified():
+    client = FakeClient([], node_clusters={"node-jup": ("jupiter", "ai2")})
+    cache: dict[str, str | None] = {}
+    assert _cluster_of_node(client, "node-jup", cache) == "ai2/jupiter"
+    assert cache == {"node-jup": "ai2/jupiter"}
+
+
+def test_unresolvable_node_is_cached_as_a_failure():
+    # Without negative caching this would be retried for every job, every pass.
+    client = FakeClient([], node_clusters={})
+    cache: dict[str, str | None] = {}
+    assert _cluster_of_node(client, "gone", cache) is None
+    assert _cluster_of_node(client, "gone", cache) is None
+    assert client.node_lookups == ["gone"]
+
+
+def test_a_job_on_an_unresolvable_node_is_charged_to_every_budget():
+    client = FakeClient([make_job(node_id="gone", started=5000)], node_clusters={})
+    (view,) = fetch_jobs(client, "ai2/ace")
+    assert view.is_placed
+    assert view.assigned_cluster is None
+    assert view.budget_clusters(LIMITS) == tuple(LIMITS)
+
+
+def test_node_cache_is_reused_across_passes():
+    jobs = [make_job(node_id="node-jup", started=5000)]
+    client = FakeClient(jobs)
+    cache: dict[str, str | None] = {}
+    fetch_jobs(client, "ai2/ace", cache)
+    fetch_jobs(client, "ai2/ace", cache)
+    assert client.node_lookups == ["node-jup"]
 
 
 # --- CM_PRIORITY parsing ----------------------------------------------------
@@ -259,29 +360,60 @@ def test_a_job_we_cannot_modify_does_not_stop_the_pass(caplog):
     assert "theirs" in caplog.text and "yyexela" in caplog.text
 
 
+def test_demotions_are_attempted_before_promotions():
+    # So a pass that dies partway through is never left over allocation.
+    client = FakeClient(
+        [
+            _labelled(
+                "holder",
+                "normal",
+                priority=pb2.JOB_PRIORITY_URGENT,
+                node_id="node-jup",
+                started=100,
+            ),
+            _labelled("contender", "high"),
+        ]
+    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert client.priority_calls == [("holder", NORMAL), ("contender", URGENT)]
+
+
 def test_run_pass_is_idempotent():
-    # A second pass over the resulting state must be a no-op, or the balancer
-    # would flap jobs between priorities on every cron tick.
     jobs = [_labelled("a", "high"), _labelled("b", "normal")]
     client = FakeClient(jobs)
     assert run_pass(client, "ai2/ace", LIMITS, dry_run=False) == 2
 
     for job in jobs:
-        job.system_details.priority = URGENT
+        job.system_details.priority = pb2.JOB_PRIORITY_URGENT
     client = FakeClient(jobs)
     assert run_pass(client, "ai2/ace", LIMITS, dry_run=False) == 0
     assert client.priority_calls == []
 
 
-def test_multi_cluster_labelled_job_is_reported_but_untouched(caplog):
+def test_multi_cluster_labelled_jobs_are_reported_once_in_aggregate(caplog):
     client = FakeClient(
-        [_labelled("both", "urgent", clusters=("ai2/titan", "ai2/jupiter"))]
+        [
+            _labelled(f"both-{i}", "urgent", clusters=("ai2/titan", "ai2/jupiter"))
+            for i in range(5)
+        ]
     )
     with caplog.at_level(logging.WARNING):
         applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
     assert applied == 0
     assert client.priority_calls == []
-    assert "both" in caplog.text
+    # One aggregate line, not one per job: most ace jobs are multi-cluster.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "5 job(s)" in warnings[0].getMessage()
+
+
+def test_run_pass_reports_usage_after_applying(caplog):
+    client = FakeClient([_labelled("a", "high", gpu_count=8)])
+    with caplog.at_level(logging.INFO):
+        run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("urgent slots before: ai2/jupiter 0/72" in m for m in messages)
+    assert any("urgent slots after: ai2/jupiter 8/72" in m for m in messages)
 
 
 # --- configuration ----------------------------------------------------------
@@ -291,15 +423,32 @@ def test_limits_default_to_the_team_allocation():
     assert parse_limits(None) == {"ai2/jupiter": 72, "ai2/titan": 32}
 
 
-def test_limits_can_be_overridden():
-    assert parse_limits(["ai2/jupiter=8", "ai2/titan=4"]) == {
-        "ai2/jupiter": 8,
-        "ai2/titan": 4,
-    }
+def test_an_override_merges_rather_than_replacing():
+    # Replacing would silently unmanage jupiter entirely.
+    assert parse_limits(["ai2/titan=0"]) == {"ai2/jupiter": 72, "ai2/titan": 0}
 
 
-@pytest.mark.parametrize("bad", ["ai2/jupiter", "ai2/jupiter=", "ai2/jupiter=lots"])
+def test_limits_can_add_a_new_cluster():
+    limits = parse_limits(["ai2/saturn=16"])
+    assert limits["ai2/saturn"] == 16
+    assert limits["ai2/jupiter"] == 72
+
+
+@pytest.mark.parametrize(
+    "bad", ["ai2/jupiter", "ai2/jupiter=", "ai2/jupiter=lots", "=8"]
+)
 def test_a_malformed_limit_is_rejected(bad):
     # Silently ignoring this would run the balancer against a wrong allocation.
     with pytest.raises(ValueError):
         parse_limits([bad])
+
+
+def test_an_unknown_cluster_name_is_rejected_at_startup():
+    # A typo would manage nothing and look exactly like a quiet cluster.
+    client = FakeClient([], unknown_clusters={"ai2/jupiter-cirrascale-2"})
+    with pytest.raises(SystemExit):
+        validate_limits(client, {"ai2/jupiter-cirrascale-2": 72})
+
+
+def test_valid_cluster_names_pass_validation():
+    validate_limits(FakeClient([]), LIMITS)

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -690,9 +690,7 @@ def test_a_refused_multi_cluster_demotion_defers_a_single_cluster_grant():
         node_clusters=NODES,
         fail_on={"theirs"},
     )
-    run_pass(
-        client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False
-    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False)
     assert client.priority_calls == []
 
 
@@ -712,9 +710,7 @@ def test_a_refused_single_cluster_demotion_defers_a_multi_cluster_grant():
         node_clusters=NODES,
         fail_on={"theirs"},
     )
-    run_pass(
-        client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False
-    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False)
     assert client.priority_calls == []
 
 

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -489,6 +489,29 @@ def test_unreclaimable_slots_are_broken_out_per_cluster(caplog):
     assert client.priority_calls == []
 
 
+def test_placed_job_on_unbudgeted_cluster_with_no_constraint_does_not_crash(caplog):
+    # A placed job with no cluster constraints that landed on a cluster outside
+    # the allocation has clusters=() and assigned_cluster set. The report must
+    # not crash on clusters[0].
+    client = FakeClient(
+        [
+            make_job(
+                job_id="stray",
+                env={"CM_PRIORITY": "high"},
+                clusters=(),
+                node_id="node-ceres",
+                started=100,
+            )
+        ],
+        node_clusters={"node-ceres": ("ceres", "ai2")},
+    )
+    with caplog.at_level(logging.WARNING):
+        run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert client.priority_calls == []
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("ai2/ceres" in m and "no allocation" in m for m in warnings)
+
+
 def test_a_replica_group_left_alone_is_reported(caplog):
     # Each rank is individually fine, so this is invisible in the per-job
     # counts: without its own line the group would be skipped silently.

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -512,6 +512,49 @@ def test_placed_job_on_unbudgeted_cluster_with_no_constraint_does_not_crash(capl
     assert any("ai2/ceres" in m and "no allocation" in m for m in warnings)
 
 
+def test_queued_job_targeting_budgeted_and_non_budgeted_clusters_is_promoted(caplog):
+    # A job eligible for jupiter and ceres is managed against jupiter alone.
+    # Ceres has no allocation, so the job is treated as a jupiter-only job.
+    NODES = {"node-jup": ("jupiter", "ai2")}
+    client = FakeClient(
+        [_labelled("mixed", "high", clusters=("ai2/jupiter", "ai2/ceres"))],
+        node_clusters=NODES,
+    )
+    applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert applied == 1
+    assert client.priority_calls == [("mixed", URGENT)]
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("no allocation" in m for m in warnings)
+
+
+def test_placed_job_on_non_budgeted_cluster_that_targeted_a_budgeted_one(caplog):
+    # The job targeted jupiter+ceres but landed on ceres. It should not be
+    # counted against jupiter, and should not produce a warning — this is a
+    # normal outcome, not an error.
+    client = FakeClient(
+        [
+            make_job(
+                job_id="on-ceres",
+                env={"CM_PRIORITY": "high"},
+                priority=pb2.JOB_PRIORITY_URGENT,
+                clusters=("ai2/jupiter", "ai2/ceres"),
+                node_id="node-ceres",
+                started=100,
+            ),
+            _labelled("contender", "high", gpu_count=72),
+        ],
+        node_clusters={"node-ceres": ("ceres", "ai2")},
+    )
+    with caplog.at_level(logging.WARNING):
+        applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    # The job on ceres is not counted against jupiter, so the contender fits.
+    assert applied == 1
+    assert client.priority_calls == [("contender", URGENT)]
+    # No warning about the job on ceres — it targeted a budgeted cluster.
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("no allocation" in m for m in warnings)
+
+
 def test_a_replica_group_left_alone_is_reported(caplog):
     # Each rank is individually fine, so this is invisible in the per-job
     # counts: without its own line the group would be skipped silently.

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -6,6 +6,8 @@ parsing and mutation paths are covered without touching a live workspace.
 """
 
 import logging
+import random
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -23,6 +25,7 @@ from balance import (  # noqa: E402
     parse_limits,
     run_pass,
     set_priority,
+    urgent_usage,
     validate_limits,
 )
 from beaker import beaker_pb2 as pb2  # noqa: E402
@@ -446,6 +449,200 @@ def test_run_pass_reports_usage_after_applying(caplog):
     messages = [r.getMessage() for r in caplog.records]
     assert any("urgent slots before: ai2/jupiter 0/72" in m for m in messages)
     assert any("urgent slots after: ai2/jupiter 8/72" in m for m in messages)
+
+
+# --- partially applied passes -----------------------------------------------
+#
+# Ordering demotions first makes any prefix of a pass safe, but a failure skips
+# one action and carries on, so what lands is an arbitrary subset. These cover
+# the subset that matters: the one where the demotion paying for a grant is the
+# call that failed.
+
+
+def _holder(job_id, cm, cluster="ai2/jupiter", **kwargs):
+    """A placed job holding urgent, i.e. one the balancer can demote."""
+    return _labelled(
+        job_id,
+        cm,
+        priority=pb2.JOB_PRIORITY_URGENT,
+        clusters=(cluster,),
+        node_id="node-jup" if cluster == "ai2/jupiter" else "node-tit",
+        started=100,
+        **kwargs,
+    )
+
+
+NODES = {"node-jup": ("jupiter", "ai2"), "node-tit": ("titan", "ai2")}
+
+
+def test_a_refused_demotion_defers_the_grant_it_was_paying_for(caplog):
+    # The whole point: without this the pass ends at 16/8, and says so.
+    client = FakeClient(
+        [
+            _holder("theirs", "normal", author="yyexela"),
+            _labelled("mine", "high"),
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    with caplog.at_level(logging.INFO):
+        applied = run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert applied == 0
+    assert client.priority_calls == []
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("urgent slots after: ai2/jupiter 8/8" in m for m in messages)
+    assert any("not granting urgent to mine" in m for m in messages)
+
+
+def test_a_refused_demotion_on_one_cluster_does_not_stall_the_other():
+    client = FakeClient(
+        [
+            _holder("theirs", "normal", author="yyexela"),
+            _labelled("mine", "high"),
+            _labelled("elsewhere", "high", clusters=("ai2/titan",)),
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False)
+    assert client.priority_calls == [("elsewhere", URGENT)]
+
+
+def test_a_deferred_grant_is_retried_once_the_demotion_lands():
+    jobs = [_holder("theirs", "normal", author="yyexela"), _labelled("mine", "high")]
+    client = FakeClient(jobs, node_clusters=NODES, fail_on={"theirs"})
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert client.priority_calls == []
+
+    # Next pass, with permission no longer refused: both halves go through.
+    client = FakeClient(jobs, node_clusters=NODES)
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
+    assert client.priority_calls == [("theirs", NORMAL), ("mine", URGENT)]
+
+
+def test_only_the_grant_the_deficit_pays_for_is_deferred():
+    # An 8-slot demotion refused must not defer 32 slots' worth of grants.
+    client = FakeClient(
+        [
+            _holder("theirs", "normal", author="yyexela", gpu_count=8),
+            _labelled("small", "high", gpu_count=8),
+            _labelled("also", "high", gpu_count=8),
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 16}, dry_run=False)
+    # 16 - 8 held by the refusal leaves room for exactly one of the two.
+    assert client.priority_calls == [("also", URGENT)]
+
+
+def test_a_refused_rank_stops_the_rest_of_its_group_being_granted():
+    """A group that cannot be granted whole stops rather than spending more.
+
+    The ranks granted before the refusal keep urgent: the next pass re-decides
+    from what is really there and either finishes the group or takes it back,
+    which is cheaper than a rollback that can fail in its turn. Permission is
+    per owner and every rank shares one, so in practice the first rank fails
+    and nothing is spent at all.
+    """
+    ranks = [
+        _labelled(f"rank-{i}", "high", replica_size=4, replica_group_id="rg-1")
+        for i in range(4)
+    ]
+    client = FakeClient(ranks, node_clusters=NODES, fail_on={"rank-2"})
+    run_pass(client, "ai2/ace", LIMITS, dry_run=False)
+    assert [job_id for job_id, _ in client.priority_calls] == ["rank-0", "rank-1"]
+
+
+def test_a_replica_group_grant_is_deferred_as_a_unit():
+    client = FakeClient(
+        [
+            _holder("theirs", "normal", author="yyexela", gpu_count=8),
+            *[
+                _labelled(
+                    f"rank-{i}",
+                    "high",
+                    gpu_count=8,
+                    replica_size=2,
+                    replica_group_id="rg-1",
+                )
+                for i in range(2)
+            ],
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    # 16 for the group leaves nothing for the holder, so the holder must be
+    # demoted to pay for it -- and that is the call that is refused.
+    run_pass(client, "ai2/ace", {"ai2/jupiter": 16}, dry_run=False)
+    assert client.priority_calls == []
+
+
+def test_negative_node_cache_is_dropped_between_passes():
+    # A transient error must not charge a job to every budget indefinitely.
+    jobs = [make_job(node_id="flaky", started=5000)]
+    client = FakeClient(jobs)
+    cache: dict[str, str | None] = {}
+    (view,) = fetch_jobs(client, "ai2/ace", cache)
+    assert view.assigned_cluster is None
+    assert view.budget_clusters(LIMITS) == tuple(LIMITS)
+
+    client._node_clusters["flaky"] = ("jupiter", "ai2")
+    (view,) = fetch_jobs(client, "ai2/ace", cache)
+    assert view.assigned_cluster == "ai2/jupiter"
+
+
+@pytest.mark.parametrize("seed", range(200))
+def test_a_pass_never_ends_over_allocation_however_calls_fail(seed):
+    """Any subset of a pass landing must leave us no worse than we started.
+
+    Every job here is manageable and single-cluster, so nothing unreclaimable
+    is propping the usage up: an overshoot could only be the balancer's doing.
+    """
+    rng = random.Random(seed)
+    limits = {"ai2/jupiter": 32, "ai2/titan": 16}
+    jobs = []
+    for i in range(rng.randrange(1, 10)):
+        cluster = rng.choice(list(limits))
+        placed = rng.random() < 0.5
+        jobs.append(
+            _labelled(
+                f"job-{i}",
+                rng.choice(["low", "normal", "high", "urgent"]),
+                priority=rng.choice(
+                    [
+                        pb2.JOB_PRIORITY_LOW,
+                        pb2.JOB_PRIORITY_NORMAL,
+                        pb2.JOB_PRIORITY_HIGH,
+                        pb2.JOB_PRIORITY_URGENT,
+                    ]
+                ),
+                gpu_count=rng.choice([1, 8, 16]),
+                clusters=(cluster,),
+                node_id=("node-jup" if cluster == "ai2/jupiter" else "node-tit")
+                if placed
+                else "",
+                started=100 + i if placed else 0,
+                created=100 + i,
+            )
+        )
+    fail_on = {job.id for job in jobs if rng.random() < 0.5}
+
+    client = FakeClient(jobs, node_clusters=NODES, fail_on=fail_on)
+    before = fetch_jobs(client, "ai2/ace")
+    run_pass(client, "ai2/ace", limits, dry_run=False)
+
+    landed = dict(client.priority_calls)
+    after = [
+        replace(view, priority=landed[view.id]) if view.id in landed else view
+        for view in before
+    ]
+    start = urgent_usage(before, limits)
+    end = urgent_usage(after, limits)
+    for cluster, limit in limits.items():
+        assert end[cluster] <= max(
+            limit, start[cluster]
+        ), f"{cluster}: {start[cluster]} -> {end[cluster]}, limit {limit}"
 
 
 # --- configuration ----------------------------------------------------------

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -235,7 +235,7 @@ def test_fetch_only_reads_cluster_placement_constraints():
     )
     (view,) = fetch_jobs(client, "ai2/ace")
     assert view.clusters == ("ai2/jupiter",)
-    assert view.managed_cluster(LIMITS) == "ai2/jupiter"
+    assert view.managed_clusters(LIMITS) == ("ai2/jupiter",)
 
 
 def test_fetch_reads_a_job_with_no_cluster_constraint():
@@ -262,7 +262,7 @@ def test_fetch_reads_the_replica_group_so_ranks_group_together():
     assert {view.replica_group_size for view in views} == {4}
     assert {view.group_key for view in views} == {"rg-1"}
     # A rank is individually manageable; the group decides whether it moves.
-    assert all(view.managed_cluster(LIMITS) == "ai2/jupiter" for view in views)
+    assert all(view.managed_clusters(LIMITS) == ("ai2/jupiter",) for view in views)
 
 
 def test_a_lone_job_is_its_own_group():
@@ -290,7 +290,7 @@ def test_fetch_leaves_cm_priority_unset_when_absent():
     client = FakeClient([make_job(env={"WANDB_NAME": "x"})])
     (view,) = fetch_jobs(client, "ai2/ace")
     assert view.cm_priority is None
-    assert view.managed_cluster(LIMITS) is None
+    assert view.managed_clusters(LIMITS) is None
 
 
 def test_fetch_reads_multi_cluster_constraints_in_order():
@@ -364,7 +364,7 @@ def test_a_job_with_an_unusable_cm_priority_is_not_managed():
     client = FakeClient([make_job(env={"CM_PRIORITY": "highest"})])
     (view,) = fetch_jobs(client, "ai2/ace")
     assert view.cm_priority is None
-    assert view.managed_cluster(LIMITS) is None
+    assert view.managed_clusters(LIMITS) is None
 
 
 # --- mutation ---------------------------------------------------------------
@@ -440,21 +440,20 @@ def test_run_pass_is_idempotent():
     assert client.priority_calls == []
 
 
-def test_multi_cluster_labelled_jobs_are_reported_once_in_aggregate(caplog):
+def test_queued_multi_cluster_labelled_jobs_are_managed(caplog):
+    # Five 8-slot urgent-labelled jobs targeting both clusters. All start at
+    # HIGH. Four fit on titan (32/32) and are promoted; the fifth stays at
+    # its resting priority (HIGH), which is already where it is.
     client = FakeClient(
         [
             _labelled(f"both-{i}", "urgent", clusters=("ai2/titan", "ai2/jupiter"))
             for i in range(5)
         ]
     )
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
-    assert applied == 0
-    assert client.priority_calls == []
-    # One aggregate line, not one per job: most ace jobs are multi-cluster.
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    assert "5 job(s)" in warnings[0].getMessage()
+    assert applied == 4
+    assert all(p == URGENT for _, p in client.priority_calls)
 
 
 def test_unreclaimable_slots_are_broken_out_per_cluster(caplog):
@@ -671,6 +670,52 @@ def test_a_deferred_group_repays_the_deficit_with_all_of_its_slots():
     # Abandoning the group frees 32 against a 16-slot deficit, so the lone job
     # still fits and must not be deferred with it.
     assert client.priority_calls == [("lone", URGENT)]
+
+
+def test_a_refused_multi_cluster_demotion_defers_a_single_cluster_grant():
+    # A queued multi-cluster job holds urgent on both clusters. Its demotion is
+    # refused, so the deficit must appear on BOTH clusters — otherwise a grant
+    # on the second cluster goes through and the pass ends over allocation.
+    client = FakeClient(
+        [
+            _labelled(
+                "theirs",
+                "normal",
+                priority=pb2.JOB_PRIORITY_URGENT,
+                clusters=("ai2/titan", "ai2/jupiter"),
+                author="yyexela",
+            ),
+            _labelled("mine", "high", clusters=("ai2/jupiter",)),
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    run_pass(
+        client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False
+    )
+    assert client.priority_calls == []
+
+
+def test_a_refused_single_cluster_demotion_defers_a_multi_cluster_grant():
+    # A placed single-cluster job's demotion on jupiter is refused. A queued
+    # multi-cluster grant targeting (titan, jupiter) must be deferred because
+    # jupiter still has a deficit, even though titan does not.
+    client = FakeClient(
+        [
+            _holder("theirs", "normal", cluster="ai2/jupiter", author="yyexela"),
+            _labelled(
+                "mine",
+                "high",
+                clusters=("ai2/titan", "ai2/jupiter"),
+            ),
+        ],
+        node_clusters=NODES,
+        fail_on={"theirs"},
+    )
+    run_pass(
+        client, "ai2/ace", {"ai2/jupiter": 8, "ai2/titan": 8}, dry_run=False
+    )
+    assert client.priority_calls == []
 
 
 def test_negative_node_cache_is_dropped_between_passes():

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -5,7 +5,6 @@ These build real protobuf messages of the shapes Beaker returns and drive
 parsing and mutation paths are covered without touching a live workspace.
 """
 
-import json
 import logging
 import random
 from dataclasses import replace
@@ -37,19 +36,6 @@ WORKSPACE_ID = "ws-ace"
 LIMITS = {"ai2/jupiter": 72, "ai2/titan": 32}
 
 
-@pytest.fixture(autouse=True)
-def state_in_tmp_path(tmp_path, monkeypatch):
-    """Keep every pass's remembered resting priorities inside the test.
-
-    ``run_pass`` defaults to a real path under the user's home directory, so
-    without this the suite would read and overwrite the memory of a balancer
-    actually running on this machine -- and leak state between tests.
-    """
-    path = tmp_path / "resting.json"
-    monkeypatch.setattr(balance, "DEFAULT_STATE_PATH", path)
-    return path
-
-
 def make_job(
     job_id="job-1",
     name="train",
@@ -67,7 +53,6 @@ def make_job(
     replica_group_id="",
     environment_id="",
     workspace_id=WORKSPACE_ID,
-    retry_ancestor_id="",
 ):
     """Build a pb2.Job mirroring the shape Beaker returns for a live job."""
     job = pb2.Job(
@@ -78,7 +63,6 @@ def make_job(
         task_id="task-1",
         workload_id="workload-1",
         environment_id=environment_id,
-        retry_ancestor_id=retry_ancestor_id,
     )
     job.container_spec.resource_request.gpu_count = gpu_count
     for key, value in (env or {}).items():
@@ -427,9 +411,7 @@ def test_demotions_are_attempted_before_promotions():
         ]
     )
     run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    # The holder was already at urgent when this balancer first saw it, so
-    # there is nothing remembered to put it back to and it falls back to high.
-    assert client.priority_calls == [("holder", HIGH), ("contender", URGENT)]
+    assert client.priority_calls == [("holder", NORMAL), ("contender", URGENT)]
 
 
 def test_run_pass_is_idempotent():
@@ -585,7 +567,7 @@ def test_a_deferred_grant_is_retried_once_the_demotion_lands():
     # Next pass, with permission no longer refused: both halves go through.
     client = FakeClient(jobs, node_clusters=NODES)
     run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    assert client.priority_calls == [("theirs", HIGH), ("mine", URGENT)]
+    assert client.priority_calls == [("theirs", NORMAL), ("mine", URGENT)]
 
 
 def test_only_the_grant_the_deficit_pays_for_is_deferred():
@@ -843,147 +825,3 @@ def test_a_transient_beaker_error_does_not_kill_an_interval_loop(monkeypatch, ca
         balance.main(["--interval", "5"])
     assert len(passes) == 2
     assert "pass failed" in caplog.text
-
-
-# --- remembering where a job rests, across passes ---------------------------
-
-
-def test_a_job_is_returned_to_the_priority_it_was_raised_from(state_in_tmp_path):
-    """The point of the memory: give the slot back, leave everything else.
-
-    The first pass raises a ``normal`` job to urgent. By the second the
-    allocation has gone, and the job must land back on ``normal`` -- where its
-    owner submitted it -- rather than on the ``high`` fallback.
-    """
-    submitted = _labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)
-    client = FakeClient([submitted])
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    assert client.priority_calls == [("mine", URGENT)]
-
-    raised = _labelled(
-        "mine",
-        "high",
-        priority=pb2.JOB_PRIORITY_URGENT,
-        node_id="node-jup",
-        started=100,
-    )
-    client = FakeClient([raised])
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
-    assert client.priority_calls == [("mine", NORMAL)]
-
-
-def test_a_manual_change_is_adopted_as_the_new_resting_priority(state_in_tmp_path):
-    # The owner dropped the job to low between passes. That is now where it
-    # belongs, overriding the normal recorded when the balancer first saw it.
-    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-
-    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_LOW)])
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    assert client.priority_calls == [("mine", URGENT)]
-
-    raised = _holder("mine", "high")
-    client = FakeClient([raised], node_clusters=NODES)
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
-    assert client.priority_calls == [("mine", LOW)]
-
-
-def test_a_requeued_job_is_not_ratcheted_up_by_preemption(state_in_tmp_path):
-    """A preempted job comes back at the priority the balancer set, not its own.
-
-    Beaker gives the retry a new id, so without following ``retry_ancestor_id``
-    every preemption would lose the submitted priority and leave the job at the
-    ``high`` fallback -- ratcheting the whole workspace up over time.
-    """
-    client = FakeClient([_labelled("first", "high", priority=pb2.JOB_PRIORITY_LOW)])
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 8}, dry_run=False)
-    assert client.priority_calls == [("first", URGENT)]
-
-    # Preempted, requeued under a new id, handed back at urgent by the source.
-    retry = _labelled(
-        "second", "high", priority=pb2.JOB_PRIORITY_URGENT, retry_ancestor_id="first"
-    )
-    client = FakeClient([retry])
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
-    assert client.priority_calls == [("second", LOW)]
-
-
-def test_a_finished_job_is_dropped_from_the_state_file(state_in_tmp_path):
-    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
-    run_pass(client, "ai2/ace", LIMITS, dry_run=False)
-    assert "mine" in json.loads(state_in_tmp_path.read_text())["resting"]
-
-    run_pass(FakeClient([]), "ai2/ace", LIMITS, dry_run=False)
-    assert json.loads(state_in_tmp_path.read_text())["resting"] == {}
-
-
-def test_a_dry_run_does_not_write_the_state_file(state_in_tmp_path):
-    # Reporting a pass must not change what a real one would then do.
-    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
-    run_pass(client, "ai2/ace", LIMITS, dry_run=True)
-    assert not state_in_tmp_path.exists()
-
-
-def test_an_unreadable_state_file_does_not_stop_a_pass(state_in_tmp_path, caplog):
-    # Forgetting costs the high fallback; refusing to run costs the allocation.
-    state_in_tmp_path.write_text("{not json")
-    client = FakeClient([_holder("mine", "high")], node_clusters=NODES)
-    with caplog.at_level(logging.WARNING):
-        run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
-    assert client.priority_calls == [("mine", HIGH)]
-    assert "could not read" in caplog.text
-
-
-def test_an_unwritable_state_file_does_not_stop_a_pass(state_in_tmp_path, caplog):
-    state_in_tmp_path.parent.joinpath("resting.json").mkdir()
-    client = FakeClient([_labelled("mine", "high")])
-    with caplog.at_level(logging.WARNING):
-        applied = run_pass(client, "ai2/ace", LIMITS, dry_run=False)
-    assert applied == 1
-    assert "could not write" in caplog.text
-
-
-def test_state_from_a_future_version_is_ignored(state_in_tmp_path, caplog):
-    state_in_tmp_path.write_text(json.dumps({"version": 99, "resting": {"mine": LOW}}))
-    client = FakeClient([_holder("mine", "high")], node_clusters=NODES)
-    with caplog.at_level(logging.WARNING):
-        run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
-    assert client.priority_calls == [("mine", HIGH)]
-
-
-def test_a_nonsense_priority_in_the_state_file_is_ignored(state_in_tmp_path):
-    # Never restore a job to urgent or immediate, whatever the file claims.
-    state_in_tmp_path.write_text(
-        json.dumps({"version": 1, "resting": {"mine": URGENT, "other": 99}})
-    )
-    client = FakeClient([_holder("mine", "high")], node_clusters=NODES)
-    run_pass(client, "ai2/ace", {"ai2/jupiter": 0}, dry_run=False)
-    assert client.priority_calls == [("mine", HIGH)]
-
-
-def test_the_state_is_written_before_any_change_is_applied(
-    state_in_tmp_path, monkeypatch
-):
-    """A pass that dies midway must still have recorded what it saw.
-
-    The record is what lets the next pass put the job back; taking it after the
-    fact would read the priority this pass had just imposed.
-    """
-    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
-    seen = {}
-
-    def crash(*args, **kwargs):
-        seen.update(json.loads(state_in_tmp_path.read_text())["resting"])
-        raise BeakerError("died midway")
-
-    monkeypatch.setattr(client.job, "rpc_request", crash)
-    run_pass(client, "ai2/ace", LIMITS, dry_run=False)
-    assert seen == {"mine": NORMAL}
-
-
-def test_the_state_path_is_taken_from_the_command_line(tmp_path, monkeypatch):
-    chosen = tmp_path / "elsewhere" / "resting.json"
-    client = FakeClient([_labelled("mine", "high", priority=pb2.JOB_PRIORITY_NORMAL)])
-    _with_client(monkeypatch, client)
-    assert balance.main(["--state", str(chosen)]) == 0
-    assert json.loads(chosen.read_text())["resting"] == {"mine": NORMAL}

--- a/scripts/beaker_balancer/test_beaker_io.py
+++ b/scripts/beaker_balancer/test_beaker_io.py
@@ -555,6 +555,20 @@ def test_placed_job_on_non_budgeted_cluster_that_targeted_a_budgeted_one(caplog)
     assert not any("no allocation" in m for m in warnings)
 
 
+def test_zero_allocation_cluster_is_transparent_for_grants(caplog):
+    # Ceres is in limits at 0: the balancer knows the cluster name, but its
+    # zero allocation does not block grants on jupiter.
+    limits_with_zero = {"ai2/jupiter": 72, "ai2/titan": 32, "ai2/ceres": 0}
+    client = FakeClient(
+        [_labelled("mixed", "high", clusters=("ai2/jupiter", "ai2/ceres"))],
+    )
+    applied = run_pass(client, "ai2/ace", limits_with_zero, dry_run=False)
+    assert applied == 1
+    assert client.priority_calls == [("mixed", URGENT)]
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("no allocation" in m for m in warnings)
+
+
 def test_a_replica_group_left_alone_is_reported(caplog):
     # Each rank is individually fine, so this is invisible in the per-job
     # counts: without its own line the group would be skipped silently.
@@ -780,6 +794,29 @@ def test_a_refused_single_cluster_demotion_defers_a_multi_cluster_grant():
     assert client.priority_calls == []
 
 
+def test_a_refused_zero_allocation_demotion_does_not_block_a_positive_grant():
+    # A managed job on ceres (limit 0) at urgent is demoted. If that demotion
+    # fails, the ceres deficit must not block a grant that only needs jupiter.
+    # The grant action's clusters must be the positive-allocation ones only,
+    # so the deficit check does not see ceres.
+    limits = {"ai2/jupiter": 8, "ai2/ceres": 0}
+    client = FakeClient(
+        [
+            _labelled(
+                "on-ceres",
+                "normal",
+                priority=pb2.JOB_PRIORITY_URGENT,
+                clusters=("ai2/ceres",),
+                author="yyexela",
+            ),
+            _labelled("mine", "high", clusters=("ai2/jupiter", "ai2/ceres")),
+        ],
+        fail_on={"on-ceres"},
+    )
+    run_pass(client, "ai2/ace", limits, dry_run=False)
+    assert ("mine", URGENT) in client.priority_calls
+
+
 def test_negative_node_cache_is_dropped_between_passes():
     # A transient error must not charge a job to every budget indefinitely.
     jobs = [make_job(node_id="flaky", started=5000)]
@@ -851,12 +888,22 @@ def test_a_pass_never_ends_over_allocation_however_calls_fail(seed):
 
 
 def test_limits_default_to_the_team_allocation():
-    assert parse_limits(None) == {"ai2/jupiter": 72, "ai2/titan": 32}
+    assert parse_limits(None) == {
+        "ai2/jupiter": 72,
+        "ai2/titan": 32,
+        "ai2/ceres": 0,
+        "ai2/saturn": 0,
+    }
 
 
 def test_an_override_merges_rather_than_replacing():
     # Replacing would silently unmanage jupiter entirely.
-    assert parse_limits(["ai2/titan=0"]) == {"ai2/jupiter": 72, "ai2/titan": 0}
+    assert parse_limits(["ai2/titan=0"]) == {
+        "ai2/jupiter": 72,
+        "ai2/titan": 0,
+        "ai2/ceres": 0,
+        "ai2/saturn": 0,
+    }
 
 
 def test_limits_can_add_a_new_cluster():


### PR DESCRIPTION
Beaker does not enforce our urgent-priority allocation (72 GPU slots on `ai2/jupiter`, 32 on `ai2/titan`), so queueing urgent jobs can silently put the team over it. That effectively bans queueing urgent work. This adds a script that keeps us inside the allocation automatically, so urgent jobs can be queued freely.

Users can set an env var on their jobs `CM_PRIORITY` to `low`, `normal`, `high` or `urgent`. The balancer only modifies such jobs, other urgent jobs still count against the allocation.

When we have more than the allocated number of urgent slots (running or in-queue), the balancer downgrades the lowest-priority CM_PRIORITY jobs (longest-running breaks ties). When we have fewer, it upgrades the highest-priority job (most time in queue breaks ties). It also will downgrade running beaker-urgent-priority jobs with lower CM_PRIORITY to make space for higher CM_PRIORITY jobs that are stuck in the queue (but not for jobs already running, as we would need to stop them to upgrade the priority).

Decisions are made per **replica group**, not per job. A multi-node job is all-or-nothing.

When downgrading a running job, priority is changed in-place without pre-emption. Upgrading priority of a running job would require stopping it, so rather than do that we never upgrade the priority of jobs already running.

Two kinds of job count against the allocation but are never changed in either direction: **interactive sessions**, which have a person attached to them, and jobs at **`immediate` priority**, which outranks urgent and which Beaker only grants with a human-supplied reason.

The allocation is the team's, not one workspace's. The balancer manages `ai2/ace` and also **counts the urgent slots held in `ai2/climate-titan`** (`--observe`, repeatable; `--no-observe` to disable), without ever modifying anything there. Without this it would grant urgent against slots that are already occupied, handing the same allocation out twice — not hypothetical, since climate-titan currently holds 33 of the 32 titan slots. `CM_PRIORITY` is not read in an observed workspace: opting in is what makes a job the balancer's to move, and nothing there is. Beaker returns the whole org's unfinished jobs in one call, so observing another workspace costs a name lookup rather than a second pass.

A job is balanced against the clusters its slots are charged to. A **running** job occupies one cluster and is balanced against that one alone, whatever it was submitted eligible for — its slots can be seen and reclaimed from that cluster's budget. A **queued** job targeting multiple clusters is managed **pessimistically**: granting it urgent requires room on every cluster it could land on and charges all of them, since nothing can preempt an urgent job and granting it commits the allocation on whichever cluster it picks. Demoting a queued multi-cluster job frees all of its clusters. This means a multi-cluster grant costs more headroom than a single-cluster one when allocations are tight, which is the right tradeoff — the alternative is to grant urgent against a budget the job might consume elsewhere.

Changes:
- `scripts/beaker_balancer/balance.py` — the balancer. Pure `decide()` computes the priority changes; `fetch_jobs`/`set_priority` wrap Beaker. Supports `--dry-run`, `--workspace`, `--limit CLUSTER=SLOTS`, `--observe`/`--no-observe` and `--interval`, and is stateless and convergent so it is safe to run from cron. Fails soft per job, so a teammate's job it lacks permission on is logged and skipped rather than failing the pass, and orders demotions before promotions so any prefix of a partially applied pass stays within allocation.
- `scripts/beaker_balancer/test_balance.py` — decision-logic tests, including randomised populations of replica groups, sessions and `immediate` jobs asserting the invariants that matter: a pass never pushes usage above the allocation, any prefix of a pass stays within it, a second pass is always a no-op, a group is never left holding urgent on only some ranks, sessions and `immediate` jobs are never touched, and a placed job is never raised. Usage is computed with an oracle written independently of the production accounting, and a further test asserts the random populations actually reach the states that matter.
- `scripts/beaker_balancer/test_beaker_io.py` — the Beaker-facing layer driven against a fake client built from real protobuf messages, covering env-var and placement-constraint parsing, replica-group and session detection, slot accounting, dry-run, and fail-soft behaviour.
- `scripts/beaker_balancer/README.md` — the allocation model, opt-in instructions, and the rationale behind each rule.

Cluster and workspace names given on the command line are resolved at startup, since a typo would silently manage or count nothing and look exactly like a quiet cluster or an idle workspace.

Verified against the live `ai2/ace` workspace: slot accounting reproduces the true per-cluster urgent usage (independently cross-checked), and feeding the real job population through `decide()` converges in one pass without exceeding either allocation.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated