### PR TITLE
Add include_input_step option to SecondaryDecoderConfig

### DIFF
--- a/fme/core/step/secondary_decoder.py
+++ b/fme/core/step/secondary_decoder.py
@@ -24,10 +24,14 @@ class SecondaryDecoderConfig:
             diagnosed directly from outputs without access to latent variables (i.e.,
             column-locally).
         network: Configuration for the decoder network.
+        include_input_step: If True, the channels provided as inputs to the
+            primary network are concatenated with its outputs before being
+            passed to this decoder.
     """
 
     secondary_diagnostic_names: list[str]
     network: ModuleSelector
+    include_input_step: bool = False
 
     def build(
         self,

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -319,9 +319,12 @@ class SecondaryModuleStep(StepABC):
         self.secondary_out_packer: Packer = Packer(all_secondary_names)
 
         if config.secondary_decoder is not None:
+            secondary_decoder_n_in = n_out_channels
+            if config.secondary_decoder.include_input_step:
+                secondary_decoder_n_in += n_in_channels
             self.secondary_decoder: SecondaryDecoder | NoSecondaryDecoder = (
                 config.secondary_decoder.build(
-                    n_in_channels=n_out_channels,
+                    n_in_channels=secondary_decoder_n_in,
                     dataset_info=dataset_info,
                 ).to(get_device())
             )
@@ -412,8 +415,16 @@ class SecondaryModuleStep(StepABC):
                     output_dict[name] = output_dict[name] + secondary_dict[name]
                 else:
                     output_dict[name] = input_norm[name] + secondary_dict[name]
+            secondary_input = output_tensor.detach()
+            if (
+                self._config.secondary_decoder is not None
+                and self._config.secondary_decoder.include_input_step
+            ):
+                secondary_input = torch.cat(
+                    [secondary_input, input_tensor.detach()], dim=self.CHANNEL_DIM
+                )
             secondary_output_dict = self.secondary_decoder.wrap_module(wrapper)(
-                output_tensor.detach()  # detach avoids changing base outputs
+                secondary_input
             )
             output_dict.update(secondary_output_dict)
             return output_dict

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -328,9 +328,12 @@ class SingleModuleStep(StepABC):
         dist = Distributed.get_instance()
 
         if config.secondary_decoder is not None:
+            secondary_decoder_n_in = n_out_channels
+            if config.secondary_decoder.include_input_step:
+                secondary_decoder_n_in += n_in_channels
             self.secondary_decoder: SecondaryDecoder | NoSecondaryDecoder = (
                 config.secondary_decoder.build(
-                    n_in_channels=n_out_channels,
+                    n_in_channels=secondary_decoder_n_in,
                     dataset_info=dataset_info,
                 ).to(get_device())
             )
@@ -427,8 +430,16 @@ class SingleModuleStep(StepABC):
                 labels=args.labels,
             )
             output_dict = self.out_packer.unpack(output_tensor, axis=self.CHANNEL_DIM)
+            secondary_input = output_tensor.detach()
+            if (
+                self._config.secondary_decoder is not None
+                and self._config.secondary_decoder.include_input_step
+            ):
+                secondary_input = torch.cat(
+                    [secondary_input, input_tensor.detach()], dim=self.CHANNEL_DIM
+                )
             secondary_output_dict = self.secondary_decoder.wrap_module(wrapper)(
-                output_tensor.detach()  # detach avoids changing base outputs
+                secondary_input
             )
             output_dict.update(secondary_output_dict)
             return output_dict

--- a/fme/core/step/test_secondary_decoder.py
+++ b/fme/core/step/test_secondary_decoder.py
@@ -21,6 +21,33 @@ class TestSecondaryDecoderConfig:
         )
         assert config.network.type == "SphericalFourierNeuralOperatorNet"
 
+    def test_include_input_step_defaults_false(self):
+        config = SecondaryDecoderConfig(
+            secondary_diagnostic_names=["diag1"],
+            network=ModuleSelector(type="MLP", config={}),
+        )
+        assert config.include_input_step is False
+
+    def test_include_input_step_true(self):
+        config = SecondaryDecoderConfig(
+            secondary_diagnostic_names=["diag1"],
+            network=ModuleSelector(type="MLP", config={}),
+            include_input_step=True,
+        )
+        assert config.include_input_step is True
+
+    def test_build_with_include_input_step(self):
+        config = SecondaryDecoderConfig(
+            secondary_diagnostic_names=["diag1"],
+            network=ModuleSelector(type="MLP", config={"hidden_dim": 16, "depth": 2}),
+            include_input_step=True,
+        )
+        decoder = config.build(n_in_channels=7, dataset_info=DatasetInfo())
+        x = torch.randn(2, 7, 8, 8)
+        output = decoder(x)
+        assert set(output.keys()) == {"diag1"}
+        assert output["diag1"].shape == (2, 8, 8)
+
 
 class TestSecondaryDecoder:
     def test_forward_and_unpack_integration(self):

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -194,6 +194,43 @@ def get_single_module_noise_conditioned_selector(
     )
 
 
+def get_single_module_include_input_step_selector(
+    dir: pathlib.Path | None = None,
+) -> StepSelector:
+    normalization = get_network_and_loss_normalization_config(
+        names=[
+            "forcing_shared",
+            "forcing_rad",
+            "diagnostic_main",
+            "diagnostic_rad",
+        ],
+        dir=dir,
+    )
+    return StepSelector(
+        type="single_module",
+        config=dataclasses.asdict(
+            SingleModuleStepConfig(
+                builder=ModuleSelector(
+                    type="SphericalFourierNeuralOperatorNet",
+                    config={
+                        "scale_factor": 1,
+                        "embed_dim": 4,
+                        "num_layers": 2,
+                    },
+                ),
+                in_names=["forcing_shared", "forcing_rad"],
+                out_names=["diagnostic_main"],
+                secondary_decoder=SecondaryDecoderConfig(
+                    secondary_diagnostic_names=["diagnostic_rad"],
+                    network=ModuleSelector(type="MLP", config={}),
+                    include_input_step=True,
+                ),
+                normalization=normalization,
+            ),
+        ),
+    )
+
+
 def get_label_conditioned_selector(
     dir: pathlib.Path | None = None,
 ) -> StepSelector:
@@ -451,6 +488,7 @@ SELECTOR_GETTERS = [
     get_separate_radiation_selector,
     get_single_module_selector,
     get_single_module_noise_conditioned_selector,
+    get_single_module_include_input_step_selector,
     get_secondary_module_selector,
     get_multi_call_selector,
 ]


### PR DESCRIPTION
Add `include_input_step: bool = False` to `SecondaryDecoderConfig`. When True, the channels provided as inputs to the primary network are concatenated with its outputs before being passed to the secondary decoder. This lets the decoder condition on both the predicted state and the original input fields (e.g. forcings). Default False preserves existing behavior.

Changes:
- `fme.core.step.secondary_decoder.SecondaryDecoderConfig`: new `include_input_step` bool field (default False)
- `fme.core.step.single_module.SingleModuleStep`: adjust secondary decoder input channel count and concatenate input tensor when `include_input_step` is True
- `fme.core.step.secondary_module.SecondaryModuleStep`: same changes for the secondary-module step variant

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated