### PR TITLE
Restructure the shutdown path so the policy layer reads without systems expertise

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -147,7 +147,7 @@ def distributed_context():
     # no signal handler: this context spans the whole session, so installing one
     # would make Ctrl-C tear the backend down and register as a test failure,
     # leaving the rest of the run without a process group. The tests that want
-    # the handler open their own `handle_termination_signals`.
+    # the listener open their own `abort_and_exit_on_termination`.
     with Distributed.context(handle_signals=False):
         yield
 

--- a/fme/ace/data_loading/test_data_loader.py
+++ b/fme/ace/data_loading/test_data_loader.py
@@ -1357,7 +1357,7 @@ def test_gridded_data_dataset_info_not_localized(_global_properties):
 
     # Sanity-check: under spatial parallelism the *local* shape differs
     dist = Distributed.get_instance()
-    if dist.world_size != dist.total_data_parallel_ranks:
+    if dist.has_spatial_parallelism:
         local_shape = gridded.horizontal_coordinates.shape[-2:]
         assert local_shape != (N_LAT, N_LON)
         assert gridded.dataset_info.img_shape == (N_LAT, N_LON)
@@ -1394,7 +1394,7 @@ def test_inference_gridded_data_dataset_info_not_localized(_global_properties):
 
     # Sanity-check: under spatial parallelism the *local* shape differs
     dist = Distributed.get_instance()
-    if dist.world_size != dist.total_data_parallel_ranks:
+    if dist.has_spatial_parallelism:
         local_shape = inference.horizontal_coordinates.shape[-2:]
         assert local_shape != (N_LAT, N_LON)
         assert inference.dataset_info.img_shape == (N_LAT, N_LON)

--- a/fme/core/distributed/_signal_listener.py
+++ b/fme/core/distributed/_signal_listener.py
@@ -1,0 +1,178 @@
+"""Deliver signals to a dedicated thread, whatever the main thread is doing.
+
+A Python signal handler runs only when the main thread returns to the
+interpreter, and a preempted rank's main thread is typically blocked inside a
+collective's stream sync, so a handler could never run in time. Instead,
+CPython's C-level handler writes each delivered signal number to a wakeup fd
+(``signal.set_wakeup_fd``; an fd, or file descriptor, is the integer handle
+the OS gives an open file or pipe). `SignalListener` points that fd at a pipe
+and reads it from its own thread, so the signal is observed regardless of
+what the main thread is doing.
+
+This module is pure delivery mechanism: what to *do* about a termination
+signal is `fme.core.distributed.shutdown`'s concern.
+"""
+
+import os
+import signal
+import threading
+import types
+from collections.abc import Callable
+from typing import Any
+
+# what signal.getsignal returns and signal.signal accepts
+_SignalHandler = (
+    Callable[[int, types.FrameType | None], Any] | int | signal.Handlers | None
+)
+
+# tells the sentinel apart from signal numbers, which are all positive
+_STOP_LISTENING = 0
+
+# The wakeup fd and signal dispositions are process-global, so at most one
+# listener is active, and the at-fork hook must be able to find it.
+_active_listener: "SignalListener | None" = None
+_at_fork_registered = False
+
+
+def _route_to_listener(signum: int, frame: types.FrameType | None) -> None:
+    # exists so CPython delivers the signal (writing it to the wakeup fd)
+    # instead of taking the default action; the listener thread does the work
+    pass
+
+
+def _disarm_in_child() -> None:
+    """Undo the parent's signal setup in a forked child.
+
+    A fork-started DataLoader worker inherits the routing handler and the
+    wakeup fd, which still feeds the parent's pipe: a signal delivered to the
+    worker would masquerade as the parent's own. Restore the defaults so the
+    child dies as it would have without the inheritance. This runs in the
+    child's main thread -- fork's surviving thread is re-designated as such
+    before the at-fork hooks run -- so the signal module cooperates.
+    """
+    global _active_listener
+    listener = _active_listener
+    if listener is None:
+        return
+    for sig in listener._signals:
+        signal.signal(sig, signal.SIG_DFL)
+    signal.set_wakeup_fd(-1)
+    os.close(listener._read_fd)
+    os.close(listener._write_fd)
+    # clear the state, or a second-generation fork (dataset code forking a
+    # worker's own subprocess) re-runs this on fd numbers the worker has
+    # since reused
+    _active_listener = None
+
+
+class SignalListener:
+    """Run a callback on a dedicated thread when one of ``signals`` arrives.
+
+    ``on_signal`` runs on the listener's own thread, so it must not assume the
+    main thread's cooperation -- and if it never returns (it may end the
+    process), the thread never finishes. While the listener is armed the
+    process's own disposition for ``signals`` is a no-op handler: nothing
+    happens on delivery except the callback.
+
+    The lifecycle is ``start()``, then exactly one of two teardowns, the
+    caller choosing by whether a signal arrived:
+
+    - no signal: ``request_stop()``, ``wait_until_finished()``, ``dismantle()``
+      to restore the previous signal setup;
+    - signal arrived: the listener stays armed -- so further signals stay
+      no-ops -- and ``block_until_process_exit()`` parks the calling thread
+      until ``on_signal`` ends the process.
+    """
+
+    def __init__(
+        self,
+        signals: tuple[signal.Signals, ...],
+        on_signal: Callable[[signal.Signals], None],
+    ) -> None:
+        self._signals = signals
+        self._on_signal = on_signal
+        self._read_fd = -1
+        self._write_fd = -1
+        self._previous_handlers: dict[signal.Signals, _SignalHandler] = {}
+        self._previous_wakeup_fd = -1
+        self._thread = threading.Thread(
+            target=self._read_pipe_until_signal_or_stop,
+            name="termination-listener",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        """Arm the listener: point the wakeup fd at a fresh pipe, route
+        ``signals`` to it, and start the thread that reads it. Main thread
+        only (only it may install signal handlers).
+        """
+        global _active_listener, _at_fork_registered
+        if not _at_fork_registered:
+            os.register_at_fork(after_in_child=_disarm_in_child)
+            _at_fork_registered = True
+        self._read_fd, self._write_fd = os.pipe()
+        os.set_blocking(self._write_fd, False)
+        self._thread.start()
+        self._previous_handlers = {sig: signal.getsignal(sig) for sig in self._signals}
+        self._previous_wakeup_fd = signal.set_wakeup_fd(
+            self._write_fd, warn_on_full_buffer=False
+        )
+        for sig in self._signals:
+            signal.signal(sig, _route_to_listener)
+        _active_listener = self
+
+    def _read_pipe_until_signal_or_stop(self) -> None:
+        while True:
+            data = os.read(self._read_fd, 64)
+            # the wakeup fd sees every signal CPython delivers (torch's
+            # DataLoader installs a SIGCHLD handler, for one); act only on
+            # ours. Checked before the sentinel: a signal racing the stop
+            # request must win, or the process walks on with its protection
+            # already removed.
+            for sig in self._signals:
+                if sig in data:
+                    self._on_signal(sig)
+                    return
+            if not data or _STOP_LISTENING in data:
+                return
+
+    def request_stop(self) -> None:
+        """Ask the listener thread to finish, assuming no signal arrived.
+
+        A signal already delivered but not yet read still wins over the stop
+        request. One delivered between the thread consuming the sentinel and
+        ``dismantle()`` restoring the dispositions is dropped; the window is
+        microseconds wide and the process is exiting anyway.
+        """
+        global _active_listener
+        _active_listener = None
+        os.write(self._write_fd, bytes([_STOP_LISTENING]))
+
+    def wait_until_finished(self, timeout: float) -> None:
+        """Block up to ``timeout`` seconds for the listener thread to finish
+        (``Thread.join``: wait for a thread to end).
+        """
+        self._thread.join(timeout=timeout)
+
+    def block_until_process_exit(self) -> None:
+        """Park the calling thread until ``on_signal`` ends the process.
+
+        Never returns: the listener thread is running an ``on_signal`` that
+        exits, and joining a thread that never finishes blocks forever. The
+        process's external kill (the scheduler's SIGKILL) is the backstop if
+        ``on_signal`` hangs.
+        """
+        self._thread.join()
+
+    def dismantle(self) -> None:
+        """Restore the pre-``start()`` signal setup and close the pipe.
+
+        Only after ``wait_until_finished`` confirms no signal arrived: this
+        removes the process's protection, and closes fds the listener thread
+        would otherwise still be reading.
+        """
+        for sig, handler in self._previous_handlers.items():
+            signal.signal(sig, handler)
+        signal.set_wakeup_fd(self._previous_wakeup_fd)
+        os.close(self._write_fd)
+        os.close(self._read_fd)

--- a/fme/core/distributed/_signal_listener.py
+++ b/fme/core/distributed/_signal_listener.py
@@ -70,18 +70,23 @@ class SignalListener:
 
     ``on_signal`` runs on the listener's own thread, so it must not assume the
     main thread's cooperation -- and if it never returns (it may end the
-    process), the thread never finishes. While the listener is armed the
-    process's own disposition for ``signals`` is a no-op handler: nothing
-    happens on delivery except the callback.
+    process), the thread never finishes. Only the first matching signal runs
+    it: the thread reads nothing further, and the process's own disposition
+    for ``signals`` stays a no-op handler, so later deliveries do nothing.
 
-    The lifecycle is ``start()``, then exactly one of two teardowns, the
-    caller choosing by whether a signal arrived:
+    The lifecycle is ``start()``, then ``request_stop()`` -- issued before the
+    caller can know whether a signal arrived, so it only asks, and a signal
+    already delivered still wins -- then one of two teardowns:
 
-    - no signal: ``request_stop()``, ``wait_until_finished()``, ``dismantle()``
-      to restore the previous signal setup;
+    - no signal: ``wait_until_finished()``, then ``dismantle()`` to restore
+      the previous signal setup;
     - signal arrived: the listener stays armed -- so further signals stay
       no-ops -- and ``block_until_process_exit()`` parks the calling thread
       until ``on_signal`` ends the process.
+
+    A forked child takes a third teardown, automatically: an at-fork hook
+    restores the default dispositions and closes the child's copy of the pipe
+    (see ``_disarm_in_child``).
     """
 
     def __init__(
@@ -137,12 +142,16 @@ class SignalListener:
                 return
 
     def request_stop(self) -> None:
-        """Ask the listener thread to finish, assuming no signal arrived.
+        """Begin teardown: ask the listener thread to finish, and stand down
+        the at-fork disarm.
 
         A signal already delivered but not yet read still wins over the stop
         request. One delivered between the thread consuming the sentinel and
         ``dismantle()`` restoring the dispositions is dropped; the window is
-        microseconds wide and the process is exiting anyway.
+        microseconds wide and the process is exiting anyway. Clearing the
+        active listener here also stops ``_disarm_in_child`` from acting in
+        children forked after the teardown has begun, when the fds it would
+        close may already be gone.
         """
         global _active_listener
         _active_listener = None

