### PR TITLE
Fix `"long_name"` attributes of vertically coarsened fields in ERA5 pipeline

### DIFF
--- a/scripts/era5/pipeline/xr-beam-pipeline.py
+++ b/scripts/era5/pipeline/xr-beam-pipeline.py
@@ -852,6 +852,7 @@ def _vertical_coarsen(
 ) -> dict:
     """Pressure-weighted vertical coarsening from 137 levels to coarse layers."""
     n_output_layers = len(output_layer_indices) - 1
+    long_name = var.attrs["long_name"]
     results = {}
     for i in range(n_output_layers):
         fine_slice = slice(output_layer_indices[i], output_layer_indices[i + 1])
@@ -859,7 +860,8 @@ def _vertical_coarsen(
         dp_fine = dp.isel(hybrid=fine_slice)
         weighted = (var_fine * dp_fine).sum("hybrid")
         total_dp = dp_fine.sum("hybrid")
-        results[i] = (weighted / total_dp).astype(np.float32)
+        coarsened = (weighted / total_dp).astype(np.float32)
+        results[i] = coarsened.assign_attrs(long_name=f"{long_name} level-{i}")
     return results
 
 
@@ -901,7 +903,7 @@ def _process_model_level_data(
         + ds_model["specific_cloud_ice_water_content"]
         + ds_model["specific_rain_water_content"]
         + ds_model["specific_snow_water_content"]
-    )
+    ).assign_attrs(long_name="Specific total water")
 
     logging.info("Computing layer thicknesses")
     surface_pressure = ds_surface["surface_pressure"]


### PR DESCRIPTION
This PR fixes two issues related to `"long_name"` attributes in the ERA5 dataset:
- The `"long_name"` of `"specific_total_water"` is erroneously set as `"Specific snow water content"`.
- Vertically coarsened fields do not include information about the level they correspond to, which is inconsistent with how we handle things in [`compute_dataset.py`](https://github.com/ai2cm/ace/blob/main/scripts/data_process/compute_dataset.py).

Changes:
- Updates the ERA5 dataset processing pipeline to explicitly provide a new and accurate `"long_name"` attribute for the sum of the water species and append `" level-{i}"` to the `"long_name"` for all vertically coarsened fields.

Verified this worked by running the test dataflow workflow and generating the small dataset here: `gs://vcm-ml-scratch/spencerc/test-updated-era5-pipeline-fixed-attrs/era5-4deg-8layer.zarr`:

```
>>> ds = xr.open_zarr("gs://vcm-ml-scratch/spencerc/test-updated-era5-pipeline-fixed-attrs/era5-4deg-8layer.zarr")
>>> fields = ["air_temperature_0", "eastward_wind_0", "northward_wind_0", "specific_total_water_0"]
>>> for field in fields:
...     print(f"long_name for {field} is: {ds[field].attrs['long_name']}")
...
long_name for air_temperature_0 is: Temperature level-0
long_name for eastward_wind_0 is: U component of wind level-0
long_name for northward_wind_0 is: V component of wind level-0
long_name for specific_total_water_0 is: Specific total water level-0
```

Resolves #1427
