### PR TITLE
Report the true best_inference_error when an epoch diverges

### DIFF
--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -1018,6 +1018,54 @@ def test_save_best_inference_epoch_ckpts(tmp_path: str):
     assert best_inference_checkpoint["epoch"] == 3
 
 
+def test_nan_inference_error_does_not_mask_best(tmp_path: str):
+    """A diverged epoch must not erase the best inference error we report.
+
+    min(nan, x) is nan, so an epoch whose inference error diverged used to be
+    logged as the best-so-far, and wandb's run summary keeps the last logged
+    value.
+    """
+    max_epochs = 4
+    n_train_batches = 5
+    train_losses = np.array([0.5, 0.4, 0.3, 0.2])
+    val_losses = np.array([0.6, 0.5, 0.4, 0.3])
+    inference_losses = np.array([0.1, np.nan, 0.05, np.nan])
+
+    with mock_wandb() as wandb:
+        LoggingConfig(log_to_wandb=True)._configure_wandb(
+            experiment_dir=tmp_path, config={}, resumable=True
+        )
+        config, trainer = get_trainer(
+            tmp_path,
+            max_epochs=max_epochs,
+            train_losses=train_losses,
+            validation_losses=val_losses,
+            inference_losses=inference_losses,
+            n_train_batches=n_train_batches,
+            validate_using_ema=False,
+        )
+        trainer.train()
+        epoch_logs = [
+            logs for logs in wandb.get_logs() if "best_inference_error" in logs
+        ]
+
+    assert [logs["best_inference_error"] for logs in epoch_logs] == [
+        0.1,
+        0.1,
+        0.05,
+        0.05,
+    ]
+    assert trainer._best_inference_error == 0.05
+
+    best_inference_checkpoint = torch.load(
+        CheckpointPaths(config.checkpoint_dir).best_inference_checkpoint_path,
+        map_location="cpu",
+        weights_only=False,
+    )
+    assert best_inference_checkpoint["best_inference_error"] == 0.05
+    assert best_inference_checkpoint["epoch"] == 3
+
+
 def test_save_best_inference_epoch_ckpts_disabled(tmp_path: str):
     """Test that when save_best_inference_epoch_checkpoints is False, no
     epoch-specific checkpoints are saved."""

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -765,14 +765,18 @@ class Trainer:
             best_checkpoint_context = self._ema_context
         else:
             best_checkpoint_context = contextlib.nullcontext  # type: ignore
+        prev_best_inference_error = self._best_inference_error
         save_best_checkpoint, save_best_inference_checkpoint = (
             self._update_best_metrics(valid_loss, inference_error)
         )
         with best_checkpoint_context():
             if save_best_inference_checkpoint:
                 logging.info(
-                    f"Epoch inference error ({self._best_inference_error}) is the "
-                    "best so far; saving lowest inference error checkpoint to "
+                    f"Epoch inference error ({inference_error}) is lower than "
+                    f"previous best inference error ({prev_best_inference_error})."
+                )
+                logging.info(
+                    "Saving lowest inference error checkpoint to "
                     f"{self.paths.best_inference_checkpoint_path}"
                 )
                 self.save_checkpoint(self.paths.best_inference_checkpoint_path)
@@ -790,7 +794,6 @@ class Trainer:
                     )
                     self.save_checkpoint(best_inference_epoch_path)
             if save_best_checkpoint:
-                # saved after the inference error so the checkpoint records it
                 logging.info(
                     "Saving lowest validation loss checkpoint to "
                     f"{self.paths.best_checkpoint_path}"

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -490,6 +490,11 @@ class Trainer:
             if inference_error is not None:
                 logging.info(f"Inference error: {inference_error}")
 
+            # must happen before logging, so the logged bests are read from the
+            # updated state rather than recomputed (min(nan, x) is nan, which
+            # let a diverged epoch report itself as the best)
+            self._update_best_metrics(valid_loss, inference_error)
+
             with self.validation_context():
                 additional_logs = self._end_of_epoch_callback(self._epochs_trained)
 
@@ -505,10 +510,8 @@ class Trainer:
                     "epoch_train_seconds": train_end - start_time,
                     "epoch_validation_seconds": valid_end - train_end,
                     "epoch_total_seconds": time_elapsed,
-                    "best_val_loss": min(valid_loss, self._best_validation_loss),
-                    "best_inference_error": min(
-                        inference_error or torch.inf, self._best_inference_error
-                    ),
+                    "best_val_loss": self._best_validation_loss,
+                    "best_inference_error": self._best_inference_error,
                 },
             }
             if inference_end is not None:
@@ -732,32 +735,46 @@ class Trainer:
             epoch, self.params.max_epochs, self.params.ema_checkpoint_save_epochs
         )
 
