### PR TITLE
Fix time_coarsen output naming: add output_names mapping

### DIFF
--- a/scripts/data_process/combine_stats.py
+++ b/scripts/data_process/combine_stats.py
@@ -41,6 +41,7 @@ class TimeCoarsenConfig:
 
     data_output_directory: str
     stats_output_directory: str
+    output_names: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass
@@ -184,7 +185,10 @@ def main(config_yaml: str):
 
     if config.time_coarsen is not None:
         stats_roots = [
-            config.time_coarsen.stats_output_directory + "/" + run + "/"
+            config.time_coarsen.stats_output_directory
+            + "/"
+            + config.time_coarsen.output_names.get(run, run)
+            + "/"
             for run in config.runs.keys()
             if run not in config.stats.exclude_runs
         ]

--- a/scripts/data_process/combine_stats.py
+++ b/scripts/data_process/combine_stats.py
@@ -184,6 +184,15 @@ def main(config_yaml: str):
     )
 
     if config.time_coarsen is not None:
+        unknown_keys = set(config.time_coarsen.output_names) - set(config.runs)
+        if unknown_keys:
+            raise ValueError(
+                f"time_coarsen.output_names keys not found in runs: {unknown_keys}"
+            )
+        if config.time_coarsen.stats_output_directory.endswith("/"):
+            config.time_coarsen.stats_output_directory = (
+                config.time_coarsen.stats_output_directory[:-1]
+            )
         stats_roots = [
             config.time_coarsen.stats_output_directory
             + "/"

--- a/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
@@ -17,8 +17,10 @@ time_coarsen:
     latitude: 180
     longitude: 360
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-1deg-8layer-daily-1940-2025
+  data_output_directory: gs://vcm-ml-intermediate
   stats_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-1deg-8layer-daily-stats-1990-2019
+  output_names:
+    2026-08-13-era5-1deg-8layer-1940-2025: 2026-08-13-era5-1deg-8layer-daily-1940-2025
   snapshot_names:
     - DPT2m
     - PRESsfc

--- a/scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-2deg-8layer-1940-2025.yaml
@@ -17,8 +17,10 @@ time_coarsen:
     latitude: 90
     longitude: 180
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-2deg-8layer-daily-1940-2025
+  data_output_directory: gs://vcm-ml-intermediate
   stats_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-2deg-8layer-daily-stats-1990-2019
+  output_names:
+    2026-08-13-era5-2deg-8layer-1940-2025: 2026-08-13-era5-2deg-8layer-daily-1940-2025
   snapshot_names:
     - DPT2m
     - PRESsfc

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -9,8 +9,10 @@ stats:
   data_type: ERA5
 time_coarsen:
   factor: 4
-  data_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-4deg-8layer-daily-1940-2025
+  data_output_directory: gs://vcm-ml-intermediate
   stats_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-4deg-8layer-daily-stats-1990-2019
+  output_names:
+    2026-08-13-era5-4deg-8layer-1940-2025: 2026-08-13-era5-4deg-8layer-daily-1940-2025
   snapshot_names:
     - DPT2m
     - PRESsfc

--- a/scripts/data_process/get_stats.py
+++ b/scripts/data_process/get_stats.py
@@ -99,6 +99,7 @@ class TimeCoarsenConfig:
     data_output_directory: str
     stats_output_directory: str
     factor: int
+    output_names: dict[str, str] = dataclasses.field(default_factory=dict)
     beaker_dataset: str | None = None
 
 
@@ -274,11 +275,12 @@ def main(config_yaml: str, run: int, debug: bool):
         debug=debug,
     )
     if config.time_coarsen is not None:
+        output_name = config.time_coarsen.output_names.get(run_name, run_name)
         time_coarsened_zarr = (
-            config.time_coarsen.data_output_directory + "/" + run_name + ".zarr"
+            config.time_coarsen.data_output_directory + "/" + output_name + ".zarr"
         )
         time_coarsened_out_dir = (
-            config.time_coarsen.stats_output_directory + "/" + run_name
+            config.time_coarsen.stats_output_directory + "/" + output_name
         )
         get_stats(
             config=config.stats,

--- a/scripts/data_process/get_stats.py
+++ b/scripts/data_process/get_stats.py
@@ -275,6 +275,19 @@ def main(config_yaml: str, run: int, debug: bool):
         debug=debug,
     )
     if config.time_coarsen is not None:
+        unknown_keys = set(config.time_coarsen.output_names) - set(config.runs)
+        if unknown_keys:
+            raise ValueError(
+                f"time_coarsen.output_names keys not found in runs: {unknown_keys}"
+            )
+        if config.time_coarsen.data_output_directory.endswith("/"):
+            config.time_coarsen.data_output_directory = (
+                config.time_coarsen.data_output_directory[:-1]
+            )
+        if config.time_coarsen.stats_output_directory.endswith("/"):
+            config.time_coarsen.stats_output_directory = (
+                config.time_coarsen.stats_output_directory[:-1]
+            )
         output_name = config.time_coarsen.output_names.get(run_name, run_name)
         time_coarsened_zarr = (
             config.time_coarsen.data_output_directory + "/" + output_name + ".zarr"

--- a/scripts/data_process/test_config.py
+++ b/scripts/data_process/test_config.py
@@ -8,6 +8,7 @@ from combine_stats import Config as CombineStatsConfig
 from create_coupled_datasets import CreateCoupledDatasetsConfig
 from create_coupled_ic import CreateCoupledICConfig
 from get_stats import Config as GetStatsConfig
+from time_coarsen import Config as TimeCoarsenConfig
 from upload_stats import Config as UploadStatsConfig
 from upload_stats import _upload_specs
 
@@ -190,3 +191,27 @@ def test_upload_config_rejects_no_datasets_requested():
 def test_upload_config_rejects_no_datasets_without_time_coarsen():
     with pytest.raises(ValueError, match="No Beaker dataset to upload"):
         _upload_stats_config(stats_beaker_dataset=None)
+
+
+OUTPUT_NAMES_CONFIG_YAMLS = [
+    f for f in CONFIG_YAMLS if "output_names" in open(f).read()
+]
+
+
+@pytest.mark.parametrize("filename", OUTPUT_NAMES_CONFIG_YAMLS)
+def test_output_names_resolve_to_distinct_paths(filename):
+    with open(filename) as f:
+        config_data = yaml.load(f, Loader=yaml.CLoader)
+    config = dacite.from_dict(data_class=TimeCoarsenConfig, data=config_data)
+    data_dir = config.data_output_directory.rstrip("/")
+    tc_dir = config.time_coarsen.data_output_directory.rstrip("/")
+    for run_name in config.runs:
+        output_name = config.time_coarsen.output_names.get(run_name, run_name)
+        input_zarr = data_dir + "/" + run_name + ".zarr"
+        output_zarr = tc_dir + "/" + output_name + ".zarr"
+        assert (
+            input_zarr != output_zarr
+        ), f"Coarsened output path equals input: {input_zarr}"
+        assert (
+            output_name != run_name
+        ), f"output_names should give run {run_name!r} a distinct name"

--- a/scripts/data_process/test_time_coarsen.py
+++ b/scripts/data_process/test_time_coarsen.py
@@ -1,8 +1,17 @@
 import json
 
 import numpy as np
+import pytest
 import xarray as xr
-from time_coarsen import TimeCoarsenConfig, TimeSlice, coarsen, process_path_pair
+from get_stats import StatsConfig
+from time_coarsen import (
+    Config,
+    TimeCoarsenConfig,
+    TimeSlice,
+    coarsen,
+    main,
+    process_path_pair,
+)
 from zarr.codecs import BloscCodec
 
 from fme.ace.testing import DimSize, DimSizes, get_nd_dataset
@@ -160,3 +169,78 @@ def test_coarsen_input_time_slice() -> None:
         xr.DataArray(times[2::2], dims=["time"]),  # Jan 3, Jan 5
     )
     assert "start='2000-01-02', stop=None" in ds_coarsened.attrs["history"]
+
+
+def test_main_output_names(tmp_path) -> None:
+    ds = xr.Dataset(
+        {
+            "temp": xr.DataArray(np.arange(4.0), dims=["time"]),
+            "temp_tendency": xr.DataArray(np.arange(4.0), dims=["time"]),
+        },
+        coords={"time": xr.date_range("2000-01-01", periods=4, freq="1D")},
+    )
+    input_dir = str(tmp_path / "raw")
+    output_dir = str(tmp_path / "daily")
+    ds.to_zarr(f"{input_dir}/my-6h-data.zarr", mode="w")
+    config = Config(
+        runs={"my-6h-data": ""},
+        data_output_directory=input_dir,
+        stats=StatsConfig(output_directory="", data_type="ERA5"),
+        time_coarsen=TimeCoarsenConfig(
+            factor=2,
+            data_output_directory=output_dir,
+            stats_output_directory="",
+            snapshot_names=["temp"],
+            window_names=["temp_tendency"],
+            constant_prefixes=[],
+            output_names={"my-6h-data": "my-daily-data"},
+        ),
+    )
+    main(config, run=0, dry_run=False)
+    assert (tmp_path / "daily" / "my-daily-data.zarr").exists()
+    assert not (tmp_path / "daily" / "my-6h-data.zarr").exists()
+
+
+def test_main_raises_on_input_equals_output(tmp_path) -> None:
+    ds = xr.Dataset(
+        {
+            "temp": xr.DataArray(np.arange(4.0), dims=["time"]),
+        },
+        coords={"time": xr.date_range("2000-01-01", periods=4, freq="1D")},
+    )
+    shared_dir = str(tmp_path / "data")
+    ds.to_zarr(f"{shared_dir}/my-data.zarr", mode="w")
+    config = Config(
+        runs={"my-data": ""},
+        data_output_directory=shared_dir,
+        stats=StatsConfig(output_directory="", data_type="ERA5"),
+        time_coarsen=TimeCoarsenConfig(
+            factor=2,
+            data_output_directory=shared_dir,
+            stats_output_directory="",
+            snapshot_names=["temp"],
+            window_names=[],
+            constant_prefixes=[],
+        ),
+    )
+    with pytest.raises(ValueError, match="identical to input path"):
+        main(config, run=0)
+
+
+def test_main_raises_on_unknown_output_names_key() -> None:
+    config = Config(
+        runs={"run-a": ""},
+        data_output_directory="/in",
+        stats=StatsConfig(output_directory="", data_type="ERA5"),
+        time_coarsen=TimeCoarsenConfig(
+            factor=2,
+            data_output_directory="/out",
+            stats_output_directory="",
+            snapshot_names=[],
+            window_names=[],
+            constant_prefixes=[],
+            output_names={"typo-run": "renamed"},
+        ),
+    )
+    with pytest.raises(ValueError, match="not found in runs"):
+        main(config, run=0)