--- a/fme/core/distributed/distributed.py
+++ b/fme/core/distributed/distributed.py
@@ -11,7 +11,7 @@ from fme.core import metrics
 from .base import DistributedBackend
 from .model_torch_distributed import ModelTorchDistributed
 from .non_distributed import NonDistributed
-from .shutdown import handle_termination_signals
+from .shutdown import abort_and_exit_on_termination
 from .torch_distributed import TorchDistributed
 
 logger = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ class Distributed:
         try:
             with contextlib.ExitStack() as stack:
                 if handle_signals and instance.is_distributed():
-                    stack.enter_context(handle_termination_signals(instance.abort))
+                    stack.enter_context(abort_and_exit_on_termination(instance.abort))
                 try:
                     yield
                 except BaseException:
@@ -211,13 +211,21 @@ class Distributed:
         """
         return self._distributed.total_ranks
 
+    @property
+    def has_spatial_parallelism(self) -> bool:
+        """Whether spatial co-ranks exist (world_size >
+        total_data_parallel_ranks), meaning each rank holds only a shard of
+        the model's spatial state rather than a full copy.
+        """
+        return self.world_size != self.total_data_parallel_ranks
+
     def require_no_spatial_parallelism(self, msg: str) -> None:
         """Raise if spatial parallelism is active.
 
         Use this to guard code paths that are known to be incorrect
-        when spatial co-ranks exist (world_size > total_data_parallel_ranks).
+        when spatial co-ranks exist.
         """
-        if self.world_size != self.total_data_parallel_ranks:
+        if self.has_spatial_parallelism:
             raise SpatialParallelismNotImplemented(msg)
 
     def get_sampler(

--- a/fme/core/distributed/distributed.py
+++ b/fme/core/distributed/distributed.py
@@ -213,7 +213,7 @@ class Distributed:
 
     @property
     def has_spatial_parallelism(self) -> bool:
-        """Whether spatial co-ranks exist (world_size >
+        """Whether spatial co-ranks exist (world_size !=
         total_data_parallel_ranks), meaning each rank holds only a shard of
         the model's spatial state rather than a full copy.
         """

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -1,4 +1,4 @@
-"""Tear the distributed backend down safely when a job is preempted.
+"""Exit safely when a job is preempted, by aborting NCCL before anything else.
 
 Schedulers preempt jobs by sending SIGTERM and escalating to SIGKILL once a
 grace period expires. A rank that is killed while a peer's NCCL kernels still
@@ -13,12 +13,13 @@ termination signal it aborts its own communicators -- ``ncclCommAbort`` kills
 the local kernels and unblocks whatever host thread was waiting on them --
 then waits out a grace period so its peers' aborts finish before it exits.
 
-A Python signal handler runs only when the main thread returns to the
-interpreter, and a preempted rank's main thread is typically blocked inside a
-collective's stream sync, so a handler could never run in time. Instead the
-signal is observed on a dedicated listener thread through
-``signal.set_wakeup_fd``, which CPython's C-level handler writes regardless of
-what the main thread is doing.
+The signal is received on a *listener* -- a dedicated thread whose only job is
+to wait for the signal -- because the main thread cannot be trusted to receive
+it: a preempted rank's main thread is typically blocked inside a collective,
+where an ordinary Python signal handler would never run. How the listener
+observes the signal anyway is `SignalListener`'s concern
+(`fme.core.distributed._signal_listener`); everything that *happens* on
+termination is decided here, in `_abort_and_exit` and the steps it calls.
 
 The instants before the listener is armed remain unprotected --
 ``init_process_group`` itself, inside ``Distributed.context()`` entry, most
@@ -31,10 +32,11 @@ import signal
 import threading
 import time
 import traceback
-import types
 from collections.abc import Callable, Generator
 
 from fme.core.device import in_dataloader_worker
+
+from ._signal_listener import SignalListener
 
 TERMINATION_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT)
 
@@ -45,18 +47,12 @@ TERMINATION_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT
 # default timeout, torch/distributed/elastic/agent/server/local_elastic_agent.py).
 DEFAULT_GRACE_PERIOD = 5.0
 
-# How long the listener waits for the main thread to unwind into the
-# context's exit before giving up on the post-abort callbacks. One batch of
-# compute bounds the unwind in the common case; together with the callbacks
-# and grace period this must fit torchrun's 30s SIGTERM-to-SIGKILL budget.
-DEFAULT_PARK_TIMEOUT = 5.0
-
-# tells the sentinel apart from signal numbers, which are all positive
-_STOP_LISTENING = 0
-
-_armed = False  # whether the wakeup fd currently belongs to this module
-_pipe_fds: tuple[int, int] | None = None
-_at_fork_registered = False
+# How long the listener waits for the main thread to stop touching training
+# state (see _ExitCoordination.training_state_frozen) before giving up on the
+# post-abort callbacks. One batch of compute bounds the wait in the common
+# case; together with the callbacks and grace period this must fit torchrun's
+# 30s SIGTERM-to-SIGKILL budget.
+DEFAULT_STATE_FREEZE_TIMEOUT = 5.0
 
 _post_abort_callbacks: list[Callable[[], None]] = []
 