+    def _update_best_metrics(
+        self, valid_loss: float, inference_error: float | None
+    ) -> tuple[bool, bool]:
+        """Record this epoch's metrics as the best so far if they improve on it.
+
+        Returns whether the validation loss and the inference error were each
+        (re-)attained this epoch, i.e. whether their best checkpoints are due to
+        be written.
+
+        A diverged epoch's NaN never becomes the best, since every comparison
+        with NaN is False. The comparisons are non-strict, so calling this twice
+        with the same values gives the same answer both times and the caller can
+        re-run it without changing what gets saved.
+        """
+        is_best_validation = valid_loss <= self._best_validation_loss
+        if is_best_validation:
+            self._best_validation_loss = valid_loss
+        is_best_inference = False
+        if inference_error is not None and (
+            inference_error <= self._best_inference_error
+        ):
+            self._best_inference_error = inference_error
+            is_best_inference = True
+        return is_best_validation, is_best_inference
+
     def save_all_checkpoints(self, valid_loss: float, inference_error: float | None):
         if self.params.validate_using_ema:
             best_checkpoint_context = self._ema_context
         else:
             best_checkpoint_context = contextlib.nullcontext  # type: ignore
+        save_best_checkpoint, save_best_inference_checkpoint = (
+            self._update_best_metrics(valid_loss, inference_error)
+        )
         with best_checkpoint_context():
-            save_best_checkpoint = False
-            if valid_loss <= self._best_validation_loss:
+            if save_best_inference_checkpoint:
                 logging.info(
-                    "Saving lowest validation loss checkpoint to "
-                    f"{self.paths.best_checkpoint_path}"
-                )
-                self._best_validation_loss = valid_loss
-                save_best_checkpoint = True  # wait until inference error is updated
-            if inference_error is not None and (
-                inference_error <= self._best_inference_error
-            ):
-                logging.info(
-                    f"Epoch inference error ({inference_error}) is lower than "
-                    f"previous best inference error ({self._best_inference_error})."
-                )
-                logging.info(
-                    "Saving lowest inference error checkpoint to "
+                    f"Epoch inference error ({self._best_inference_error}) is the "
+                    "best so far; saving lowest inference error checkpoint to "
                     f"{self.paths.best_inference_checkpoint_path}"
                 )
-                self._best_inference_error = inference_error
                 self.save_checkpoint(self.paths.best_inference_checkpoint_path)
 
                 # Save epoch-specific best inference checkpoint if configured
@@ -773,6 +790,11 @@ class Trainer:
                     )
                     self.save_checkpoint(best_inference_epoch_path)
             if save_best_checkpoint:
+                # saved after the inference error so the checkpoint records it
+                logging.info(
+                    "Saving lowest validation loss checkpoint to "
+                    f"{self.paths.best_checkpoint_path}"
+                )
                 self.save_checkpoint(self.paths.best_checkpoint_path)
 
         self._save_restart_checkpoints()


### PR DESCRIPTION
`Trainer.train()` logged `best_inference_error` as `min(inference_error or torch.inf, self._best_inference_error)`. Python's `min` returns its first argument whenever the comparison is False, and every comparison with NaN is False, so an epoch whose inline inference diverged was reported as the best so far. Only the reported value was affected — `self._best_inference_error` and the best-checkpoint decisions were already NaN-safe — but wandb's run summary keeps the last logged value, so a run whose most recent inference epoch diverged ended up summarized as `best_inference_error: NaN`. `best_val_loss` was computed the same way; validation loss is never NaN, so it was not wrong in practice, and it now reads from stored state as well.

The fix moves the best-metric bookkeeping out of `save_all_checkpoints`, which ran after the logging and only on the root rank with checkpointing enabled, into a method called once per epoch on every rank before the log dict is built. Its comparisons are non-strict, so running it a second time with the same values changes nothing and `save_all_checkpoints` still behaves correctly when called on its own.

Changes:
- `fme.core.generics.trainer.Trainer._update_best_metrics`: new; updates `_best_validation_loss` and `_best_inference_error`, and returns which of the two best checkpoints is due to be written. `Trainer.train` calls it before building the epoch's wandb log dict.
- `fme.core.generics.trainer.Trainer.train`: logs `best_val_loss` and `best_inference_error` from stored state instead of recomputing them with `min`.
- `fme.core.generics.trainer.Trainer.save_all_checkpoints`: takes its save decisions from `_update_best_metrics` instead of repeating the comparisons. The "is lower than previous best inference error" log line folds into the save message, which now names the new best rather than the superseded one.
- `fme.core.generics.test_trainer.test_nan_inference_error_does_not_mask_best`: trains four epochs with inference errors `[0.1, nan, 0.05, nan]` and checks the per-epoch logged best, the trainer state, and the best inference checkpoint.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
