### PR TITLE
Load time-invariant variables once instead of per sample

### DIFF
--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -570,6 +570,67 @@ def test_time_invariant_variable_is_repeated(mock_monthly_netcdfs):
     assert data["constant_scalar_var"].shape == (15, 4, 8)
 
 
+def _count_file_opens_while_reading(
+    monkeypatch, dataset: XarrayDataset, indices: Sequence[int]
+) -> int:
+    """Number of times the dataset opens a file while reading the samples."""
+    n_opens = 0
+    original = XarrayDataset._open_file
+
+    def counting_open_file(self, idx):
+        nonlocal n_opens
+        n_opens += 1
+        return original(self, idx)
+
+    monkeypatch.setattr(XarrayDataset, "_open_file", counting_open_file)
+    for idx in indices:
+        dataset[idx]
+    return n_opens
+
+
+def test_time_invariant_variables_do_not_open_files_per_sample(
+    mock_monthly_netcdfs, monkeypatch
+):
+    """Requesting time-invariant variables should not add per-sample file opens.
+
+    They are loaded once at construction, so reading samples costs the same
+    number of file opens whether or not they were requested.
+    """
+    mock_data: MockData = mock_monthly_netcdfs
+    config = XarrayDataConfig(data_path=mock_data.tmpdir)
+    names = mock_data.var_names
+    # samples spread across the underlying monthly files
+    indices = [0, 100, 400, 700, 0]
+
+    without = xarray_dataset_constructor(config, list(names.time_dependent_names), 2)
+    with_invariant = xarray_dataset_constructor(config, names.all_names, 2)
+
+    n_without = _count_file_opens_while_reading(monkeypatch, without, indices)
+    n_with = _count_file_opens_while_reading(monkeypatch, with_invariant, indices)
+
+    assert n_with == n_without
+
+
+def test_time_invariant_variable_values_match_source(mock_monthly_netcdfs):
+    """Caching must not change the values that are returned."""
+    mock_data: MockData = mock_monthly_netcdfs
+    config = XarrayDataConfig(data_path=mock_data.tmpdir)
+    dataset = xarray_dataset_constructor(config, mock_data.var_names.all_names, 3)
+    source = xr.open_dataset(
+        mock_data.tmpdir / f"{mock_data.start_times[0].strftime('%Y%m%d%H')}.nc",
+        decode_times=False,
+        decode_timedelta=False,
+    )
+    # read several samples spanning different files to confirm the cached
+    # tensor is not mutated or aliased between reads
+    for idx in [0, 250, 500, 0]:
+        data = dataset[idx][0]
+        expected = torch.as_tensor(source["constant_var"].values)
+        np.testing.assert_array_equal(data["constant_var"][0].numpy(), expected.numpy())
+        assert data["constant_var"].shape == (3, 4, 8)
+    source.close()
+
+
 def _get_repeat_dataset(
     mock_data: MockData, n_timesteps: int, n_repeats: int
 ) -> XarrayDataset:

