### PR TITLE
Add an inference-time corrector-disable override

### DIFF
--- a/fme/ace/inference/test_evaluator.py
+++ b/fme/ace/inference/test_evaluator.py
@@ -49,6 +49,7 @@ from fme.core.coordinates import (
     HybridSigmaPressureCoordinate,
     LatLonCoordinates,
 )
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.dataset_info import DatasetInfo
@@ -85,6 +86,7 @@ def save_plus_one_stepper(
     ocean=None,
     multi_call: MultiCallConfig | None = None,
     derived_forcings: DerivedForcingsConfig | None = None,
+    corrector: AtmosphereCorrectorConfig | None = None,
 ):
     if multi_call is None:
         all_names = list(set(in_names).union(out_names))
@@ -94,6 +96,8 @@ def save_plus_one_stepper(
         normalization_names = all_names
     if derived_forcings is None:
         derived_forcings = DerivedForcingsConfig()
+    if corrector is None:
+        corrector = AtmosphereCorrectorConfig()
     with tempfile.TemporaryDirectory() as temp_dir:
         mean_filename = pathlib.Path(temp_dir) / "means.nc"
         std_filename = pathlib.Path(temp_dir) / "stds.nc"
@@ -129,6 +133,7 @@ def save_plus_one_stepper(
                                         ),
                                     ),
                                     ocean=ocean,
+                                    corrector=corrector,
                                 ),
                             ),
                         ),

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
 import dacite