--- a/scripts/data_process/time_coarsen.py
+++ b/scripts/data_process/time_coarsen.py
@@ -94,6 +94,10 @@ def main(config: Config, run: int, dry_run: bool = False):
         )
     if config.data_output_directory.endswith("/"):
         config.data_output_directory = config.data_output_directory[:-1]
+    if config.time_coarsen.data_output_directory.endswith("/"):
+        config.time_coarsen.data_output_directory = (
+            config.time_coarsen.data_output_directory[:-1]
+        )
     output_name = config.time_coarsen.output_names.get(run_name, run_name)
     input_zarr = config.data_output_directory + "/" + run_name + ".zarr"
     output_zarr = (

--- a/scripts/data_process/time_coarsen.py
+++ b/scripts/data_process/time_coarsen.py
@@ -67,6 +67,7 @@ class TimeCoarsenConfig:
     snapshot_names: list[str]
     window_names: list[str]
     constant_prefixes: list[str]
+    output_names: dict[str, str] = dataclasses.field(default_factory=dict)
     n_split: int = 1
     chunking: dict[str, int] = dataclasses.field(default_factory=lambda: {"time": 1})
     sharding: dict[str, int] | None = dataclasses.field(
@@ -86,10 +87,24 @@ class Config:
 def main(config: Config, run: int, dry_run: bool = False):
     logging.basicConfig(level=logging.INFO)
     run_name = list(config.runs.keys())[run]
+    unknown_keys = set(config.time_coarsen.output_names) - set(config.runs)
+    if unknown_keys:
+        raise ValueError(
+            f"time_coarsen.output_names keys not found in runs: {unknown_keys}"
+        )
     if config.data_output_directory.endswith("/"):
         config.data_output_directory = config.data_output_directory[:-1]
+    output_name = config.time_coarsen.output_names.get(run_name, run_name)
     input_zarr = config.data_output_directory + "/" + run_name + ".zarr"
-    output_zarr = config.time_coarsen.data_output_directory + "/" + run_name + ".zarr"
+    output_zarr = (
+        config.time_coarsen.data_output_directory + "/" + output_name + ".zarr"
+    )
+    if input_zarr == output_zarr:
+        raise ValueError(
+            f"Coarsened output path is identical to input path: {input_zarr}. "
+            "Use time_coarsen.output_names to give the coarsened store a "
+            "distinct name."
+        )
     process_path_pair(
         input_path=input_zarr,
         output_path=output_zarr,


### PR DESCRIPTION
The time coarsening pipeline used the same run key to name both input and
output zarr stores. For ERA5 configs where the run key is the dataset
name and `data_output_directory` is the bucket root, the coarsened store
inherited the 6-hourly name — only distinguishable by its parent
directory. This adds an `output_names` mapping to `TimeCoarsenConfig`
that lets configs give coarsened artifacts a distinct identity.

Changes:
- `TimeCoarsenConfig.output_names` in `time_coarsen.py`, `get_stats.py`,
  `combine_stats.py`: optional dict mapping run key to output store name,
  defaulting to identity (no change for ensemble configs)
- `time_coarsen.main`: validates `output_names` keys are a subset of `runs`;
  raises if the resolved output path equals the input path; strips trailing
  slash from `time_coarsen.data_output_directory`
- ERA5 1deg/2deg/4deg configs: restructured to use `output_names` with the
  bucket root as `data_output_directory`, producing bare stores like
  `gs://vcm-ml-intermediate/2026-08-13-era5-1deg-8layer-daily-1940-2025.zarr`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated