### PR TITLE
Add a seed for coupled inference

### DIFF
--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -157,7 +157,7 @@ class PrognosticState:
             )
         )
 
-    def apply_config_seed(self, seed: int | None) -> "PrognosticState":
+    def apply_config_seed(self, seed: int | None, label: str = "") -> "PrognosticState":
         """Return a state seeded from ``config.seed``, unless one is already
         present.
 
@@ -172,13 +172,17 @@ class PrognosticState:
 
         Args:
             seed: The configured seed, or None to leave the state unseeded.
+            label: Name of the state for logging, used when more than one state
+                is seeded in a run (e.g. the components of a coupled model) so
+                the log line says which one skipped its seed.
         """
         if seed is None:
             return self
         stepper_state = self._data.stepper_state
         if stepper_state is not None and stepper_state.random_state is not None:
+            subject = f"the {label} config seed" if label else "config seed"
             logging.info(
-                "Ignoring config seed because a random state was restored from "
+                f"Ignoring {subject} because a random state was restored from "
                 "the restart stepper state; the restored generator continues "
                 "instead."
             )

--- a/fme/ace/data_loading/batch_data.py
+++ b/fme/ace/data_loading/batch_data.py
@@ -172,9 +172,8 @@ class PrognosticState:
 
         Args:
             seed: The configured seed, or None to leave the state unseeded.
-            label: Name of the state for logging, used when more than one state
-                is seeded in a run (e.g. the components of a coupled model) so
-                the log line says which one skipped its seed.
+            label: Name of the state, used to say which one skipped its seed
+                when a run seeds more than one (e.g. coupled components).
         """
         if seed is None:
             return self

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -32,13 +32,21 @@ class CoupledPrognosticState:
     def apply_config_seed(self, seed: int | None) -> "CoupledPrognosticState":
         """Return a state whose components are seeded from ``config.seed``.
 
-        Each component gets its own generator, seeded from a *different* value
-        derived from the configured seed (ocean ``seed``, atmosphere
-        ``seed + 1``), following the offset convention of
-        ``fme.core.rand.set_seed``. Seeding both from the same value would make
-        their draws identical, not merely independent, whenever they request the
-        same shapes in the same order - two ``NoiseConditionedSFNO`` components
-        on a shared grid would then see perfectly correlated noise fields.
+        The atmosphere takes the configured value unchanged, so a coupled run
+        draws the same atmospheric noise sequence as an ``fme.ace`` run of the
+        same checkpoint at the same seed. The atmosphere is also the only realm
+        that consumes a generator today: the ocean steppers in use are
+        deterministic, and their stochasticity comes from the atmosphere
+        ensemble they are trained against.
+
+        The ocean gets its own generator seeded at ``seed + 1``, following the
+        offset convention of ``fme.core.rand.set_seed``. The offset is
+        unobservable while the ocean is deterministic; it is there so that a
+        future stochastic ocean stepper does not silently draw the *same* noise
+        as the atmosphere - separate generators are independent, but equal seeds
+        give equal draws whenever both components request the same shapes in the
+        same order, which two ``NoiseConditionedSFNO`` components on a shared
+        grid would.
 
         Precedence is resolved per component (see
         ``PrognosticState.apply_config_seed``): a component carrying a restored
@@ -51,8 +59,8 @@ class CoupledPrognosticState:
         if seed is None:
             return self
         return CoupledPrognosticState(
-            self.ocean_data.apply_config_seed(seed, label="ocean"),
-            self.atmosphere_data.apply_config_seed(seed + 1, label="atmosphere"),
+            self.ocean_data.apply_config_seed(seed + 1, label="ocean"),
+            self.atmosphere_data.apply_config_seed(seed, label="atmosphere"),
         )
 
     def as_batch_data(self) -> "CoupledBatchData":

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -32,14 +32,27 @@ class CoupledPrognosticState:
     def apply_config_seed(self, seed: int | None) -> "CoupledPrognosticState":
         """Return a state whose components are seeded from ``config.seed``.
 
-        Each component gets its own generator seeded from the same value; they
-        are separate models, so their noise sequences do not interact. See
-        ``PrognosticState.apply_config_seed`` for the precedence rule when a
-        random state is already present.
+        Each component gets its own generator, seeded from a *different* value
+        derived from the configured seed (ocean ``seed``, atmosphere
+        ``seed + 1``), following the offset convention of
+        ``fme.core.rand.set_seed``. Seeding both from the same value would make
+        their draws identical, not merely independent, whenever they request the
+        same shapes in the same order - two ``NoiseConditionedSFNO`` components
+        on a shared grid would then see perfectly correlated noise fields.
+
+        Precedence is resolved per component (see
+        ``PrognosticState.apply_config_seed``): a component carrying a restored
+        random state continues it, while a component without one takes its
+        derived config seed. A partially restored coupled state therefore
+        continues one realm and seeds the other, which is deliberate - each
+        realm continues the sequence it was started with, rather than the whole
+        run falling back to one behavior because of the other realm.
         """
+        if seed is None:
+            return self
         return CoupledPrognosticState(
-            self.ocean_data.apply_config_seed(seed),
-            self.atmosphere_data.apply_config_seed(seed),
+            self.ocean_data.apply_config_seed(seed, label="ocean"),
+            self.atmosphere_data.apply_config_seed(seed + 1, label="atmosphere"),
         )
 
     def as_batch_data(self) -> "CoupledBatchData":

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -29,6 +29,19 @@ class CoupledPrognosticState:
             self.ocean_data.to_device(), self.atmosphere_data.to_device()
         )
 