--- a/fme/core/dataset/utils.py
+++ b/fme/core/dataset/utils.py
@@ -59,16 +59,28 @@ def _get_indexers(
     return tuple(indexers)
 
 
+def as_alignable_tensor(
+    variable: xr.Variable,
+    dims: Sequence[Hashable],
+) -> torch.tensor:
+    """Load data from variable as a tensor with a singleton axis for each of the
+    given dims that the variable does not have.
+
+    The result is not yet broadcast to a particular shape, so it does not depend
+    on the length of the time dimension and can be reused across samples.
+    """
+    arr = variable.values
+    indexers = _get_indexers(variable, dims)
+    return torch.as_tensor(arr[indexers])
+
+
 def as_broadcasted_tensor(
     variable: xr.Variable,
     dims: Sequence[Hashable],
     shape: Sequence[int],
 ) -> torch.tensor:
     """Load data from variable and broadcast to tensor with the given shape."""
-    arr = variable.values
-    indexers = _get_indexers(variable, dims)
-    tensor = torch.as_tensor(arr[indexers])
-    return torch.broadcast_to(tensor, shape)
+    return torch.broadcast_to(as_alignable_tensor(variable, dims), shape)
 
 
 def _broadcast_array_to_tensor(

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -38,7 +38,7 @@ from fme.core.typing_ import Slice, TensorDict
 from .data_typing import VariableMetadata
 from .dataset import DatasetABC, DatasetItem
 from .utils import (
-    as_broadcasted_tensor,
+    as_alignable_tensor,
     get_horizontal_coordinates,
     get_nonspacetime_dimensions,
     load_series_data,
@@ -617,11 +617,35 @@ class XarrayDataset(DatasetABC):
         )
         self._check_isel_dimensions(first_dataset.sizes)
         first_dataset.close()
+        self._time_invariant_tensors = self._load_time_invariant_tensors()
         self._apply_sample_n_times(self._n_timesteps_schedule.get_value(0))
         self._labels = set(config.labels) if config.labels is not None else None
         self._infer_timestep = config.infer_timestep
         self._local_epoch: int = -1
         self._global_epoch = torch.tensor(-1)
+
+    def _load_time_invariant_tensors(self) -> dict[str, torch.Tensor]:
+        """Load the time-invariant variables into memory.
+
+        These do not vary in time, so they are read once here and broadcast over
+        the time dimension of each sample rather than being re-read per sample.
+        Values are taken from the first file, consistent with how coordinates,
+        vertical coordinate and variable metadata are read in __init__.
+        """
+        if len(self._time_invariant_names) == 0:
+            return {}
+        # opened directly rather than via _open_file so that closing this
+        # handle cannot close one shared through the file handle cache
+        ds = _open_xr_dataset(self.full_paths[0], engine=self.engine)
+        ds = ds.isel(**self.isel)
+        tensors = {}
+        for name in self._time_invariant_names:
+            variable = ds[name].variable
+            if self.fill_nans is not None:
+                variable = variable.fillna(self.fill_nans.value)
+            tensors[name] = as_alignable_tensor(variable, self.dims)
+        ds.close()
+        return tensors
 
     def _ensure_epoch_synchronized(self):
         """Ensure that the local epoch is synchronized with the global epoch.
@@ -935,18 +959,10 @@ class XarrayDataset(DatasetABC):
             tensors[n] = torch.cat(tensor_list)
         del arrays
 
-        # load time-invariant variables from first dataset
-        if len(self._time_invariant_names) > 0:
-            ds = self._open_file(idxs[0])
-            ds = ds.isel(**self.isel)
-            shape = [total_steps] + self._shape_excluding_time_after_selection
-            for name in self._time_invariant_names:
-                variable = ds[name].variable
-                if self.fill_nans is not None:
-                    variable = variable.fillna(self.fill_nans.value)
-                tensors[name] = as_broadcasted_tensor(variable, self.dims, shape)
-            ds.close()
-            del ds
+        # broadcast the time-invariant variables loaded at construction
+        shape = [total_steps] + self._shape_excluding_time_after_selection
+        for name, tensor in self._time_invariant_tensors.items():
+            tensors[name] = torch.broadcast_to(tensor, shape)
 
         # load static derived variables
         for name in self._static_derived_names:


### PR DESCRIPTION
Time-invariant variables were re-read from disk on every `__getitem__`, via a full `xr.open_dataset` of the file each sample happened to start in. These variables do not vary in time, so they are now read once when the dataset is constructed and broadcast over the time dimension of each sample.

Changes:
- `fme.core.dataset.xarray.XarrayDataset`: new `_load_time_invariant_tensors`, called from `__init__`; `get_sample_by_time_slice` now broadcasts the stored tensors instead of opening a file. The one-time read uses `_open_xr_dataset` directly rather than `_open_file`, so closing the handle cannot close one shared through the file handle cache.
- `fme.core.dataset.utils.as_alignable_tensor`: new, holding the part of `as_broadcasted_tensor` that does not depend on the target shape and so can be reused across samples. `as_broadcasted_tensor` is now a thin wrapper over it and is unchanged for callers.


- [x] Tests added