### PR TITLE
Cache zarr group and array handles across samples

### DIFF
--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -628,8 +628,8 @@ def test_zarr_cached_handles_return_correct_values(mock_monthly_zarr):
                 data[name].shape,
             )
             np.testing.assert_array_equal(data[name].numpy(), expected)
-            
-            
+
+
 def _count_file_opens_while_reading(
     monkeypatch, dataset: XarrayDataset, indices: Sequence[int]
 ) -> int:

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 import torch
 import xarray as xr
+import zarr
 from xarray.coding.times import CFDatetimeCoder
 
 from fme.core.coordinates import (
@@ -568,6 +569,66 @@ def test_time_invariant_variable_is_repeated(mock_monthly_netcdfs):
     data = dataset[0][0]
     assert data["constant_var"].shape[0] == 15
     assert data["constant_scalar_var"].shape == (15, 4, 8)
+
+
+def test_zarr_array_handles_are_reused_across_samples(mock_monthly_zarr, monkeypatch):
+    """Reading a sample should not re-read the zarr metadata for each variable.
+
+    The group and each array are opened once and reused, so the number of
+    metadata reads does not grow with the number of samples read.
+    """
+    from . import utils
+
+    utils._open_async_group.cache_clear()
+    utils._get_async_array.cache_clear()
+
+    n_group_opens = 0
+    original_open = zarr.api.asynchronous.open
+
+    async def counting_open(*args, **kwargs):
+        nonlocal n_group_opens
+        n_group_opens += 1
+        return await original_open(*args, **kwargs)
+
+    monkeypatch.setattr(zarr.api.asynchronous, "open", counting_open)
+
+    mock_data: MockData = mock_monthly_zarr
+    config = XarrayDataConfig(
+        data_path=mock_data.tmpdir, file_pattern="*.zarr", engine="zarr"
+    )
+    names = list(mock_data.var_names.time_dependent_names)
+    dataset = xarray_dataset_constructor(config, names, 2)
+
+    for idx in [0, 100, 400, 700, 0]:
+        dataset[idx]
+
+    assert n_group_opens == 1
+    assert utils._get_async_array.cache_info().currsize == len(names)
+
+
+def test_zarr_cached_handles_return_correct_values(mock_monthly_zarr):
+    """Cached handles must return the same data as the underlying store."""
+    mock_data: MockData = mock_monthly_zarr
+    config = XarrayDataConfig(
+        data_path=mock_data.tmpdir, file_pattern="*.zarr", engine="zarr"
+    )
+    names = list(mock_data.var_names.time_dependent_names)
+    dataset = xarray_dataset_constructor(config, names, 3)
+    source = xr.open_dataset(
+        mock_data.tmpdir / "data.zarr", engine="zarr", decode_timedelta=False
+    )
+    # repeat an index to confirm cached handles are not stateful across reads
+    for idx in [0, 250, 500, 0]:
+        data = dataset[idx][0]
+        for name in names:
+            expected = source[name].isel(time=slice(idx, idx + 3)).values
+            # scalar-per-time variables are broadcast over the spatial dims
+            expected = np.broadcast_to(
+                expected.reshape(expected.shape + (1,) * (3 - expected.ndim)),
+                data[name].shape,
+            )
+            np.testing.assert_array_equal(data[name].numpy(), expected)
+    source.close()
 
 
 def _get_repeat_dataset(

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -12,7 +12,6 @@ import pandas as pd
 import pytest
 import torch
 import xarray as xr
-import zarr
 from xarray.coding.times import CFDatetimeCoder
 
 from fme.core.coordinates import (
@@ -569,41 +568,6 @@ def test_time_invariant_variable_is_repeated(mock_monthly_netcdfs):
     data = dataset[0][0]
     assert data["constant_var"].shape[0] == 15
     assert data["constant_scalar_var"].shape == (15, 4, 8)
-
-
-def test_zarr_array_handles_are_reused_across_samples(mock_monthly_zarr, monkeypatch):
-    """Reading a sample should not re-read the zarr metadata for each variable.
-
-    The group and each array are opened once and reused, so the number of
-    metadata reads does not grow with the number of samples read.
-    """
-    from . import utils
-
-    utils._open_async_group.cache_clear()
-    utils._get_async_array.cache_clear()
-
-    n_group_opens = 0
-    original_open = zarr.api.asynchronous.open
-
-    async def counting_open(*args, **kwargs):
-        nonlocal n_group_opens
-        n_group_opens += 1
-        return await original_open(*args, **kwargs)
-
-    monkeypatch.setattr(zarr.api.asynchronous, "open", counting_open)
-
-    mock_data: MockData = mock_monthly_zarr
-    config = XarrayDataConfig(
-        data_path=mock_data.tmpdir, file_pattern="*.zarr", engine="zarr"
-    )
-    names = list(mock_data.var_names.time_dependent_names)
-    dataset = xarray_dataset_constructor(config, names, 2)
-
-    for idx in [0, 100, 400, 700, 0]:
-        dataset[idx]
-
-    assert n_group_opens == 1
-    assert utils._get_async_array.cache_info().currsize == len(names)
 
 
 def test_zarr_cached_handles_return_correct_values(mock_monthly_zarr):

--- a/fme/core/dataset/utils.py
+++ b/fme/core/dataset/utils.py
@@ -122,11 +122,9 @@ def _get_array_selection(
     return selection
 
 
-# Opening a group and getting an array from it each read the corresponding
-# zarr.json, so without caching every sample re-reads one metadata document per
-# requested variable. The cached objects hold metadata and a store reference,
-# and the set of keys is fixed by the configured datasets (files x variables),
-# so these do not grow without bound at runtime.
+# Cache the opened zarr group and arrays to avoid repeated metadata reads when
+# loading multiple time slices from the same zarr store. Assumes that the zarr store is
+# not modified between calls.
 @functools.cache
 def _open_async_group(path: str):
     loop = asyncio.get_event_loop()

--- a/fme/core/dataset/utils.py
+++ b/fme/core/dataset/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import datetime
+import functools
 from collections.abc import Hashable, MutableMapping, Sequence
 from typing import Literal
 
@@ -94,28 +95,42 @@ def _broadcast_array_to_tensor(
     return torch.broadcast_to(tensor, shape)
 
 
-async def _get_item(group, name, selection):
-    async_array = await group.getitem(name)
-    if len(async_array.shape) != len(selection):
-        if len(async_array.shape) != 1:
+def _get_array_selection(
+    name: str, shape: tuple[int, ...], selection: tuple[slice | int, ...]
+) -> tuple[slice | int, ...] | slice | int:
+    """Resolve the selection to apply to an array with the given shape."""
+    if len(shape) != len(selection):
+        if len(shape) != 1:
             raise ValueError(
                 f"Index selection slices/indices were provided as {selection} "
-                f"but array {name} has {len(async_array.shape)} dimensions. "
+                f"but array {name} has {len(shape)} dimensions. "
             )
-        else:
-            # 1d scalar arrays are sliced along time dim
-            array_selection = selection[0]
-    else:
-        array_selection = selection
-    return await async_array.getitem(array_selection)
+        # 1d scalar arrays are sliced along time dim
+        return selection[0]
+    return selection
 
 
-async def _get_items(url, names, selection):
-    async_group = await zarr.api.asynchronous.open(store=url)
-    coroutines = []
-    for name in names:
-        coroutines.append(_get_item(async_group, name, selection))
-    return await asyncio.gather(*coroutines)
+# Opening a group and getting an array from it each read the corresponding
+# zarr.json, so without caching every sample re-reads one metadata document per
+# requested variable. The cached objects hold metadata and a store reference,
+# and the set of keys is fixed by the configured datasets (files x variables),
+# so these do not grow without bound at runtime.
+@functools.cache
+def _open_async_group(path: str):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(zarr.api.asynchronous.open(store=path))
+
+
+@functools.cache
+def _get_async_array(path: str, name: str):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(_open_async_group(path).getitem(name))
+
+
+async def _get_items(arrays_and_selections):
+    return await asyncio.gather(
+        *(array.getitem(selection) for array, selection in arrays_and_selections)
+    )
 
 
 def _load_all_variables_zarr_async(
@@ -127,8 +142,16 @@ def _load_all_variables_zarr_async(
 
     Assumes that the time dimension is the first dimension in the dataset.
     """
+    # arrays are resolved before gathering so that the metadata reads hit the
+    # cache instead of being repeated on every call
+    arrays_and_selections = []
+    for name in variables:
+        async_array = _get_async_array(path, name)
+        arrays_and_selections.append(
+            (async_array, _get_array_selection(name, async_array.shape, selection))
+        )
     loop = asyncio.get_event_loop()
-    arrays = loop.run_until_complete(_get_items(path, variables, selection))
+    arrays = loop.run_until_complete(_get_items(arrays_and_selections))
     return {k: v for k, v in zip(variables, arrays)}
 
 


### PR DESCRIPTION
when using `XarrayDataset` with the zarr engine, we opened the zarr group and fetched each requested array from that group on every `__getitem__`. Both of those operations read a metadata file which can be assumed to not change. So the group and array handles are now cached per process.

Claude says: Caches are per process so each dataloader worker builds its own. This relies on zarr datasets using the `forkserver` start method, which `fme.ace.data_loading.getters` already forces whenever the zarr engine is used with workers; a cached handle inherited across a bare `fork` would reference an event loop that does not exist in the child.

- [x] Tests added