@@ -67,8 +63,8 @@ def add_post_abort_callback(callback: Callable[[], None]) -> None:
     Callbacks run only once the main thread has unwound into the context's
     exit, where it blocks until the process ends -- so their reads of training
     state cannot race it. A main thread that has not unwound within
-    ``park_timeout`` (still computing, or stuck somewhere that is not a
-    collective) forfeits the callbacks rather than risk a torn snapshot.
+    ``state_freeze_timeout`` (still computing, or stuck somewhere that is not
+    a collective) forfeits the callbacks rather than risk a torn snapshot.
     Best-effort in duration too: the scheduler's SIGKILL caps how long a
     callback may take. The communicators are gone by then, so callbacks must
     not use collectives, nor the logging module (see ``write_stderr``).
@@ -78,38 +74,6 @@ def add_post_abort_callback(callback: Callable[[], None]) -> None:
 
 def clear_post_abort_callbacks() -> None:
     _post_abort_callbacks.clear()
-
-
-def _disarm_in_child() -> None:
-    """Undo the parent's signal setup in a forked child.
-
-    A fork-started DataLoader worker inherits the ignore-handler and the wakeup
-    fd, which still feeds the parent's pipe: a signal delivered to the worker
-    would masquerade as the parent's own preemption. Restore the defaults so
-    the child dies as it would have without the inheritance. This runs in the
-    child's main thread -- fork's surviving thread is re-designated as such
-    before the at-fork hooks run -- so the signal module cooperates.
-    """
-    global _armed, _pipe_fds
-    if not _armed:
-        return
-    for sig in TERMINATION_SIGNALS:
-        signal.signal(sig, signal.SIG_DFL)
-    signal.set_wakeup_fd(-1)
-    if _pipe_fds is not None:
-        for fd in _pipe_fds:
-            os.close(fd)
-    # clear the state, or a second-generation fork (dataset code forking a
-    # worker's own subprocess) re-runs this on fd numbers the worker has
-    # since reused
-    _armed = False
-    _pipe_fds = None
-
-
-def _ignore_signal(signum: int, frame: types.FrameType | None) -> None:
-    # exists so CPython delivers the signal (writing it to the wakeup fd)
-    # instead of taking the default action; the listener thread does the work
-    pass
 
 
 def write_stderr(message: str) -> None:
@@ -127,73 +91,105 @@ def write_stderr(message: str) -> None:
         pass
 
 
-def _wait_for_termination_signal(read_fd: int) -> signal.Signals | None:
-    while True:
-        data = os.read(read_fd, 64)
-        # the wakeup fd sees every signal CPython delivers (torch's DataLoader
-        # installs a SIGCHLD handler, for one); act only on termination.
-        # Checked before the sentinel: a signal racing the context's exit must
-        # win, or the process walks on with its protection already removed.
-        for sig in TERMINATION_SIGNALS:
-            if sig in data:
-                return sig
-        if not data or _STOP_LISTENING in data:
-            return None
+class _ExitCoordination:
+    """The two facts the main thread and the listener thread tell each other.
+
+    Each starts false and flips true exactly once; the methods wrap the
+    thread-safe flag primitive (``threading.Event``) in the fact it records.
+    """
+
+    def __init__(self) -> None:
+        self._listener_owns_exit = threading.Event()
+        self._training_state_frozen = threading.Event()
+
+    def mark_listener_owns_exit(self) -> None:
+        """A termination signal arrived: from now on the listener thread ends
+        the process, and the main thread must not exit on its own.
+        """
+        self._listener_owns_exit.set()
+
+    def listener_owns_exit(self) -> bool:
+        return self._listener_owns_exit.is_set()
+
+    def mark_training_state_frozen(self) -> None:
+        """The main thread will never touch training state again, so the
+        post-abort callbacks may read it without racing a mutation.
+        """
+        self._training_state_frozen.set()
+
+    def wait_until_training_state_frozen(self, timeout: float) -> bool:
+        """Block up to ``timeout`` seconds for the freeze; False on timeout."""
+        return self._training_state_frozen.wait(timeout)
 
 
-def _listen(
-    read_fd: int,
-    abort: Callable[[], None],
-    grace_period: float,
-    park_timeout: float,
-    terminating: threading.Event,
-    main_parked: threading.Event,
-) -> None:
-    signum = _wait_for_termination_signal(read_fd)
-    if signum is None:  # the context exited normally
-        return
-    terminating.set()  # from here on this thread owns the process's exit
-    write_stderr(
-        f"Received {signal.Signals(signum).name}, aborting distributed "
-        "communicators before exiting.\n"
-    )
+def _abort_local_communicators(abort: Callable[[], None]) -> None:
+    """Stop this rank's own NCCL kernels and release its wedged host threads."""
     try:
         # not bounded: if the abort hangs, exiting anyway would guarantee the
         # peer-GPU fault, so the rank rides to the scheduler's SIGKILL instead
         abort()
     except BaseException:
         write_stderr(f"Aborting communicators failed:\n{traceback.format_exc()}")
