### PR TITLE
Add configs/examples/samudrace-e2s: paired SamudrACE CM4-piControl inference jobs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,5 +32,6 @@ repos:
         (?x)^(
         .+/conf.py |
         .+/conftest.py |
+        configs/examples/samudrace-e2s/e2s/run_inference.py |
         fme/ace/models/makani_fcn3/.*
         )$

--- a/configs/examples/samudrace-e2s/README.md
+++ b/configs/examples/samudrace-e2s/README.md
@@ -1,0 +1,48 @@
+# SamudrACE CM4-piControl paired inference jobs
+
+Two Beaker/gantry jobs that run the same SamudrACE CM4-piControl inference,
+each the other's comparison counterpart:
+
+- `e2s/` — earth2studio-side job, running the SamudrACE prognostic wrapper
+  from the earth2studio fork branch. See
+  [the wrapper PR](https://github.com/jpdunc23/earth2studio/pull/1)
+  (TODO: replace with the upstream earth2studio PR once opened).
+- `fme/` — fme reference-side job, running vanilla coupled inference at a
+  pinned ace tag.
+
+Details (what each runs, outputs, environment) are in `e2s/README.md` and
+`fme/README.md`.
+
+## Submitting
+
+```bash
+bash e2s/submit.sh
+bash fme/submit.sh
+```
+
+## Varying an experiment
+
+The two sides are varied differently:
+
+- `e2s/`: everything is set by environment variables — artifact dataset,
+  scenario, initial condition, cycle count. See `e2s/submit.sh` for the
+  variable names and defaults.
+- `fme/`: edit `fme/inference-config.yaml`; only the artifact dataset is
+  env-overridable. See `fme/submit.sh`.
+
+**Warning:** each `submit.sh` hardcodes its gantry `--name`/`--description`
+strings (the fme side's description restates values that really come from
+`inference-config.yaml`). If you vary an experiment, edit those strings too
+or the Beaker job metadata will lie.
+
+These scripts diverge from the commit-and-push convention in
+`configs/README.md`: instead of running gantry from this repo's current
+commit, each `submit.sh` clones a pinned ref into a temp dir itself.
+
+## Last validated
+
+Both jobs succeeded on GPU on 2026-07-30. Pins that will age:
+
+- the torch wheel pinned for the cluster's driver era in each `submit.sh`
+- gantry's `--min-runtime` flag
+- the ace tag (`ACE_TAG` in `fme/submit.sh`)

--- a/configs/examples/samudrace-e2s/e2s/README.md
+++ b/configs/examples/samudrace-e2s/e2s/README.md
@@ -25,10 +25,9 @@ in `../fme/`.
 `SAMUDRACE_DEVICE` now defaults to `cuda`, not "cuda if available". If CUDA is
 unavailable (or `SAMUDRACE_DEVICE=cpu`), the payload raises before loading the
 checkpoint unless `SAMUDRACE_ALLOW_CPU=1` is set; the error names the torch
-version and the CUDA version it was built for. This is deliberate: the first
-submission of this job silently ran on CPU for 15 minutes at ~37 min/epoch of
-progress before being cancelled, because the old default quietly degraded when
-`torch.cuda.is_available()` returned False (see "GPU wheel pin" below).
+version and the CUDA version it was built for. This is deliberate: the old
+default quietly degraded to CPU when `torch.cuda.is_available()` returned
+False (see "GPU wheel pin" below).
 
 ## GPU wheel pin
 
@@ -91,24 +90,23 @@ equivalents into the `earth2studio.run` namespace before calling
 `run.deterministic`; nothing else in the workflow needs changing. The zarr
 backend itself is fine: it creates coordinate arrays with the incoming numpy
 dtype, and `datetime64[s]` round-trips through zarr and xarray unchanged
-(verified). A NetCDF backend would not have been a safe default here, since
-its coordinate handling normalises datetimes to nanoseconds.
+(verified).
 
 ## Environment / install
 
 No `--beaker-image`: gantry installs from the cloned repo with
 `--system-python` and a pip `--install` command (see "GPU wheel pin" above for
-the torch pin that precedes `pip install '.[samudrace]'`). The repo is
-uv-managed, but the `samudrace` extra is plain PEP 621 metadata resolvable by
-pip — `fme==2026.4.0`, `pandas`, `scipy`, plus base deps, all PyPI releases,
-with no `[tool.uv.sources]` git pins in play (the `[tool.uv]` extra conflicts
-only matter when several extras are installed at once, and torch-harmonics
-comes from fme's own pin). Using pip keeps the flags identical in shape to the
-reference-side job in `../fme/` and avoids depending on gantry's uv support or on
-`uv sync` + `uv run` wrapping the entrypoint. If pip resolution turns out to
-diverge from `uv.lock` on the GPU image, the fallback is
-`--install "uv sync --frozen --extra samudrace"` with the entrypoint prefixed
-by `uv run`.
+the torch pin that precedes `pip install '.[samudrace]'`).
+
+- The repo is uv-managed, but the `samudrace` extra is plain PEP 621 metadata
+  resolvable by pip — `fme==2026.4.0`, `pandas`, `scipy`, plus base deps, all
+  PyPI releases, with no `[tool.uv.sources]` git pins in play
+  (torch-harmonics comes from fme's own pin).
+- Pip keeps the flags identical in shape to the reference-side job in
+  `../fme/`.
+- Fallback if pip resolution diverges from `uv.lock` on the GPU image:
+  `--install "uv sync --frozen --extra samudrace"` with the entrypoint
+  prefixed by `uv run`.
 
 ## Payload delivery
 
@@ -136,8 +134,7 @@ The job is submitted with `--min-runtime 2h` (gantry >= 3.5) rather than
 3.7.0 and is rejected if combined with `--min-runtime`, so it is removed
 entirely. `--min-runtime` guarantees the job runs for at least the given
 duration before Beaker may preempt it; `--priority high` is unchanged and
-orthogonal (the first submission was repeatedly preempted by `urgent`-priority
-jobs, which `--min-runtime` is exactly the guard for).
+orthogonal.
 
 ## Expected runtime
 

--- a/configs/examples/samudrace-e2s/e2s/README.md
+++ b/configs/examples/samudrace-e2s/e2s/README.md
@@ -42,6 +42,20 @@ and fme's `>=2.4.0`, so the project install leaves it alone), and the install
 step ends by printing `torch.__version__`, `torch.version.cuda`, and
 `torch.cuda.is_available()` so the build log records the outcome.
 
+## cuDNN autotuning
+
+`run_inference.py` sets `torch.backends.cudnn.benchmark = True` on GPU,
+matching what fme's inference entrypoint
+(`fme/coupled/inference/inference.py`) does. earth2studio calls the stepper
+directly and never runs that entrypoint, so the flag would otherwise keep its
+torch default of `False`, and cuDNN would pick convolution algorithms by
+heuristic instead of by timing. Comparing the two 24-cycle runs showed the
+consequence: the SFNO atmosphere matched the reference bit-for-bit through a
+whole coupled window (its convolutions are all 1x1 and dispatch as GEMMs),
+while the dilated convolutions in the Samudra ocean network landed on a
+different algorithm and differed by ~1.5e-3 K rms in sst at the first coupled
+step -- a seed that then amplifies chaotically and saturates by ~day 40.
+
 ## Local paths, not HuggingFace
 
 `run_inference.py` reads every model input from the artifact directory:

--- a/configs/examples/samudrace-e2s/e2s/README.md
+++ b/configs/examples/samudrace-e2s/e2s/README.md
@@ -1,0 +1,146 @@
+# SamudrACE earth2studio inference job
+
+Single-GPU Beaker/gantry job running earth2studio's `run.deterministic`
+through the `SamudrACE` prognostic wrapper with the SamudrACE CM4 piControl
+checkpoint. Its outputs are compared against the vanilla fme reference run
+in `../fme/`.
+
+## What it runs
+
+- earth2studio from the fork branch `feature/samudrace-predict-paired`
+  (`jpdunc23/earth2studio`), entrypoint `run_inference.py`.
+- Checkpoint `samudrACE_CM4_piControl_ckpt.tar`, forcing scenario `0311`,
+  initial condition `0311-01-01T00:00:00`, 24 coupled cycles (120 days; 480
+  six-hourly atmosphere steps at `n_inner_steps=20`), all read from the
+  Beaker artifact dataset mounted at `/samudrace-artifacts` (mirrors the
+  `allenai/SamudrACE-CM4-piControl` HF repo layout).
+- Everything is overridable by environment variable
+  (`SAMUDRACE_N_COUPLED_CYCLES`, `SAMUDRACE_SCENARIO`, `SAMUDRACE_IC_TIME`,
+  `SAMUDRACE_ARTIFACTS`, `SAMUDRACE_OUTPUT_DIR`, `SAMUDRACE_DEVICE`,
+  `SAMUDRACE_ALLOW_CPU`), which is how the payload is smoke-tested for one
+  cycle on CPU (`SAMUDRACE_DEVICE=cpu SAMUDRACE_ALLOW_CPU=1`).
+
+## No silent CPU fallback
+
+`SAMUDRACE_DEVICE` now defaults to `cuda`, not "cuda if available". If CUDA is
+unavailable (or `SAMUDRACE_DEVICE=cpu`), the payload raises before loading the
+checkpoint unless `SAMUDRACE_ALLOW_CPU=1` is set; the error names the torch
+version and the CUDA version it was built for. This is deliberate: the first
+submission of this job silently ran on CPU for 15 minutes at ~37 min/epoch of
+progress before being cancelled, because the old default quietly degraded when
+`torch.cuda.is_available()` returned False (see "GPU wheel pin" below).
+
+## GPU wheel pin
+
+`earth2studio` only requires `torch>=2.5.0`, which resolves on PyPI to torch
+2.13 — a **CUDA 13** build (it pulls `nvidia-cudnn-cu13`, `nvidia-nccl-cu13`,
+etc.). The ai2 A100 nodes run driver 570.124.06 / CUDA 12.8, and CUDA 13
+requires driver r580+, so `torch.cuda.is_available()` is False on an otherwise
+perfectly healthy GPU node. `submit.sh` therefore installs
+`torch==2.9.1` from `https://download.pytorch.org/whl/cu128` before
+`pip install '.[samudrace]'` (2.9.1 satisfies both earth2studio's `>=2.5.0`
+and fme's `>=2.4.0`, so the project install leaves it alone), and the install
+step ends by printing `torch.__version__`, `torch.version.cuda`, and
+`torch.cuda.is_available()` so the build log records the outcome.
+
+## Local paths, not HuggingFace
+
+`run_inference.py` reads every model input from the artifact directory:
+
+- Checkpoint: `Package(/samudrace-artifacts)` — earth2studio's `Package`
+  resolves a plain directory through the local filesystem, so
+  `SamudrACE.load_model` loads the tar without touching `hf://`. The
+  commit-pinned `load_default_package` is deliberately not used.
+- Initial conditions and forcing: `LocalSamudrACEData` /
+  `LocalSamudrACEForcingData`, thin subclasses of the branch's data sources
+  that override the file-fetch hook to resolve repository-relative paths
+  against the artifact root (the mount mirrors the repo layout exactly, so
+  the same relative paths work) and raise if a file is missing.
+- `HF_HUB_OFFLINE=1` is set on the job as a backstop.
+
+## Outputs
+
+`/results/samudrace_forecast.zarr` (gantry's default Beaker result-dataset
+directory), one zarr array per variable with dims
+`(time, lead_time, lat, lon)`:
+
+| earth2studio name | FME name | field |
+| --- | --- | --- |
+| `t2m` | `TMP2m` | atmosphere 2 m temperature |
+| `u10m` | `UGRD10m` | atmosphere 10 m eastward wind |
+| `v10m` | `VGRD10m` | atmosphere 10 m northward wind |
+| `skt` | `surface_temperature` | atmosphere surface temperature |
+| `sst` | `sst` | ocean sea surface temperature |
+| `siconc` | `ocean_sea_ice_fraction` | ocean sea-ice fraction |
+
+`lead_time` covers 0 to 480 steps of 6 h (`timedelta64[s]`); `time` is the
+initial-condition timestamp (`datetime64[s]`), so valid times are
+`time + lead_time`. Latitude is north-to-south, matching the earth2studio
+convention (the fme reference output from `../fme/` is south-to-north and needs flipping at
+comparison time). Atmosphere fields update every step; ocean fields update at
+cycle boundaries (every 20th step) and are held constant in between, so the
+ocean series is directly comparable with the reference run's 5-daily ocean
+output.
+
+## Time precision
+
+CM4 model years (e.g. 311) overflow `datetime64[ns]`, which the stock workflow
+helpers `to_time_array` and `fetch_data` cast to unconditionally — year 311
+silently wraps to 2064. The payload therefore substitutes second-precision
+equivalents into the `earth2studio.run` namespace before calling
+`run.deterministic`; nothing else in the workflow needs changing. The zarr
+backend itself is fine: it creates coordinate arrays with the incoming numpy
+dtype, and `datetime64[s]` round-trips through zarr and xarray unchanged
+(verified). A NetCDF backend would not have been a safe default here, since
+its coordinate handling normalises datetimes to nanoseconds.
+
+## Environment / install
+
+No `--beaker-image`: gantry installs from the cloned repo with
+`--system-python` and a pip `--install` command (see "GPU wheel pin" above for
+the torch pin that precedes `pip install '.[samudrace]'`). The repo is
+uv-managed, but the `samudrace` extra is plain PEP 621 metadata resolvable by
+pip — `fme==2026.4.0`, `pandas`, `scipy`, plus base deps, all PyPI releases,
+with no `[tool.uv.sources]` git pins in play (the `[tool.uv]` extra conflicts
+only matter when several extras are installed at once, and torch-harmonics
+comes from fme's own pin). Using pip keeps the flags identical in shape to the
+reference-side job in `../fme/` and avoids depending on gantry's uv support or on
+`uv sync` + `uv run` wrapping the entrypoint. If pip resolution turns out to
+diverge from `uv.lock` on the GPU image, the fallback is
+`--install "uv sync --frozen --extra samudrace"` with the entrypoint prefixed
+by `uv run`.
+
+## Payload delivery
+
+`run_inference.py` is job tooling rather than library code, and gantry ships
+only what is on the remote at the checked-out ref, so `submit.sh`
+base64-encodes it into `RUN_INFERENCE_B64` and the entrypoint decodes it to
+`/tmp/run_inference.py`. This keeps the branch diff limited to the wrapper,
+lexicon, and data sources, and lets the payload be edited without another
+push.
+
+## Prerequisites
+
+- The branch `feature/samudrace-predict-paired` must be pushed to
+  `jpdunc23/earth2studio` before submission — `submit.sh` clones it from the
+  remote and will fail otherwise.
+- `SAMUDRACE_ARTIFACTS_DATASET`: the Beaker dataset with the checkpoint,
+  forcing, and initial conditions. Defaults in `submit.sh` to the uploaded
+  dataset [`01KYQZBGSVF220C1QGMHP08GFT`](https://beaker.org/orgs/ai2/workspaces/ace/datasets/01KYQZBGSVF220C1QGMHP08GFT);
+  set the env var to override.
+
+## Preemption
+
+The job is submitted with `--min-runtime 2h` (gantry >= 3.5) rather than
+`--preemptible`. `--preemptible/--not-preemptible` is deprecated in gantry
+3.7.0 and is rejected if combined with `--min-runtime`, so it is removed
+entirely. `--min-runtime` guarantees the job runs for at least the given
+duration before Beaker may preempt it; `--priority high` is unchanged and
+orthogonal (the first submission was repeatedly preempted by `urgent`-priority
+jobs, which `--min-runtime` is exactly the guard for).
+
+## Expected runtime
+
+Environment build ~10-20 min (fme plus CUDA torch wheels). One coupled cycle
+takes ~3.5 min on CPU and seconds on an A100, so 24 cycles is minutes of GPU
+time. Budget well under an hour end to end.

--- a/configs/examples/samudrace-e2s/e2s/run_inference.py
+++ b/configs/examples/samudrace-e2s/e2s/run_inference.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+"""earth2studio SamudrACE validation inference.
+
+Runs the earth2studio ``SamudrACE`` prognostic wrapper through
+``earth2studio.run.deterministic`` with the SamudrACE CM4 piControl
+checkpoint, and writes the comparison fields to a zarr store.
+
+All model inputs (checkpoint tar, forcing NetCDF, initial conditions) are read
+from a local artifact directory that mirrors the
+``allenai/SamudrACE-CM4-piControl`` HuggingFace repository layout; nothing is
+fetched from the network at run time.
+
+Configuration comes from the environment:
+
+``SAMUDRACE_ARTIFACTS``
+    Artifact root directory, default ``/samudrace-artifacts``.
+``SAMUDRACE_OUTPUT_DIR``
+    Output directory, default ``/results``.
+``SAMUDRACE_N_COUPLED_CYCLES``
+    Number of coupled (ocean) cycles to run, default ``24``.
+``SAMUDRACE_SCENARIO``
+    Forcing scenario, default ``0311``.
+``SAMUDRACE_IC_TIME``
+    Initial-condition timestamp, default ``0311-01-01T00:00:00``.
+``SAMUDRACE_DEVICE``
+    Torch device, default ``cuda``. Running on CPU is refused unless
+    ``SAMUDRACE_ALLOW_CPU=1``.
+``SAMUDRACE_ALLOW_CPU``
+    Set to ``1`` to permit a CPU run (smoke tests). Without it, a missing or
+    unusable CUDA device is a hard error rather than a silent degradation to
+    CPU, which would turn a minutes-long GPU job into an hours-long one.
+"""
+
+import os
+from collections import OrderedDict
+from inspect import signature
+
+import earth2studio.run as run
+import numpy as np
+import torch
+import xarray as xr
+from earth2studio.data.samudrace import SamudrACEData, SamudrACEForcingData
+from earth2studio.data.utils import prep_data_array
+from earth2studio.io import ZarrBackend
+from earth2studio.models.auto import Package
+from earth2studio.models.px.samudrace import SamudrACE
+from loguru import logger
+
+CHECKPOINT_FILE = "samudrACE_CM4_piControl_ckpt.tar"
+
+# Comparison fields, in earth2studio names (see SamudrACELexicon):
+#   atmosphere t2m/u10m/v10m/skt -> FME TMP2m/UGRD10m/VGRD10m/surface_temperature
+#   ocean      sst/siconc        -> FME sst/ocean_sea_ice_fraction
+COMPARISON_VARIABLES = ["t2m", "u10m", "v10m", "skt", "sst", "siconc"]
+
+
+class LocalSamudrACEData(SamudrACEData):
+    """Initial-condition data source backed by a local artifact directory.
+
+    Parameters
+    ----------
+    root : str
+        Directory mirroring the SamudrACE HuggingFace repository layout.
+    verbose : bool, optional
+        Log file access, by default True.
+    """
+
+    def __init__(self, root: str, verbose: bool = True):
+        super().__init__(cache=True, verbose=verbose)
+        self._root = root
+
+    def _fetch_file(self, filename: str) -> str:
+        """Resolve a repository-relative filename against the local root.
+
+        Parameters
+        ----------
+        filename : str
+            Path of the file within the repository layout.
+
+        Returns:
+        -------
+        str
+            Local filesystem path.
+        """
+        return _resolve_local(self._root, filename, self._verbose)
+
+
+class LocalSamudrACEForcingData(SamudrACEForcingData):
+    """Forcing data source backed by a local artifact directory.
+
+    Parameters
+    ----------
+    root : str
+        Directory mirroring the SamudrACE HuggingFace repository layout.
+    scenario : str, optional
+        Forcing scenario, by default "0311".
+    verbose : bool, optional
+        Log file access, by default True.
+    """
+
+    def __init__(self, root: str, scenario: str = "0311", verbose: bool = True):
+        super().__init__(scenario=scenario, cache=True, verbose=verbose)
+        self._root = root
+
+    def _fetch_file(self, filename: str) -> str:
+        """Resolve a repository-relative filename against the local root.
+
+        Parameters
+        ----------
+        filename : str
+            Path of the file within the repository layout.
+
+        Returns:
+        -------
+        str
+            Local filesystem path.
+        """
+        return _resolve_local(self._root, filename, self._verbose)
+
+
+def _resolve_local(root: str, filename: str, verbose: bool) -> str:
+    """Resolve a repository-relative filename inside a local artifact root.
+
+    Parameters
+    ----------
+    root : str
+        Artifact root directory.
+    filename : str
+        Path of the file within the repository layout.
+    verbose : bool
+        Log the resolved path.
+
+    Returns:
+    -------
+    str
+        Local filesystem path.
+
+    Raises:
+    ------
+    FileNotFoundError
+        If the file is absent from the artifact directory.
+    """
+    path = os.path.join(root, filename)
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"SamudrACE artifact '{filename}' not found at '{path}'; the "
+            f"artifact directory must mirror the HuggingFace repository layout"
+        )
+    if verbose:
+        logger.info("Using local SamudrACE artifact: {}", path)
+    return path
+
+
+def _to_time_array_seconds(time: list) -> np.ndarray:
+    """Convert a time iterable to a second-precision datetime64 array.
+
+    Replaces ``earth2studio.utils.time.to_time_array``, which casts to
+    nanosecond precision. SamudrACE times are CM4 model years (e.g. year 311),
+    which silently wrap around when cast to ``datetime64[ns]``.
+
+    Parameters
+    ----------
+    time : list
+        Iterable of strings, datetimes, or np.datetime64 values.
+
+    Returns:
+    -------
+    np.ndarray
+        Array of np.datetime64 with second precision.
+    """
+    return np.array([np.datetime64(ts) for ts in time], dtype="datetime64[s]")
+
+
+def _fetch_data_seconds(
+    source: object,
+    time: np.ndarray,
+    variable: np.ndarray,
+    lead_time: np.ndarray = np.array([np.timedelta64(0, "h")]),
+    device: torch.device = "cpu",
+    interp_to: OrderedDict | None = None,
+    interp_method: str = "nearest",
+) -> tuple[torch.Tensor, OrderedDict]:
+    """Fetch data from a data source at second time precision.
+
+    Replaces ``earth2studio.data.utils.fetch_data``, which casts requested
+    times to nanosecond precision and so cannot address CM4 model years.
+
+    Parameters
+    ----------
+    source : object
+        Data source to fetch from.
+    time : np.ndarray
+        Timestamps to fetch, second precision.
+    variable : np.ndarray
+        Variable names to fetch.
+    lead_time : np.ndarray, optional
+        Lead times to fetch for each time, by default a single zero lead time.
+    device : torch.device, optional
+        Device to load the data tensor onto, by default "cpu".
+    interp_to : OrderedDict | None, optional
+        Unsupported here; must be None, by default None.
+    interp_method : str, optional
+        Unused, kept for signature compatibility, by default "nearest".
+
+    Returns:
+    -------
+    tuple[torch.Tensor, OrderedDict]
+        Data tensor and coordinate system.
+
+    Raises:
+    ------
+    ValueError
+        If regridding is requested, or the source is a forecast source.
+    """
+    if interp_to is not None:
+        raise ValueError("Regridding is not supported for SamudrACE data sources")
+    if "lead_time" in signature(source.__call__).parameters:
+        raise ValueError("Forecast data sources are not supported")
+
+    time = time.astype("datetime64[s]")
+    arrays = []
+    for lead in lead_time:
+        adjusted = time + lead.astype("timedelta64[s]")
+        da = source(adjusted, variable)
+        da = da.expand_dims(dim={"lead_time": 1}, axis=1)
+        da = da.assign_coords(
+            lead_time=np.array([lead], dtype="timedelta64[s]"), time=time
+        )
+        arrays.append(da)
+    da = xr.concat(arrays, "lead_time") if len(arrays) > 1 else arrays[0]
+    return prep_data_array(da, device=device)
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive integer from the environment.
+
+    Parameters
+    ----------
+    name : str
+        Environment variable name.
+    default : int
+        Value used when the variable is unset.
+
+    Returns:
+    -------
+    int
+        Parsed value.
+    """
+    value = int(os.environ.get(name, default))
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer, got {value}")
+    return value
+
+
+def _resolve_device() -> torch.device:
+    """Resolve the torch device, refusing to silently fall back to CPU.
+
+    The device is ``SAMUDRACE_DEVICE`` if set, else ``cuda``. Running on CPU
+    -- either because ``SAMUDRACE_DEVICE`` asked for it or because CUDA is
+    unavailable -- requires the explicit opt-in ``SAMUDRACE_ALLOW_CPU=1``.
+
+    Returns:
+    -------
+    torch.device
+        Device to run inference on.
+
+    Raises:
+    ------
+    RuntimeError
+        If the run would land on CPU without ``SAMUDRACE_ALLOW_CPU=1``.
+    """
+    allow_cpu = os.environ.get("SAMUDRACE_ALLOW_CPU") == "1"
+    requested = os.environ.get("SAMUDRACE_DEVICE", "cuda")
+    device = torch.device(requested)
+
+    if device.type == "cuda" and not torch.cuda.is_available():
+        message = (
+            f"CUDA was requested (SAMUDRACE_DEVICE={requested}) but "
+            f"torch.cuda.is_available() is False. torch {torch.__version__} "
+            f"is built for CUDA {torch.version.cuda}; check that the torch "
+            f"wheel's CUDA version is supported by the node's driver "
+            f"(`nvidia-smi`) and that the job actually requested a GPU."
+        )
+        if not allow_cpu:
+            raise RuntimeError(
+                f"{message} Refusing to fall back to CPU: this run takes "
+                f"minutes on a GPU and hours on CPU. Set "
+                f"SAMUDRACE_ALLOW_CPU=1 to run on CPU anyway."
+            )
+        logger.warning("{} Falling back to CPU (SAMUDRACE_ALLOW_CPU=1).", message)
+        device = torch.device("cpu")
+
+    if device.type == "cpu" and not allow_cpu:
+        raise RuntimeError(
+            f"SAMUDRACE_DEVICE={requested} would run this job on CPU, which "
+            f"is orders of magnitude slower. Set SAMUDRACE_ALLOW_CPU=1 to "
+            f"confirm."
+        )
+
+    return device
+
+
+def main() -> None:
+    """Run the SamudrACE validation forecast and write the outputs."""
+    artifacts = os.environ.get("SAMUDRACE_ARTIFACTS", "/samudrace-artifacts")
+    output_dir = os.environ.get("SAMUDRACE_OUTPUT_DIR", "/results")
+    n_cycles = _env_int("SAMUDRACE_N_COUPLED_CYCLES", 24)
+    scenario = os.environ.get("SAMUDRACE_SCENARIO", "0311")
+    ic_time = os.environ.get("SAMUDRACE_IC_TIME", "0311-01-01T00:00:00")
+    device = _resolve_device()
+
+    # Second-precision time handling: CM4 model years overflow the
+    # nanosecond-precision timestamps that the stock workflow helpers use
+    run.to_time_array = _to_time_array_seconds
+    run.fetch_data = _fetch_data_seconds
+
+    # Local package: Package resolves a plain directory through the local
+    # filesystem, so no HuggingFace fetch happens. The forcing and
+    # initial-condition sources read the same artifact directory.
+    package = Package(artifacts)
+    _resolve_local(artifacts, CHECKPOINT_FILE, verbose=True)
+    forcing = LocalSamudrACEForcingData(artifacts, scenario=scenario)
+    model = SamudrACE.load_model(package, forcing_data_source=forcing)
+    data = LocalSamudrACEData(artifacts)
+
+    n_inner_steps = model.stepper.n_inner_steps
+    nsteps = n_cycles * n_inner_steps
+    logger.info(
+        "SamudrACE forecast: IC {}, scenario {}, {} coupled cycles = {} "
+        "atmosphere steps ({} steps per cycle), device {}",
+        ic_time,
+        scenario,
+        n_cycles,
+        nsteps,
+        n_inner_steps,
+        device,
+    )
+
+    os.makedirs(output_dir, exist_ok=True)
+    store_path = os.path.join(output_dir, "samudrace_forecast.zarr")
+    io = ZarrBackend(
+        file_name=store_path,
+        chunks={"time": 1, "lead_time": 1},
+        backend_kwargs={"overwrite": True},
+    )
+
+    run.deterministic(
+        [np.datetime64(ic_time, "s")],
+        nsteps,
+        model,
+        data,
+        io,
+        output_coords=OrderedDict(
+            {"variable": np.array(COMPARISON_VARIABLES, dtype=object)}
+        ),
+        device=device,
+    )
+
+    logger.info("Wrote {}", store_path)
+    logger.info("Store arrays: {}", sorted(io.root.array_keys()))
+
+
+if __name__ == "__main__":
+    main()

--- a/configs/examples/samudrace-e2s/e2s/run_inference.py
+++ b/configs/examples/samudrace-e2s/e2s/run_inference.py
@@ -309,6 +309,12 @@ def main() -> None:
     ic_time = os.environ.get("SAMUDRACE_IC_TIME", "0311-01-01T00:00:00")
     device = _resolve_device()
 
+    # Match the fme inference entrypoint (fme/coupled/inference/inference.py),
+    # which enables cuDNN autotuning on GPU. earth2studio calls the stepper
+    # directly and never runs that entrypoint.
+    if device.type == "cuda":
+        torch.backends.cudnn.benchmark = True
+
     # Second-precision time handling: CM4 model years overflow the
     # nanosecond-precision timestamps that the stock workflow helpers use
     run.to_time_array = _to_time_array_seconds

--- a/configs/examples/samudrace-e2s/e2s/submit.sh
+++ b/configs/examples/samudrace-e2s/e2s/submit.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Submit the earth2studio-side SamudrACE inference job via gantry.
+#
+# Runs earth2studio's `run.deterministic` through the SamudrACE prognostic
+# wrapper with the SamudrACE CM4 piControl checkpoint (single GPU), using the
+# payload in run_inference.py next to this script. Gantry clones the source
+# repo from GitHub, so this script clones the earth2studio fork branch into a
+# temp dir and runs gantry from there; the branch must exist on the remote.
+# The payload is not part of the repo, so it is shipped to the job
+# base64-encoded in an env var and decoded in the entrypoint.
+#
+# SAMUDRACE_ARTIFACTS_DATASET defaults to the uploaded artifact dataset (the
+# beaker.org URL below), which mirrors the allenai/SamudrACE-CM4-piControl
+# HF repo layout and is mounted at /samudrace-artifacts; the upload script
+# that produced it stays with the maintainer. Override the env var to point
+# at a different dataset.
+
+set -euo pipefail
+
+# https://beaker.org/orgs/ai2/workspaces/ace/datasets/01KYQZBGSVF220C1QGMHP08GFT
+SAMUDRACE_ARTIFACTS_DATASET="${SAMUDRACE_ARTIFACTS_DATASET:-01KYQZBGSVF220C1QGMHP08GFT}"
+
+E2S_REPO="https://github.com/jpdunc23/earth2studio.git"
+E2S_BRANCH="feature/samudrace-predict-paired"
+JOB_NAME="samudrace-e2s-inference"
+N_COUPLED_CYCLES="${SAMUDRACE_N_COUPLED_CYCLES:-24}"
+SCENARIO="${SAMUDRACE_SCENARIO:-0311}"
+IC_TIME="${SAMUDRACE_IC_TIME:-0311-01-01T00:00:00}"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PAYLOAD_PATH="${SCRIPT_DIR}/run_inference.py"
+
+# Cheap local check that the payload at least parses.
+python -m py_compile "$PAYLOAD_PATH"
+
+PAYLOAD_B64=$(base64 -w0 "$PAYLOAD_PATH")
+
+CLONE_DIR=$(mktemp -d)
+trap 'rm -rf "$CLONE_DIR"' EXIT
+git clone --depth 1 --branch "$E2S_BRANCH" "$E2S_REPO" "$CLONE_DIR"
+cd "$CLONE_DIR"
+
+# No --beaker-image: gantry builds the environment from the cloned repo's
+# pyproject. The `samudrace` extra pulls fme==2026.4.0 plus pandas/scipy, all
+# from PyPI, so plain pip resolves it without uv's [tool.uv.sources] pins.
+#
+# torch is pinned to a CUDA 12.8 build from the PyTorch index BEFORE the
+# project install. earth2studio only asks for `torch>=2.5.0`, which now
+# resolves on PyPI to torch 2.13, a CUDA 13 build (nvidia-*-cu13 wheels). The
+# ai2 A100 nodes run driver 570.124.06 (CUDA 12.8); CUDA 13 needs r580+, so
+# torch.cuda.is_available() is False there and the job silently ran on CPU.
+# The subsequent `pip install '.[samudrace]'` leaves this torch in place
+# (2.9.1 satisfies both `torch>=2.5.0` and fme's `torch>=2.4.0`).
+# Outputs go to /results, the job's Beaker result dataset (gantry default).
+# HF_HUB_OFFLINE guards against any accidental HuggingFace fetch: every model
+# input comes from the mounted artifact dataset.
+gantry run \
+    --name "$JOB_NAME" \
+    --task-name "$JOB_NAME" \
+    --description "SamudrACE CM4 piControl earth2studio inference (${N_COUPLED_CYCLES} coupled cycles, scenario ${SCENARIO})" \
+    --workspace ai2/ace \
+    --priority high \
+    --min-runtime 2h \
+    --cluster ai2/saturn-cirrascale \
+    --gpus 1 \
+    --shared-memory 50GiB \
+    --budget ai2/atec-climate \
+    --system-python \
+    --install "pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cu128 && pip install '.[samudrace]' && python -c 'import torch; print(\"torch\", torch.__version__, \"cuda\", torch.version.cuda, \"available\", torch.cuda.is_available())'" \
+    --dataset "${SAMUDRACE_ARTIFACTS_DATASET}:/samudrace-artifacts" \
+    --env SAMUDRACE_ARTIFACTS=/samudrace-artifacts \
+    --env SAMUDRACE_OUTPUT_DIR=/results \
+    --env SAMUDRACE_N_COUPLED_CYCLES="$N_COUPLED_CYCLES" \
+    --env SAMUDRACE_SCENARIO="$SCENARIO" \
+    --env SAMUDRACE_IC_TIME="$IC_TIME" \
+    --env HF_HUB_OFFLINE=1 \
+    --env RUN_INFERENCE_B64="$PAYLOAD_B64" \
+    -- bash -c 'echo "$RUN_INFERENCE_B64" | base64 -d > /tmp/run_inference.py && python /tmp/run_inference.py'

--- a/configs/examples/samudrace-e2s/e2s/submit.sh
+++ b/configs/examples/samudrace-e2s/e2s/submit.sh
@@ -33,7 +33,7 @@ PAYLOAD_PATH="${SCRIPT_DIR}/run_inference.py"
 # Cheap local check that the payload at least parses.
 python -m py_compile "$PAYLOAD_PATH"
 
-PAYLOAD_B64=$(base64 -w0 "$PAYLOAD_PATH")
+PAYLOAD_B64=$(base64 -w0 "$PAYLOAD_PATH" 2>/dev/null || base64 -i "$PAYLOAD_PATH" | tr -d '\n')
 
 CLONE_DIR=$(mktemp -d)
 trap 'rm -rf "$CLONE_DIR"' EXIT

--- a/configs/examples/samudrace-e2s/fme/README.md
+++ b/configs/examples/samudrace-e2s/fme/README.md
@@ -1,0 +1,79 @@
+# SamudrACE fme reference inference job (ace v2026.4.0)
+
+Single-GPU Beaker/gantry job running vanilla `fme.coupled.inference` with the
+SamudrACE CM4 piControl checkpoint, as the reference against which the
+earth2studio SamudrACE port (`../e2s/`) is validated.
+
+## What it runs
+
+- ace at tag `v2026.4.0`, entrypoint `python -m fme.coupled.inference`
+  (single GPU, so no `torchrun`).
+- Config: `inference-config.yaml` — checkpoint
+  `samudrACE_CM4_piControl_ckpt.tar`, forcing scenario `0311`, initial
+  condition `0311-01-01T00:00:00`, 24 coupled cycles (120 days; 480
+  six-hourly atmosphere steps), read from the Beaker artifact dataset
+  mounted at `/samudrace-artifacts` (mirrors the
+  `allenai/SamudrACE-CM4-piControl` HF repo layout).
+- The config validates against the tag's schema:
+  `python -m fme.coupled.validate_config inference-config.yaml --config_type inference`
+  (pure schema check; it does not resolve paths, so the mount paths are fine
+  locally). `submit.sh` re-runs this check when `fme` is importable.
+
+## Outputs
+
+`experiment_dir: /results`, gantry's default Beaker result-dataset directory,
+so all outputs land in the job's result dataset. The prediction writers save
+per-step NetCDF for atmosphere (6-hourly) and ocean (cycle boundaries, i.e.
+5-daily) with full coordinates and timestamps, covering the comparison
+fields (atmosphere 2m temperature, 10m winds, surface temperature; ocean SST
+and sea-ice fraction) plus everything else the checkpoint predicts. Monthly
+files are also saved.
+
+## Environment / install
+
+No `--beaker-image`: gantry installs the environment from the cloned repo at
+the tag with `--system-python` and a pip `--install` command. The tag's
+`pyproject.toml` is a plain setuptools package whose deps install cleanly from
+PyPI, so no deps-only image is needed for a one-off inference job.
+
+**GPU wheel pin.** fme's `torch>=2.4.0` resolves on PyPI to torch 2.13, which
+is a **CUDA 13** build (`nvidia-cudnn-cu13`, `nvidia-nccl-cu13`, ...). The ai2
+A100 nodes run driver 570.124.06 / CUDA 12.8 and CUDA 13 needs r580+, so
+`torch.cuda.is_available()` is False there — this is what made the
+earth2studio-side job (`../e2s/`) run on CPU. `submit.sh` therefore installs
+`torch==2.9.1` from `https://download.pytorch.org/whl/cu128` before
+`pip install .` (2.9.1 satisfies `torch>=2.4.0`, so the project install leaves
+it in place), and the install step prints `torch.__version__`,
+`torch.version.cuda`, and `torch.cuda.is_available()` into the build log.
+
+**No silent CPU fallback.** The entrypoint asserts `torch.cuda.is_available()`
+before decoding the config and starting inference, and exits with a loud
+message naming the torch/CUDA versions otherwise. Set `SAMUDRACE_ALLOW_CPU=1`
+on the job to override (smoke tests only).
+
+## Preemption
+
+The job is submitted with `--min-runtime 2h` rather than `--preemptible`.
+`--preemptible/--not-preemptible` is deprecated in gantry 3.7.0 and is
+rejected if combined with `--min-runtime`, so it is removed entirely.
+`--min-runtime` guarantees at least that much runtime before Beaker may
+preempt the job; `--priority high` is unchanged and orthogonal.
+
+## Config delivery
+
+The config is not part of the ace repo, and gantry ships only what is on the
+remote at the checked-out ref, so `submit.sh` base64-encodes
+`inference-config.yaml` into the `INFERENCE_CONFIG_B64` env var and the job
+entrypoint decodes it to `/tmp/inference-config.yaml` before running.
+
+## Prerequisites
+
+- `SAMUDRACE_ARTIFACTS_DATASET`: the Beaker dataset with the checkpoint,
+  forcing, and initial conditions. Defaults in `submit.sh` to the uploaded
+  dataset [`01KYQZBGSVF220C1QGMHP08GFT`](https://beaker.org/orgs/ai2/workspaces/ace/datasets/01KYQZBGSVF220C1QGMHP08GFT);
+  set the env var to override.
+
+## Expected runtime
+
+Environment build ~10-15 min; 24 coupled cycles of SamudrACE on a single
+A100 is minutes, not hours. Budget well under an hour end to end.

--- a/configs/examples/samudrace-e2s/fme/README.md
+++ b/configs/examples/samudrace-e2s/fme/README.md
@@ -24,23 +24,26 @@ earth2studio SamudrACE port (`../e2s/`) is validated.
 `experiment_dir: /results`, gantry's default Beaker result-dataset directory,
 so all outputs land in the job's result dataset. The prediction writers save
 per-step NetCDF for atmosphere (6-hourly) and ocean (cycle boundaries, i.e.
-5-daily) with full coordinates and timestamps, covering the comparison
-fields (atmosphere 2m temperature, 10m winds, surface temperature; ocean SST
-and sea-ice fraction) plus everything else the checkpoint predicts. Monthly
-files are also saved.
+5-daily) with full coordinates and timestamps; monthly files are also saved.
+Comparison fields covered (plus everything else the checkpoint predicts):
+
+- atmosphere 2m temperature
+- atmosphere 10m winds
+- atmosphere surface temperature
+- ocean SST
+- ocean sea-ice fraction
 
 ## Environment / install
 
 No `--beaker-image`: gantry installs the environment from the cloned repo at
 the tag with `--system-python` and a pip `--install` command. The tag's
 `pyproject.toml` is a plain setuptools package whose deps install cleanly from
-PyPI, so no deps-only image is needed for a one-off inference job.
+PyPI.
 
 **GPU wheel pin.** fme's `torch>=2.4.0` resolves on PyPI to torch 2.13, which
 is a **CUDA 13** build (`nvidia-cudnn-cu13`, `nvidia-nccl-cu13`, ...). The ai2
 A100 nodes run driver 570.124.06 / CUDA 12.8 and CUDA 13 needs r580+, so
-`torch.cuda.is_available()` is False there — this is what made the
-earth2studio-side job (`../e2s/`) run on CPU. `submit.sh` therefore installs
+`torch.cuda.is_available()` is False there. `submit.sh` therefore installs
 `torch==2.9.1` from `https://download.pytorch.org/whl/cu128` before
 `pip install .` (2.9.1 satisfies `torch>=2.4.0`, so the project install leaves
 it in place), and the install step prints `torch.__version__`,

--- a/configs/examples/samudrace-e2s/fme/inference-config.yaml
+++ b/configs/examples/samudrace-e2s/fme/inference-config.yaml
@@ -1,0 +1,41 @@
+# Vanilla fme coupled inference (ace v2026.4.0) with the SamudrACE CM4
+# piControl checkpoint: scenario 0311, IC 0311-01-01T00, 24 coupled cycles
+# (= 120 days; 480 six-hourly atmosphere steps at n_inner_steps=20).
+#
+# Paths reference the Beaker artifact dataset mounted at /samudrace-artifacts
+# (mirrors the allenai/SamudrACE-CM4-piControl HF repo layout). Outputs are
+# written to /results, the job's Beaker result dataset (gantry default).
+experiment_dir: /results
+n_coupled_steps: 24
+# Small in-memory window for single-GPU memory headroom; must divide
+# n_coupled_steps.
+coupled_steps_in_memory: 4
+checkpoint_path: /samudrace-artifacts/samudrACE_CM4_piControl_ckpt.tar
+data_writer:
+  ocean:
+    save_prediction_files: true
+    save_monthly_files: true
+  atmosphere:
+    save_prediction_files: true
+    save_monthly_files: true
+forcing_loader:
+  atmosphere:
+    dataset:
+      data_path: /samudrace-artifacts/forcing_data
+      file_pattern: forcing_0311.nc
+      # forcing_0311.nc covers one full year at 6h (1460 steps); the run needs
+      # 480 steps + 1 initial step, so no tiling is required.
+      n_repeats: 1
+  num_data_workers: 1
+initial_condition:
+  ocean:
+    path: /samudrace-artifacts/initial_conditions/0311-01-01T00:00:00/ocean/initial_condition.nc
+  atmosphere:
+    path: /samudrace-artifacts/initial_conditions/0311-01-01T00:00:00/atmosphere/initial_condition.nc
+  start_indices:
+    first: 0
+    n_initial_conditions: 1
+logging:
+  log_to_screen: true
+  log_to_wandb: false
+  log_to_file: true

--- a/configs/examples/samudrace-e2s/fme/submit.sh
+++ b/configs/examples/samudrace-e2s/fme/submit.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Submit the ace/fme reference-side SamudrACE inference job via gantry.
+#
+# Runs vanilla fme coupled inference at ace tag v2026.4.0 (single GPU, no
+# torchrun) with the SamudrACE CM4 piControl checkpoint, using the config in
+# inference-config.yaml next to this script. Gantry clones the source repo
+# from GitHub, so this script clones ace at the tag into a temp dir and runs
+# gantry from there; the tag exists on the public remote, which is all gantry
+# needs. The config file is not part of the ace repo, so it is shipped to the
+# job base64-encoded in an env var and decoded in the entrypoint.
+#
+# SAMUDRACE_ARTIFACTS_DATASET defaults to the uploaded artifact dataset (the
+# beaker.org URL below), which mirrors the allenai/SamudrACE-CM4-piControl
+# HF repo layout and is mounted at /samudrace-artifacts; the upload script
+# that produced it stays with the maintainer. Override the env var to point
+# at a different dataset.
+
+set -euo pipefail
+
+# https://beaker.org/orgs/ai2/workspaces/ace/datasets/01KYQZBGSVF220C1QGMHP08GFT
+SAMUDRACE_ARTIFACTS_DATASET="${SAMUDRACE_ARTIFACTS_DATASET:-01KYQZBGSVF220C1QGMHP08GFT}"
+
+ACE_TAG="v2026.4.0"
+JOB_NAME="samudrace-fme-reference-inference"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG_PATH="${SCRIPT_DIR}/inference-config.yaml"
+
+# Best-effort local validation (requires fme==2026.4.0 in the current env).
+if python -c "import fme.coupled.validate_config" 2>/dev/null; then
+    python -m fme.coupled.validate_config "$CONFIG_PATH" --config_type inference
+else
+    echo "WARNING: fme not importable locally; skipping config validation." >&2
+fi
+
+CONFIG_B64=$(base64 -w0 "$CONFIG_PATH")
+
+CLONE_DIR=$(mktemp -d)
+trap 'rm -rf "$CLONE_DIR"' EXIT
+git clone --depth 1 --branch "$ACE_TAG" https://github.com/ai2cm/ace.git "$CLONE_DIR"
+cd "$CLONE_DIR"
+
+# No --beaker-image: gantry builds the environment from the repo's pyproject.
+#
+# torch is pinned to a CUDA 12.8 build from the PyTorch index BEFORE the
+# project install. fme only asks for `torch>=2.4.0`, which now resolves on
+# PyPI to torch 2.13, a CUDA 13 build (nvidia-*-cu13 wheels). The ai2 A100
+# nodes run driver 570.124.06 (CUDA 12.8); CUDA 13 needs r580+, so
+# torch.cuda.is_available() would be False and the job would run on CPU (this
+# is what happened to the earth2studio-side job, ../e2s/). The subsequent
+# `pip install .` leaves this torch in place. The entrypoint then asserts a
+# GPU is visible before starting inference, so a bad wheel fails fast instead
+# of silently degrading to CPU.
+# Outputs go to /results, the job's Beaker result dataset (gantry default),
+# matching experiment_dir in the config.
+gantry run \
+    --name "$JOB_NAME" \
+    --task-name "$JOB_NAME" \
+    --description "SamudrACE CM4 piControl reference inference (fme ${ACE_TAG}, 24 coupled cycles, scenario 0311)" \
+    --workspace ai2/ace \
+    --priority high \
+    --min-runtime 2h \
+    --cluster ai2/saturn-cirrascale \
+    --gpus 1 \
+    --shared-memory 50GiB \
+    --budget ai2/atec-climate \
+    --system-python \
+    --install "pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cu128 && pip install . && python -c 'import torch; print(\"torch\", torch.__version__, \"cuda\", torch.version.cuda, \"available\", torch.cuda.is_available())'" \
+    --dataset "${SAMUDRACE_ARTIFACTS_DATASET}:/samudrace-artifacts" \
+    --env INFERENCE_CONFIG_B64="$CONFIG_B64" \
+    -- bash -c 'python -c "
+import os, sys, torch
+if torch.cuda.is_available():
+    sys.exit(0)
+if os.environ.get(\"SAMUDRACE_ALLOW_CPU\") == \"1\":
+    print(\"WARNING: no CUDA device; running on CPU because SAMUDRACE_ALLOW_CPU=1\")
+    sys.exit(0)
+sys.exit(
+    f\"REFUSING TO RUN: torch.cuda.is_available() is False (torch {torch.__version__}, \"
+    f\"built for CUDA {torch.version.cuda}). This job requests a GPU; running on \"
+    \"CPU would waste hours. Set SAMUDRACE_ALLOW_CPU=1 to override.\"
+)
+" && echo "$INFERENCE_CONFIG_B64" | base64 -d > /tmp/inference-config.yaml && python -m fme.coupled.inference /tmp/inference-config.yaml'

--- a/configs/test_configs.py
+++ b/configs/test_configs.py
@@ -7,6 +7,7 @@ import fme
 from fme.coupled.inference.evaluator import (
     InferenceEvaluatorConfig as CoupledInferenceEvaluatorConfig,
 )
+from fme.coupled.inference.inference import InferenceConfig as CoupledInferenceConfig
 from fme.coupled.train.train_config import TrainConfig as CoupledTrainConfig
 from fme.downscaling.evaluator import EvaluatorConfig
 from fme.downscaling.train import TrainerConfig as DownscalingTrainConfig
@@ -95,7 +96,17 @@ def test_downscaling_evaluator_configs_are_valid():
 
 
 def test_inference_configs_are_valid():
-    inference_files = get_yaml_files("*inference*.yaml")
+    inference_files = get_yaml_files(
+        "*inference*.yaml",
+        exclude=["samudrace-e2s/fme/inference-config"],
+    )
     assert len(inference_files) > 0, "No inference files found"
     for file in inference_files:
         validate_config(file, fme.ace.InferenceConfig)
+
+
+def test_coupled_inference_configs_are_valid():
+    inference_files = get_yaml_files("**/samudrace-e2s/fme/inference-config.yaml")
+    assert len(inference_files) > 0, "No coupled inference files found"
+    for file in inference_files:
+        validate_config(file, CoupledInferenceConfig)


### PR DESCRIPTION
Adds `configs/examples/samudrace-e2s/`: Beaker/gantry submission scripts for the paired SamudrACE CM4-piControl inference jobs, each the other's comparison counterpart — an earth2studio-side job (`e2s/`) running the SamudrACE prognostic wrapper from the earth2studio fork PR <https://github.com/jpdunc23/earth2studio/pull/1> (the README carries a visible TODO to replace this link with the upstream earth2studio PR once opened), and an fme reference-side job (`fme/`) running vanilla coupled inference at a pinned ace tag. The top-level README orients a colleague on submitting each job and varying it for new experiments. Both submit scripts clone pinned refs into temp dirs themselves, so they diverge — the README says so — from `configs/README.md`'s commit-and-push convention.

Two changes land outside `configs/examples/samudrace-e2s/`: `configs/test_configs.py` and `.pre-commit-config.yaml` (detailed in the last two bullets).

Changes:
- `configs/examples/samudrace-e2s/` — new example directory: top-level `README.md`, `e2s/` (`README.md`, `run_inference.py`, `submit.sh`), `fme/` (`README.md`, `inference-config.yaml`, `submit.sh`)
- `configs/test_configs.py` — `test_inference_configs_are_valid` excludes the new `fme/inference-config.yaml` (a coupled config, not an `fme.ace.InferenceConfig`); a new `test_coupled_inference_configs_are_valid` validates it against `fme.coupled.inference.inference.InferenceConfig`
- `.pre-commit-config.yaml` — adds `configs/examples/samudrace-e2s/e2s/run_inference.py` to the mypy exclude block, rather than editing the delivered script to satisfy mypy

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