+    def apply_config_seed(self, seed: int | None) -> "CoupledPrognosticState":
+        """Return a state whose components are seeded from ``config.seed``.
+
+        Each component gets its own generator seeded from the same value; they
+        are separate models, so their noise sequences do not interact. See
+        ``PrognosticState.apply_config_seed`` for the precedence rule when a
+        random state is already present.
+        """
+        return CoupledPrognosticState(
+            self.ocean_data.apply_config_seed(seed),
+            self.atmosphere_data.apply_config_seed(seed),
+        )
+
     def as_batch_data(self) -> "CoupledBatchData":
         return CoupledBatchData(
             self.ocean_data.as_batch_data(), self.atmosphere_data.as_batch_data()

--- a/fme/coupled/data_loading/batch_data.py
+++ b/fme/coupled/data_loading/batch_data.py
@@ -32,29 +32,15 @@ class CoupledPrognosticState:
     def apply_config_seed(self, seed: int | None) -> "CoupledPrognosticState":
         """Return a state whose components are seeded from ``config.seed``.
 
-        The atmosphere takes the configured value unchanged, so a coupled run
-        draws the same atmospheric noise sequence as an ``fme.ace`` run of the
-        same checkpoint at the same seed. The atmosphere is also the only realm
-        that consumes a generator today: the ocean steppers in use are
-        deterministic, and their stochasticity comes from the atmosphere
-        ensemble they are trained against.
+        The atmosphere, the only realm that draws noise today, takes the seed
+        unchanged, so a coupled run matches an ``fme.ace`` run of the same
+        checkpoint at the same seed. The ocean is offset by 1 (as in
+        ``fme.core.rand.set_seed``) so that a future stochastic ocean stepper
+        would not draw the same noise as the atmosphere.
 
-        The ocean gets its own generator seeded at ``seed + 1``, following the
-        offset convention of ``fme.core.rand.set_seed``. The offset is
-        unobservable while the ocean is deterministic; it is there so that a
-        future stochastic ocean stepper does not silently draw the *same* noise
-        as the atmosphere - separate generators are independent, but equal seeds
-        give equal draws whenever both components request the same shapes in the
-        same order, which two ``NoiseConditionedSFNO`` components on a shared
-        grid would.
-
-        Precedence is resolved per component (see
-        ``PrognosticState.apply_config_seed``): a component carrying a restored
-        random state continues it, while a component without one takes its
-        derived config seed. A partially restored coupled state therefore
-        continues one realm and seeds the other, which is deliberate - each
-        realm continues the sequence it was started with, rather than the whole
-        run falling back to one behavior because of the other realm.
+        Precedence is per component (see ``PrognosticState.apply_config_seed``),
+        so a partially restored state deliberately continues one realm and seeds
+        the other.
         """
         if seed is None:
             return self

--- a/fme/coupled/data_loading/gridded_data.py
+++ b/fme/coupled/data_loading/gridded_data.py
@@ -199,6 +199,13 @@ class InferenceGriddedData(InferenceDataABC[CoupledPrognosticState, CoupledBatch
     def initial_condition(self) -> CoupledPrognosticState:
         return self._initial_condition
 
+    def apply_config_seed(self, seed: int | None) -> None:
+        """Seed the initial condition's random state from ``config.seed``,
+        unless it already carries one (see
+        ``CoupledPrognosticState.apply_config_seed``).
+        """
+        self._initial_condition = self._initial_condition.apply_config_seed(seed)
+
     @property
     def loader(self) -> DataLoader[CoupledBatchData]:
         def on_device(x: CoupledBatchData) -> CoupledBatchData:

--- a/fme/coupled/data_loading/test_batch_data.py
+++ b/fme/coupled/data_loading/test_batch_data.py
@@ -1,0 +1,62 @@
+import torch
+import xarray as xr
+
+from fme.ace.data_loading.batch_data import BatchData
+from fme.core.random_state import RandomState
+from fme.coupled.data_loading.batch_data import CoupledPrognosticState
+
+
+def _prognostic_state(name: str):
+    index = xr.date_range("2000", freq="6h", periods=1, use_cftime=True)
+    time = xr.DataArray(index.values[None, :], dims=["sample", "time"])
+    return BatchData.new_on_cpu(
+        data={name: torch.zeros(1, 1, 4, 8)},
+        time=time,
+        horizontal_dims=["lat", "lon"],
+    ).get_start([name], n_ic_timesteps=1)
+
+
+def _coupled_state() -> CoupledPrognosticState:
+    return CoupledPrognosticState(
+        ocean_data=_prognostic_state("sst"),
+        atmosphere_data=_prognostic_state("surface_temperature"),
+    )
+
+
+def test_apply_config_seed_seeds_both_components():
+    """Coupled inference needs a seed so the stochastic atmosphere replays the
+    same noise sequence across runs (e.g. between ablation arms)."""
+    state = _coupled_state()
+    seeded = state.apply_config_seed(0)
+    for component in (seeded.ocean_data, seeded.atmosphere_data):
+        stepper_state = component.as_batch_data().stepper_state
+        assert stepper_state is not None
+        assert stepper_state.random_state is not None
+    # the original is unchanged
+    assert state.ocean_data.as_batch_data().stepper_state is None
+    assert state.atmosphere_data.as_batch_data().stepper_state is None
+
+
+def test_apply_config_seed_none_leaves_both_components_unseeded():
+    state = _coupled_state()
+    result = state.apply_config_seed(None)
+    assert result.ocean_data is state.ocean_data
+    assert result.atmosphere_data is state.atmosphere_data
+
+
+def test_apply_config_seed_defers_to_a_restored_random_state():
+    restored = RandomState.from_seed(11)
+    state = CoupledPrognosticState(
+        ocean_data=_prognostic_state("sst"),
+        atmosphere_data=_prognostic_state("surface_temperature").with_random_state(
+            restored
+        ),
+    )
+    result = state.apply_config_seed(0)
+    atmosphere_state = result.atmosphere_data.as_batch_data().stepper_state
+    assert atmosphere_state is not None
+    assert atmosphere_state.random_state is restored
+    # the ocean carried no restored state, so it takes the config seed
+    ocean_state = result.ocean_data.as_batch_data().stepper_state
+    assert ocean_state is not None
+    assert ocean_state.random_state is not None

--- a/fme/coupled/data_loading/test_batch_data.py
+++ b/fme/coupled/data_loading/test_batch_data.py
@@ -44,7 +44,24 @@ def test_apply_config_seed_none_leaves_both_components_unseeded():
     assert result.atmosphere_data is state.atmosphere_data
 
 
+def test_apply_config_seed_gives_the_components_different_streams():
+    """The components are seeded from the configured value but not from the
+    *same* stream: two identical stochastic modules on a shared grid would
+    otherwise draw bitwise-identical noise fields in the two realms."""
+    seeded = _coupled_state().apply_config_seed(0)
+    draws = []
+    for component in (seeded.ocean_data, seeded.atmosphere_data):
+        stepper_state = component.as_batch_data().stepper_state
+        assert stepper_state is not None
+        random_state = stepper_state.random_state
+        assert random_state is not None
+        draws.append(torch.randn(4, generator=random_state.generator))
+    assert not torch.equal(draws[0], draws[1])
+
+
 def test_apply_config_seed_defers_to_a_restored_random_state():
+    """Precedence is resolved per component, so a half-restored coupled restart
+    continues the realm that has a restored generator and seeds the other."""
     restored = RandomState.from_seed(11)
     state = CoupledPrognosticState(
         ocean_data=_prognostic_state("sst"),

--- a/fme/coupled/data_loading/test_batch_data.py
+++ b/fme/coupled/data_loading/test_batch_data.py
@@ -44,6 +44,19 @@ def test_apply_config_seed_none_leaves_both_components_unseeded():
     assert result.atmosphere_data is state.atmosphere_data
 
 
+def test_apply_config_seed_gives_the_atmosphere_the_configured_seed():
+    """The atmosphere - the realm that actually consumes a generator today -
+    takes the configured value unchanged, so a coupled run draws the same noise
+    sequence as a single-realm run of the same checkpoint at that seed."""
+    seeded = _coupled_state().apply_config_seed(0)
+    stepper_state = seeded.atmosphere_data.as_batch_data().stepper_state
+    assert stepper_state is not None
+    random_state = stepper_state.random_state
+    assert random_state is not None
+    expected = torch.randn(4, generator=RandomState.from_seed(0).generator)
+    assert torch.equal(torch.randn(4, generator=random_state.generator), expected)
+
+
 def test_apply_config_seed_gives_the_components_different_streams():
     """The components are seeded from the configured value but not from the
     *same* stream: two identical stochastic modules on a shared grid would

--- a/fme/coupled/data_loading/test_batch_data.py
+++ b/fme/coupled/data_loading/test_batch_data.py
@@ -45,9 +45,8 @@ def test_apply_config_seed_none_leaves_both_components_unseeded():
 
 
 def test_apply_config_seed_gives_the_atmosphere_the_configured_seed():
-    """The atmosphere - the realm that actually consumes a generator today -
-    takes the configured value unchanged, so a coupled run draws the same noise
-    sequence as a single-realm run of the same checkpoint at that seed."""
+    """The atmosphere takes the seed unchanged, so a coupled run draws the same
+    noise sequence as a single-realm run at that seed."""
     seeded = _coupled_state().apply_config_seed(0)
     stepper_state = seeded.atmosphere_data.as_batch_data().stepper_state
     assert stepper_state is not None
@@ -58,9 +57,8 @@ def test_apply_config_seed_gives_the_atmosphere_the_configured_seed():
 
 
 def test_apply_config_seed_gives_the_components_different_streams():
-    """The components are seeded from the configured value but not from the
-    *same* stream: two identical stochastic modules on a shared grid would
-    otherwise draw bitwise-identical noise fields in the two realms."""
+    """The components draw different streams, so two identical stochastic
+    modules would not see identical noise."""
     seeded = _coupled_state().apply_config_seed(0)
     draws = []
     for component in (seeded.ocean_data, seeded.atmosphere_data):
@@ -73,8 +71,8 @@ def test_apply_config_seed_gives_the_components_different_streams():
 
 
 def test_apply_config_seed_defers_to_a_restored_random_state():
-    """Precedence is resolved per component, so a half-restored coupled restart
-    continues the realm that has a restored generator and seeds the other."""
+    """Precedence is per component: a half-restored restart continues the realm
+    with a restored generator and seeds the other."""
     restored = RandomState.from_seed(11)
     state = CoupledPrognosticState(
         ocean_data=_prognostic_state("sst"),

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -311,12 +311,14 @@ class InferenceEvaluatorConfig:
         atmosphere_stepper_override: Optional overrides for the atmosphere Stepper
             when loading a single coupled checkpoint.
         seed: If set, seeds the random state threaded through the rollout so that
-            stochastic modules (e.g. NoiseConditionedSFNO) in either component
-            produce a reproducible noise sequence, independent of
-            ``coupled_steps_in_memory``. The two components are seeded from
-            distinct values derived from this one, so their noise streams
-            differ. Leave unset (None) for the default non-reproducible
-            behavior. Only affects the stepper rollout (not the
+            stochastic modules (e.g. NoiseConditionedSFNO) produce a
+            reproducible noise sequence, independent of
+            ``coupled_steps_in_memory``. The atmosphere - the only realm that
+            draws noise today - takes this value unchanged, matching an
+            ``fme.ace`` run of the same checkpoint at the same seed; the ocean
+            gets a separate generator at ``seed + 1`` so the two realms cannot
+            draw identical noise. Leave unset (None) for the default
+            non-reproducible behavior. Only affects the stepper rollout (not the
             ``prediction_loader`` comparison path).
     """
 

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -313,11 +313,8 @@ class InferenceEvaluatorConfig:
         seed: If set, seeds the random state threaded through the rollout so that
             stochastic modules (e.g. NoiseConditionedSFNO) produce a
             reproducible noise sequence, independent of
-            ``coupled_steps_in_memory``. The atmosphere - the only realm that
-            draws noise today - takes this value unchanged, matching an
-            ``fme.ace`` run of the same checkpoint at the same seed; the ocean
-            gets a separate generator at ``seed + 1`` so the two realms cannot
-            draw identical noise. Leave unset (None) for the default
+            ``coupled_steps_in_memory``. The atmosphere takes this value and the
+            ocean ``seed + 1``. Leave unset (None) for the default
             non-reproducible behavior. Only affects the stepper rollout (not the
             ``prediction_loader`` comparison path).
     """

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -310,6 +310,12 @@ class InferenceEvaluatorConfig:
             (e.g. ``StepperOverrideConfig(prescribed_prognostic_names=[...])``).
         atmosphere_stepper_override: Optional overrides for the atmosphere Stepper
             when loading a single coupled checkpoint.
+        seed: If set, seeds the random state threaded through the rollout so that
+            stochastic modules (e.g. NoiseConditionedSFNO in the atmosphere
+            component) produce a reproducible noise sequence, independent of
+            ``coupled_steps_in_memory``. Leave unset (None) for the default
+            non-reproducible behavior. Only affects the stepper rollout (not the
+            ``prediction_loader`` comparison path).
     """
 
     experiment_dir: str
@@ -327,6 +333,7 @@ class InferenceEvaluatorConfig:
     prediction_loader: InferenceDataLoaderConfig | None = None
     ocean_stepper_override: StepperOverrideConfig | None = None
     atmosphere_stepper_override: StepperOverrideConfig | None = None
+    seed: int | None = None
 
     def __post_init__(self):
         _validate_coupled_steps_config(
@@ -478,6 +485,7 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
         initial_condition=initial_condition_requirements,
         dataset_info=stepper.training_dataset_info,
     )
+    data.apply_config_seed(config.seed)
     stepper.set_eval()
 
     aggregator_config: InferenceEvaluatorAggregatorConfig = config.aggregator

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -311,10 +311,12 @@ class InferenceEvaluatorConfig:
         atmosphere_stepper_override: Optional overrides for the atmosphere Stepper
             when loading a single coupled checkpoint.
         seed: If set, seeds the random state threaded through the rollout so that
-            stochastic modules (e.g. NoiseConditionedSFNO in the atmosphere
-            component) produce a reproducible noise sequence, independent of
-            ``coupled_steps_in_memory``. Leave unset (None) for the default
-            non-reproducible behavior. Only affects the stepper rollout (not the
+            stochastic modules (e.g. NoiseConditionedSFNO) in either component
+            produce a reproducible noise sequence, independent of
+            ``coupled_steps_in_memory``. The two components are seeded from
+            distinct values derived from this one, so their noise streams
+            differ. Leave unset (None) for the default non-reproducible
+            behavior. Only affects the stepper rollout (not the
             ``prediction_loader`` comparison path).
     """
 

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -136,10 +136,12 @@ class InferenceConfig:
         atmosphere_stepper_override: Optional overrides for the atmosphere Stepper
             when loading a single coupled checkpoint.
         seed: If set, seeds the random state threaded through the rollout so that
-            stochastic modules (e.g. NoiseConditionedSFNO in the atmosphere
-            component) produce a reproducible noise sequence, independent of
-            ``coupled_steps_in_memory``. Leave unset (None) for the default
-            non-reproducible behavior.
+            stochastic modules (e.g. NoiseConditionedSFNO) in either component
+            produce a reproducible noise sequence, independent of
+            ``coupled_steps_in_memory``. The two components are seeded from
+            distinct values derived from this one, so their noise streams
+            differ. Leave unset (None) for the default non-reproducible
+            behavior.
     """
 
     experiment_dir: str

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -138,11 +138,8 @@ class InferenceConfig:
         seed: If set, seeds the random state threaded through the rollout so that
             stochastic modules (e.g. NoiseConditionedSFNO) produce a
             reproducible noise sequence, independent of
-            ``coupled_steps_in_memory``. The atmosphere - the only realm that
-            draws noise today - takes this value unchanged, matching an
-            ``fme.ace`` run of the same checkpoint at the same seed; the ocean
-            gets a separate generator at ``seed + 1`` so the two realms cannot
-            draw identical noise. Leave unset (None) for the default
+            ``coupled_steps_in_memory``. The atmosphere takes this value and the
+            ocean ``seed + 1``. Leave unset (None) for the default
             non-reproducible behavior.
     """
 

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -135,6 +135,11 @@ class InferenceConfig:
             (e.g. ``StepperOverrideConfig(prescribed_prognostic_names=[...])``).
         atmosphere_stepper_override: Optional overrides for the atmosphere Stepper
             when loading a single coupled checkpoint.
+        seed: If set, seeds the random state threaded through the rollout so that
+            stochastic modules (e.g. NoiseConditionedSFNO in the atmosphere
+            component) produce a reproducible noise sequence, independent of
+            ``coupled_steps_in_memory``. Leave unset (None) for the default
+            non-reproducible behavior.
     """
 
     experiment_dir: str
@@ -153,6 +158,7 @@ class InferenceConfig:
     n_ensemble_per_ic: int = 1
     ocean_stepper_override: StepperOverrideConfig | None = None
     atmosphere_stepper_override: StepperOverrideConfig | None = None
+    seed: int | None = None
 
     def __post_init__(self):
         _validate_coupled_steps_config(
@@ -275,6 +281,7 @@ def run_inference_from_config(config: InferenceConfig):
         initial_condition=initial_condition,
         dataset_info=stepper.training_dataset_info,
     )
+    data.apply_config_seed(config.seed)
 
     aggregator_config: InferenceAggregatorConfig = config.aggregator
     variable_metadata = get_derived_variable_metadata() | data.variable_metadata

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -136,12 +136,14 @@ class InferenceConfig:
         atmosphere_stepper_override: Optional overrides for the atmosphere Stepper
             when loading a single coupled checkpoint.
         seed: If set, seeds the random state threaded through the rollout so that
-            stochastic modules (e.g. NoiseConditionedSFNO) in either component
-            produce a reproducible noise sequence, independent of
-            ``coupled_steps_in_memory``. The two components are seeded from
-            distinct values derived from this one, so their noise streams
-            differ. Leave unset (None) for the default non-reproducible
-            behavior.
+            stochastic modules (e.g. NoiseConditionedSFNO) produce a
+            reproducible noise sequence, independent of
+            ``coupled_steps_in_memory``. The atmosphere - the only realm that
+            draws noise today - takes this value unchanged, matching an
+            ``fme.ace`` run of the same checkpoint at the same seed; the ocean
+            gets a separate generator at ``seed + 1`` so the two realms cannot
+            draw identical noise. Leave unset (None) for the default
+            non-reproducible behavior.
     """
 
     experiment_dir: str

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -165,6 +165,7 @@ def inference_helper(
     use_prediction_data: bool = False,
     expected_derived_names: list[str] | None = None,
     mock_data: MockCoupledData | None = None,
+    seed: int | None = None,
 ):
     """
     Reusable helper for running coupled inference tests.
@@ -242,6 +243,7 @@ def inference_helper(
             ),
         ),
         coupled_steps_in_memory=coupled_steps_in_memory,
+        seed=seed,
     )
     config_filename = tmp_path / "config.yaml"
     with open(config_filename, "w") as f:
@@ -424,12 +426,13 @@ def test_evaluator_rejects_top_level_override_with_standalone_checkpoint():
 
 @pytest.mark.parametrize(
     "n_coupled_steps,coupled_steps_in_memory,n_initial_conditions,"
-    "save_standalone_component_checkpoints,use_prediction_data",
+    "save_standalone_component_checkpoints,use_prediction_data,seed",
     [
-        (2, 1, 2, True, False),
-        (4, 2, 1, False, False),
-        (2, 2, 1, False, False),
-        (2, 1, 2, False, True),
+        (2, 1, 2, True, False, None),
+        (4, 2, 1, False, False, None),
+        (2, 2, 1, False, False, None),
+        (2, 1, 2, False, True, None),
+        (2, 1, 1, False, False, 0),
     ],
 )
 @pytest.mark.medium_duration
@@ -440,6 +443,7 @@ def test_evaluator_inference(
     n_initial_conditions: int,
     save_standalone_component_checkpoints: bool,
     use_prediction_data: bool,
+    seed: int | None,
 ):
     ocean_in_names = ["o_prog", "sst", "mask_0", "a_diag", "thetao_0"]
     ocean_out_names = ["o_prog", "sst", "o_diag", "thetao_0"]
@@ -485,6 +489,7 @@ def test_evaluator_inference(
         use_prediction_data=use_prediction_data,
         expected_derived_names=expected_derived_names,
         mock_data=mock_data,
+        seed=seed,
     )
 
 

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -5,6 +5,7 @@ import pathlib
 import shutil
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 import torch
 import xarray as xr
@@ -15,6 +16,7 @@ from fme.ace.stepper import StepperOverrideConfig
 from fme.ace.stepper.derived_forcings import DerivedForcingsConfig
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.logging_utils import LoggingConfig
+from fme.core.registry.module import ModuleSelector
 from fme.core.testing import mock_wandb
 from fme.coupled.data_loading.config import CoupledDatasetWithOptionalOceanConfig
 from fme.coupled.data_loading.inference import (
@@ -36,7 +38,11 @@ from fme.coupled.inference.evaluator import (
     main,
 )
 from fme.coupled.stepper import CoupledStepperConfig
-from fme.coupled.test_stepper import CoupledDatasetInfoBuilder, get_stepper_config
+from fme.coupled.test_stepper import (
+    AddOneWithNoise,
+    CoupledDatasetInfoBuilder,
+    get_stepper_config,
+)
 
 DIR = pathlib.Path(__file__).parent
 
@@ -116,6 +122,8 @@ def save_coupled_stepper(
     save_standalone_component_checkpoints: bool = False,
     ocean_timedelta: str = "2D",
     atmosphere_timedelta: str = "1D",
+    ocean_builder: ModuleSelector | None = None,
+    atmosphere_builder: ModuleSelector | None = None,
 ) -> str | StandaloneComponentCheckpointsConfig:
     config = get_stepper_config(
         ocean_in_names=ocean_in_names,
@@ -127,6 +135,8 @@ def save_coupled_stepper(
         ocean_fraction_name=ocean_fraction_name,
         ocean_timedelta=ocean_timedelta,
         atmosphere_timedelta=atmosphere_timedelta,
+        ocean_builder=ocean_builder,
+        atmosphere_builder=atmosphere_builder,
     )
     if save_standalone_component_checkpoints:
         ocean_stepper = config.ocean.stepper.get_stepper(dataset_info.ocean)
@@ -165,7 +175,6 @@ def inference_helper(
     use_prediction_data: bool = False,
     expected_derived_names: list[str] | None = None,
     mock_data: MockCoupledData | None = None,
-    seed: int | None = None,
 ):
     """
     Reusable helper for running coupled inference tests.
@@ -243,7 +252,6 @@ def inference_helper(
             ),
         ),
         coupled_steps_in_memory=coupled_steps_in_memory,
-        seed=seed,
     )
     config_filename = tmp_path / "config.yaml"
     with open(config_filename, "w") as f:
@@ -426,13 +434,12 @@ def test_evaluator_rejects_top_level_override_with_standalone_checkpoint():
 
 @pytest.mark.parametrize(
     "n_coupled_steps,coupled_steps_in_memory,n_initial_conditions,"
-    "save_standalone_component_checkpoints,use_prediction_data,seed",
+    "save_standalone_component_checkpoints,use_prediction_data",
     [
-        (2, 1, 2, True, False, None),
-        (4, 2, 1, False, False, None),
-        (2, 2, 1, False, False, None),
-        (2, 1, 2, False, True, None),
-        (2, 1, 1, False, False, 0),
+        (2, 1, 2, True, False),
+        (4, 2, 1, False, False),
+        (2, 2, 1, False, False),
+        (2, 1, 2, False, True),
     ],
 )
 @pytest.mark.medium_duration
@@ -443,7 +450,6 @@ def test_evaluator_inference(
     n_initial_conditions: int,
     save_standalone_component_checkpoints: bool,
     use_prediction_data: bool,
-    seed: int | None,
 ):
     ocean_in_names = ["o_prog", "sst", "mask_0", "a_diag", "thetao_0"]
     ocean_out_names = ["o_prog", "sst", "o_diag", "thetao_0"]
@@ -489,7 +495,6 @@ def test_evaluator_inference(
         use_prediction_data=use_prediction_data,
         expected_derived_names=expected_derived_names,
         mock_data=mock_data,
-        seed=seed,
     )
 
 
@@ -549,3 +554,120 @@ def test_inference_backwards_compatibility(tmp_path: pathlib.Path):
         checkpoint_path=str(stepper_path),
         mock_data=mock_data,
     )
+
+
+# names shared by the seeded-reproducibility helpers below
+_SEED_OCEAN_IN_NAMES = ["o_prog", "sst", "mask_0", "a_diag"]
+_SEED_OCEAN_OUT_NAMES = ["o_prog", "sst", "o_diag"]
+_SEED_ATMOS_IN_NAMES = ["a_prog", "surface_temperature", "ocean_fraction"]
+_SEED_ATMOS_OUT_NAMES = ["a_prog", "surface_temperature", "a_diag"]
+_SEED_N_COUPLED_STEPS = 2
+
+
+def _save_stochastic_coupled_stepper(
+    tmp_path: pathlib.Path,
+) -> tuple[str, MockCoupledData]:
+    """A coupled checkpoint whose atmosphere draws noise, and its mock data.
+
+    The noise is what makes the configured seed observable in the output; the
+    ocean module stays deterministic, matching the coupled configurations run
+    today.
+    """
+    dataset_info, mock_data = _create_dataset_info_for_stepper(
+        ocean_in_names=_SEED_OCEAN_IN_NAMES,
+        ocean_out_names=_SEED_OCEAN_OUT_NAMES,
+        atmos_in_names=_SEED_ATMOS_IN_NAMES,
+        atmos_out_names=_SEED_ATMOS_OUT_NAMES,
+        n_coupled_steps=_SEED_N_COUPLED_STEPS,
+        n_initial_conditions=1,
+        data_dir=tmp_path / "data",
+    )
+    checkpoint_path = save_coupled_stepper(
+        tmp_path,
+        ocean_in_names=_SEED_OCEAN_IN_NAMES,
+        ocean_out_names=_SEED_OCEAN_OUT_NAMES,
+        atmos_in_names=_SEED_ATMOS_IN_NAMES,
+        atmos_out_names=_SEED_ATMOS_OUT_NAMES,
+        dataset_info=dataset_info,
+        ocean_timedelta=mock_data.ocean.timedelta,
+        atmosphere_timedelta=mock_data.atmosphere.timedelta,
+        atmosphere_builder=ModuleSelector(
+            type="prebuilt", config={"module": AddOneWithNoise()}
+        ),
+    )
+    assert isinstance(checkpoint_path, str)
+    return checkpoint_path, mock_data
+
+
+def _run_seeded_evaluator(
+    run_dir: pathlib.Path,
+    checkpoint_path: str,
+    mock_data: MockCoupledData,
+    seed: int | None,
+    coupled_steps_in_memory: int = 1,
+) -> np.ndarray:
+    """Run the coupled evaluator entrypoint, returning the atmosphere prognostic."""
+    run_dir.mkdir()
+    config = InferenceEvaluatorConfig(
+        experiment_dir=str(run_dir),
+        n_coupled_steps=_SEED_N_COUPLED_STEPS,
+        coupled_steps_in_memory=coupled_steps_in_memory,
+        checkpoint_path=checkpoint_path,
+        logging=LoggingConfig(
+            log_to_screen=False, log_to_file=False, log_to_wandb=True
+        ),
+        loader=InferenceDataLoaderConfig(
+            dataset=CoupledDatasetWithOptionalOceanConfig(
+                ocean=XarrayDataConfig(data_path=mock_data.ocean.data_dir),
+                atmosphere=XarrayDataConfig(data_path=mock_data.atmosphere.data_dir),
+            ),
+            start_indices=InferenceInitialConditionIndices(
+                first=0, n_initial_conditions=1, interval=1
+            ),
+        ),
+        data_writer=CoupledDataWriterConfig(
+            ocean=DataWriterConfig(
+                save_prediction_files=False, save_monthly_files=False
+            ),
+            atmosphere=DataWriterConfig(
+                save_prediction_files=True, save_monthly_files=False
+            ),
+        ),
+        seed=seed,
+    )
+    config_filename = run_dir / "config.yaml"
+    with open(config_filename, "w") as f:
+        yaml.dump(dataclasses.asdict(config), f)
+    with mock_wandb() as wandb:
+        wandb.configure(log_to_wandb=True)
+        main(yaml_config=str(config_filename))
+    ds = xr.open_dataset(
+        run_dir / "atmosphere" / "autoregressive_predictions.nc",
+        decode_timedelta=False,
+    )
+    return ds["a_prog"].values
+
+
+@pytest.mark.slow
+def test_evaluator_seed_reproducible(tmp_path: pathlib.Path):
+    """A seeded coupled evaluator run is reproducible end-to-end and independent
+    of ``coupled_steps_in_memory``, while a different seed gives a different
+    answer - which is what makes the reproducibility non-vacuous.
+    """
+    checkpoint_path, mock_data = _save_stochastic_coupled_stepper(tmp_path)
+    seed0 = _run_seeded_evaluator(tmp_path / "s0", checkpoint_path, mock_data, 0)
+    seed0_again = _run_seeded_evaluator(
+        tmp_path / "s0_again", checkpoint_path, mock_data, 0
+    )
+    seed0_chunked = _run_seeded_evaluator(
+        tmp_path / "s0_chunked",
+        checkpoint_path,
+        mock_data,
+        0,
+        coupled_steps_in_memory=_SEED_N_COUPLED_STEPS,
+    )
+    seed1 = _run_seeded_evaluator(tmp_path / "s1", checkpoint_path, mock_data, 1)
+
+    np.testing.assert_array_equal(seed0, seed0_again)
+    np.testing.assert_array_equal(seed0, seed0_chunked)
+    assert not np.allclose(seed0, seed1)

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -569,9 +569,8 @@ def _save_stochastic_coupled_stepper(
 ) -> tuple[str, MockCoupledData]:
     """A coupled checkpoint whose atmosphere draws noise, and its mock data.
 
-    The noise is what makes the configured seed observable in the output; the
-    ocean module stays deterministic, matching the coupled configurations run
-    today.
+    The noise is what makes the seed observable in the output. The ocean stays
+    deterministic, as in the coupled configurations run today.
     """
     dataset_info, mock_data = _create_dataset_info_for_stepper(
         ocean_in_names=_SEED_OCEAN_IN_NAMES,
@@ -650,9 +649,9 @@ def _run_seeded_evaluator(
 
 @pytest.mark.slow
 def test_evaluator_seed_reproducible(tmp_path: pathlib.Path):
-    """A seeded coupled evaluator run is reproducible end-to-end and independent
-    of ``coupled_steps_in_memory``, while a different seed gives a different
-    answer - which is what makes the reproducibility non-vacuous.
+    """A seeded run is reproducible end-to-end and independent of
+    ``coupled_steps_in_memory``, and a different seed gives a different answer
+    (confirming the noise is active, so the reproducibility is not vacuous).
     """
     checkpoint_path, mock_data = _save_stochastic_coupled_stepper(tmp_path)
     seed0 = _run_seeded_evaluator(tmp_path / "s0", checkpoint_path, mock_data, 0)

--- a/fme/coupled/inference/test_inference.py
+++ b/fme/coupled/inference/test_inference.py
@@ -13,6 +13,7 @@ from fme.ace.inference.data_writer.main import DataWriterConfig
 from fme.ace.inference.inference import ForcingDataLoaderConfig
 from fme.ace.stepper import StepperOverrideConfig
 from fme.core.logging_utils import LoggingConfig
+from fme.core.registry.module import ModuleSelector
 from fme.core.testing import mock_wandb
 from fme.coupled.data_loading.inference import CoupledForcingDataLoaderConfig
 from fme.coupled.data_loading.test_data_loader import create_coupled_data_on_disk
@@ -32,7 +33,7 @@ from fme.coupled.inference.test_evaluator import (
     _create_dataset_info_for_stepper,
     save_coupled_stepper,
 )
-from fme.coupled.test_stepper import CoupledDatasetInfoBuilder
+from fme.coupled.test_stepper import AddOneWithNoise, CoupledDatasetInfoBuilder
 
 
 def _setup(
@@ -46,6 +47,7 @@ def _setup(
     n_initial_conditions: int,
     empty_ocean_forcing: bool = False,
     atmosphere_times_offset: int = 0,
+    atmosphere_builder: ModuleSelector | None = None,
 ):
     all_ocean_names = set(ocean_in_names + ocean_out_names)
     all_atmos_names = set(atmos_in_names + atmos_out_names)
@@ -90,6 +92,7 @@ def _setup(
         save_standalone_component_checkpoints=True,
         ocean_timedelta=mock_data.ocean.timedelta,
         atmosphere_timedelta=mock_data.atmosphere.timedelta,
+        atmosphere_builder=atmosphere_builder,
     )
     if empty_ocean_forcing:
         atmos_forcing_config = mock_data.dataset_config.atmosphere
@@ -341,3 +344,50 @@ def test_inference_with_empty_ocean_forcing(
     with mock_wandb() as wandb:
         wandb.configure(log_to_wandb=True)
         main(yaml_config=str(config_filename))
+
+
+def _run_seeded_inference(
+    run_dir: pathlib.Path, base_config: InferenceConfig, seed: int | None
+) -> np.ndarray:
+    """Run the coupled inference entrypoint, returning the atmosphere prognostic."""
+    run_dir.mkdir()
+    config = dataclasses.replace(base_config, experiment_dir=str(run_dir), seed=seed)
+    config_filename = run_dir / "config.yaml"
+    with open(config_filename, "w") as f:
+        yaml.dump(dataclasses.asdict(config), f)
+    with mock_wandb() as wandb:
+        wandb.configure(log_to_wandb=True)
+        main(yaml_config=str(config_filename))
+    ds = xr.open_dataset(
+        run_dir / "atmosphere" / "autoregressive_predictions.nc",
+        decode_timedelta=False,
+    )
+    return ds["a_prog"].values
+
+
+@pytest.mark.slow
+def test_inference_seed_reproducible(tmp_path: pathlib.Path):
+    """A seeded coupled inference run is reproducible end-to-end, while a
+    different seed gives a different answer - which is what makes the
+    reproducibility non-vacuous. Independence from ``coupled_steps_in_memory``
+    is covered on the evaluator entrypoint, which shares the seeding path.
+    """
+    config, _, _ = _setup(
+        ocean_in_names=["o_prog", "sst", "mask_0", "a_diag"],
+        ocean_out_names=["o_prog", "sst", "o_diag"],
+        atmos_in_names=["a_prog", "surface_temperature", "ocean_fraction"],
+        atmos_out_names=["a_prog", "surface_temperature", "a_diag"],
+        tmp_path=tmp_path,
+        n_coupled_steps=2,
+        coupled_steps_in_memory=1,
+        n_initial_conditions=1,
+        atmosphere_builder=ModuleSelector(
+            type="prebuilt", config={"module": AddOneWithNoise()}
+        ),
+    )
+    seed0 = _run_seeded_inference(tmp_path / "s0", config, 0)
+    seed0_again = _run_seeded_inference(tmp_path / "s0_again", config, 0)
+    seed1 = _run_seeded_inference(tmp_path / "s1", config, 1)
+
+    np.testing.assert_array_equal(seed0, seed0_again)
+    assert not np.allclose(seed0, seed1)

--- a/fme/coupled/inference/test_inference.py
+++ b/fme/coupled/inference/test_inference.py
@@ -367,10 +367,10 @@ def _run_seeded_inference(
 
 @pytest.mark.slow
 def test_inference_seed_reproducible(tmp_path: pathlib.Path):
-    """A seeded coupled inference run is reproducible end-to-end, while a
-    different seed gives a different answer - which is what makes the
-    reproducibility non-vacuous. Independence from ``coupled_steps_in_memory``
-    is covered on the evaluator entrypoint, which shares the seeding path.
+    """A seeded run is reproducible end-to-end, and a different seed gives a
+    different answer (so the reproducibility is not vacuous). Independence from
+    ``coupled_steps_in_memory`` is covered on the evaluator entrypoint, which
+    shares the seeding path.
     """
     config, _, _ = _setup(
         ocean_in_names=["o_prog", "sst", "mask_0", "a_diag"],

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -24,6 +24,7 @@ from fme.core.dataset_info import DatasetInfo
 from fme.core.loss import StepLossConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
 from fme.core.optimization import NullOptimization
+from fme.core.rand import randn_like
 from fme.core.random_state import RandomState
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
@@ -1192,6 +1193,18 @@ class AddOne(torch.nn.Module):
 class TimesTwo(torch.nn.Module):
     def forward(self, x):
         return 2 * x
+
+
+class AddOneWithNoise(torch.nn.Module):
+    """``AddOne`` plus a standard-normal draw made through ``fme.core.rand``.
+
+    Stands in for a trained stochastic module such as ``NoiseConditionedSFNO``
+    in tests that need seeding to have an observable effect on the output,
+    without paying to build and de-zero-initialize a real one.
+    """
+
+    def forward(self, x):
+        return x + 1 + randn_like(x)
 
 
 def get_stepper_config(

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -1199,8 +1199,7 @@ class AddOneWithNoise(torch.nn.Module):
     """``AddOne`` plus a standard-normal draw made through ``fme.core.rand``.
 
     Stands in for a trained stochastic module such as ``NoiseConditionedSFNO``
-    in tests that need seeding to have an observable effect on the output,
-    without paying to build and de-zero-initialize a real one.
+    in tests that need seeding to have an observable effect.
     """
 
     def forward(self, x):


### PR DESCRIPTION
`fme.ace.*` inference takes a `seed:` and threads a `RandomState` through the rollout via the initial condition's stepper state, so a stochastic model replays the same noise sequence across runs. The coupled path had no equivalent, which makes two coupled runs that differ only in a deliberate change (e.g. a stepper override) also differ by an uncontrolled noise draw when the atmosphere component is stochastic.

Changes:
- `fme.coupled.inference.evaluator.InferenceEvaluatorConfig.seed` and `fme.coupled.inference.inference.InferenceConfig.seed` — `int | None`, defaulting to `None` (the existing non-reproducible behavior).
- `fme.coupled.data_loading.batch_data.CoupledPrognosticState.apply_config_seed` — the atmosphere takes the configured value unchanged, so a coupled run draws the same atmospheric noise sequence as an `fme.ace` run of the same checkpoint at the same seed. The atmosphere is also the only realm that consumes a generator today: the ocean steppers in use are deterministic, and their stochasticity comes from the atmosphere ensemble they are trained against. The ocean gets its own generator at `seed + 1`, following the offset convention of `fme.core.rand.set_seed`; that offset is unobservable while the ocean is deterministic, and is there so a future stochastic ocean stepper does not silently draw the *same* noise as the atmosphere (separate generators are independent, but equal seeds give equal draws when both components request the same shapes in the same order). Precedence is resolved per component: a component carrying a random state restored from a restart continues it, matching `PrognosticState.apply_config_seed`, while the other takes its derived config seed.
- `fme.coupled.data_loading.gridded_data.InferenceGriddedData.apply_config_seed` — applies the seed to the initial condition, mirroring the single-realm implementation, and is called from both coupled entrypoints.
- `PrognosticState.apply_config_seed` takes an optional `label`, so the "restored random state supersedes the config seed" log line — which fires once per component on a coupled restart — says which realm it is about.

The coupled stepper already carries `stepper_state` across outer coupled steps, so a seeded initial condition propagates for the whole rollout, independent of `coupled_steps_in_memory`.

Tests: both coupled entrypoints get an end-to-end reproducibility test built on a test module that draws noise through `fme.core.rand`, asserting that the same seed reproduces bitwise while a different seed diverges (so the reproducibility is not vacuous); the evaluator test also asserts independence from `coupled_steps_in_memory`. Replacing the body of `InferenceGriddedData.apply_config_seed` with a bare `return` fails both. Unit tests cover the atmosphere receiving the configured seed unchanged, and the two components receiving different streams.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
