### PR TITLE
[DO NOT MERGE] Combined zarr data loading performance changes

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 torch==2.10.0  # version matches torch in Docker image
 xarray>=2025.01.2
 zarr>=3.0.3
+zarrs>=0.2.3

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -570,6 +570,67 @@ def test_time_invariant_variable_is_repeated(mock_monthly_netcdfs):
     assert data["constant_scalar_var"].shape == (15, 4, 8)
 
 
+def _count_file_opens_while_reading(
+    monkeypatch, dataset: XarrayDataset, indices: Sequence[int]
+) -> int:
+    """Number of times the dataset opens a file while reading the samples."""
+    n_opens = 0
+    original = XarrayDataset._open_file
+
+    def counting_open_file(self, idx):
+        nonlocal n_opens
+        n_opens += 1
+        return original(self, idx)
+
+    monkeypatch.setattr(XarrayDataset, "_open_file", counting_open_file)
+    for idx in indices:
+        dataset[idx]
+    return n_opens
+
+
+def test_time_invariant_variables_do_not_open_files_per_sample(
+    mock_monthly_netcdfs, monkeypatch
+):
+    """Requesting time-invariant variables should not add per-sample file opens.
+
+    They are loaded once at construction, so reading samples costs the same
+    number of file opens whether or not they were requested.
+    """
+    mock_data: MockData = mock_monthly_netcdfs
+    config = XarrayDataConfig(data_path=mock_data.tmpdir)
+    names = mock_data.var_names
+    # samples spread across the underlying monthly files
+    indices = [0, 100, 400, 700, 0]
+
+    without = xarray_dataset_constructor(config, list(names.time_dependent_names), 2)
+    with_invariant = xarray_dataset_constructor(config, names.all_names, 2)
+
+    n_without = _count_file_opens_while_reading(monkeypatch, without, indices)
+    n_with = _count_file_opens_while_reading(monkeypatch, with_invariant, indices)
+
+    assert n_with == n_without
+
+
+def test_time_invariant_variable_values_match_source(mock_monthly_netcdfs):
+    """Caching must not change the values that are returned."""
+    mock_data: MockData = mock_monthly_netcdfs
+    config = XarrayDataConfig(data_path=mock_data.tmpdir)
+    dataset = xarray_dataset_constructor(config, mock_data.var_names.all_names, 3)
+    source = xr.open_dataset(
+        mock_data.tmpdir / f"{mock_data.start_times[0].strftime('%Y%m%d%H')}.nc",
+        decode_times=False,
+        decode_timedelta=False,
+    )
+    # read several samples spanning different files to confirm the cached
+    # tensor is not mutated or aliased between reads
+    for idx in [0, 250, 500, 0]:
+        data = dataset[idx][0]
+        expected = torch.as_tensor(source["constant_var"].values)
+        np.testing.assert_array_equal(data["constant_var"][0].numpy(), expected.numpy())
+        assert data["constant_var"].shape == (3, 4, 8)
+    source.close()
+
+
 def _get_repeat_dataset(
     mock_data: MockData, n_timesteps: int, n_repeats: int
 ) -> XarrayDataset:

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -606,6 +606,24 @@ def test_zarr_array_handles_are_reused_across_samples(mock_monthly_zarr, monkeyp
     assert utils._get_async_array.cache_info().currsize == len(names)
 
 
+def test_zarr_arrays_use_zarrs_codec_pipeline(mock_monthly_zarr):
+    """Arrays opened for reading use the zarrs pipeline, others do not."""
+    from . import utils
+
+    utils._open_async_group.cache_clear()
+    utils._get_async_array.cache_clear()
+
+    mock_data: MockData = mock_monthly_zarr
+    store = str(mock_data.tmpdir / "data.zarr")
+    name = list(mock_data.var_names.time_dependent_names)[0]
+
+    array = utils._get_async_array(store, name)
+    assert type(array.codec_pipeline).__name__ == "ZarrsCodecPipeline"
+    # the global pipeline is left alone, so zarr use elsewhere (e.g. the
+    # inference data writers) is unaffected
+    assert zarr.config.get("codec_pipeline.path") != utils.ZARRS_CODEC_PIPELINE
+
+
 def test_zarr_cached_handles_return_correct_values(mock_monthly_zarr):
     """Cached handles must return the same data as the underlying store."""
     mock_data: MockData = mock_monthly_zarr

--- a/fme/core/dataset/test_xarray.py
+++ b/fme/core/dataset/test_xarray.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 import torch
 import xarray as xr
+import zarr
 from xarray.coding.times import CFDatetimeCoder
 
 from fme.core.coordinates import (
@@ -568,6 +569,66 @@ def test_time_invariant_variable_is_repeated(mock_monthly_netcdfs):
     data = dataset[0][0]
     assert data["constant_var"].shape[0] == 15
     assert data["constant_scalar_var"].shape == (15, 4, 8)
+
+
+def test_zarr_array_handles_are_reused_across_samples(mock_monthly_zarr, monkeypatch):
+    """Reading a sample should not re-read the zarr metadata for each variable.
+
+    The group and each array are opened once and reused, so the number of
+    metadata reads does not grow with the number of samples read.
+    """
+    from . import utils
+
+    utils._open_async_group.cache_clear()
+    utils._get_async_array.cache_clear()
+
+    n_group_opens = 0
+    original_open = zarr.api.asynchronous.open
+
+    async def counting_open(*args, **kwargs):
+        nonlocal n_group_opens
+        n_group_opens += 1
+        return await original_open(*args, **kwargs)
+
+    monkeypatch.setattr(zarr.api.asynchronous, "open", counting_open)
+
+    mock_data: MockData = mock_monthly_zarr
+    config = XarrayDataConfig(
+        data_path=mock_data.tmpdir, file_pattern="*.zarr", engine="zarr"
+    )
+    names = list(mock_data.var_names.time_dependent_names)
+    dataset = xarray_dataset_constructor(config, names, 2)
+
+    for idx in [0, 100, 400, 700, 0]:
+        dataset[idx]
+
+    assert n_group_opens == 1
+    assert utils._get_async_array.cache_info().currsize == len(names)
+
+
+def test_zarr_cached_handles_return_correct_values(mock_monthly_zarr):
+    """Cached handles must return the same data as the underlying store."""
+    mock_data: MockData = mock_monthly_zarr
+    config = XarrayDataConfig(
+        data_path=mock_data.tmpdir, file_pattern="*.zarr", engine="zarr"
+    )
+    names = list(mock_data.var_names.time_dependent_names)
+    dataset = xarray_dataset_constructor(config, names, 3)
+    source = xr.open_dataset(
+        mock_data.tmpdir / "data.zarr", engine="zarr", decode_timedelta=False
+    )
+    # repeat an index to confirm cached handles are not stateful across reads
+    for idx in [0, 250, 500, 0]:
+        data = dataset[idx][0]
+        for name in names:
+            expected = source[name].isel(time=slice(idx, idx + 3)).values
+            # scalar-per-time variables are broadcast over the spatial dims
+            expected = np.broadcast_to(
+                expected.reshape(expected.shape + (1,) * (3 - expected.ndim)),
+                data[name].shape,
+            )
+            np.testing.assert_array_equal(data[name].numpy(), expected)
+    source.close()
 
 
 def _get_repeat_dataset(

--- a/fme/core/dataset/utils.py
+++ b/fme/core/dataset/utils.py
@@ -59,16 +59,28 @@ def _get_indexers(
     return tuple(indexers)
 
 
+def as_alignable_tensor(
+    variable: xr.Variable,
+    dims: Sequence[Hashable],
+) -> torch.tensor:
+    """Load data from variable as a tensor with a singleton axis for each of the
+    given dims that the variable does not have.
+
+    The result is not yet broadcast to a particular shape, so it does not depend
+    on the length of the time dimension and can be reused across samples.
+    """
+    arr = variable.values
+    indexers = _get_indexers(variable, dims)
+    return torch.as_tensor(arr[indexers])
+
+
 def as_broadcasted_tensor(
     variable: xr.Variable,
     dims: Sequence[Hashable],
     shape: Sequence[int],
 ) -> torch.tensor:
     """Load data from variable and broadcast to tensor with the given shape."""
-    arr = variable.values
-    indexers = _get_indexers(variable, dims)
-    tensor = torch.as_tensor(arr[indexers])
-    return torch.broadcast_to(tensor, shape)
+    return torch.broadcast_to(as_alignable_tensor(variable, dims), shape)
 
 
 def _broadcast_array_to_tensor(

--- a/fme/core/dataset/utils.py
+++ b/fme/core/dataset/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import datetime
+import functools
 from collections.abc import Hashable, MutableMapping, Sequence
 from typing import Literal
 
@@ -94,28 +95,42 @@ def _broadcast_array_to_tensor(
     return torch.broadcast_to(tensor, shape)
 
 
-async def _get_item(group, name, selection):
-    async_array = await group.getitem(name)
-    if len(async_array.shape) != len(selection):
-        if len(async_array.shape) != 1:
+def _get_array_selection(
+    name: str, shape: tuple[int, ...], selection: tuple[slice | int, ...]
+) -> tuple[slice | int, ...] | slice | int:
+    """Resolve the selection to apply to an array with the given shape."""
+    if len(shape) != len(selection):
+        if len(shape) != 1:
             raise ValueError(
                 f"Index selection slices/indices were provided as {selection} "
-                f"but array {name} has {len(async_array.shape)} dimensions. "
+                f"but array {name} has {len(shape)} dimensions. "
             )
-        else:
-            # 1d scalar arrays are sliced along time dim
-            array_selection = selection[0]
-    else:
-        array_selection = selection
-    return await async_array.getitem(array_selection)
+        # 1d scalar arrays are sliced along time dim
+        return selection[0]
+    return selection
 
 
-async def _get_items(url, names, selection):
-    async_group = await zarr.api.asynchronous.open(store=url)
-    coroutines = []
-    for name in names:
-        coroutines.append(_get_item(async_group, name, selection))
-    return await asyncio.gather(*coroutines)
+# Opening a group and getting an array from it each read the corresponding
+# zarr.json, so without caching every sample re-reads one metadata document per
+# requested variable. The cached objects hold metadata and a store reference,
+# and the set of keys is fixed by the configured datasets (files x variables),
+# so these do not grow without bound at runtime.
+@functools.cache
+def _open_async_group(path: str):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(zarr.api.asynchronous.open(store=path))
+
+
+@functools.cache
+def _get_async_array(path: str, name: str):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(_open_async_group(path).getitem(name))
+
+
+async def _get_items(arrays_and_selections):
+    return await asyncio.gather(
+        *(array.getitem(selection) for array, selection in arrays_and_selections)
+    )
 
 
 def _load_all_variables_zarr_async(
@@ -127,8 +142,16 @@ def _load_all_variables_zarr_async(
 
     Assumes that the time dimension is the first dimension in the dataset.
     """
+    # arrays are resolved before gathering so that the metadata reads hit the
+    # cache instead of being repeated on every call
+    arrays_and_selections = []
+    for name in variables:
+        async_array = _get_async_array(path, name)
+        arrays_and_selections.append(
+            (async_array, _get_array_selection(name, async_array.shape, selection))
+        )
     loop = asyncio.get_event_loop()
-    arrays = loop.run_until_complete(_get_items(path, variables, selection))
+    arrays = loop.run_until_complete(_get_items(arrays_and_selections))
     return {k: v for k, v in zip(variables, arrays)}
 
 

--- a/fme/core/dataset/utils.py
+++ b/fme/core/dataset/utils.py
@@ -18,6 +18,8 @@ from fme.core.coordinates import (
 
 SLICE_NONE = slice(None)
 
+ZARRS_CODEC_PIPELINE = "zarrs.ZarrsCodecPipeline"
+
 
 def accumulate_labels(labels: list[set[str] | None]) -> set[str] | None:
     """
@@ -124,7 +126,13 @@ def _open_async_group(path: str):
 @functools.cache
 def _get_async_array(path: str, name: str):
     loop = asyncio.get_event_loop()
-    return loop.run_until_complete(_open_async_group(path).getitem(name))
+    # zarrs decodes chunks in Rust and does its own chunk IO, rather than going
+    # through zarr-python's per-chunk buffer and store handling. The pipeline is
+    # bound to an array when it is opened, so setting it here applies it to the
+    # arrays read for training data without changing the pipeline used
+    # elsewhere, such as by the inference data writers.
+    with zarr.config.set({"codec_pipeline.path": ZARRS_CODEC_PIPELINE}):
+        return loop.run_until_complete(_open_async_group(path).getitem(name))
 
 
 async def _get_items(arrays_and_selections):

--- a/fme/core/dataset/xarray.py
+++ b/fme/core/dataset/xarray.py
@@ -38,7 +38,7 @@ from fme.core.typing_ import Slice, TensorDict
 from .data_typing import VariableMetadata
 from .dataset import DatasetABC, DatasetItem
 from .utils import (
-    as_broadcasted_tensor,
+    as_alignable_tensor,
     get_horizontal_coordinates,
     get_nonspacetime_dimensions,
     load_series_data,
@@ -617,11 +617,35 @@ class XarrayDataset(DatasetABC):
         )
         self._check_isel_dimensions(first_dataset.sizes)
         first_dataset.close()
+        self._time_invariant_tensors = self._load_time_invariant_tensors()
         self._apply_sample_n_times(self._n_timesteps_schedule.get_value(0))
         self._labels = set(config.labels) if config.labels is not None else None
         self._infer_timestep = config.infer_timestep
         self._local_epoch: int = -1
         self._global_epoch = torch.tensor(-1)
+
+    def _load_time_invariant_tensors(self) -> dict[str, torch.Tensor]:
+        """Load the time-invariant variables into memory.
+
+        These do not vary in time, so they are read once here and broadcast over
+        the time dimension of each sample rather than being re-read per sample.
+        Values are taken from the first file, consistent with how coordinates,
+        vertical coordinate and variable metadata are read in __init__.
+        """
+        if len(self._time_invariant_names) == 0:
+            return {}
+        # opened directly rather than via _open_file so that closing this
+        # handle cannot close one shared through the file handle cache
+        ds = _open_xr_dataset(self.full_paths[0], engine=self.engine)
+        ds = ds.isel(**self.isel)
+        tensors = {}
+        for name in self._time_invariant_names:
+            variable = ds[name].variable
+            if self.fill_nans is not None:
+                variable = variable.fillna(self.fill_nans.value)
+            tensors[name] = as_alignable_tensor(variable, self.dims)
+        ds.close()
+        return tensors
 
     def _ensure_epoch_synchronized(self):
         """Ensure that the local epoch is synchronized with the global epoch.
@@ -935,18 +959,10 @@ class XarrayDataset(DatasetABC):
             tensors[n] = torch.cat(tensor_list)
         del arrays
 
-        # load time-invariant variables from first dataset
-        if len(self._time_invariant_names) > 0:
-            ds = self._open_file(idxs[0])
-            ds = ds.isel(**self.isel)
-            shape = [total_steps] + self._shape_excluding_time_after_selection
-            for name in self._time_invariant_names:
-                variable = ds[name].variable
-                if self.fill_nans is not None:
-                    variable = variable.fillna(self.fill_nans.value)
-                tensors[name] = as_broadcasted_tensor(variable, self.dims, shape)
-            ds.close()
-            del ds
+        # broadcast the time-invariant variables loaded at construction
+        shape = [total_steps] + self._shape_excluding_time_after_selection
+        for name, tensor in self._time_invariant_tensors.items():
+            tensors[name] = torch.broadcast_to(tensor, shape)
 
         # load static derived variables
         for name in self._static_derived_names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "wandb[media]>=0.19.0",
     "xarray",
     "zarr>=3",
+    "zarrs>=0.2.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**DO NOT MERGE.** This branch exists to benchmark all three data loading changes together on Weka. The individual PRs are the ones to review and merge:

- #1420 — load time-invariant variables once instead of per sample (off `main`)
- #1421 — cache zarr group and array handles across samples (off `main`)
- #1422 — read training data with the zarrs codec pipeline (stacked on #1421)

This branch is `main` plus a merge of #1420 and #1422. The only conflict was two additive blocks of tests in `test_xarray.py`; both were kept.

## Local numbers

Interleaved A/B against `main`, local zarr store, 51 variables, 8 dataloader workers, warm page cache:

| sample length | main | combined | speedup |
|---|---|---|---|
| 3 timesteps | 2014 MB/s | 3816 MB/s | 1.89x |
| 30 timesteps | 1991 MB/s | 4198 MB/s | 2.11x |

Short-window per-pair speedups were 1.98, 1.71, 1.81, 2.16. The long-window measurement is much noisier — `main` ranged from 882 to 2295 MB/s over three runs — so treat 2.11x as indicative only.

## Why Weka testing is the point

Every number above is a warm page cache on a local SSD, so they measure decompression and Python overhead rather than IO. Weka should shift the picture in two directions at once, and neither is captured here:

- The handle caching (#1421) should matter **more**. It removes N+1 metadata reads per sample, which are cheap local file reads here but round trips on a network store.
- The zarrs pipeline (#1422) should matter **less** once IO rather than decode dominates. zarrs also does its own chunk IO, so its behavior against Weka is genuinely unexercised by anything measured so far.

Note also that zarrs falls back silently to zarr-python's pipeline for dtypes and selections it does not support, so a Weka run should confirm the fast path is actually engaging rather than inferring it from throughput alone.

## Before running on Beaker

`zarrs` is a new dependency (see #1422). The deps-only image needs rebuilding via `make build_deps_only_image` and `latest_deps_only_image.txt` updating, or gantry runs will fail on import. CI on this branch will fail for the same reason.

`configs/experiments/2025-05-23-ace-data-loading-benchmark/` already has a Weka-targeted benchmark config and a `run.sh` that mounts `climate-default` through gantry, which is the natural harness for this.