@@ -306,6 +306,9 @@ class FCN3StepConfig(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return list(self.prescribed_prognostic_names)
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        self.corrector.disable_corrections(names)
 
     @classmethod
     def _remove_deprecated_keys(cls, state: dict[str, Any]) -> dict[str, Any]:

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -3,7 +3,7 @@ import dataclasses
 import datetime
 import logging
 import pathlib
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import Callable, Generator, Mapping, Sequence
 from typing import Any, Literal, cast
 
 import dacite
@@ -745,6 +745,15 @@ class StepperConfig:
     def get_prescribed_prognostic_names(self) -> list[str]:
         return self.step.get_prescribed_prognostic_names()
 
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        """Disable the named corrections of this stepper's step, in place.
+
+        Used for inference / evaluation ablations: the corrector options are
+        serialized in the trained checkpoint, so switching one off is only
+        possible after loading.
+        """
+        self.step.disable_corrections(names)
+
     def replace_multi_call(
         self, multi_call: MultiCallConfig | None, state: dict[str, Any]
     ) -> dict[str, Any]:
@@ -994,6 +1003,25 @@ class Stepper:
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return self._config.get_prescribed_prognostic_names()
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        """
+        Disable the named corrections of the step's corrector.
+
+        The corrector is built when the step is built, so the step is rebuilt
+        from the mutated config and the trained state reloaded into it. Only
+        meant to be used at inference time: a disabled conservation correction
+        makes the model's budgets open.
+
+        Args:
+            names: The corrector option names to switch off.
+        """
+        self._config.disable_corrections(names)
+        new_stepper: Stepper = self._config.get_stepper(
+            dataset_info=self._dataset_info,
+        )
+        new_stepper._step_obj.load_state(self._step_obj.get_state())
+        self._step_obj = new_stepper._step_obj
 
     def replace_derived_forcings(self, derived_forcings: DerivedForcingsConfig):
         """
@@ -1862,12 +1890,19 @@ class StepperOverrideConfig:
             producing a serialized stepper.
         prescribed_prognostic_names: List of prognostic variable names to overwrite
             from forcing at each step during inference.
+        disable_corrections: Names of corrector options to switch off, e.g.
+            ``[total_energy_budget_correction]``. Corrector options are
+            serialized into the checkpoint, so this is the only way to ablate a
+            correction at inference time. A name that is not an option of the
+            checkpoint's corrector, or that is already off, is an error rather
+            than a silent no-op.
     """
 
     ocean: Literal["keep"] | OceanConfig | None = "keep"
     multi_call: Literal["keep"] | MultiCallConfig | None = "keep"
     derived_forcings: Literal["keep"] | DerivedForcingsConfig = "keep"
     prescribed_prognostic_names: Literal["keep"] | list[str] = "keep"
+    disable_corrections: Literal["keep"] | list[str] = "keep"
 
 
 def load_stepper_config(
@@ -1960,6 +1995,9 @@ def apply_stepper_override(
         stepper.replace_prescribed_prognostic_names(
             override_config.prescribed_prognostic_names
         )
+    if override_config.disable_corrections != "keep":
+        logging.info("Disabling corrections %s.", override_config.disable_corrections)
+        stepper.disable_corrections(override_config.disable_corrections)
 
 
 def apply_stepper_override_to_stepper_config(
@@ -1999,3 +2037,6 @@ def apply_stepper_override_to_stepper_config(
         stepper_config.replace_prescribed_prognostic_names(
             override_config.prescribed_prognostic_names
         )
+    if override_config.disable_corrections != "keep":
+        logging.info("Disabling corrections %s.", override_config.disable_corrections)
+        stepper_config.disable_corrections(override_config.disable_corrections)

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -2197,6 +2197,91 @@ def test_load_stepper_with_prescribed_prognostic_override(tmp_path: pathlib.Path
     torch.testing.assert_close(output.data["var"], expected_var)
 
 
+def _predict_one_step(stepper: Stepper, value: float) -> torch.Tensor:
+    """Run one step from a constant input and return the predicted "var"."""
+    index = xr.date_range("2000", freq="6h", periods=2, use_cftime=True)
+    time = xr.DataArray(np.stack([index]), dims=["sample", "time"])
+    input_data = BatchData.new_on_device(
+        data={"var": torch.full((1, 1, 4, 8), value).to(DEVICE)},
+        time=time.isel(time=[0]),
+        labels=None,
+    ).get_start(prognostic_names=["var"], n_ic_timesteps=1)
+    forcing_data = BatchData.new_on_device(
+        data={"var": torch.full((1, 2, 4, 8), value).to(DEVICE)},
+        time=time,
+        labels=None,
+    )
+    output, _ = stepper.predict(input_data, forcing_data)
+    return output.data["var"]
+
+
+@pytest.mark.medium_duration
+def test_load_stepper_with_disable_corrections_override(tmp_path: pathlib.Path):
+    """StepperOverrideConfig(disable_corrections=...) ablates a correction of a
+    trained checkpoint, whose corrector options are otherwise fixed.
+
+    Uses the force-positive clamp as the correction, so the effect is visible in
+    the prediction: the saved stepper adds one, so an input of -3 predicts -2,
+    which the clamp turns into 0.
+    """
+    stepper_path = tmp_path / "stepper"
+    dim_sizes = DimSizes(
+        n_time=9,
+        horizontal=[DimSize("grid_yt", 4), DimSize("grid_xt", 8)],
+        nz_interface=4,
+    )
+    save_plus_one_stepper(
+        stepper_path,
+        in_names=["var"],
+        out_names=["var"],
+        normalization_names={"var"},
+        mean=0.0,
+        std=1.0,
+        data_shape=dim_sizes.shape_nd,
+        corrector=AtmosphereCorrectorConfig(force_positive_names=["var"]),
+    )
+
+    stepper = load_stepper(stepper_path)
+    clamped = _predict_one_step(stepper, -3.0)
+    torch.testing.assert_close(clamped, torch.zeros_like(clamped))
+
+    stepper = load_stepper(
+        stepper_path,
+        StepperOverrideConfig(disable_corrections=["force_positive_names"]),
+    )
+    unclamped = _predict_one_step(stepper, -3.0)
+    torch.testing.assert_close(unclamped, torch.full_like(unclamped, -2.0))
+    config = _get_inner_single_module_config(stepper)
+    assert config.corrector.force_positive_names == []
+
+
+@pytest.mark.medium_duration
+def test_disable_corrections_override_rejects_a_name_that_is_not_a_correction(
+    tmp_path: pathlib.Path,
+):
+    stepper_path = tmp_path / "stepper"
+    dim_sizes = DimSizes(
+        n_time=9,
+        horizontal=[DimSize("grid_yt", 4), DimSize("grid_xt", 8)],
+        nz_interface=4,
+    )
+    save_plus_one_stepper(
+        stepper_path,
+        in_names=["var"],
+        out_names=["var"],
+        normalization_names={"var"},
+        mean=0.0,
+        std=1.0,
+        data_shape=dim_sizes.shape_nd,
+        corrector=AtmosphereCorrectorConfig(force_positive_names=["var"]),
+    )
+    with pytest.raises(ValueError, match="not a correction"):
+        load_stepper(
+            stepper_path,
+            StepperOverrideConfig(disable_corrections=["conserve_moisture"]),
+        )
+
+
 class _LargeLinear(torch.nn.Module):
     """Module defined at module scope so it can be pickled by torch.save."""
 

--- a/fme/core/corrector/atmosphere.py
+++ b/fme/core/corrector/atmosphere.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 from collections.abc import Callable
-from typing import Literal, Protocol
+from typing import ClassVar, Literal, Protocol
 
 import torch
 
@@ -335,6 +335,13 @@ class AtmosphereCorrectorConfig(CorrectorConfigABC):
     total_energy_budget_correction: EnergyBudgetConfig | None = None
     keep_gradient_through_clamps: bool = False
     clip_frozen_precipitation: bool = False
+
+    # keep_gradient_through_clamps only changes how gradient flows through the
+    # clamps, not whether they are applied, so it is not a correction that
+    # disable_corrections can switch off (it is also a no-op under no_grad).
+    NON_CORRECTION_OPTIONS: ClassVar[frozenset[str]] = (
+        CorrectorConfigABC.NON_CORRECTION_OPTIONS | {"keep_gradient_through_clamps"}
+    )
 
     def _get_corrector(
         self,

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 from collections.abc import Mapping
-from typing import Any, Literal, Protocol
+from typing import Any, ClassVar, Literal, Protocol
 
 import torch
 
@@ -265,6 +265,13 @@ class OceanCorrectorConfig(CorrectorConfigABC):
     surface_energy_flux_correction: SurfaceEnergyFluxCorrectionConfig | None = None
     ocean_heat_content_correction: OceanHeatContentBudgetConfig | None = None
     keep_gradient_through_clamps: bool = False
+
+    # keep_gradient_through_clamps only changes how gradient flows through the
+    # clamps, not whether they are applied, so it is not a correction that
+    # disable_corrections can switch off (it is also a no-op under no_grad).
+    NON_CORRECTION_OPTIONS: ClassVar[frozenset[str]] = (
+        CorrectorConfigABC.NON_CORRECTION_OPTIONS | {"keep_gradient_through_clamps"}
+    )
 
     @classmethod
     def remove_deprecated_keys(cls, state: Mapping[str, Any]) -> dict[str, Any]:

--- a/fme/core/corrector/registry.py
+++ b/fme/core/corrector/registry.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
-from collections.abc import Mapping
-from typing import Any, Protocol, Self, final
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar, Protocol, Self, final
 
 import dacite
 
@@ -27,6 +27,14 @@ class CorrectorConfigABC(abc.ABC):
     """
 
     corrector_disabled_epochs: int = dataclasses.field(default=0, kw_only=True)
+
+    # Options that are not corrections: they schedule the corrector or shape how
+    # a correction is applied, rather than being a correction that can be
+    # switched off. ``disable_corrections`` rejects these names, since resetting
+    # them to their default disables no correction. Subclasses extend the set.
+    NON_CORRECTION_OPTIONS: ClassVar[frozenset[str]] = frozenset(
+        {"corrector_disabled_epochs"}
+    )
 
     def __post_init__(self):
         if self.corrector_disabled_epochs < 0:
@@ -59,6 +67,53 @@ class CorrectorConfigABC(abc.ABC):
             wrapped=corrector,
             disabled_epochs=self.corrector_disabled_epochs,
         )
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        """Switch the named corrections off in place, for inference-time ablation.
+
+        A correction is disabled by resetting its option to that field's
+        declared default, which is the "not applied" value for every option on
+        every corrector config (``None`` for an optional sub-config, ``False``
+        for a flag, empty for a name list). Using the default rather than a
+        per-option rule keeps this uniform across corrector types.
+
+        Only the corrections themselves can be disabled; the options in
+        ``NON_CORRECTION_OPTIONS`` schedule the corrector or shape how a
+        correction is applied rather than being corrections, so naming one is an
+        error -- resetting it to its default would disable no correction.
+
+        Raises:
+            ValueError: if a name is not an option on this corrector config, if
+                it has no default (so no disabled state), or if it is already
+                disabled. An unknown or already-off name would make the
+                ablation silently reproduce the un-ablated run, so it fails
+                loudly instead.
+        """
+        fields = {field.name: field for field in dataclasses.fields(self)}
+        non_corrections = type(self).NON_CORRECTION_OPTIONS
+        for name in names:
+            if name in non_corrections or name not in fields:
+                options = sorted(set(fields) - non_corrections)
+                raise ValueError(
+                    f"cannot disable {name!r}: not a correction of "
+                    f"{type(self).__name__}, whose corrections are {options}"
+                )
+            field = fields[name]
+            if field.default is not dataclasses.MISSING:
+                disabled = field.default
+            elif field.default_factory is not dataclasses.MISSING:
+                disabled = field.default_factory()
+            else:
+                raise ValueError(
+                    f"cannot disable {name!r}: it has no default, so it has no "
+                    "disabled state"
+                )
+            if getattr(self, name) == disabled:
+                raise ValueError(
+                    f"cannot disable {name!r}: it is already disabled "
+                    f"({disabled!r}) on this {type(self).__name__}"
+                )
+            setattr(self, name, disabled)
 
     @abc.abstractmethod
     def _get_corrector(

--- a/fme/core/corrector/test_atmosphere.py
+++ b/fme/core/corrector/test_atmosphere.py
@@ -807,3 +807,70 @@ def test_atmosphere_corrector_empty_delta_when_nothing_modified():
     assert set(result.modified_names) == set()
     for name in gen_data:
         torch.testing.assert_close(result.corrected[name], gen_data[name])
+
+
+def test_disable_corrections_switches_off_only_the_named_correction():
+    config = AtmosphereCorrectorConfig(
+        conserve_dry_air=True,
+        zero_global_mean_moisture_advection=True,
+        force_positive_names=["PRATEsfc"],
+        total_energy_budget_correction=EnergyBudgetConfig(
+            method="constant_temperature"
+        ),
+    )
+    config.disable_corrections(["total_energy_budget_correction"])
+    assert config.total_energy_budget_correction is None
+    # the other corrections are untouched
+    assert config.conserve_dry_air
+    assert config.zero_global_mean_moisture_advection
+    assert config.force_positive_names == ["PRATEsfc"]
+
+
+def test_disable_corrections_resets_a_flag_and_a_name_list():
+    config = AtmosphereCorrectorConfig(
+        conserve_dry_air=True,
+        force_positive_names=["PRATEsfc"],
+    )
+    config.disable_corrections(["conserve_dry_air", "force_positive_names"])
+    assert config.conserve_dry_air is False
+    assert config.force_positive_names == []
+
+
+@pytest.mark.parametrize(
+    "name,match",
+    [
+        pytest.param("not_a_correction", "not a correction", id="unknown_name"),
+        pytest.param(
+            "corrector_disabled_epochs", "not a correction", id="training_schedule"
+        ),
+        pytest.param(
+            "keep_gradient_through_clamps", "not a correction", id="gradient_shaping"
+        ),
+    ],
+)
+def test_disable_corrections_rejects_a_name_that_is_not_a_correction(name, match):
+    config = AtmosphereCorrectorConfig(conserve_dry_air=True)
+    with pytest.raises(ValueError, match=match):
+        config.disable_corrections([name])
+
+
+def test_disable_corrections_rejects_gradient_shaping_without_touching_the_clamp():
+    """keep_gradient_through_clamps changes only how gradient flows through the
+    clamps, not whether they run, so "disabling" it would ablate nothing --
+    exactly the silent no-op the raise-on-already-off rule exists to prevent."""
+    config = AtmosphereCorrectorConfig(
+        force_positive_names=["PRATEsfc"],
+        keep_gradient_through_clamps=True,
+    )
+    with pytest.raises(ValueError, match="not a correction"):
+        config.disable_corrections(["keep_gradient_through_clamps"])
+    assert config.keep_gradient_through_clamps is True
+    assert config.force_positive_names == ["PRATEsfc"]
+
+
+def test_disable_corrections_rejects_an_already_disabled_correction():
+    """An already-off name would make an ablation silently reproduce the
+    un-ablated run, so it must fail rather than no-op."""
+    config = AtmosphereCorrectorConfig(conserve_dry_air=True)
+    with pytest.raises(ValueError, match="already disabled"):
+        config.disable_corrections(["total_energy_budget_correction"])

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -15,6 +15,7 @@ from fme.core.corrector.ocean import (
 )
 from fme.core.gridded_ops import LatLonOperations
 from fme.core.ocean_data import OceanData
+from fme.core.registry import CorrectorSelector
 from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.typing_ import TensorMapping
 
@@ -539,3 +540,115 @@ def test_ocean_corrector_empty_delta_when_nothing_modified():
     assert dict(result.diagnostics.delta) == {}
     assert set(result.modified_names) == set()
     torch.testing.assert_close(result.corrected["so_0"], gen_data["so_0"])
+
+
+def test_disable_corrections_through_a_corrector_selector():
+    """The ocean corrector is configured as ``type: ocean_corrector``, i.e.
+    wrapped in a CorrectorSelector, so disabling has to reach the wrapped
+    config and keep the serialized ``config`` mapping in step with it."""
+    selector = CorrectorSelector(
+        type="ocean_corrector",
+        config=dataclasses.asdict(
+            OceanCorrectorConfig(
+                force_positive_names=["so_0"],
+                surface_energy_flux_correction=SurfaceEnergyFluxCorrectionConfig(
+                    method="prescribed"
+                ),
+                ocean_heat_content_correction=OceanHeatContentBudgetConfig(
+                    method="scaled_temperature"
+                ),
+            )
+        ),
+    )
+    selector.disable_corrections(["surface_energy_flux_correction"])
+
+    wrapped = selector._corrector_config_instance
+    assert isinstance(wrapped, OceanCorrectorConfig)
+    assert wrapped.surface_energy_flux_correction is None
+    assert wrapped.ocean_heat_content_correction is not None
+    # `config` is what gets serialized, so it must reflect the mutation
+    assert selector.config["surface_energy_flux_correction"] is None
+    assert selector.config["ocean_heat_content_correction"] is not None
+    assert selector.config["force_positive_names"] == ["so_0"]
+
+    # and the refreshed `config` survives a serialize -> reload cycle, the path
+    # a re-dumped inference config takes
+    reloaded = CorrectorSelector.from_state(dataclasses.asdict(selector))
+    reloaded_wrapped = reloaded._corrector_config_instance
+    assert isinstance(reloaded_wrapped, OceanCorrectorConfig)
+    assert reloaded_wrapped.surface_energy_flux_correction is None
+    assert reloaded_wrapped.ocean_heat_content_correction is not None
+    assert reloaded_wrapped.force_positive_names == ["so_0"]
+
+
+def test_reload_of_a_disabled_ocean_heat_content_correction():
+    """disable_corrections writes ``ocean_heat_content_correction: null`` into
+    the serialized config, so remove_deprecated_keys must accept an explicit
+    null rather than treating it as a dict to inspect."""
+    selector = CorrectorSelector(
+        type="ocean_corrector",
+        config=dataclasses.asdict(
+            OceanCorrectorConfig(
+                ocean_heat_content_correction=OceanHeatContentBudgetConfig(
+                    method="scaled_temperature"
+                ),
+            )
+        ),
+    )
+    selector.disable_corrections(["ocean_heat_content_correction"])
+    assert selector.config["ocean_heat_content_correction"] is None
+    reloaded = CorrectorSelector.from_state(dataclasses.asdict(selector))
+    reloaded_wrapped = reloaded._corrector_config_instance
+    assert isinstance(reloaded_wrapped, OceanCorrectorConfig)
+    assert reloaded_wrapped.ocean_heat_content_correction is None
+
+
+def test_disable_corrections_through_a_selector_rejects_a_non_correction():
+    """The selector resolves names against the wrapped config, so the wrapped
+    config's non-correction options are rejected there too."""
+    selector = CorrectorSelector(
+        type="ocean_corrector",
+        config=dataclasses.asdict(
+            OceanCorrectorConfig(
+                force_positive_names=["so_0"],
+                keep_gradient_through_clamps=True,
+            )
+        ),
+    )
+    with pytest.raises(ValueError, match="not a correction"):
+        selector.disable_corrections(["keep_gradient_through_clamps"])
+    assert selector.config["keep_gradient_through_clamps"] is True
+
+
+def test_disabled_surface_energy_flux_correction_leaves_hfds_untouched():
+    """With the correction off, the generated hfds is the raw prediction."""
+    config = OceanCorrectorConfig(
+        surface_energy_flux_correction=SurfaceEnergyFluxCorrectionConfig(
+            method="prescribed"
+        ),
+    )
+    ops = LatLonOperations(torch.ones(size=IMG_SHAPE))
+    timestep = datetime.timedelta(seconds=3600)
+
+    gen_hfds = torch.full(IMG_SHAPE, 5.0, device=DEVICE)
+    gen_data = {
+        "sst": torch.full(IMG_SHAPE, 300.0, device=DEVICE),
+        "hfds": gen_hfds,
+        "sea_ice_fraction": torch.zeros(IMG_SHAPE, device=DEVICE),
+    }
+    forcing_data = {
+        "land_fraction": torch.zeros(IMG_SHAPE, device=DEVICE),
+        **_make_atmos_forcing_data(IMG_SHAPE),
+    }
+    input_data = {**forcing_data, **gen_data}
+
+    corrected_on = config._build(ops, None, timestep)(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    assert not torch.allclose(corrected_on["hfds"], gen_hfds)
+
+    config.disable_corrections(["surface_energy_flux_correction"])
+    corrected_off = config._build(ops, None, timestep)(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    torch.testing.assert_close(corrected_off["hfds"], gen_hfds)

--- a/fme/core/registry/corrector.py
+++ b/fme/core/registry/corrector.py
@@ -1,5 +1,5 @@
 import dataclasses
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar  # noqa: UP035
 
 from fme.core.corrector.registry import CorrectorABC, CorrectorConfigABC
@@ -50,6 +50,17 @@ class CorrectorSelector(CorrectorConfigABC):
     def get_available_types(cls) -> set[str]:
         """This class method is used to expose all available types of Correctors."""
         return set(cls.registry._types.keys())
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        """Disable the named corrections on the wrapped corrector config.
+
+        The selector's own fields are ``type``/``config``, not corrections, so
+        the names are resolved against the wrapped config. ``config`` is then
+        rewritten from the mutated instance, since it -- not the instance -- is
+        what gets serialized.
+        """
+        self._corrector_config_instance.disable_corrections(names)
+        self.config = dataclasses.asdict(self._corrector_config_instance)
 
     def _get_corrector(
         self,

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -1,5 +1,5 @@
 import dataclasses
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from copy import copy
 from typing import Any, TypeVar
 
@@ -201,6 +201,9 @@ class MultiCallStepConfig(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return self.wrapped_step.get_prescribed_prognostic_names()
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        self.wrapped_step.disable_corrections(names)
 
     def replace_multi_call(self, multi_call: MultiCallConfig | None):
         self.config = multi_call

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import dacite
@@ -166,6 +166,9 @@ class SeparateRadiationStepConfig(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return []
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        self.corrector.disable_corrections(names)
 
     @property
     def allow_missing_variables(self) -> bool:

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import dacite
@@ -237,6 +237,9 @@ class SecondaryModuleStepConfig(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return list(self.prescribed_prognostic_names)
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        self.corrector.disable_corrections(names)
 
     def get_step(
         self,

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import dacite
@@ -230,6 +230,9 @@ class SingleModuleStepConfig(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return list(self.prescribed_prognostic_names)
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        self.corrector.disable_corrections(names)
 
     @classmethod
     def _remove_deprecated_keys(cls, state: dict[str, Any]) -> dict[str, Any]:

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -1,6 +1,6 @@
 import abc
 import dataclasses
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, ClassVar, Self, TypeVar, final
 
 import dacite
@@ -119,6 +119,16 @@ class StepConfigABC(abc.ABC):
         step configs (e.g. multi-call) delegate to the wrapped config.
         """
 
+    @abc.abstractmethod
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        """Disable the named corrections on this step's corrector, in place.
+
+        Used for inference-time ablation of a trained checkpoint, whose corrector
+        options are otherwise fixed at training time. A step type with no
+        corrector must raise, so that naming a correction fails loudly rather
+        than silently leaving the corrections on.
+        """
+
     @property
     @abc.abstractmethod
     def allow_missing_variables(self) -> bool:
@@ -229,6 +239,10 @@ class StepSelector(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return self._step_config_instance.get_prescribed_prognostic_names()
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        self._step_config_instance.disable_corrections(names)
+        self.config = dataclasses.asdict(self._step_config_instance)
 
     @property
     def allow_missing_variables(self) -> bool:

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -1,6 +1,6 @@
 import dataclasses
 import datetime
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from unittest.mock import MagicMock
 
 import dacite
@@ -132,6 +132,9 @@ class MockStepConfig(StepConfigABC):
 
     def get_prescribed_prognostic_names(self) -> list[str]:
         return []
+
+    def disable_corrections(self, names: Sequence[str]) -> None:
+        raise NotImplementedError("MockStepConfig has no corrector")
 
     @property
     def allow_missing_variables(self) -> bool:

--- a/fme/coupled/inference/evaluator.py
+++ b/fme/coupled/inference/evaluator.py
@@ -44,13 +44,18 @@ from fme.coupled.stepper import (
 def _validate_coupled_component_override(
     override: StepperOverrideConfig | None,
 ) -> None:
-    """Restrict coupled inference overrides to ``prescribed_prognostic_names``.
+    """Restrict coupled inference overrides to the name-preserving ones.
 
     ``CoupledStepperConfig`` caches cross-component forcing-name sets and
-    validates component compatibility at construction. Only
-    ``prescribed_prognostic_names`` is recomputed on demand; an ``ocean``,
+    validates component compatibility at construction. An ``ocean``,
     ``multi_call`` or ``derived_forcings`` override applied afterward would leave
     those caches stale, so reject them rather than silently use stale values.
+
+    ``prescribed_prognostic_names`` is recomputed on demand, and
+    ``disable_corrections`` only switches corrections off inside a component's
+    corrector -- it changes no variable names at all (not ``in_names``,
+    ``out_names`` or ``next_step_input_names``), so neither leaves a stale
+    cache.
     """
     if override is None:
         return
@@ -65,7 +70,8 @@ def _validate_coupled_component_override(
     ]
     if unsupported:
         raise ValueError(
-            "Coupled inference overrides only support prescribed_prognostic_names, "
+            "Coupled inference overrides only support "
+            "prescribed_prognostic_names and disable_corrections, "
             f"but got unsupported override(s): {sorted(unsupported)}."
         )
 

--- a/fme/coupled/inference/test_evaluator.py
+++ b/fme/coupled/inference/test_evaluator.py
@@ -13,6 +13,7 @@ import yaml
 from fme.ace.inference.data_writer.main import DataWriterConfig
 from fme.ace.stepper import StepperOverrideConfig
 from fme.ace.stepper.derived_forcings import DerivedForcingsConfig
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.dataset.xarray import XarrayDataConfig
 from fme.core.logging_utils import LoggingConfig
 from fme.core.testing import mock_wandb
@@ -383,6 +384,38 @@ def test_apply_coupled_overrides_rejects_non_prescribed_override(override):
         apply_coupled_stepper_config_inference_overrides(
             config, ocean_override=override, atmosphere_override=None
         )
+
+
+def test_apply_coupled_overrides_accepts_disable_corrections():
+    """disable_corrections changes no variable names, so unlike ocean /
+    multi_call / derived_forcings it cannot leave a stale forcing-name cache and
+    is allowed in coupled inference."""
+    config = get_stepper_config(
+        ocean_in_names=["o_exog", "exog", "sst", "a_diag", "sfc_temp"],
+        ocean_out_names=["sst"],
+        atmosphere_in_names=["exog", "ocean_frac", "sfc_temp"],
+        atmosphere_out_names=["a_diag", "sfc_temp"],
+        sst_name_in_ocean_data="sst",
+        sfc_temp_name_in_atmosphere_data="sfc_temp",
+        ocean_fraction_name="ocean_frac",
+        atmosphere_corrector=AtmosphereCorrectorConfig(
+            force_positive_names=["sfc_temp"]
+        ),
+    )
+    atmosphere_corrector = config.atmosphere.stepper.step.config["corrector"]
+    assert atmosphere_corrector["force_positive_names"] == ["sfc_temp"]
+    ocean_forcing_names_before = set(config.ocean_forcing_window_names)
+
+    apply_coupled_stepper_config_inference_overrides(
+        config,
+        ocean_override=None,
+        atmosphere_override=StepperOverrideConfig(
+            disable_corrections=["force_positive_names"]
+        ),
+    )
+    atmosphere_corrector = config.atmosphere.stepper.step.config["corrector"]
+    assert atmosphere_corrector["force_positive_names"] == []
+    assert set(config.ocean_forcing_window_names) == ocean_forcing_names_before
 
 
 def test_apply_coupled_overrides_rejects_ocean_supplied_prescribed_collision():

--- a/fme/coupled/test_stepper.py
+++ b/fme/coupled/test_stepper.py
@@ -20,6 +20,7 @@ from fme.core.coordinates import (
     NullVerticalCoordinate,
     VerticalCoordinate,
 )
+from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
 from fme.core.dataset_info import DatasetInfo
 from fme.core.loss import StepLossConfig
 from fme.core.ocean import OceanConfig, SlabOceanConfig
@@ -1210,6 +1211,7 @@ def get_stepper_config(
     ocean_prescribed_prognostic_names: list[str] | None = None,
     atmosphere_prescribed_prognostic_names: list[str] | None = None,
     atmosphere_input_dropout: VariableMaskingConfig | None = None,
+    atmosphere_corrector: AtmosphereCorrectorConfig | None = None,
 ):
     # CoupledStepper requires that both component datasets include prognostic
     # surface temperature variables and that the atmosphere data includes an
@@ -1233,6 +1235,8 @@ def get_stepper_config(
 
     ocean_prescribed = list(ocean_prescribed_prognostic_names or [])
     atmosphere_prescribed = list(atmosphere_prescribed_prognostic_names or [])
+    if atmosphere_corrector is None:
+        atmosphere_corrector = AtmosphereCorrectorConfig()
 
     config = CoupledStepperConfig(
         atmosphere=ComponentConfig(
@@ -1254,6 +1258,7 @@ def get_stepper_config(
                                 ocean_fraction_name=ocean_fraction_name,
                             ),
                             input_dropout=atmosphere_input_dropout,
+                            corrector=atmosphere_corrector,
                         ),
                     ),
                 ),


### PR DESCRIPTION
Corrector options are serialized into a trained checkpoint, so a conservation correction could not be ablated at evaluation time without retraining. Separating a genuine learned sensitivity from an artifact of the energy correctors requires exactly that: evaluation-time ablations of a *fixed* checkpoint. Prescribing a prognostic from forcing was already supported; disabling a corrector was not.

This adds `disable_corrections` to `StepperOverrideConfig`, a list of corrector option names to switch off when loading a checkpoint for inference:

```yaml
stepper_override:
  disable_corrections: [total_energy_budget_correction]
```

Changes:
- `fme.ace.stepper.StepperOverrideConfig.disable_corrections` — applied by `apply_stepper_override` and `apply_stepper_override_to_stepper_config`. A correction is disabled by resetting its option to that field's declared default, which is the "not applied" value for every option that is a correction, so the rule is uniform across corrector types.
- `fme.core.corrector.registry.CorrectorConfigABC.disable_corrections` and `NON_CORRECTION_OPTIONS` — options that are not corrections are rejected: `corrector_disabled_epochs` schedules the corrector during training, and `keep_gradient_through_clamps` (on both `AtmosphereCorrectorConfig` and `OceanCorrectorConfig`) only selects whether the clamps use a straight-through estimator, a no-op under `no_grad`. An unknown, non-correction, or already-off name raises, since each would make an ablation silently reproduce the un-ablated run.
- Plumbed along the existing `prescribed_prognostic_names` path — `fme.core.registry.corrector.CorrectorSelector` (which also refreshes its serialized `config` mapping, the path the ocean corrector takes), `fme.core.step.step.StepConfigABC`/`StepSelector`, each step config holding a corrector, `MultiCallStepConfig`, `StepperConfig` and `Stepper` (rebuilding the step from the mutated config and reloading its trained state, as `replace_ocean` does). It is abstract on `StepConfigABC`, as its `replace_ocean`/`replace_prescribed_prognostic_names` neighbours are, so a step type with no corrector has to raise deliberately.
- `fme.coupled.inference.evaluator` admits the new override: unlike `ocean`/`multi_call`/`derived_forcings` it changes no variable names, so it cannot leave `CoupledStepperConfig`'s cached cross-component forcing-name sets stale.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
