### PR TITLE
Ship fs_utils.py to argo pods in compute_dataset workflow

### DIFF
--- a/scripts/data_process/compute_dataset.sh
+++ b/scripts/data_process/compute_dataset.sh
@@ -47,6 +47,7 @@ output=$(argo submit compute_dataset_argo_workflow.yaml \
     -p combine_stats_script="$(< combine_stats.py)" \
     -p upload_stats_script="$(< upload_stats.py)" \
     -p time_coarsen_script="$(< time_coarsen.py)" \
+    -p fs_utils_script="$(< fs_utils.py)" \
     -p config="$(< ${CONFIG})" \
     -p names="${names[*]}" \
     -p run_directories="${run_directories[*]}" \

--- a/scripts/data_process/compute_dataset_argo_workflow.yaml
+++ b/scripts/data_process/compute_dataset_argo_workflow.yaml
@@ -16,6 +16,7 @@ spec:
     - name: combine_stats_script
     - name: upload_stats_script
     - name: time_coarsen_script
+    - name: fs_utils_script
     - name: config
     - name: names
     - name: run_directories
@@ -41,6 +42,8 @@ spec:
               value: "{{workflow.parameters.get_stats_script}}"
             - name: time_coarsen_script
               value: "{{workflow.parameters.time_coarsen_script}}"
+            - name: fs_utils_script
+              value: "{{workflow.parameters.fs_utils_script}}"
             - name: config
               value: "{{workflow.parameters.config}}"
             - name: names
@@ -63,6 +66,8 @@ spec:
               value: "{{workflow.parameters.time_coarsen_script}}"
             - name: stats_script
               value: "{{workflow.parameters.get_stats_script}}"
+            - name: fs_utils_script
+              value: "{{workflow.parameters.fs_utils_script}}"
             - name: config
               value: "{{workflow.parameters.config}}"
             - name: run
@@ -77,6 +82,8 @@ spec:
             parameters:
             - name: python_script
               value: "{{workflow.parameters.get_stats_script}}"
+            - name: fs_utils_script
+              value: "{{workflow.parameters.fs_utils_script}}"
             - name: config
               value: "{{workflow.parameters.config}}"
             - name: run
@@ -102,6 +109,8 @@ spec:
               value: "{{workflow.parameters.upload_stats_script}}"
             - name: stats_script
               value: "{{workflow.parameters.get_stats_script}}"
+            - name: fs_utils_script
+              value: "{{workflow.parameters.fs_utils_script}}"
             - name: config
               value: "{{workflow.parameters.config}}"
     - name: compute-fme-dataset-individual
@@ -113,6 +122,7 @@ spec:
         parameters:
           - name: python_script
           - name: stats_script
+          - name: fs_utils_script
           - name: config
           - name: names
           - name: run_directories
@@ -136,6 +146,10 @@ spec:
 
             cat << EOF > get_stats.py
             {{inputs.parameters.stats_script}}
+            EOF
+
+            cat << EOF > fs_utils.py
+            {{inputs.parameters.fs_utils_script}}
             EOF
 
             cat << EOF > config.yaml
@@ -171,6 +185,8 @@ spec:
               parameters:
               - name: python_script
                 value: "{{workflow.parameters.get_stats_script}}"
+              - name: fs_utils_script
+                value: "{{workflow.parameters.fs_utils_script}}"
               - name: config
                 value: "{{workflow.parameters.config}}"
               - name: run
@@ -195,6 +211,7 @@ spec:
         parameters:
           - name: python_script
           - name: stats_script
+          - name: fs_utils_script
           - name: config
           - name: run
       container:
@@ -215,6 +232,10 @@ spec:
 
             cat << EOF > get_stats.py
             {{inputs.parameters.stats_script}}
+            EOF
+
+            cat << EOF > fs_utils.py
+            {{inputs.parameters.fs_utils_script}}
             EOF
 
             cat << EOF > config.yaml
@@ -240,6 +261,7 @@ spec:
       inputs:
         parameters:
           - name: python_script
+          - name: fs_utils_script
           - name: config
           - name: run
       container:
@@ -256,6 +278,10 @@ spec:
           - |
             cat << EOF > script.py
             {{inputs.parameters.python_script}}
+            EOF
+
+            cat << EOF > fs_utils.py
+            {{inputs.parameters.fs_utils_script}}
             EOF
 
             cat << EOF > config.yaml
@@ -320,6 +346,7 @@ spec:
         parameters:
           - name: python_script
           - name: stats_script
+          - name: fs_utils_script
           - name: config
       container:
         image: us-central1-docker.pkg.dev/vcm-ml/full-model/atmosphere-processing:v2025.12.0
@@ -339,6 +366,10 @@ spec:
 
             cat << EOF > get_stats.py
             {{inputs.parameters.stats_script}}
+            EOF
+
+            cat << EOF > fs_utils.py
+            {{inputs.parameters.fs_utils_script}}
             EOF
 
             cat << EOF > config.yaml


### PR DESCRIPTION
<!-- This description becomes the squash-and-merge commit message: keep it self-contained and describe the final state from main. Put PR-process notes (stacking/rebase, review responses, commit-by-commit narratives) in a PR comment, not here. -->
`get_stats.py` imports `fs_utils` (added in #1363), but the argo workflow
never shipped `fs_utils.py` to pods. Every pod running `time_coarsen`,
`get_stats`, or `upload_stats` fails with
`ModuleNotFoundError: No module named 'fs_utils'`.

Changes:
- `compute_dataset.sh`: pass `fs_utils.py` as a new `-p fs_utils_script`
  parameter to `argo submit`
- `compute_dataset_argo_workflow.yaml`: add `fs_utils_script` as a
  workflow parameter, thread it through all step arguments that need it,
  and write it via heredoc in the `compute-fme-dataset-individual`,
  `time-coarsen`, `get-stats`, and `upload-beaker-stats` container
  templates (`combine-stats` does not import `fs_utils`)

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