-    if _post_abort_callbacks:
-        # the abort releases only a main thread blocked in a collective; one
-        # between collectives keeps computing until the next collective
-        # raises, and the callbacks' reads of training state would race it.
-        # Wait for it to block in the context's exit, and forfeit the
-        # callbacks rather than record a torn snapshot if it never does.
-        if main_parked.wait(park_timeout):
-            for callback in _post_abort_callbacks:
-                try:
-                    callback()
-                except BaseException:
-                    write_stderr(
-                        f"Post-abort callback failed:\n{traceback.format_exc()}"
-                    )
-        else:
-            write_stderr(
-                f"Main thread still running {park_timeout}s after the abort; "
-                "skipping post-abort callbacks.\n"
-            )
-    # peers' aborts must finish, so their kernels stop touching our memory,
-    # before we exit
+
+
+def _run_post_abort_callbacks(
+    coordination: _ExitCoordination, state_freeze_timeout: float
+) -> None:
+    """Run the registered callbacks once training state is safe to read.
+
+    The abort releases only a main thread blocked in a collective; one between
+    collectives keeps computing until the next collective raises, and the
+    callbacks' reads of training state would race it. Wait for it to block in
+    the context's exit, and forfeit the callbacks rather than record a torn
+    snapshot if it never does.
+    """
+    if not _post_abort_callbacks:
+        return
+    if not coordination.wait_until_training_state_frozen(state_freeze_timeout):
+        write_stderr(
+            f"Main thread still running {state_freeze_timeout}s after the "
+            "abort; skipping post-abort callbacks.\n"
+        )
+        return
+    for callback in _post_abort_callbacks:
+        try:
+            callback()
+        except BaseException:
+            write_stderr(f"Post-abort callback failed:\n{traceback.format_exc()}")
+
+
+def _wait_for_peer_aborts(grace_period: float) -> None:
+    """Peers' aborts must finish, so their kernels stop touching this rank's
+    memory, before this rank exits.
+    """
     time.sleep(grace_period)
+
+
+def _abort_and_exit(
+    signum: signal.Signals,
+    abort: Callable[[], None],
+    coordination: _ExitCoordination,
+    grace_period: float,
+    state_freeze_timeout: float,
+) -> None:
+    """The termination policy. Runs on the listener thread."""
+    coordination.mark_listener_owns_exit()
+    write_stderr(
+        f"Received {signal.Signals(signum).name}, aborting distributed "
+        "communicators before exiting.\n"
+    )
+    _abort_local_communicators(abort)
+    _run_post_abort_callbacks(coordination, state_freeze_timeout)
+    _wait_for_peer_aborts(grace_period)
     write_stderr(f"Exiting with code {128 + signum}.\n")
     os._exit(128 + signum)
 
 
 @contextlib.contextmanager
-def handle_termination_signals(
+def abort_and_exit_on_termination(
     abort: Callable[[], None],
     grace_period: float = DEFAULT_GRACE_PERIOD,
-    park_timeout: float = DEFAULT_PARK_TIMEOUT,
+    state_freeze_timeout: float = DEFAULT_STATE_FREEZE_TIMEOUT,
 ) -> Generator[None, None, None]:
     """Exit on SIGTERM or SIGINT, aborting the distributed backend first.
 
@@ -213,11 +209,10 @@ def handle_termination_signals(
             collective, so it must not require the main thread's cooperation.
         grace_period: Seconds to wait between aborting and exiting, so that
             peers' aborts finish while this process's memory is still mapped.
-        park_timeout: Seconds the listener waits for the main thread to block
-            in this context's exit before skipping the post-abort callbacks
-            (see ``add_post_abort_callback``).
+        state_freeze_timeout: Seconds the listener waits for the main thread
+            to block in this context's exit before skipping the post-abort
+            callbacks (see ``add_post_abort_callback``).
     """
-    global _armed, _pipe_fds, _at_fork_registered
     if threading.current_thread() is not threading.main_thread():
         # only the main thread may install handlers; a thread shares the
         # process disposition its main thread installed
@@ -230,58 +225,33 @@ def handle_termination_signals(
         yield
         return
 
-    if not _at_fork_registered:
-        os.register_at_fork(after_in_child=_disarm_in_child)
-        _at_fork_registered = True
-
-    read_fd, write_fd = os.pipe()
-    os.set_blocking(write_fd, False)
-    terminating = threading.Event()
-    main_parked = threading.Event()
-    listener = threading.Thread(
-        target=_listen,
-        args=(read_fd, abort, grace_period, park_timeout, terminating, main_parked),
-        name="termination-listener",
-        daemon=True,
+    coordination = _ExitCoordination()
+    listener = SignalListener(
+        signals=TERMINATION_SIGNALS,
+        on_signal=lambda signum: _abort_and_exit(
+            signum, abort, coordination, grace_period, state_freeze_timeout
+        ),
     )
     listener.start()
-    previous_handlers = {sig: signal.getsignal(sig) for sig in TERMINATION_SIGNALS}
-    previous_fd = signal.set_wakeup_fd(write_fd, warn_on_full_buffer=False)
-    for sig in TERMINATION_SIGNALS:
-        signal.signal(sig, _ignore_signal)
-    _pipe_fds = (read_fd, write_fd)
-    _armed = True
     try:
         yield
     finally:
-        _armed = False
-        _pipe_fds = None
-        # the main thread only joins the listener and restores dispositions
-        # from here; it will not touch training state again, so the
-        # post-abort callbacks may read it
-        main_parked.set()
-        # a signal delivered between the listener consuming this sentinel and
-        # the dispositions being restored below is dropped; the window is
-        # microseconds wide and the process is exiting anyway
-        os.write(write_fd, bytes([_STOP_LISTENING]))
-        if not terminating.is_set():
+        # the main thread only winds the listener down from here; it will not
+        # touch training state again, so the post-abort callbacks may read it
+        coordination.mark_training_state_frozen()
+        listener.request_stop()
+        if not coordination.listener_owns_exit():
             # covers the race where a signal was delivered but not yet read:
             # long enough for the listener to abort and exit
-            listener.join(timeout=grace_period + 10.0)
-        if terminating.is_set():
-            # the listener owns the exit: hold the unwinding main thread for
-            # the abort and grace period, with the ignore-handlers still
-            # installed -- restoring the previous dispositions (typically
-            # SIG_DFL) here would let a repeated signal kill the rank before
-            # the grace period ends. If the abort hangs, the scheduler's
-            # SIGKILL is the backstop.
-            listener.join()
+            listener.wait_until_finished(timeout=grace_period + 10.0)
+        if coordination.listener_owns_exit():
+            # hold the unwinding main thread for the abort and grace period,
+            # with the listener still armed -- dismantling it here would
+            # restore the previous dispositions (typically SIG_DFL) and let a
+            # repeated signal kill the rank before the grace period ends
+            listener.block_until_process_exit()
         else:
-            for sig, handler in previous_handlers.items():
-                signal.signal(sig, handler)
-            signal.set_wakeup_fd(previous_fd)
-            os.close(write_fd)
-            os.close(read_fd)
+            listener.dismantle()
             # the callbacks belonged to this context's session; a later
             # context must not fire them against torn-down state
             clear_post_abort_callbacks()

--- a/fme/core/distributed/shutdown.py
+++ b/fme/core/distributed/shutdown.py
@@ -48,7 +48,7 @@ TERMINATION_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM, signal.SIGINT
 DEFAULT_GRACE_PERIOD = 5.0
 
 # How long the listener waits for the main thread to stop touching training
-# state (see _ExitCoordination.training_state_frozen) before giving up on the
+# state (see _ExitCoordination.mark_training_state_frozen) before giving up on the
 # post-abort callbacks. One batch of compute bounds the wait in the common
 # case; together with the callbacks and grace period this must fit torchrun's
 # 30s SIGTERM-to-SIGKILL budget.

--- a/fme/core/distributed/test_shutdown.py
+++ b/fme/core/distributed/test_shutdown.py
@@ -10,7 +10,7 @@ import torch.utils.data
 
 from fme.core.distributed.shutdown import (
     TERMINATION_SIGNALS,
-    handle_termination_signals,
+    abort_and_exit_on_termination,
 )
 
 
@@ -34,9 +34,9 @@ def test_aborts_then_exits_with_conventional_code_for_signal(sig):
     result = _run_listener_program(
         f"""
         import signal, threading
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: print("abort", flush=True), grace_period=0.1
         ):
             signal.raise_signal(signal.Signals({int(sig)}))
@@ -62,7 +62,7 @@ def test_acts_while_the_main_thread_is_wedged_holding_the_logging_lock():
         """
         import logging, os, signal, sys, threading, time
         logging.basicConfig(level=logging.INFO, stream=sys.stderr)
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
         def signal_later():
             time.sleep(0.5)
@@ -70,7 +70,7 @@ def test_acts_while_the_main_thread_is_wedged_holding_the_logging_lock():
 
         threading.Thread(target=signal_later, daemon=True).start()
         lock = threading.Lock()
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: print("abort", flush=True), grace_period=0.1
         ):
             # stands in for being interrupted mid-emit, inside `Handler.handle`
@@ -94,12 +94,12 @@ def test_exits_even_if_abort_raises():
     result = _run_listener_program(
         """
         import signal, threading
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
         def abort():
             raise RuntimeError("no process group")
 
-        with handle_termination_signals(abort=abort, grace_period=0.1):
+        with abort_and_exit_on_termination(abort=abort, grace_period=0.1):
             signal.raise_signal(signal.SIGTERM)
             threading.Event().wait()
         """
@@ -121,9 +121,9 @@ def test_exit_waits_out_the_grace_period():
     program = textwrap.dedent(
         f"""
         import signal, threading
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: None, grace_period={grace_period}
         ):
             print("ready", flush=True)
@@ -162,7 +162,7 @@ def test_post_abort_callbacks_run_after_the_abort_and_cannot_stop_the_exit():
         import signal, threading
         from fme.core.distributed.shutdown import (
             add_post_abort_callback,
-            handle_termination_signals,
+            abort_and_exit_on_termination,
         )
 
         released = threading.Event()
@@ -177,7 +177,7 @@ def test_post_abort_callbacks_run_after_the_abort_and_cannot_stop_the_exit():
         add_post_abort_callback(lambda: print("first", flush=True))
         add_post_abort_callback(broken)
         add_post_abort_callback(lambda: print("second", flush=True))
-        with handle_termination_signals(abort=abort, grace_period=0.1):
+        with abort_and_exit_on_termination(abort=abort, grace_period=0.1):
             signal.raise_signal(signal.SIGTERM)
             released.wait()  # blocked "in the collective" until the abort
             raise RuntimeError("rank unwinding after its collective died")
@@ -202,7 +202,7 @@ def test_callbacks_wait_for_the_main_thread_to_stop_running():
         import signal, threading, time
         from fme.core.distributed.shutdown import (
             add_post_abort_callback,
-            handle_termination_signals,
+            abort_and_exit_on_termination,
         )
 
         released = threading.Event()
@@ -212,7 +212,7 @@ def test_callbacks_wait_for_the_main_thread_to_stop_running():
             released.set()
 
         add_post_abort_callback(lambda: print("callback", flush=True))
-        with handle_termination_signals(abort=abort, grace_period=0.1):
+        with abort_and_exit_on_termination(abort=abort, grace_period=0.1):
             signal.raise_signal(signal.SIGTERM)
             released.wait()
             time.sleep(1.0)  # compute continuing between collectives
@@ -236,14 +236,14 @@ def test_callbacks_are_skipped_when_the_main_thread_never_stops():
         import signal, threading
         from fme.core.distributed.shutdown import (
             add_post_abort_callback,
-            handle_termination_signals,
+            abort_and_exit_on_termination,
         )
 
         add_post_abort_callback(lambda: print("callback", flush=True))
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: print("abort", flush=True),
             grace_period=0.1,
-            park_timeout=0.2,
+            state_freeze_timeout=0.2,
         ):
             signal.raise_signal(signal.SIGTERM)
             threading.Event().wait()  # never unwinds
@@ -264,12 +264,12 @@ def test_a_dead_stderr_cannot_stop_the_abort_or_the_exit():
     result = _run_listener_program(
         """
         import os, signal, threading
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
         r, w = os.pipe()
         os.close(r)
         os.dup2(w, 2)  # every stderr write now raises BrokenPipeError
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: print("abort", flush=True), grace_period=0.1
         ):
             signal.raise_signal(signal.SIGTERM)
@@ -294,7 +294,7 @@ def test_a_main_thread_released_by_the_abort_cannot_exit_first():
     result = _run_listener_program(
         """
         import signal, threading
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
         released = threading.Event()
 
@@ -302,7 +302,7 @@ def test_a_main_thread_released_by_the_abort_cannot_exit_first():
             print("abort", flush=True)
             released.set()
 
-        with handle_termination_signals(abort=abort, grace_period=1.0):
+        with abort_and_exit_on_termination(abort=abort, grace_period=1.0):
             signal.raise_signal(signal.SIGTERM)
             released.wait()  # blocked "in the collective" until the abort
             raise RuntimeError("rank unwinding after its collective died")
@@ -327,7 +327,7 @@ def test_a_repeated_signal_cannot_cut_the_grace_period_short(sig):
     program = textwrap.dedent(
         f"""
         import threading
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
         released = threading.Event()
 
@@ -336,7 +336,9 @@ def test_a_repeated_signal_cannot_cut_the_grace_period_short(sig):
             released.set()
 
         try:
-            with handle_termination_signals(abort=abort, grace_period={grace_period}):
+            with abort_and_exit_on_termination(
+                abort=abort, grace_period={grace_period}
+            ):
                 print("ready", flush=True)
                 released.wait()  # blocked "in the collective" until the abort
                 raise RuntimeError("rank unwinding after its collective died")
@@ -386,9 +388,9 @@ def test_forked_child_does_not_trigger_the_parent_abort():
     result = _run_listener_program(
         """
         import os, signal, time
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: print("abort", flush=True), grace_period=0.1
         ):
             pid = os.fork()
@@ -425,9 +427,9 @@ def test_second_generation_fork_does_not_close_recycled_fds():
     result = _run_listener_program(
         """
         import os
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
-        with handle_termination_signals(abort=lambda: None, grace_period=0.1):
+        with abort_and_exit_on_termination(abort=lambda: None, grace_period=0.1):
             pid = os.fork()
             if pid == 0:  # worker: its at-fork disarm closed the pipe fds
                 a, b = os.pipe()  # recycle those fd numbers
@@ -462,10 +464,10 @@ def test_other_handled_signals_do_not_trigger_the_abort():
     result = _run_listener_program(
         """
         import os, signal, time
-        from fme.core.distributed.shutdown import handle_termination_signals
+        from fme.core.distributed.shutdown import abort_and_exit_on_termination
 
         signal.signal(signal.SIGCHLD, lambda signum, frame: None)
-        with handle_termination_signals(
+        with abort_and_exit_on_termination(
             abort=lambda: print("abort", flush=True), grace_period=0.1
         ):
             pid = os.fork()
@@ -484,7 +486,7 @@ def test_other_handled_signals_do_not_trigger_the_abort():
 def test_previous_dispositions_are_restored_on_exit():
     original = {sig: signal.getsignal(sig) for sig in TERMINATION_SIGNALS}
 
-    with handle_termination_signals(abort=lambda: None):
+    with abort_and_exit_on_termination(abort=lambda: None):
         for sig in TERMINATION_SIGNALS:
             assert signal.getsignal(sig) is not original[sig]
         assert any(
@@ -506,7 +508,7 @@ def test_no_listener_installed_off_the_main_thread():
     observed = []
 
     def run():
-        with handle_termination_signals(abort=lambda: None):
+        with abort_and_exit_on_termination(abort=lambda: None):
             observed.append(signal.getsignal(signal.SIGTERM))
 
     thread = threading.Thread(target=run)
@@ -521,5 +523,5 @@ def test_no_listener_installed_in_a_dataloader_worker(monkeypatch):
     monkeypatch.setattr(torch.utils.data, "get_worker_info", lambda: object())
     original = signal.getsignal(signal.SIGTERM)
 
-    with handle_termination_signals(abort=lambda: None):
+    with abort_and_exit_on_termination(abort=lambda: None):
         assert signal.getsignal(signal.SIGTERM) is original

--- a/fme/core/distributed/test_shutdown_dataloader.py
+++ b/fme/core/distributed/test_shutdown_dataloader.py
@@ -81,7 +81,7 @@ _DRIVER = textwrap.dedent(
 
 
     dist = Distributed.get_instance()
-    # Production passes `instance.abort` to `handle_termination_signals`;
+    # Production passes `instance.abort` to `abort_and_exit_on_termination`;
     # wrapping it here observes which process ran it, without touching
     # production code.
     backend_abort = dist.abort
@@ -246,7 +246,7 @@ def test_dataloader_workers_do_not_abort_when_the_group_is_signalled(tmp_path):
             "start_method=fork" in started[pid]
         ), f"worker {pid} was not fork-started: {started[pid]}"
         # the at-fork disarm restored the default disposition; the parent's
-        # ignore-handler would read as `_ignore_signal` here
+        # routing handler would read as `_route_to_listener` here
         assert (
             "sigint=<Handlers.SIG_DFL" in started[pid]
         ), f"worker {pid} was not disarmed at fork: {started[pid]}"

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -355,10 +355,10 @@ class Trainer:
                     )
 
         dist = Distributed.get_instance()
-        if dist.world_size == dist.total_data_parallel_ranks:
+        if not dist.has_spatial_parallelism:
             # rank 0 holds the full model state, so the save needs no other
-            # rank's cooperation; a domain-parallel stepper's state is sharded,
-            # and assembling it would need the aborted communicators
+            # rank's cooperation; a spatially-parallel stepper's state is
+            # sharded, and assembling it would need the aborted communicators
             add_post_abort_callback(save_restart_checkpoints_on_terminate)
 
     def switch_off_grad(self, model: torch.nn.Module):

--- a/fme/core/models/conditional_sfno/test_sfnonet.py
+++ b/fme/core/models/conditional_sfno/test_sfnonet.py
@@ -494,7 +494,7 @@ def test_sfnonet_spectral_ratio_preserve_global_mean_spatial_parallel():
     path, so it needs no full-grid quadrature and no rejection."""
     torch.manual_seed(0)
     dist = Distributed.get_instance()
-    if dist.world_size == dist.total_data_parallel_ranks:
+    if not dist.has_spatial_parallelism:
         pytest.skip("no spatial parallelism in this configuration")
     embed_dim = 16
     img_shape = (8, 16)  # divides evenly across spatial ranks


### PR DESCRIPTION
The shutdown path from #1425 interleaves three concerns in one file, and only one of them needs low-level expertise. This PR separates them so a reader fluent in signals and distributed training — but not threads, pipes, or file descriptors — can review the termination policy and later modify it (step order, timeouts, callback conditions) without touching the delivery mechanism. Structure and naming carry the load; no behavior change is intended. The only added prose is three one-time definitions the naming cannot carry alone: what a "listener" is (`shutdown.py`), what an "fd" is, and what `Thread.join` does (`_signal_listener.py`).

- The signal-delivery plumbing (pipe, wakeup fd, no-op routing handler, at-fork disarm) moves to `fme.core.distributed._signal_listener.SignalListener`, whose contract is one sentence: run a callback on a dedicated thread when one of the given signals arrives, whatever the main thread is doing. The module stays explicit for a reader who does know those concepts.
- `fme.core.distributed.shutdown` keeps only policy: `_abort_and_exit` is a linear sequence of named steps (`_abort_local_communicators`, `_run_post_abort_callbacks`, `_wait_for_peer_aborts`, then `os._exit`), each carrying its invariant in its name and docstring.
- The two cross-thread flags become an `_ExitCoordination` object whose method names state the facts they record — `mark_listener_owns_exit()`, `wait_until_training_state_frozen(timeout)` — so no policy code outside that wrapper touches `threading.Event`.

Changes:
- `fme.core.distributed._signal_listener` (new): `SignalListener`, plus the at-fork disarm and the routing handler (renamed from `_ignore_signal` to `_route_to_listener`; it routes the signal to the listener rather than ignoring it).
- `fme.core.distributed.shutdown`: policy only; `handle_termination_signals` renamed to `abort_and_exit_on_termination` (the name now states the outcome), `park_timeout`/`DEFAULT_PARK_TIMEOUT` to `state_freeze_timeout`/`DEFAULT_STATE_FREEZE_TIMEOUT`. The API other modules import (`add_post_abort_callback`, `write_stderr`, `TERMINATION_SIGNALS`) is unchanged.
- `Distributed.has_spatial_parallelism` (new property): replaces world-size arithmetic in `require_no_spatial_parallelism`, in the Trainer's restart-checkpoint guard (which now reads as the checkpoint-safety condition it is), and in three test sites that spelled the same predicate by hand.
- Tests: renames and the three predicate conversions above; the suite's assertions are unchanged.

- [x] Tests added (no new functionality; the existing suite pins behavior across the restructure)