### PR TITLE
Add conditional GAN discriminator loss to Step training

### DIFF
--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -408,7 +408,9 @@ def run_evaluator_from_config(config: InferenceEvaluatorConfig):
 
             logging.info("Building validation stepper and aggregator")
             train_stepper_config = config.validation.stepper_training
-            train_stepper = TrainStepper(stepper=stepper, config=train_stepper_config)
+            train_stepper = TrainStepper(
+                stepper=stepper, config=train_stepper_config, training=False
+            )
 
             val_aggregator = config.validation.aggregator.build(
                 dataset_info=dataset_info,

--- a/fme/ace/registry/__init__.py
+++ b/fme/ace/registry/__init__.py
@@ -4,10 +4,21 @@ from fme.core.models import mlp as _mlp
 from . import land_net as _landnet
 from . import local_net as _localnet
 from . import m2lines as _m2lines
+from . import patch_discriminator as _patch_disc
 from . import prebuilt as _prebuilt
 from . import sfno as _sfno
 from . import stochastic_sfno as _sfno_crps
 from . import swin_transformer as _swin
-from .registry import ModuleSelector
+from .registry import ModuleSelector as ModuleSelector
 
-del _prebuilt, _sfno, _m2lines, _landnet, _localnet, _sfno_crps, _mlp, _swin
+del (
+    _prebuilt,
+    _sfno,
+    _m2lines,
+    _landnet,
+    _localnet,
+    _sfno_crps,
+    _mlp,
+    _swin,
+    _patch_disc,
+)

--- a/fme/ace/registry/patch_discriminator.py
+++ b/fme/ace/registry/patch_discriminator.py
@@ -1,0 +1,103 @@
+import dataclasses
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from fme.ace.registry.registry import ModuleConfig, ModuleSelector
+from fme.core.dataset_info import DatasetInfo
+
+
+def _circular_pad_lon(x: torch.Tensor, pad: int) -> torch.Tensor:
+    """Pad the longitude (last) dimension circularly; leave latitude alone."""
+    return F.pad(x, (pad, pad, 0, 0), mode="circular")
+
+
+@ModuleSelector.register("PatchDiscriminator")
+@dataclasses.dataclass
+class PatchDiscriminatorConfig(ModuleConfig):
+    """
+    Configuration for a small convolutional patch discriminator.
+
+    Applies two 3x3 convolutions with circular longitude padding and valid
+    latitude padding, followed by a 1x1 projection. All convolutions use
+    spectral normalization. Two positional channels (sin(lat), cos(lat)) are
+    concatenated to the input.
+
+    Parameters:
+        hidden_dim: First hidden layer width; the second layer doubles it.
+    """
+
+    hidden_dim: int = 64
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        dataset_info: DatasetInfo,
+    ) -> nn.Module:
+        return PatchDiscriminator(
+            n_in_channels=n_in_channels,
+            n_out_channels=n_out_channels,
+            hidden_dim=self.hidden_dim,
+            lat=dataset_info.horizontal_coordinates.lat_1d,
+            n_lon=dataset_info.img_shape[1],
+        )
+
+
+class PatchDiscriminator(nn.Module):
+    """Two-layer 3x3 CNN with spectral normalization and positional encoding.
+
+    The forward pass prepends sin(lat) and cos(lat) as two extra input
+    channels, then runs::
+
+        CircularPadLon(1) -> Conv3x3 -> LeakyReLU(0.2)
+        CircularPadLon(1) -> Conv3x3 -> LeakyReLU(0.2)
+        Conv1x1
+
+    Latitude shrinks by 2 per 3x3 layer (valid padding), longitude stays
+    constant (circular padding).
+    """
+
+    def __init__(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        hidden_dim: int,
+        lat: torch.Tensor,
+        n_lon: int,
+    ):
+        super().__init__()
+        # Positional encoding buffers: (1, 2, n_lat, n_lon)
+        lat_rad = lat.float()
+        sin_lat = torch.sin(lat_rad).unsqueeze(0).unsqueeze(0)  # (1, 1, n_lat)
+        cos_lat = torch.cos(lat_rad).unsqueeze(0).unsqueeze(0)  # (1, 1, n_lat)
+        pos = torch.cat([sin_lat, cos_lat], dim=1)  # (1, 2, n_lat)
+        pos = pos.unsqueeze(-1).expand(-1, -1, -1, n_lon).contiguous()
+        self.register_buffer("pos_encoding", pos)
+
+        ch_in = n_in_channels + 2  # +2 for positional channels
+        self.conv1 = nn.utils.spectral_norm(
+            nn.Conv2d(ch_in, hidden_dim, kernel_size=3, padding=0)
+        )
+        self.conv2 = nn.utils.spectral_norm(
+            nn.Conv2d(hidden_dim, hidden_dim * 2, kernel_size=3, padding=0)
+        )
+        self.conv3 = nn.utils.spectral_norm(
+            nn.Conv2d(hidden_dim * 2, n_out_channels, kernel_size=1)
+        )
+        self.act = nn.LeakyReLU(0.2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Concatenate positional encoding
+        pos = self.pos_encoding.expand(x.shape[0], -1, -1, -1)
+        x = torch.cat([x, pos], dim=1)
+
+        x = _circular_pad_lon(x, 1)
+        x = self.act(self.conv1(x))
+
+        x = _circular_pad_lon(x, 1)
+        x = self.act(self.conv2(x))
+
+        x = self.conv3(x)
+        return x

--- a/fme/ace/registry/patch_discriminator.py
+++ b/fme/ace/registry/patch_discriminator.py
@@ -8,9 +8,11 @@ from fme.ace.registry.registry import ModuleConfig, ModuleSelector
 from fme.core.dataset_info import DatasetInfo
 
 
-def _circular_pad_lon(x: torch.Tensor, pad: int) -> torch.Tensor:
-    """Pad the longitude (last) dimension circularly; leave latitude alone."""
-    return F.pad(x, (pad, pad, 0, 0), mode="circular")
+def _pad_sphere(x: torch.Tensor, pad: int) -> torch.Tensor:
+    """Circular padding in longitude, zero padding in latitude."""
+    x = F.pad(x, (pad, pad, 0, 0), mode="circular")
+    x = F.pad(x, (0, 0, pad, pad), mode="constant", value=0)
+    return x
 
 
 @ModuleSelector.register("PatchDiscriminator")
@@ -19,8 +21,9 @@ class PatchDiscriminatorConfig(ModuleConfig):
     """
     Configuration for a small convolutional patch discriminator.
 
-    Applies two 3x3 convolutions with circular longitude padding and valid
-    latitude padding, followed by a 1x1 projection. All convolutions use
+    Applies two 3x3 convolutions with circular longitude padding and zero
+    latitude padding (barrier condition at the poles), followed by a 1x1
+    projection. All convolutions use
     spectral normalization. Two positional channels (sin(lat), cos(lat)) are
     concatenated to the input.
 
@@ -51,12 +54,12 @@ class PatchDiscriminator(nn.Module):
     The forward pass prepends sin(lat) and cos(lat) as two extra input
     channels, then runs::
 
-        CircularPadLon(1) -> Conv3x3 -> LeakyReLU(0.2)
-        CircularPadLon(1) -> Conv3x3 -> LeakyReLU(0.2)
+        PadSphere(1) -> Conv3x3 -> LeakyReLU(0.2)
+        PadSphere(1) -> Conv3x3 -> LeakyReLU(0.2)
         Conv1x1
 
-    Latitude shrinks by 2 per 3x3 layer (valid padding), longitude stays
-    constant (circular padding).
+    Output has the same spatial shape as the input: longitude is circular-
+    padded, latitude is zero-padded (barrier condition at the poles).
     """
 
     def __init__(
@@ -93,10 +96,10 @@ class PatchDiscriminator(nn.Module):
         pos = self.pos_encoding.expand(x.shape[0], -1, -1, -1)
         x = torch.cat([x, pos], dim=1)
 
-        x = _circular_pad_lon(x, 1)
+        x = _pad_sphere(x, 1)
         x = self.act(self.conv1(x))
 
-        x = _circular_pad_lon(x, 1)
+        x = _pad_sphere(x, 1)
         x = self.act(self.conv2(x))
 
         x = self.conv3(x)

--- a/fme/ace/registry/test_patch_discriminator.py
+++ b/fme/ace/registry/test_patch_discriminator.py
@@ -32,10 +32,7 @@ def test_output_shape():
     module = config.build(n_in, n_out, dataset_info)
     x = torch.randn(2, n_in, *IMG_SHAPE, device=fme.get_device())
     out = module(x)
-    # Two 3x3 convs with valid lat padding each shrink lat by 2
-    expected_h = IMG_SHAPE[0] - 4
-    expected_w = IMG_SHAPE[1]
-    assert out.shape == (2, n_out, expected_h, expected_w)
+    assert out.shape == (2, n_out, *IMG_SHAPE)
 
 
 def test_circular_lon_padding():
@@ -128,5 +125,4 @@ def test_via_module_selector():
     module = module.to(fme.get_device())
     x = torch.randn(2, 4, *IMG_SHAPE, device=fme.get_device())
     out = module(x)
-    expected_h = IMG_SHAPE[0] - 4
-    assert out.shape == (2, 1, expected_h, IMG_SHAPE[1])
+    assert out.shape == (2, 1, *IMG_SHAPE)

--- a/fme/ace/registry/test_patch_discriminator.py
+++ b/fme/ace/registry/test_patch_discriminator.py
@@ -1,0 +1,132 @@
+import dataclasses
+
+import torch
+
+import fme
+from fme.ace.registry.patch_discriminator import PatchDiscriminatorConfig
+from fme.core.coordinates import LatLonCoordinates
+from fme.core.registry import ModuleSelector
+from fme.core.testing.dataset_info import get_dataset_info
+
+IMG_SHAPE = (12, 24)
+
+
+def _get_dataset_info() -> fme.core.dataset_info.DatasetInfo:
+    device = fme.get_device()
+    lat = torch.linspace(-torch.pi / 2, torch.pi / 2, IMG_SHAPE[0], device=device)
+    lon = torch.linspace(0, 2 * torch.pi, IMG_SHAPE[1], device=device)
+    return get_dataset_info(
+        img_shape=IMG_SHAPE,
+        horizontal_coordinate=LatLonCoordinates(lat=lat, lon=lon),
+    )
+
+
+def test_is_registered():
+    assert "PatchDiscriminator" in ModuleSelector.get_available_types()
+
+
+def test_output_shape():
+    n_in, n_out = 5, 1
+    dataset_info = _get_dataset_info()
+    config = PatchDiscriminatorConfig(hidden_dim=32)
+    module = config.build(n_in, n_out, dataset_info)
+    x = torch.randn(2, n_in, *IMG_SHAPE, device=fme.get_device())
+    out = module(x)
+    # Two 3x3 convs with valid lat padding each shrink lat by 2
+    expected_h = IMG_SHAPE[0] - 4
+    expected_w = IMG_SHAPE[1]
+    assert out.shape == (2, n_out, expected_h, expected_w)
+
+
+def test_circular_lon_padding():
+    """Shifting input circularly in lon should circularly shift the output."""
+    n_in, n_out = 3, 1
+    dataset_info = _get_dataset_info()
+    config = PatchDiscriminatorConfig(hidden_dim=16)
+    module = config.build(n_in, n_out, dataset_info)
+    module.eval()
+
+    torch.manual_seed(42)
+    x = torch.randn(1, n_in, *IMG_SHAPE, device=fme.get_device())
+    out_base = module(x)
+
+    shift = 5
+    x_shifted = torch.roll(x, shifts=shift, dims=-1)
+    out_shifted = module(x_shifted)
+    out_base_shifted = torch.roll(out_base, shifts=shift, dims=-1)
+
+    torch.testing.assert_close(out_shifted, out_base_shifted, atol=1e-5, rtol=1e-5)
+
+
+def test_spectral_norm_applied():
+    """All three conv layers should have spectral normalization hooks."""
+    n_in, n_out = 4, 1
+    dataset_info = _get_dataset_info()
+    config = PatchDiscriminatorConfig(hidden_dim=16)
+    module = config.build(n_in, n_out, dataset_info)
+
+    for name in ["conv1", "conv2", "conv3"]:
+        layer = getattr(module, name)
+        assert hasattr(
+            layer, "weight_orig"
+        ), f"{name} missing spectral norm (no weight_orig)"
+
+
+def test_positional_channels():
+    """Latitude information should affect the output: identical input fields
+    at different latitudes should produce different outputs."""
+    n_in, n_out = 3, 1
+    device = fme.get_device()
+    n_lat, n_lon = IMG_SHAPE
+
+    # Build two modules with different latitude grids
+    lat_a = torch.linspace(-torch.pi / 2, torch.pi / 2, n_lat, device=device)
+    lat_b = torch.linspace(0, torch.pi / 4, n_lat, device=device)
+
+    info_a = get_dataset_info(
+        img_shape=IMG_SHAPE,
+        horizontal_coordinate=LatLonCoordinates(
+            lat=lat_a, lon=torch.zeros(n_lon, device=device)
+        ),
+    )
+    info_b = get_dataset_info(
+        img_shape=IMG_SHAPE,
+        horizontal_coordinate=LatLonCoordinates(
+            lat=lat_b, lon=torch.zeros(n_lon, device=device)
+        ),
+    )
+
+    config = PatchDiscriminatorConfig(hidden_dim=16)
+    module_a = config.build(n_in, n_out, info_a)
+    module_b = config.build(n_in, n_out, info_b)
+
+    # Copy only conv weights (not the pos_encoding buffer) so the
+    # positional encoding is the only difference between the two modules.
+    state_a = {k: v for k, v in module_a.state_dict().items() if k != "pos_encoding"}
+    module_b.load_state_dict(state_a, strict=False)
+
+    torch.manual_seed(0)
+    x = torch.randn(1, n_in, *IMG_SHAPE, device=device)
+    out_a = module_a(x)
+    out_b = module_b(x)
+
+    assert not torch.allclose(
+        out_a, out_b, atol=1e-6
+    ), "Outputs should differ when latitude grids differ"
+
+
+def test_via_module_selector():
+    """Build through the ModuleSelector registry round-trip."""
+    dataset_info = _get_dataset_info()
+    selector = ModuleSelector(
+        type="PatchDiscriminator",
+        config=dataclasses.asdict(PatchDiscriminatorConfig(hidden_dim=32)),
+    )
+    module = selector.build(
+        n_in_channels=4, n_out_channels=1, dataset_info=dataset_info
+    )
+    module = module.to(fme.get_device())
+    x = torch.randn(2, 4, *IMG_SHAPE, device=fme.get_device())
+    out = module(x)
+    expected_h = IMG_SHAPE[0] - 4
+    assert out.shape == (2, 1, expected_h, IMG_SHAPE[1])

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -42,7 +42,7 @@ from fme.core.normalizer import (
     StandardNormalizer,
 )
 from fme.core.ocean import OceanConfig
-from fme.core.optimization import NullOptimization
+from fme.core.optimization import NullOptimization, Optimization, OptimizationConfig
 from fme.core.rand import use_generator
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.spatial_masking import (
@@ -51,6 +51,11 @@ from fme.core.spatial_masking import (
     StaticSpatialMaskingConfig,
 )
 from fme.core.step.args import StepArgs
+from fme.core.step.discriminator import (
+    GanStepLosses,
+    StepDiscriminator,
+    compute_gan_step_losses,
+)
 from fme.core.step.global_mean_removal import GlobalMeanRemovalConfigUnion
 from fme.core.step.multi_call import (
     MultiCallConfig,
@@ -1039,6 +1044,10 @@ class Stepper:
         return self._step_obj.modules
 
     @property
+    def discriminator(self) -> StepDiscriminator | None:
+        return self._step_obj.discriminator
+
+    @property
     def normalizer(self) -> StandardNormalizer:
         return self._step_obj.normalizer
 
@@ -1163,6 +1172,7 @@ class Stepper:
                 )
             state = result.output
             stepper_state = result.stepper_state
+            result.input = input_data
             yield result
             state = optimizer.detach_if_using_gradient_accumulation(state)
 
@@ -1462,6 +1472,17 @@ class TrainStepperConfig:
             be less than or equal to the number of timesteps present
             in the training dataset samples.
         parameter_init: The parameter initialization configuration for fine-tuning.
+        discriminator_loss_weight: Weight of the adversarial (generator-side)
+            loss term, added to the base loss on every optimized forward step.
+            Requires the step to define a discriminator; must be positive when
+            one is defined.
+        discriminator_optimization: Optimization configuration for the
+            discriminator. When None, mirrors the run's main optimization
+            config (optimizer type, lr, kwargs, mixed precision, and gradient
+            clipping — never its scheduler). The discriminator's learning rate
+            stays constant: schedulers are not supported, since the training
+            stepper never sees the epoch and validation-loss signals that
+            drive them.
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
@@ -1471,6 +1492,8 @@ class TrainStepperConfig:
     parameter_init: ParameterInitializationConfig = dataclasses.field(
         default_factory=lambda: ParameterInitializationConfig()
     )
+    discriminator_loss_weight: float = 0.0
+    discriminator_optimization: OptimizationConfig | None = None
 
     def __post_init__(self):
         if self.n_ensemble == -1:
@@ -1478,6 +1501,25 @@ class TrainStepperConfig:
                 self.n_ensemble = 2
             else:
                 self.n_ensemble = 1
+        if self.discriminator_loss_weight < 0:
+            raise ValueError(
+                "discriminator_loss_weight must be non-negative, got "
+                f"{self.discriminator_loss_weight}"
+            )
+        if self.discriminator_optimization is not None:
+            if self.discriminator_optimization.has_lr_schedule:
+                raise ValueError(
+                    "discriminator_optimization does not support learning rate "
+                    "schedulers: the training stepper never sees the epoch and "
+                    "validation-loss signals that drive them."
+                )
+            if self.discriminator_optimization.use_gradient_accumulation:
+                raise ValueError(
+                    "discriminator_optimization does not support "
+                    "use_gradient_accumulation: the discriminator loss is "
+                    "accumulated across forward steps and backpropagated once "
+                    "per batch."
+                )
 
     @property
     def n_forward_steps_schedule(self) -> TimeLengthSchedule | None:
@@ -1503,11 +1545,43 @@ class TrainStepperConfig:
             load_weights_and_history=load_weights_and_history_fn
         )
 
+    def get_discriminator_optimization_config(
+        self, default_optimization: OptimizationConfig | None
+    ) -> OptimizationConfig:
+        """Resolve the discriminator's optimization config.
+
+        Args:
+            default_optimization: The run's main optimization config, mirrored
+                (optimizer type, lr, kwargs, mixed precision, gradient
+                clipping — never its scheduler) when no explicit
+                discriminator_optimization is configured.
+
+        Returns:
+            The optimization config to build the discriminator optimizer from.
+        """
+        if self.discriminator_optimization is not None:
+            return self.discriminator_optimization
+        if default_optimization is None:
+            raise ValueError(
+                "discriminator_optimization must be provided when no default "
+                "optimization config is available to mirror."
+            )
+        return OptimizationConfig(
+            optimizer_type=default_optimization.optimizer_type,
+            lr=default_optimization.lr,
+            kwargs=default_optimization.kwargs,
+            enable_automatic_mixed_precision=(
+                default_optimization.enable_automatic_mixed_precision
+            ),
+            max_grad_norm=default_optimization.max_grad_norm,
+        )
+
     def get_train_stepper(
         self,
         stepper_config: StepperConfig,
         dataset_info: DatasetInfo,
         load_weights_and_history_fn: WeightsAndHistoryLoader = load_weights_and_history,
+        default_optimization: OptimizationConfig | None = None,
     ) -> "TrainStepper":
         """
         Build a TrainStepper from this configuration and a StepperConfig.
@@ -1523,6 +1597,9 @@ class TrainStepperConfig:
             load_weights_and_history_fn: Function for loading weights and
                 history. Default implementation loads a Trainer checkpoint
                 containing a Stepper.
+            default_optimization: The run's main optimization config, used as
+                the template for the discriminator optimizer when
+                discriminator_optimization is not set.
 
         Returns:
             A TrainStepper wrapping the built stepper with training
@@ -1538,6 +1615,7 @@ class TrainStepperConfig:
         return TrainStepper(
             stepper=stepper,
             config=self,
+            default_optimization=default_optimization,
         )
 
 
@@ -1579,11 +1657,15 @@ class TrainStepper(
         self,
         stepper: Stepper,
         config: TrainStepperConfig,
+        default_optimization: OptimizationConfig | None = None,
     ):
         """
         Args:
             stepper: The underlying stepper for inference operations.
             config: Training-specific configuration.
+            default_optimization: The run's main optimization config, used as
+                the template for the discriminator optimizer when
+                config.discriminator_optimization is not set.
         """
         self._stepper = stepper
         self._config = config
@@ -1594,6 +1676,35 @@ class TrainStepper(
         self._prognostic_names = self._stepper.prognostic_names
         self._derive_func = self._stepper.derive_func
         self._loss_obj = self._stepper.build_loss(config.loss)
+
+        discriminator = stepper.discriminator
+        if config.discriminator_loss_weight > 0 and discriminator is None:
+            raise ValueError(
+                "discriminator_loss_weight is positive but the step defines "
+                "no discriminator."
+            )
+        if discriminator is not None and config.discriminator_loss_weight == 0:
+            raise ValueError(
+                "The step defines a discriminator but discriminator_loss_weight "
+                "is 0. With no adversarial term the generator never sees the "
+                "discriminator's signal, so the discriminator would train to "
+                "trivially identify the generator's outputs. Remove the "
+                "discriminator or set a positive weight."
+            )
+        self._discriminator = discriminator
+        if discriminator is not None:
+            discriminator_optimization_config = (
+                config.get_discriminator_optimization_config(default_optimization)
+            )
+            # max_epochs only parameterizes LR schedulers, which are rejected
+            # for the discriminator, so any value serves.
+            self._discriminator_optimization: Optimization | None = (
+                discriminator_optimization_config.build(
+                    discriminator.modules, max_epochs=1
+                )
+            )
+        else:
+            self._discriminator_optimization = None
 
     def train_on_batch(
         self,
@@ -1635,7 +1746,16 @@ class TrainStepper(
         data = self._stepper.forcing_deriver(data)
 
         optimization.set_mode(self._stepper.modules)
-        output_list, per_channel_losses = self._accumulate_loss(
+        if self._discriminator is not None:
+            if data.data_mask is not None:
+                raise NotImplementedError(
+                    "Adversarial training does not support data_mask."
+                )
+            # The optimization argument is the in-batch train/eval authority
+            # (NullOptimization sets eval), so the discriminator's mode — which
+            # gates its update below — must come from the same call.
+            optimization.set_mode(self._discriminator.modules)
+        output_list, per_channel_losses, discriminator_losses = self._accumulate_loss(
             data,
             target_data,
             optimization,
@@ -1649,6 +1769,15 @@ class TrainStepper(
             optimization.accumulate_loss(regularizer_loss)
         metrics["loss"] = optimization.get_accumulated_loss().detach()
         optimization.step_weights()
+
+        if self._discriminator_optimization is not None and discriminator_losses:
+            # The generator's backward deposited adversarial-term gradients on
+            # the discriminator; discard them so only its own loss steps it.
+            self._discriminator_optimization.zero_gradients()
+            self._discriminator_optimization.accumulate_loss(
+                torch.stack(discriminator_losses).sum()
+            )
+            self._discriminator_optimization.step_weights()
 
         gen_data = process_ensemble_prediction_generator_list(output_list)
 
@@ -1678,7 +1807,11 @@ class TrainStepper(
         metrics: dict[str, float],
         n_forward_steps: int,
         n_loss_steps: int,
-    ) -> tuple[list[EnsembleTensorDict], dict[str, ChannelLossInfo] | None]:
+    ) -> tuple[
+        list[EnsembleTensorDict],
+        dict[str, ChannelLossInfo] | None,
+        list[torch.Tensor],
+    ]:
         input_data = data.get_start(self._prognostic_names, self.n_ic_timesteps)
         n_ensemble = self._config.n_ensemble
         input_batch_data = input_data.as_batch_data()
@@ -1702,6 +1835,8 @@ class TrainStepper(
         output_iterator = iter(output_generator)
         weighted_sums: dict[str, torch.Tensor] = {}
         total_counts: dict[str, int] = {}
+        discriminator_losses: list[torch.Tensor] = []
+        gan_step_losses: list[GanStepLosses] = []
         for step in range(n_forward_steps):
             if self._config.optimize_last_step_only:
                 optimize_step = step == n_loss_steps - 1
@@ -1711,8 +1846,10 @@ class TrainStepper(
                 contextlib.nullcontext() if optimize_step else torch.no_grad()
             )
             with grad_context:
-                gen_step = next(output_iterator).output
-                gen_step = unfold_ensemble_dim(gen_step, n_ensemble=n_ensemble)
+                step_output = next(output_iterator)
+                gen_step = unfold_ensemble_dim(
+                    step_output.output, n_ensemble=n_ensemble
+                )
                 output_list.append(gen_step)
                 target_step = add_ensemble_dim(
                     {
@@ -1730,9 +1867,92 @@ class TrainStepper(
                     weighted_sums=weighted_sums,
                     total_counts=total_counts,
                 )
+                if self._discriminator is not None and optimize_step:
+                    gan_losses = self._compute_gan_losses(
+                        discriminator=self._discriminator,
+                        data=data,
+                        target_data=target_data,
+                        step=step,
+                        step_output=step_output,
+                        fake_labels=forcing_ensemble_data.labels,
+                    )
+                    metrics[f"adversarial_loss_step_{step}"] = (
+                        gan_losses.generator_loss.detach()
+                    )
+                    gan_step_losses.append(gan_losses)
+                    if self._discriminator.training:
+                        step_total_loss = (
+                            step_total_loss
+                            + self._config.discriminator_loss_weight
+                            * gan_losses.generator_loss
+                        )
+                        discriminator_losses.append(gan_losses.discriminator_loss)
             if optimize_step:
                 optimization.accumulate_loss(step_total_loss)
-        return output_list, _finalize_per_channel_losses(weighted_sums, total_counts)
+        if gan_step_losses:
+            metrics["discriminator_loss_real"] = torch.stack(
+                [losses.discriminator_loss_real for losses in gan_step_losses]
+            ).mean()
+            metrics["discriminator_loss_fake"] = torch.stack(
+                [losses.discriminator_loss_fake for losses in gan_step_losses]
+            ).mean()
+            metrics["discriminator_score_real"] = torch.stack(
+                [losses.score_real for losses in gan_step_losses]
+            ).mean()
+            metrics["discriminator_score_fake"] = torch.stack(
+                [losses.score_fake for losses in gan_step_losses]
+            ).mean()
+        return (
+            output_list,
+            _finalize_per_channel_losses(weighted_sums, total_counts),
+            discriminator_losses,
+        )
+
+    def _compute_gan_losses(
+        self,
+        discriminator: StepDiscriminator,
+        data: BatchData,
+        target_data: BatchData,
+        step: int,
+        step_output: StepOutput,
+        fake_labels: BatchLabels | None,
+    ) -> GanStepLosses:
+        """Compute this step's adversarial losses.
+
+        The generated ("fake") pair is the input the generator consumed —
+        following its between-step detach behavior, with ensemble members
+        folded into the batch dimension — and its output. The real pair is
+        the corresponding dataset transition, assembled with the same
+        next-step-forcing convention the generator's inputs use.
+        """
+        if step_output.input is None:
+            raise RuntimeError(
+                "predict_generator did not populate StepOutput.input, which "
+                "adversarial training requires."
+            )
+        next_step_forcing_names = set(self._stepper.config.next_step_forcing_names)
+        real_input = {
+            name: (
+                data.data[name][:, step + 1]
+                if name in next_step_forcing_names
+                else data.data[name][:, step]
+            )
+            for name in discriminator.in_names
+        }
+        real_output = {
+            name: target_data.data[name].select(self.TIME_DIM, step)
+            for name in discriminator.out_names
+        }
+        return compute_gan_step_losses(
+            discriminator=discriminator,
+            gridded_operations=(self._stepper.training_dataset_info.gridded_operations),
+            real_input=real_input,
+            real_output=real_output,
+            fake_input=step_output.input,
+            fake_output=step_output.output,
+            real_labels=data.labels,
+            fake_labels=fake_labels,
+        )
 
     def _accumulate_step_loss(
         self,
@@ -1774,9 +1994,26 @@ class TrainStepper(
         self._stepper.update_training_history(training_job)
 
     def get_state(self) -> dict[str, Any]:
-        return self._stepper.get_state()
+        state = self._stepper.get_state()
+        if self._discriminator_optimization is not None:
+            # Training-only state riding in the stepper payload so it survives
+            # preemption restarts; inference loads read only the keys they
+            # know, and load_state below pops it before delegating.
+            state["discriminator_optimization"] = (
+                self._discriminator_optimization.get_state()
+            )
+        return state
 
     def load_state(self, state: dict[str, Any]) -> None:
+        state = dict(state)
+        discriminator_optimization_state = state.pop("discriminator_optimization", None)
+        if (
+            discriminator_optimization_state is not None
+            and self._discriminator_optimization is not None
+        ):
+            self._discriminator_optimization.load_state(
+                discriminator_optimization_state
+            )
         self._stepper.load_state(state)
 
     def get_base_weights(self):

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -52,9 +52,10 @@ from fme.core.spatial_masking import (
 )
 from fme.core.step.args import StepArgs
 from fme.core.step.discriminator import (
-    GanStepLosses,
+    GanStepPair,
     StepDiscriminator,
-    compute_gan_step_losses,
+    compute_discriminator_losses,
+    compute_generator_adversarial_loss,
 )
 from fme.core.step.global_mean_removal import GlobalMeanRemovalConfigUnion
 from fme.core.step.multi_call import (
@@ -1048,6 +1049,11 @@ class Stepper:
         return self._step_obj.discriminator
 
     @property
+    def next_step_forcing_names(self) -> list[str]:
+        """Names of input variables which come from the output timestep."""
+        return self._step_obj.next_step_forcing_names
+
+    @property
     def normalizer(self) -> StandardNormalizer:
         return self._step_obj.normalizer
 
@@ -1170,9 +1176,9 @@ class Stepper:
                     ),
                     wrapper=checkpoint,
                 )
+            result = dataclasses.replace(result, input=input_data)
             state = result.output
             stepper_state = result.stepper_state
-            result.input = input_data
             yield result
             state = optimizer.detach_if_using_gradient_accumulation(state)
 
@@ -1566,15 +1572,7 @@ class TrainStepperConfig:
                 "discriminator_optimization must be provided when no default "
                 "optimization config is available to mirror."
             )
-        return OptimizationConfig(
-            optimizer_type=default_optimization.optimizer_type,
-            lr=default_optimization.lr,
-            kwargs=default_optimization.kwargs,
-            enable_automatic_mixed_precision=(
-                default_optimization.enable_automatic_mixed_precision
-            ),
-            max_grad_norm=default_optimization.max_grad_norm,
-        )
+        return default_optimization.copy_without_schedule()
 
     def get_train_stepper(
         self,
@@ -1652,12 +1650,14 @@ class TrainStepper(
 
     TIME_DIM = 1
     CHANNEL_DIM = -3
+    TRAINING_ONLY_STATE_KEYS = ("discriminator_optimization",)
 
     def __init__(
         self,
         stepper: Stepper,
         config: TrainStepperConfig,
         default_optimization: OptimizationConfig | None = None,
+        training: bool = True,
     ):
         """
         Args:
@@ -1666,6 +1666,12 @@ class TrainStepper(
             default_optimization: The run's main optimization config, used as
                 the template for the discriminator optimizer when
                 config.discriminator_optimization is not set.
+            training: Whether this instance will train the model. When False
+                (evaluation-only use, e.g. the inference evaluator's
+                validation pass), training-only validation of the
+                discriminator configuration is skipped and no discriminator
+                optimizer is built; train_on_batch then evaluates without
+                updating the discriminator.
         """
         self._stepper = stepper
         self._config = config
@@ -1678,21 +1684,29 @@ class TrainStepper(
         self._loss_obj = self._stepper.build_loss(config.loss)
 
         discriminator = stepper.discriminator
-        if config.discriminator_loss_weight > 0 and discriminator is None:
-            raise ValueError(
-                "discriminator_loss_weight is positive but the step defines "
-                "no discriminator."
-            )
-        if discriminator is not None and config.discriminator_loss_weight == 0:
-            raise ValueError(
-                "The step defines a discriminator but discriminator_loss_weight "
-                "is 0. With no adversarial term the generator never sees the "
-                "discriminator's signal, so the discriminator would train to "
-                "trivially identify the generator's outputs. Remove the "
-                "discriminator or set a positive weight."
+        if training:
+            if config.discriminator_loss_weight > 0 and discriminator is None:
+                raise ValueError(
+                    "discriminator_loss_weight is positive but the step defines "
+                    "no discriminator."
+                )
+            if discriminator is not None and config.discriminator_loss_weight == 0:
+                raise ValueError(
+                    "The step defines a discriminator but "
+                    "discriminator_loss_weight is 0. With no adversarial term "
+                    "the generator never sees the discriminator's signal, so "
+                    "the discriminator would train to trivially identify the "
+                    "generator's outputs. Remove the discriminator or set a "
+                    "positive weight."
+                )
+        if discriminator is not None and stepper.n_ic_timesteps != 1:
+            raise NotImplementedError(
+                "Adversarial training assumes a single initial-condition "
+                "timestep when assembling real transition pairs, got "
+                f"n_ic_timesteps={stepper.n_ic_timesteps}."
             )
         self._discriminator = discriminator
-        if discriminator is not None:
+        if discriminator is not None and training:
             discriminator_optimization_config = (
                 config.get_discriminator_optimization_config(default_optimization)
             )
@@ -1755,7 +1769,7 @@ class TrainStepper(
             # (NullOptimization sets eval), so the discriminator's mode — which
             # gates its update below — must come from the same call.
             optimization.set_mode(self._discriminator.modules)
-        output_list, per_channel_losses, discriminator_losses = self._accumulate_loss(
+        output_list, per_channel_losses, gan_pairs = self._accumulate_loss(
             data,
             target_data,
             optimization,
@@ -1770,14 +1784,8 @@ class TrainStepper(
         metrics["loss"] = optimization.get_accumulated_loss().detach()
         optimization.step_weights()
 
-        if self._discriminator_optimization is not None and discriminator_losses:
-            # The generator's backward deposited adversarial-term gradients on
-            # the discriminator; discard them so only its own loss steps it.
-            self._discriminator_optimization.zero_gradients()
-            self._discriminator_optimization.accumulate_loss(
-                torch.stack(discriminator_losses).sum()
-            )
-            self._discriminator_optimization.step_weights()
+        if self._discriminator is not None and gan_pairs:
+            self._update_and_monitor_discriminator(gan_pairs, metrics)
 
         gen_data = process_ensemble_prediction_generator_list(output_list)
 
@@ -1810,7 +1818,7 @@ class TrainStepper(
     ) -> tuple[
         list[EnsembleTensorDict],
         dict[str, ChannelLossInfo] | None,
-        list[torch.Tensor],
+        list[GanStepPair],
     ]:
         input_data = data.get_start(self._prognostic_names, self.n_ic_timesteps)
         n_ensemble = self._config.n_ensemble
@@ -1835,8 +1843,7 @@ class TrainStepper(
         output_iterator = iter(output_generator)
         weighted_sums: dict[str, torch.Tensor] = {}
         total_counts: dict[str, int] = {}
-        discriminator_losses: list[torch.Tensor] = []
-        gan_step_losses: list[GanStepLosses] = []
+        gan_pairs: list[GanStepPair] = []
         for step in range(n_forward_steps):
             if self._config.optimize_last_step_only:
                 optimize_step = step == n_loss_steps - 1
@@ -1868,74 +1875,82 @@ class TrainStepper(
                     total_counts=total_counts,
                 )
                 if self._discriminator is not None and optimize_step:
-                    gan_losses = self._compute_gan_losses(
-                        discriminator=self._discriminator,
-                        data=data,
-                        target_data=target_data,
-                        step=step,
-                        step_output=step_output,
-                        fake_labels=forcing_ensemble_data.labels,
+                    if step_output.input is None:
+                        raise RuntimeError(
+                            "predict_generator did not populate "
+                            "StepOutput.input, which adversarial training "
+                            "requires."
+                        )
+                    gan_pairs.append(
+                        self._get_gan_pair(
+                            data=data,
+                            target_data=target_data,
+                            step=step,
+                            fake_input=step_output.input,
+                            fake_output=step_output.output,
+                            fake_labels=forcing_ensemble_data.labels,
+                        )
                     )
-                    metrics[f"adversarial_loss_step_{step}"] = (
-                        gan_losses.generator_loss.detach()
+                    # Monitor-only when the discriminator is in eval mode, so
+                    # skip building an unused graph. The forward runs under the
+                    # generator's autocast, matching the dtype of its outputs.
+                    generator_grad_context = (
+                        contextlib.nullcontext()
+                        if self._discriminator.training
+                        else torch.no_grad()
                     )
-                    gan_step_losses.append(gan_losses)
+                    with generator_grad_context, optimization.autocast():
+                        generator_loss = compute_generator_adversarial_loss(
+                            discriminator=self._discriminator,
+                            gridded_operations=(
+                                self._stepper.training_dataset_info.gridded_operations
+                            ),
+                            fake_input=step_output.input,
+                            fake_output=step_output.output,
+                            fake_labels=forcing_ensemble_data.labels,
+                        )
+                    metrics[f"adversarial_loss_step_{step}"] = generator_loss.detach()
                     if self._discriminator.training:
                         step_total_loss = (
                             step_total_loss
-                            + self._config.discriminator_loss_weight
-                            * gan_losses.generator_loss
+                            + self._config.discriminator_loss_weight * generator_loss
                         )
-                        discriminator_losses.append(gan_losses.discriminator_loss)
             if optimize_step:
                 optimization.accumulate_loss(step_total_loss)
-        if gan_step_losses:
-            metrics["discriminator_loss_real"] = torch.stack(
-                [losses.discriminator_loss_real for losses in gan_step_losses]
-            ).mean()
-            metrics["discriminator_loss_fake"] = torch.stack(
-                [losses.discriminator_loss_fake for losses in gan_step_losses]
-            ).mean()
-            metrics["discriminator_score_real"] = torch.stack(
-                [losses.score_real for losses in gan_step_losses]
-            ).mean()
-            metrics["discriminator_score_fake"] = torch.stack(
-                [losses.score_fake for losses in gan_step_losses]
-            ).mean()
         return (
             output_list,
             _finalize_per_channel_losses(weighted_sums, total_counts),
-            discriminator_losses,
+            gan_pairs,
         )
 
-    def _compute_gan_losses(
+    def _get_gan_pair(
         self,
-        discriminator: StepDiscriminator,
         data: BatchData,
         target_data: BatchData,
         step: int,
-        step_output: StepOutput,
+        fake_input: TensorMapping,
+        fake_output: TensorMapping,
         fake_labels: BatchLabels | None,
-    ) -> GanStepLosses:
-        """Compute this step's adversarial losses.
+    ) -> GanStepPair:
+        """Assemble this step's real and generated discriminator pairs.
 
         The generated ("fake") pair is the input the generator consumed —
         following its between-step detach behavior, with ensemble members
-        folded into the batch dimension — and its output. The real pair is
-        the corresponding dataset transition, assembled with the same
-        next-step-forcing convention the generator's inputs use.
+        folded into the batch dimension — and its output; it is detached so
+        the discriminator's loss cannot flow into the generator. The real
+        pair is the corresponding dataset transition, assembled with the same
+        next-step-forcing convention the generator's inputs use. Time
+        indexing assumes a single initial-condition timestep, enforced at
+        construction.
         """
-        if step_output.input is None:
-            raise RuntimeError(
-                "predict_generator did not populate StepOutput.input, which "
-                "adversarial training requires."
-            )
-        next_step_forcing_names = set(self._stepper.config.next_step_forcing_names)
+        discriminator = self._discriminator
+        assert discriminator is not None
+        next_step_forcing_names = set(self._stepper.next_step_forcing_names)
         real_input = {
             name: (
-                data.data[name][:, step + 1]
+                data.data[name].select(self.TIME_DIM, step + 1)
                 if name in next_step_forcing_names
-                else data.data[name][:, step]
+                else data.data[name].select(self.TIME_DIM, step)
             )
             for name in discriminator.in_names
         }
@@ -1943,16 +1958,53 @@ class TrainStepper(
             name: target_data.data[name].select(self.TIME_DIM, step)
             for name in discriminator.out_names
         }
-        return compute_gan_step_losses(
-            discriminator=discriminator,
-            gridded_operations=(self._stepper.training_dataset_info.gridded_operations),
+        return GanStepPair.from_step_data(
             real_input=real_input,
             real_output=real_output,
-            fake_input=step_output.input,
-            fake_output=step_output.output,
+            fake_input=fake_input,
+            fake_output=fake_output,
             real_labels=data.labels,
             fake_labels=fake_labels,
         )
+
+    def _update_and_monitor_discriminator(
+        self,
+        gan_pairs: list[GanStepPair],
+        metrics: dict[str, float],
+    ) -> None:
+        """Train the discriminator on the batch's cached pairs, or — when it
+        is not being trained — only compute its monitor metrics.
+
+        Runs after the generator's optimizer step so that under DDP the
+        discriminator's real/fake forwards immediately precede its backward:
+        those forwards arm the gradient reducer, and the next backward is the
+        one it services (see ``StepDiscriminator.gradient_sync_disabled``).
+        """
+        assert self._discriminator is not None
+        gridded_operations = self._stepper.training_dataset_info.gridded_operations
+        if (
+            self._discriminator.training
+            and self._discriminator_optimization is not None
+        ):
+            # The generator's backward deposited (unsynced) adversarial-term
+            # gradients on the discriminator; discard them so only its own
+            # loss steps it.
+            self._discriminator_optimization.zero_gradients()
+            with self._discriminator_optimization.autocast():
+                losses = compute_discriminator_losses(
+                    self._discriminator, gridded_operations, gan_pairs
+                )
+            self._discriminator_optimization.accumulate_loss(losses.loss)
+            self._discriminator_optimization.step_weights()
+        else:
+            with torch.no_grad():
+                losses = compute_discriminator_losses(
+                    self._discriminator, gridded_operations, gan_pairs
+                )
+        metrics["discriminator_loss_real"] = losses.loss_real
+        metrics["discriminator_loss_fake"] = losses.loss_fake
+        metrics["discriminator_score_real"] = losses.score_real
+        metrics["discriminator_score_fake"] = losses.score_fake
 
     def _accumulate_step_loss(
         self,

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1489,6 +1489,12 @@ class TrainStepperConfig:
             stays constant: schedulers are not supported, since the training
             stepper never sees the epoch and validation-loss signals that
             drive them.
+        discriminator_r1_penalty: R1 gradient penalty coefficient (λ/2 in
+            Mescheder et al. 2018). Added to the discriminator's loss as
+            ``coefficient * ||∇_x D(x)||²`` on the real data, penalizing
+            sharp decision boundaries that let the discriminator separate
+            real from generated pairs too easily. 0 disables. Typical values
+            are 1–10.
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
@@ -1500,6 +1506,7 @@ class TrainStepperConfig:
     )
     discriminator_loss_weight: float = 0.0
     discriminator_optimization: OptimizationConfig | None = None
+    discriminator_r1_penalty: float = 0.0
 
     def __post_init__(self):
         if self.n_ensemble == -1:
@@ -1526,6 +1533,11 @@ class TrainStepperConfig:
                     "accumulated across forward steps and backpropagated once "
                     "per batch."
                 )
+        if self.discriminator_r1_penalty < 0:
+            raise ValueError(
+                "discriminator_r1_penalty must be non-negative, got "
+                f"{self.discriminator_r1_penalty}"
+            )
 
     @property
     def n_forward_steps_schedule(self) -> TimeLengthSchedule | None:
@@ -1992,7 +2004,10 @@ class TrainStepper(
             self._discriminator_optimization.zero_gradients()
             with self._discriminator_optimization.autocast():
                 losses = compute_discriminator_losses(
-                    self._discriminator, gridded_operations, gan_pairs
+                    self._discriminator,
+                    gridded_operations,
+                    gan_pairs,
+                    r1_penalty_coefficient=self._config.discriminator_r1_penalty,
                 )
             self._discriminator_optimization.accumulate_loss(losses.loss)
             self._discriminator_optimization.step_weights()
@@ -2003,6 +2018,7 @@ class TrainStepper(
                 )
         metrics["discriminator_loss_real"] = losses.loss_real
         metrics["discriminator_loss_fake"] = losses.loss_fake
+        metrics["discriminator_r1_penalty"] = losses.r1_penalty
         metrics["discriminator_score_real"] = losses.score_real
         metrics["discriminator_score_fake"] = losses.score_fake
 

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1491,10 +1491,12 @@ class TrainStepperConfig:
             drive them.
         discriminator_r1_penalty: R1 gradient penalty coefficient (λ/2 in
             Mescheder et al. 2018). Added to the discriminator's loss as
-            ``coefficient * ||∇_x D(x)||²`` on the real data, penalizing
-            sharp decision boundaries that let the discriminator separate
-            real from generated pairs too easily. 0 disables. Typical values
-            are 1–10.
+            ``coefficient * E[mean_spatial(||∇_x D(x)||²)]`` on the real
+            data, where the squared gradient norm is summed over input
+            channels and area-weighted-averaged over the sphere. Penalizes
+            sharp decision boundaries. 0 disables. Typical values are
+            0.1–10 (scaled by input channel count relative to the image-GAN
+            literature's 3-channel convention).
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1497,6 +1497,14 @@ class TrainStepperConfig:
             sharp decision boundaries. 0 disables. Typical values are
             0.1–10 (scaled by input channel count relative to the image-GAN
             literature's 3-channel convention).
+        discriminator_r1_warmup_epochs: Number of epochs at the start of
+            training during which the R1 gradient penalty coefficient is
+            forced to 0. The full ``discriminator_r1_penalty`` value is
+            applied from this epoch onward (i.e. epochs 0 through
+            ``discriminator_r1_warmup_epochs - 1`` see no R1 penalty).
+            This prevents the penalty — which can be ~10^6 larger at random
+            initialization than at convergence — from freezing the
+            discriminator before it has learned useful gradients.
     """
 
     loss: StepLossConfig = dataclasses.field(default_factory=lambda: StepLossConfig())
@@ -1509,6 +1517,7 @@ class TrainStepperConfig:
     discriminator_loss_weight: float = 0.0
     discriminator_optimization: OptimizationConfig | None = None
     discriminator_r1_penalty: float = 0.0
+    discriminator_r1_warmup_epochs: int = 0
 
     def __post_init__(self):
         if self.n_ensemble == -1:
@@ -1539,6 +1548,11 @@ class TrainStepperConfig:
             raise ValueError(
                 "discriminator_r1_penalty must be non-negative, got "
                 f"{self.discriminator_r1_penalty}"
+            )
+        if self.discriminator_r1_warmup_epochs < 0:
+            raise ValueError(
+                "discriminator_r1_warmup_epochs must be non-negative, got "
+                f"{self.discriminator_r1_warmup_epochs}"
             )
 
     @property
@@ -1799,7 +1813,7 @@ class TrainStepper(
         optimization.step_weights()
 
         if self._discriminator is not None and gan_pairs:
-            self._update_and_monitor_discriminator(gan_pairs, metrics)
+            self._update_and_monitor_discriminator(gan_pairs, metrics, epoch=data.epoch)
 
         gen_data = process_ensemble_prediction_generator_list(output_list)
 
@@ -1985,6 +1999,7 @@ class TrainStepper(
         self,
         gan_pairs: list[GanStepPair],
         metrics: dict[str, float],
+        epoch: int | None = None,
     ) -> None:
         """Train the discriminator on the batch's cached pairs, or — when it
         is not being trained — only compute its monitor metrics.
@@ -1996,6 +2011,11 @@ class TrainStepper(
         """
         assert self._discriminator is not None
         gridded_operations = self._stepper.training_dataset_info.gridded_operations
+        warmup = self._config.discriminator_r1_warmup_epochs
+        if warmup > 0 and (epoch is None or epoch < warmup):
+            effective_r1_coefficient = 0.0
+        else:
+            effective_r1_coefficient = self._config.discriminator_r1_penalty
         if (
             self._discriminator.training
             and self._discriminator_optimization is not None
@@ -2009,7 +2029,7 @@ class TrainStepper(
                     self._discriminator,
                     gridded_operations,
                     gan_pairs,
-                    r1_penalty_coefficient=self._config.discriminator_r1_penalty,
+                    r1_penalty_coefficient=effective_r1_coefficient,
                 )
             self._discriminator_optimization.accumulate_loss(losses.loss)
             self._discriminator_optimization.step_weights()

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -68,6 +68,7 @@ from fme.core.corrector.state import CorrectorState
 from fme.core.corrector.test_registry import ConstantOffsetCorrection
 from fme.core.dataset_info import DatasetInfo, MissingDatasetInfo
 from fme.core.device import get_device
+from fme.core.distributed import Distributed
 from fme.core.generics.aggregator import AggregatorABC, AggregatorSummary
 from fme.core.generics.data import GriddedDataABC
 from fme.core.generics.optimization import OptimizationABC
@@ -3242,13 +3243,14 @@ def _get_gan_stepper_config(discriminator_module: torch.nn.Module) -> StepperCon
 def _get_gan_train_stepper(
     discriminator_module: torch.nn.Module,
     discriminator_loss_weight: float = 0.5,
+    n_ensemble: int = 1,
     **train_config_kwargs,
 ) -> TrainStepper:
     return _get_train_stepper(
         _get_gan_stepper_config(discriminator_module),
         discriminator_loss_weight=discriminator_loss_weight,
         discriminator_optimization=OptimizationConfig(optimizer_type="Adam", lr=0.01),
-        n_ensemble=1,
+        n_ensemble=n_ensemble,
         **train_config_kwargs,
     )
 
@@ -3390,8 +3392,9 @@ def test_gan_discriminator_judges_dataset_transitions_against_generated_pairs():
     train_stepper = _get_gan_train_stepper(discriminator_module)
     data = get_data(["a", "b"], n_samples=2, n_time=3).data
     train_stepper.train_on_batch(data, NullOptimization())
-    # per optimized step, three judgments in order: generated pair with
-    # generator gradients, generated pair detached, dataset transition
+    # in the step loop, one generator-gradient judgment per optimized step;
+    # then after the generator's optimizer step, per step: generated pair
+    # detached, dataset transition
     assert len(records) == 6
     input_channels = slice(0, 2)
     output_channels = slice(2, 4)
@@ -3403,18 +3406,22 @@ def test_gan_discriminator_judges_dataset_transitions_against_generated_pairs():
 
     # normalization is trivial (mean 0, std 1) and the generator adds one,
     # so generated values are directly comparable to the data
-    step1_real = records[5]
-    torch.testing.assert_close(step1_real[:, input_channels], packed(1))
-    torch.testing.assert_close(step1_real[:, output_channels], packed(2))
-    step1_generated = records[3]
-    torch.testing.assert_close(step1_generated[:, input_channels], packed(0) + 1)
-    torch.testing.assert_close(step1_generated[:, output_channels], packed(0) + 2)
-    step0_real = records[2]
-    torch.testing.assert_close(step0_real[:, input_channels], packed(0))
-    torch.testing.assert_close(step0_real[:, output_channels], packed(1))
     step0_generated = records[0]
     torch.testing.assert_close(step0_generated[:, input_channels], packed(0))
     torch.testing.assert_close(step0_generated[:, output_channels], packed(0) + 1)
+    step1_generated = records[1]
+    torch.testing.assert_close(step1_generated[:, input_channels], packed(0) + 1)
+    torch.testing.assert_close(step1_generated[:, output_channels], packed(0) + 2)
+    step0_fake_detached = records[2]
+    torch.testing.assert_close(step0_fake_detached, step0_generated)
+    step0_real = records[3]
+    torch.testing.assert_close(step0_real[:, input_channels], packed(0))
+    torch.testing.assert_close(step0_real[:, output_channels], packed(1))
+    step1_fake_detached = records[4]
+    torch.testing.assert_close(step1_fake_detached, step1_generated)
+    step1_real = records[5]
+    torch.testing.assert_close(step1_real[:, input_channels], packed(1))
+    torch.testing.assert_close(step1_real[:, output_channels], packed(2))
 
 
 @pytest.mark.parametrize("use_gradient_accumulation", [False, True])
@@ -3498,3 +3505,240 @@ def test_gan_train_stepper_warm_starts_from_checkpoint_without_discriminator():
     assert train_stepper._discriminator is not None
     (weight,) = train_stepper._discriminator.modules.parameters()
     torch.testing.assert_close(weight, torch.full_like(weight, 0.3))
+
+
+def test_gan_real_pair_uses_next_step_forcing_from_next_timestep():
+    """A next-step forcing variable enters the real pair's input at step + 1,
+    matching the convention of the generator's own inputs."""
+    torch.manual_seed(0)
+    records: list[torch.Tensor] = []
+
+    class ChannelMeanLogits(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.full((1,), 0.3))
+
+        def forward(self, x):
+            records.append(x)
+            return x.mean(dim=-3, keepdim=True) * self.weight
+
+    class DropForcingAddOne(torch.nn.Module):
+        """Maps (a, b, f) input channels to (a, b) outputs."""
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(1))
+
+        def forward(self, x):
+            return x[:, :2] + 1 + self.weight
+
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": DropForcingAddOne()}
+                    ),
+                    in_names=["a", "b", "f"],
+                    out_names=["a", "b"],
+                    normalization=trivial_network_and_loss_normalization(
+                        ["a", "b", "f"]
+                    ),
+                    next_step_forcing_names=["f"],
+                    discriminator=ModuleSelector(
+                        type="prebuilt", config={"module": ChannelMeanLogits()}
+                    ),
+                )
+            ),
+        ),
+    )
+    train_stepper = _get_train_stepper(
+        config,
+        discriminator_loss_weight=0.5,
+        discriminator_optimization=OptimizationConfig(optimizer_type="Adam", lr=0.01),
+        n_ensemble=1,
+    )
+    data = get_data(["a", "b", "f"], n_samples=2, n_time=2).data
+    train_stepper.train_on_batch(data, NullOptimization())
+    # one optimized step: generator judgment, then detached fake, then real
+    assert len(records) == 3
+    forcing_channel = 2  # packed in the discriminator's in_names order
+    real = records[2]
+    torch.testing.assert_close(real[:, forcing_channel], data.data["f"][:, 1])
+    torch.testing.assert_close(real[:, 0], data.data["a"][:, 0])
+    fake = records[1]
+    torch.testing.assert_close(fake[:, forcing_channel], data.data["f"][:, 1])
+
+
+def test_gan_fake_side_folds_ensemble_members():
+    """With n_ensemble > 1 the generated pairs fold the ensemble into the
+    batch dimension while the real side keeps the data batch size."""
+    torch.manual_seed(0)
+    discriminator_module, records = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(
+        discriminator_module,
+        n_ensemble=2,
+        loss=StepLossConfig(
+            type="EnsembleLoss",
+            kwargs={"crps_weight": 0.9, "energy_score_weight": 0.1},
+        ),
+    )
+    data = get_data(["a", "b"], n_samples=3, n_time=2).data
+    optimization = OptimizationConfig(optimizer_type="Adam", lr=1e-3).build(
+        train_stepper.modules, max_epochs=1
+    )
+    output = train_stepper.train_on_batch(data, optimization)
+    assert len(records) == 3
+    generated, fake_detached, real = records
+    assert generated.shape[0] == 6
+    assert fake_detached.shape[0] == 6
+    assert real.shape[0] == 3
+    assert "discriminator_loss_real" in output.metrics
+    assert "discriminator_loss_fake" in output.metrics
+
+
+def test_gan_training_with_gradient_accumulation():
+    """The adversarial term is part of the same accumulated per-step loss, so
+    gradient-accumulation mode (backward inside the step loop) must train both
+    networks."""
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    data = get_data(["a", "b"], n_samples=3, n_time=3).data
+    optimization = OptimizationConfig(
+        optimizer_type="Adam", lr=1e-3, use_gradient_accumulation=True
+    ).build(train_stepper.modules, max_epochs=1)
+    assert train_stepper._discriminator is not None
+    generator_params_before = [
+        p.detach().clone() for p in train_stepper.modules.parameters()
+    ]
+    discriminator_params_before = [
+        p.detach().clone() for p in train_stepper._discriminator.modules.parameters()
+    ]
+    output = train_stepper.train_on_batch(data, optimization)
+    assert torch.isfinite(output.metrics["loss"])
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(
+            generator_params_before, train_stepper.modules.parameters()
+        )
+    )
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(
+            discriminator_params_before,
+            train_stepper._discriminator.modules.parameters(),
+        )
+    )
+
+
+def test_get_train_stepper_builds_mirrored_discriminator_optimizer():
+    """The end-to-end construction path mirrors the run's main optimization
+    config for the discriminator, minus scheduler and gradient accumulation."""
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    config = TrainStepperConfig(discriminator_loss_weight=0.5, n_ensemble=1)
+    default_optimization = OptimizationConfig(
+        optimizer_type="AdamW",
+        lr=3e-4,
+        kwargs={"weight_decay": 0.01},
+        scheduler=SchedulerConfig(type="CosineAnnealingLR"),
+        use_gradient_accumulation=True,
+    )
+    train_stepper = config.get_train_stepper(
+        _get_gan_stepper_config(discriminator_module),
+        get_dataset_info(),
+        default_optimization=default_optimization,
+    )
+    discriminator_optimization = train_stepper._discriminator_optimization
+    assert discriminator_optimization is not None
+    assert isinstance(discriminator_optimization.optimizer, torch.optim.AdamW)
+    assert discriminator_optimization.learning_rate == 3e-4
+    assert not discriminator_optimization._use_gradient_accumulation
+
+
+def test_gan_data_mask_raises_not_implemented():
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    data = get_data(["a", "b"], n_samples=2, n_time=2).data
+    data.data_mask = {"a": torch.ones(2, dtype=torch.bool, device=DEVICE)}
+    with pytest.raises(NotImplementedError, match="data_mask"):
+        train_stepper.train_on_batch(data, NullOptimization())
+
+
+def test_train_stepper_eval_construction_for_gan_checkpoint():
+    """The inference evaluator constructs a TrainStepper (training=False) with
+    a validation config unrelated to how the checkpoint was trained; this must
+    work for a GAN checkpoint, must not update the discriminator, and must
+    still log its monitor metrics."""
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    stepper = _get_gan_stepper_config(discriminator_module).get_stepper(
+        get_dataset_info()
+    )
+    train_stepper = TrainStepper(
+        stepper=stepper, config=TrainStepperConfig(n_ensemble=1), training=False
+    )
+    assert train_stepper._discriminator_optimization is None
+    # a positive weight with no optimization config to mirror also constructs
+    TrainStepper(
+        stepper=stepper,
+        config=TrainStepperConfig(discriminator_loss_weight=0.1, n_ensemble=1),
+        training=False,
+    )
+    data = get_data(["a", "b"], n_samples=2, n_time=3).data
+    assert train_stepper._discriminator is not None
+    discriminator_params_before = [
+        p.detach().clone() for p in train_stepper._discriminator.modules.parameters()
+    ]
+    metrics = train_stepper.train_on_batch(data, NullOptimization()).metrics
+    assert "discriminator_score_real" in metrics
+    torch.testing.assert_close(
+        metrics["loss"], metrics["loss_step_0"] + metrics["loss_step_1"]
+    )
+    for before, after in zip(
+        discriminator_params_before,
+        train_stepper._discriminator.modules.parameters(),
+    ):
+        assert torch.equal(before, after)
+
+
+@pytest.mark.parallel
+def test_gan_training_synchronizes_parameters_across_ranks():
+    """Each rank trains on different data; after one batch both the generator
+    and the discriminator must hold identical parameters on every rank — the
+    discriminator's own backward is the one DDP reduces (its real/fake
+    forwards run last, after the generator's optimizer step)."""
+    dist = Distributed.get_instance()
+    if dist.has_spatial_parallelism:
+        pytest.skip("GAN training is exercised data-parallel only")
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    optimization = OptimizationConfig(optimizer_type="Adam", lr=1e-3).build(
+        train_stepper.modules, max_epochs=1
+    )
+    assert train_stepper._discriminator is not None
+    discriminator_params_before = [
+        p.detach().clone() for p in train_stepper._discriminator.modules.parameters()
+    ]
+    # Multiple batches: Adam's first update is lr * sign(grad), which hides
+    # unsynchronized gradients of equal sign; divergence of the second-moment
+    # estimates across ranks exposes them from the second update on.
+    for batch in range(3):
+        torch.manual_seed(1 + batch * dist.world_size + dist.rank)
+        data = get_data(["a", "b"], n_samples=2, n_time=3).data
+        train_stepper.train_on_batch(data, optimization)
+    # the discriminator actually updated (otherwise the cross-rank check
+    # below would pass vacuously)
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(
+            discriminator_params_before,
+            train_stepper._discriminator.modules.parameters(),
+        )
+    )
+    for module in (train_stepper.modules, train_stepper._discriminator.modules):
+        for param in module.parameters():
+            local = param.detach().clone()
+            torch.testing.assert_close(dist.reduce_max(param.detach().clone()), local)
+            torch.testing.assert_close(dist.reduce_min(param.detach().clone()), local)

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -3625,6 +3625,40 @@ def test_gan_training_with_r1_penalty():
         assert not torch.equal(before, after)
 
 
+def test_gan_r1_warmup_disables_penalty_during_warmup_epochs():
+    """R1 penalty is 0 during warmup epochs, then the configured value after."""
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(
+        discriminator_module,
+        discriminator_r1_penalty=5.0,
+        discriminator_r1_warmup_epochs=2,
+    )
+    optimization = OptimizationConfig(optimizer_type="Adam", lr=1e-3).build(
+        train_stepper.modules, max_epochs=3
+    )
+
+    # Epoch 0: within warmup, R1 penalty should be 0.
+    data_epoch0 = get_data(["a", "b"], n_samples=3, n_time=3, epoch=0).data
+    output0 = train_stepper.train_on_batch(data_epoch0, optimization)
+    assert output0.metrics["discriminator_r1_penalty"] == 0.0
+
+    # Epoch 1: still within warmup, R1 penalty should be 0.
+    data_epoch1 = get_data(["a", "b"], n_samples=3, n_time=3, epoch=1).data
+    output1 = train_stepper.train_on_batch(data_epoch1, optimization)
+    assert output1.metrics["discriminator_r1_penalty"] == 0.0
+
+    # Epoch 2: warmup over, R1 penalty should be active (> 0).
+    data_epoch2 = get_data(["a", "b"], n_samples=3, n_time=3, epoch=2).data
+    output2 = train_stepper.train_on_batch(data_epoch2, optimization)
+    assert output2.metrics["discriminator_r1_penalty"] > 0.0
+
+
+def test_gan_r1_warmup_config_rejects_negative():
+    with pytest.raises(ValueError, match="discriminator_r1_warmup_epochs"):
+        TrainStepperConfig(discriminator_r1_warmup_epochs=-1)
+
+
 def test_gan_training_with_gradient_accumulation():
     """The adversarial term is part of the same accumulated per-step loss, so
     gradient-accumulation mode (backward inside the step loop) must train both

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -3598,6 +3598,33 @@ def test_gan_fake_side_folds_ensemble_members():
     assert "discriminator_loss_fake" in output.metrics
 
 
+def test_gan_training_with_r1_penalty():
+    """R1 gradient penalty is logged and the discriminator still trains."""
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(
+        discriminator_module, discriminator_r1_penalty=5.0
+    )
+    data = get_data(["a", "b"], n_samples=3, n_time=3).data
+    optimization = OptimizationConfig(optimizer_type="Adam", lr=1e-3).build(
+        train_stepper.modules, max_epochs=1
+    )
+    assert train_stepper._discriminator is not None
+    discriminator_params_before = [
+        p.detach().clone() for p in train_stepper._discriminator.modules.parameters()
+    ]
+    output = train_stepper.train_on_batch(data, optimization)
+    metrics = output.metrics
+    assert "discriminator_r1_penalty" in metrics
+    assert metrics["discriminator_r1_penalty"] > 0
+    assert torch.isfinite(metrics["loss"])
+    for before, after in zip(
+        discriminator_params_before,
+        train_stepper._discriminator.modules.parameters(),
+    ):
+        assert not torch.equal(before, after)
+
+
 def test_gan_training_with_gradient_accumulation():
     """The adversarial term is part of the same accumulated per-step loss, so
     gradient-accumulation mode (backward inside the step loop) must train both

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -84,6 +84,7 @@ from fme.core.optimization import (
 from fme.core.random_state import RandomState
 from fme.core.registry.corrector import CorrectorSelector
 from fme.core.registry.module import ModuleSelector
+from fme.core.scheduler import SchedulerConfig
 from fme.core.spatial_mask_provider import SpatialMaskProvider
 from fme.core.spatial_masking import StaticSpatialMaskingConfig
 from fme.core.step import SingleModuleStepConfig, StepOutput, StepSelector
@@ -1247,6 +1248,7 @@ def _init_train_stepper(
 ) -> TrainStepper:
     if stepper is None:
         stepper = unittest.mock.Mock()
+        stepper.discriminator = None
     config = TrainStepperConfig(**train_config_kwargs)
     return TrainStepper(stepper=stepper, config=config)
 
@@ -3181,3 +3183,318 @@ def test_step_masks_corrector_diagnostics():
     assert torch.isnan(delta[..., 0, 0]).all()
     on_mask = delta[~torch.isnan(delta)]
     torch.testing.assert_close(on_mask, torch.full_like(on_mask, offset))
+
+
+class _ParamAddOne(torch.nn.Module):
+    """AddOne with a parameter, so optimizers can build and gradients flow."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, x):
+        return x + 1 + self.weight
+
+
+def _make_channel_mean_discriminator(
+    weight: float = 0.3,
+) -> tuple[torch.nn.Module, list[torch.Tensor]]:
+    """Per-pixel logit head recording the packed pairs it judges.
+
+    Records through a closure: config round-trips deep-copy prebuilt module
+    instances, so instance attributes would record into the copy.
+    """
+    records: list[torch.Tensor] = []
+
+    class ChannelMeanLogits(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.full((1,), weight))
+
+        def forward(self, x):
+            records.append(x)
+            return x.mean(dim=-3, keepdim=True) * self.weight
+
+    return ChannelMeanLogits(), records
+
+
+def _get_gan_stepper_config(discriminator_module: torch.nn.Module) -> StepperConfig:
+    return StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": _ParamAddOne()}
+                    ),
+                    in_names=["a", "b"],
+                    out_names=["a", "b"],
+                    normalization=trivial_network_and_loss_normalization(["a", "b"]),
+                    discriminator=ModuleSelector(
+                        type="prebuilt", config={"module": discriminator_module}
+                    ),
+                )
+            ),
+        ),
+    )
+
+
+def _get_gan_train_stepper(
+    discriminator_module: torch.nn.Module,
+    discriminator_loss_weight: float = 0.5,
+    **train_config_kwargs,
+) -> TrainStepper:
+    return _get_train_stepper(
+        _get_gan_stepper_config(discriminator_module),
+        discriminator_loss_weight=discriminator_loss_weight,
+        discriminator_optimization=OptimizationConfig(optimizer_type="Adam", lr=0.01),
+        n_ensemble=1,
+        **train_config_kwargs,
+    )
+
+
+def test_train_stepper_positive_weight_requires_discriminator():
+    config = _get_stepper_config(["a"], ["a"])
+    with pytest.raises(ValueError, match="no discriminator"):
+        _get_train_stepper(config, discriminator_loss_weight=0.1)
+
+
+def test_train_stepper_discriminator_requires_positive_weight():
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    config = _get_stepper_config(
+        ["a"],
+        ["a"],
+        discriminator=ModuleSelector(
+            type="prebuilt", config={"module": discriminator_module}
+        ),
+    )
+    with pytest.raises(ValueError, match="discriminator_loss_weight"):
+        _get_train_stepper(config)
+
+
+def test_train_stepper_config_rejects_negative_discriminator_weight():
+    with pytest.raises(ValueError, match="non-negative"):
+        TrainStepperConfig(discriminator_loss_weight=-0.1)
+
+
+def test_discriminator_optimization_rejects_scheduler():
+    with pytest.raises(ValueError, match="scheduler"):
+        TrainStepperConfig(
+            discriminator_optimization=OptimizationConfig(
+                scheduler=SchedulerConfig(type="CosineAnnealingLR")
+            )
+        )
+
+
+def test_discriminator_optimization_rejects_gradient_accumulation():
+    with pytest.raises(ValueError, match="use_gradient_accumulation"):
+        TrainStepperConfig(
+            discriminator_optimization=OptimizationConfig(
+                use_gradient_accumulation=True
+            )
+        )
+
+
+def test_discriminator_optimization_mirrors_default_without_scheduler():
+    config = TrainStepperConfig()
+    default = OptimizationConfig(
+        optimizer_type="AdamW",
+        lr=3e-4,
+        kwargs={"weight_decay": 0.01},
+        scheduler=SchedulerConfig(type="CosineAnnealingLR"),
+        max_grad_norm=1.0,
+    )
+    mirrored = config.get_discriminator_optimization_config(default)
+    assert mirrored.optimizer_type == "AdamW"
+    assert mirrored.lr == 3e-4
+    assert mirrored.kwargs == {"weight_decay": 0.01}
+    assert mirrored.max_grad_norm == 1.0
+    assert not mirrored.has_lr_schedule
+
+
+def test_discriminator_optimization_requires_default_or_explicit_config():
+    config = TrainStepperConfig()
+    with pytest.raises(ValueError, match="discriminator_optimization"):
+        config.get_discriminator_optimization_config(None)
+
+
+def test_train_on_batch_gan_training_updates_and_metrics():
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    data = get_data(["a", "b"], n_samples=3, n_time=3).data
+    optimization = OptimizationConfig(optimizer_type="Adam", lr=1e-3).build(
+        train_stepper.modules, max_epochs=1
+    )
+    generator_params_before = [
+        p.detach().clone() for p in train_stepper.modules.parameters()
+    ]
+    assert train_stepper._discriminator is not None
+    discriminator_params_before = [
+        p.detach().clone() for p in train_stepper._discriminator.modules.parameters()
+    ]
+    output = train_stepper.train_on_batch(data, optimization)
+    metrics = output.metrics
+    for key in [
+        "adversarial_loss_step_0",
+        "adversarial_loss_step_1",
+        "discriminator_loss_real",
+        "discriminator_loss_fake",
+        "discriminator_score_real",
+        "discriminator_score_fake",
+    ]:
+        assert key in metrics, key
+    expected_loss = (
+        metrics["loss_step_0"]
+        + metrics["loss_step_1"]
+        + 0.5
+        * (metrics["adversarial_loss_step_0"] + metrics["adversarial_loss_step_1"])
+    )
+    torch.testing.assert_close(metrics["loss"], expected_loss)
+    for before, after in zip(
+        generator_params_before, train_stepper.modules.parameters()
+    ):
+        assert not torch.equal(before, after)
+    for before, after in zip(
+        discriminator_params_before,
+        train_stepper._discriminator.modules.parameters(),
+    ):
+        assert not torch.equal(before, after)
+
+
+def test_train_on_batch_gan_validation_excludes_adversarial_term():
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    data = get_data(["a", "b"], n_samples=3, n_time=3).data
+    assert train_stepper._discriminator is not None
+    discriminator_params_before = [
+        p.detach().clone() for p in train_stepper._discriminator.modules.parameters()
+    ]
+    output = train_stepper.train_on_batch(data, NullOptimization())
+    metrics = output.metrics
+    assert "adversarial_loss_step_0" in metrics
+    assert "discriminator_score_fake" in metrics
+    expected_loss = metrics["loss_step_0"] + metrics["loss_step_1"]
+    torch.testing.assert_close(metrics["loss"], expected_loss)
+    for before, after in zip(
+        discriminator_params_before,
+        train_stepper._discriminator.modules.parameters(),
+    ):
+        assert torch.equal(before, after)
+
+
+def test_gan_discriminator_judges_dataset_transitions_against_generated_pairs():
+    torch.manual_seed(0)
+    discriminator_module, records = _make_channel_mean_discriminator()
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    data = get_data(["a", "b"], n_samples=2, n_time=3).data
+    train_stepper.train_on_batch(data, NullOptimization())
+    # per optimized step, three judgments in order: generated pair with
+    # generator gradients, generated pair detached, dataset transition
+    assert len(records) == 6
+    input_channels = slice(0, 2)
+    output_channels = slice(2, 4)
+
+    def packed(time_index: int) -> torch.Tensor:
+        return torch.stack(
+            [data.data["a"][:, time_index], data.data["b"][:, time_index]], dim=-3
+        )
+
+    # normalization is trivial (mean 0, std 1) and the generator adds one,
+    # so generated values are directly comparable to the data
+    step1_real = records[5]
+    torch.testing.assert_close(step1_real[:, input_channels], packed(1))
+    torch.testing.assert_close(step1_real[:, output_channels], packed(2))
+    step1_generated = records[3]
+    torch.testing.assert_close(step1_generated[:, input_channels], packed(0) + 1)
+    torch.testing.assert_close(step1_generated[:, output_channels], packed(0) + 2)
+    step0_real = records[2]
+    torch.testing.assert_close(step0_real[:, input_channels], packed(0))
+    torch.testing.assert_close(step0_real[:, output_channels], packed(1))
+    step0_generated = records[0]
+    torch.testing.assert_close(step0_generated[:, input_channels], packed(0))
+    torch.testing.assert_close(step0_generated[:, output_channels], packed(0) + 1)
+
+
+@pytest.mark.parametrize("use_gradient_accumulation", [False, True])
+def test_predict_generator_input_follows_detach_pattern(use_gradient_accumulation):
+    torch.manual_seed(0)
+    config = StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(
+                        type="prebuilt", config={"module": _ParamAddOne()}
+                    ),
+                    in_names=["a", "b"],
+                    out_names=["a", "b"],
+                    normalization=trivial_network_and_loss_normalization(["a", "b"]),
+                )
+            ),
+        ),
+    )
+    stepper = config.get_stepper(get_dataset_info())
+    optimization = OptimizationConfig(
+        optimizer_type="Adam",
+        lr=1e-3,
+        use_gradient_accumulation=use_gradient_accumulation,
+    ).build(stepper.modules, max_epochs=1)
+    data = get_data(["a", "b"], n_samples=2, n_time=3).data
+    ic_dict = {name: data.data[name][:, :1] for name in ["a", "b"]}
+    outputs = list(
+        stepper.predict_generator(
+            ic_dict, data.data, n_forward_steps=2, optimizer=optimization, labels=None
+        )
+    )
+    assert outputs[0].input is not None
+    torch.testing.assert_close(outputs[0].input["a"], data.data["a"][:, 0])
+    assert outputs[0].input["a"].grad_fn is None
+    assert outputs[1].input is not None
+    if use_gradient_accumulation:
+        assert outputs[1].input["a"].grad_fn is None
+    else:
+        assert outputs[1].input["a"].grad_fn is not None
+
+
+def test_gan_train_stepper_state_round_trip():
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator(weight=0.3)
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    data = get_data(["a", "b"], n_samples=2, n_time=2).data
+    # a training batch gives the discriminator optimizer non-trivial state
+    optimization = OptimizationConfig(optimizer_type="Adam", lr=1e-3).build(
+        train_stepper.modules, max_epochs=1
+    )
+    train_stepper.train_on_batch(data, optimization)
+    state = train_stepper.get_state()
+    assert "discriminator_optimization" in state
+    assert "discriminator" in state["step"]
+
+    other_module, _ = _make_channel_mean_discriminator(weight=0.9)
+    other = _get_gan_train_stepper(other_module)
+    other.load_state(state)
+    assert train_stepper._discriminator is not None
+    assert other._discriminator is not None
+    for expected, loaded in zip(
+        train_stepper._discriminator.modules.parameters(),
+        other._discriminator.modules.parameters(),
+    ):
+        torch.testing.assert_close(loaded, expected)
+    assert other._discriminator_optimization is not None
+    assert len(other._discriminator_optimization.optimizer.state_dict()["state"]) > 0
+
+
+def test_gan_train_stepper_warm_starts_from_checkpoint_without_discriminator():
+    torch.manual_seed(0)
+    discriminator_module, _ = _make_channel_mean_discriminator(weight=0.3)
+    train_stepper = _get_gan_train_stepper(discriminator_module)
+    state = train_stepper.get_state()
+    # simulate a donor checkpoint from a run without a discriminator
+    del state["step"]["discriminator"]
+    del state["discriminator_optimization"]
+    train_stepper.load_state(state)
+    assert train_stepper._discriminator is not None
+    (weight,) = train_stepper._discriminator.modules.parameters()
+    torch.testing.assert_close(weight, torch.full_like(weight, 0.3))

--- a/fme/ace/train/train_config.py
+++ b/fme/ace/train/train_config.py
@@ -683,6 +683,7 @@ class TrainConfig:
         return self.stepper_training.get_train_stepper(
             stepper_config=self.stepper_config,
             dataset_info=dataset_info,
+            default_optimization=self.optimization,
         )
 
     def _get_ema(self, modules) -> EMATracker:

--- a/fme/core/generics/test_trainer.py
+++ b/fme/core/generics/test_trainer.py
@@ -503,6 +503,27 @@ def get_trainer(
     return config, trainer
 
 
+def test_training_only_state_keys_excluded_from_inference_checkpoints(
+    tmp_path: str, monkeypatch
+):
+    """Keys a train stepper declares training-only (e.g. a GAN discriminator's
+    optimizer state) ride only in checkpoints saved with optimization state."""
+    monkeypatch.setattr(
+        TrainStepper, "TRAINING_ONLY_STATE_KEYS", ("dependent_optimizer",)
+    )
+    config, trainer = get_trainer(
+        tmp_path,
+        max_epochs=1,
+        stepper_state={"dependent_optimizer": {"step": 1}},
+    )
+    trainer.train()
+    paths = CheckpointPaths(config.checkpoint_dir)
+    latest = torch.load(paths.latest_checkpoint_path, weights_only=False)
+    assert "dependent_optimizer" in latest["stepper"]
+    best = torch.load(paths.best_checkpoint_path, weights_only=False)
+    assert "dependent_optimizer" not in best["stepper"]
+
+
 @pytest.mark.parametrize(
     "checkpoint_save_epochs",
     [None, Slice(start=2, stop=3), Slice(start=1, step=2)],

--- a/fme/core/generics/train_stepper.py
+++ b/fme/core/generics/train_stepper.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar
 
 from torch import nn
 
@@ -24,6 +24,11 @@ SD = TypeVar("SD")  # stepped data
 
 class TrainStepperABC(abc.ABC, Generic[PS, BD, FD, SD, TO]):
     SelfType = TypeVar("SelfType", bound="TrainStepperABC")
+
+    # Keys in get_state() that exist only to resume training (e.g. a dependent
+    # optimizer's state riding in the stepper payload); the trainer drops them
+    # from checkpoints saved without optimization state.
+    TRAINING_ONLY_STATE_KEYS: ClassVar[tuple[str, ...]] = ()
 
     @abc.abstractmethod
     def train_on_batch(

--- a/fme/core/generics/trainer.py
+++ b/fme/core/generics/trainer.py
@@ -713,6 +713,8 @@ class Trainer:
                 data["optimization"] = self.optimization.get_state()
             else:
                 data["ema"].pop("ema_params")  # don't need if not saving optimization
+                for key in type(self.stepper).TRAINING_ONLY_STATE_KEYS:
+                    data["stepper"].pop(key, None)
             torch.save(data, temporary_location)
             os.replace(temporary_location, checkpoint_path)
         finally:

--- a/fme/core/optimization.py
+++ b/fme/core/optimization.py
@@ -358,6 +358,24 @@ class OptimizationConfig:
             return True
         return self.scheduler.type is not None
 
+    def copy_without_schedule(self) -> "OptimizationConfig":
+        """A copy of the per-step optimizer settings (optimizer type, learning
+        rate, kwargs, mixed precision, gradient clipping) with no scheduler,
+        gradient accumulation, activation checkpointing, or checkpoint resume.
+
+        Used to derive the config for a dependent optimizer (e.g. a GAN
+        discriminator's) that mirrors this one's optimizer settings but runs
+        its own simple accumulate-once-per-batch loop at a constant learning
+        rate.
+        """
+        return OptimizationConfig(
+            optimizer_type=self.optimizer_type,
+            lr=self.lr,
+            kwargs=self.kwargs,
+            enable_automatic_mixed_precision=self.enable_automatic_mixed_precision,
+            max_grad_norm=self.max_grad_norm,
+        )
+
     def build(self, modules: torch.nn.ModuleList, max_epochs: int) -> Optimization:
         parameters = itertools.chain(*[module.parameters() for module in modules])
         optimizer = _build_optimizer(

--- a/fme/core/optimization.py
+++ b/fme/core/optimization.py
@@ -207,6 +207,16 @@ class Optimization(OptimizationABC):
             self.gscaler.update()
         self._accumulated_loss = torch.tensor(0.0, device=get_device())
 
+    def zero_gradients(self):
+        """Zero all parameter gradients without stepping.
+
+        Used to discard gradients another loss's backward deposited on these
+        parameters (e.g. a generator's adversarial term backpropagating
+        through a discriminator) before accumulating this optimizer's own
+        loss.
+        """
+        self.optimizer.zero_grad()
+
     def set_learning_rate(self, lr: float):
         for param_group in self.optimizer.param_groups:
             param_group["lr"] = lr

--- a/fme/core/step/discriminator.py
+++ b/fme/core/step/discriminator.py
@@ -244,10 +244,13 @@ class DiscriminatorLosses:
     over the batch's optimized steps.
 
     Parameters:
-        loss: The discriminator's training loss (real + fake sides, summed
-            over steps), with gradients flowing only into the discriminator.
+        loss: The discriminator's training loss (real + fake sides + R1 if
+            enabled, summed over steps), with gradients flowing only into the
+            discriminator.
         loss_real: Detached real-side component, averaged over steps.
         loss_fake: Detached fake-side component, averaged over steps.
+        r1_penalty: Detached R1 gradient penalty, averaged over steps
+            (0 when R1 is not enabled).
         score_real: Detached mean sigmoid score on real pairs, averaged over
             steps (1 = confidently real; 0.5 at equilibrium).
         score_fake: Detached mean sigmoid score on generated pairs, averaged
@@ -257,14 +260,37 @@ class DiscriminatorLosses:
     loss: torch.Tensor
     loss_real: torch.Tensor
     loss_fake: torch.Tensor
+    r1_penalty: torch.Tensor
     score_real: torch.Tensor
     score_fake: torch.Tensor
+
+
+def _r1_gradient_penalty(
+    real_logits: torch.Tensor,
+    real_inputs: list[torch.Tensor],
+    gridded_operations: GriddedOperations,
+) -> torch.Tensor:
+    """R1 gradient penalty (Mescheder et al. 2018) on real data.
+
+    Returns the area-weighted mean of ``||∇_x D(x)||²`` over the real
+    inputs — the unweighted penalty; the caller multiplies by ``λ/2``.
+    ``create_graph=True`` so the penalty's own gradients flow into the
+    discriminator's optimizer step.
+    """
+    (grads,) = torch.autograd.grad(
+        outputs=real_logits.sum(),
+        inputs=real_inputs,
+        create_graph=True,
+    )
+    grad_sq = grads.square()
+    return gridded_operations.area_weighted_mean(grad_sq).mean()
 
 
 def compute_discriminator_losses(
     discriminator: StepDiscriminator,
     gridded_operations: GriddedOperations,
     pairs: list[GanStepPair],
+    r1_penalty_coefficient: float = 0.0,
 ) -> DiscriminatorLosses:
     """
     Compute the discriminator's training loss over a batch's optimized steps.
@@ -281,6 +307,9 @@ def compute_discriminator_losses(
         gridded_operations: Provides the area-weighted spherical mean reducing
             per-pixel binary cross-entropy to a scalar.
         pairs: One real/fake pair per optimized step.
+        r1_penalty_coefficient: R1 gradient penalty coefficient (λ/2 in
+            Mescheder et al. 2018). 0 disables the penalty. Applied to
+            the real-side forward, per step.
 
     Returns:
         The discriminator's loss and detached diagnostics.
@@ -289,26 +318,57 @@ def compute_discriminator_losses(
         raise ValueError("pairs must be non-empty")
     losses_real = []
     losses_fake = []
+    r1_penalties = []
     scores_real = []
     scores_fake = []
+    use_r1 = r1_penalty_coefficient > 0
     for pair in pairs:
         fake_logits = discriminator.forward(
             pair.fake_input, pair.fake_output, labels=pair.fake_labels
         )
-        real_logits = discriminator.forward(
-            pair.real_input, pair.real_output, labels=pair.real_labels
-        )
+        if use_r1:
+            real_packed = torch.cat(
+                [
+                    torch.stack(list(pair.real_input.values()), dim=-3),
+                    torch.stack(list(pair.real_output.values()), dim=-3),
+                ],
+                dim=-3,
+            )
+            real_packed.requires_grad_(True)
+            n_in = len(pair.real_input)
+            real_input_r1 = dict(
+                zip(pair.real_input.keys(), real_packed[:, :n_in].unbind(dim=1))
+            )
+            real_output_r1 = dict(
+                zip(pair.real_output.keys(), real_packed[:, n_in:].unbind(dim=1))
+            )
+            real_logits = discriminator.forward(
+                real_input_r1, real_output_r1, labels=pair.real_labels
+            )
+            r1 = _r1_gradient_penalty(real_logits, [real_packed], gridded_operations)
+            r1_penalties.append(r1)
+        else:
+            real_logits = discriminator.forward(
+                pair.real_input, pair.real_output, labels=pair.real_labels
+            )
         losses_real.append(_area_weighted_bce(real_logits, 1.0, gridded_operations))
         losses_fake.append(_area_weighted_bce(fake_logits, 0.0, gridded_operations))
         scores_real.append(_area_weighted_score(real_logits, gridded_operations))
         scores_fake.append(_area_weighted_score(fake_logits, gridded_operations))
     loss_real = torch.stack(losses_real).sum()
     loss_fake = torch.stack(losses_fake).sum()
+    if use_r1:
+        r1_total = torch.stack(r1_penalties).sum()
+        total_loss = loss_real + loss_fake + r1_penalty_coefficient * r1_total
+    else:
+        r1_total = torch.tensor(0.0, device=loss_real.device)
+        total_loss = loss_real + loss_fake
     n_steps = len(pairs)
     return DiscriminatorLosses(
-        loss=loss_real + loss_fake,
+        loss=total_loss,
         loss_real=loss_real.detach() / n_steps,
         loss_fake=loss_fake.detach() / n_steps,
+        r1_penalty=r1_total.detach() / n_steps,
         score_real=torch.stack(scores_real).mean(),
         score_fake=torch.stack(scores_fake).mean(),
     )

--- a/fme/core/step/discriminator.py
+++ b/fme/core/step/discriminator.py
@@ -1,0 +1,240 @@
+import contextlib
+import dataclasses
+from typing import Any
+
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+
+from fme.core.dataset_info import DatasetInfo
+from fme.core.device import get_device
+from fme.core.distributed import Distributed
+from fme.core.gridded_ops import GriddedOperations
+from fme.core.labels import BatchLabels
+from fme.core.normalizer import StandardNormalizer
+from fme.core.packer import Packer
+from fme.core.registry import ModuleSelector
+from fme.core.typing_ import TensorDict, TensorMapping
+
+
+class StepDiscriminator:
+    """
+    Judges whether an (input, output) timestep pair comes from the training
+    data or was produced by the model.
+
+    Operates at the same API level as StepABC: callers pass denormalized
+    variable dicts and receive per-pixel logits; normalization, packing, and
+    module concerns stay internal. Positive logits mean "judged real".
+    """
+
+    CHANNEL_DIM = -3
+
+    def __init__(
+        self,
+        builder: ModuleSelector,
+        in_names: list[str],
+        out_names: list[str],
+        normalizer: StandardNormalizer,
+        dataset_info: DatasetInfo,
+    ):
+        """
+        Args:
+            builder: Builder for the discriminator module.
+            in_names: Names of the input-timestep variables the discriminator
+                is conditioned on.
+            out_names: Names of the output-timestep variables it judges.
+            normalizer: Normalizer applied to both timesteps before packing.
+            dataset_info: Information about the dataset.
+        """
+        self._in_names = list(in_names)
+        self._out_names = list(out_names)
+        self._in_packer = Packer(self._in_names)
+        self._out_packer = Packer(self._out_names)
+        self._normalizer = normalizer
+        module = builder.build(
+            n_in_channels=len(self._in_names) + len(self._out_names),
+            n_out_channels=1,
+            dataset_info=dataset_info,
+        )
+        dist = Distributed.get_instance()
+        self._module = module.to(get_device()).wrap_module(dist.wrap_module)
+
+    @property
+    def in_names(self) -> list[str]:
+        """Names of the input-timestep (conditioning) variables."""
+        return list(self._in_names)
+
+    @property
+    def out_names(self) -> list[str]:
+        """Names of the output-timestep variables being judged."""
+        return list(self._out_names)
+
+    @property
+    def modules(self) -> nn.ModuleList:
+        return nn.ModuleList([self._module.torch_module])
+
+    @property
+    def training(self) -> bool:
+        return self._module.torch_module.training
+
+    def train(self, mode: bool = True) -> "StepDiscriminator":
+        self._module.torch_module.train(mode)
+        return self
+
+    @contextlib.contextmanager
+    def gradient_sync_disabled(self):
+        """Context under which forward passes do not sync gradients across
+        ranks on backward.
+
+        Used for forward passes whose gradients with respect to discriminator
+        parameters will be discarded (the generator's adversarial term), so
+        the single synchronized backward per batch is the discriminator's own
+        loss. ``no_sync`` only exists on DistributedDataParallel, hence the
+        isinstance check; other wrappers have nothing to disable.
+        """
+        torch_module = self._module.torch_module
+        if isinstance(torch_module, DistributedDataParallel):
+            with torch_module.no_sync():
+                yield
+        else:
+            yield
+
+    def forward(
+        self,
+        input: TensorMapping,
+        output: TensorMapping,
+        labels: BatchLabels | None = None,
+    ) -> torch.Tensor:
+        """
+        Judge (input, output) timestep pairs.
+
+        Args:
+            input: Denormalized input-timestep data, containing at least
+                ``in_names``. Tensors of shape [n_batch, n_lat, n_lon].
+            output: Denormalized output-timestep data, containing at least
+                ``out_names``. Tensors of shape [n_batch, n_lat, n_lon].
+            labels: Labels for each batch member.
+
+        Returns:
+            Per-pixel logits of shape [n_batch, 1, n_lat, n_lon]; positive
+            means "judged real".
+        """
+        input_norm = self._normalizer.normalize(
+            {name: input[name] for name in self._in_names}
+        )
+        output_norm = self._normalizer.normalize(
+            {name: output[name] for name in self._out_names}
+        )
+        input_tensor = self._in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
+        output_tensor = self._out_packer.pack(output_norm, axis=self.CHANNEL_DIM)
+        pair_tensor = torch.cat([input_tensor, output_tensor], dim=self.CHANNEL_DIM)
+        return self._module(pair_tensor, labels=labels)
+
+    def get_state(self) -> dict[str, Any]:
+        return {"module": self._module.get_state()}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self._module.load_state(state["module"])
+
+
+@dataclasses.dataclass
+class GanStepLosses:
+    """Adversarial losses and diagnostics for one forward step.
+
+    Parameters:
+        generator_loss: Non-saturating generator term (how strongly the
+            discriminator rejects the generated pair), with gradients flowing
+            into the generator. Unweighted.
+        discriminator_loss: The discriminator's training loss (real + fake
+            sides), with gradients flowing only into the discriminator.
+        discriminator_loss_real: Detached real-side component.
+        discriminator_loss_fake: Detached fake-side component.
+        score_real: Detached mean sigmoid score on real pairs (1 = confidently
+            real; 0.5 at equilibrium).
+        score_fake: Detached mean sigmoid score on generated pairs.
+    """
+
+    generator_loss: torch.Tensor
+    discriminator_loss: torch.Tensor
+    discriminator_loss_real: torch.Tensor
+    discriminator_loss_fake: torch.Tensor
+    score_real: torch.Tensor
+    score_fake: torch.Tensor
+
+
+def _area_weighted_bce(
+    logits: torch.Tensor,
+    target_value: float,
+    gridded_operations: GriddedOperations,
+) -> torch.Tensor:
+    bce = torch.nn.functional.binary_cross_entropy_with_logits(
+        logits, torch.full_like(logits, target_value), reduction="none"
+    )
+    return gridded_operations.area_weighted_mean(bce).mean()
+
+
+def _area_weighted_score(
+    logits: torch.Tensor, gridded_operations: GriddedOperations
+) -> torch.Tensor:
+    return gridded_operations.area_weighted_mean(torch.sigmoid(logits)).mean().detach()
+
+
+def _detached(data: TensorMapping) -> TensorDict:
+    return {k: v.detach() for k, v in data.items()}
+
+
+def compute_gan_step_losses(
+    discriminator: StepDiscriminator,
+    gridded_operations: GriddedOperations,
+    real_input: TensorMapping,
+    real_output: TensorMapping,
+    fake_input: TensorMapping,
+    fake_output: TensorMapping,
+    real_labels: BatchLabels | None = None,
+    fake_labels: BatchLabels | None = None,
+) -> GanStepLosses:
+    """
+    Compute non-saturating GAN losses for one forward step.
+
+    The generated pair is judged twice: once with gradients flowing into the
+    generator (the generator's adversarial term, computed with gradient sync
+    disabled since its discriminator-parameter gradients are discarded), and
+    once fully detached for the discriminator's own loss. Real and fake sides
+    of the discriminator loss are averaged separately, so differing batch
+    sizes (e.g. ensemble members on the fake side only) stay balanced.
+
+    Args:
+        discriminator: The discriminator to evaluate and train.
+        gridded_operations: Provides the area-weighted spherical mean reducing
+            per-pixel binary cross-entropy to a scalar.
+        real_input: Denormalized input-timestep data from the dataset.
+        real_output: Denormalized output-timestep data from the dataset.
+        fake_input: Denormalized input the model consumed this step (already
+            detached from previous steps when the host detaches between
+            steps).
+        fake_output: Denormalized model output for this step.
+        real_labels: Labels for the real pairs' batch members.
+        fake_labels: Labels for the generated pairs' batch members.
+
+    Returns:
+        The step's adversarial losses and detached diagnostics.
+    """
+    with discriminator.gradient_sync_disabled():
+        generator_logits = discriminator.forward(
+            fake_input, fake_output, labels=fake_labels
+        )
+    generator_loss = _area_weighted_bce(generator_logits, 1.0, gridded_operations)
+    fake_logits = discriminator.forward(
+        _detached(fake_input), _detached(fake_output), labels=fake_labels
+    )
+    real_logits = discriminator.forward(real_input, real_output, labels=real_labels)
+    loss_real = _area_weighted_bce(real_logits, 1.0, gridded_operations)
+    loss_fake = _area_weighted_bce(fake_logits, 0.0, gridded_operations)
+    return GanStepLosses(
+        generator_loss=generator_loss,
+        discriminator_loss=loss_real + loss_fake,
+        discriminator_loss_real=loss_real.detach(),
+        discriminator_loss_fake=loss_fake.detach(),
+        score_real=_area_weighted_score(real_logits, gridded_operations),
+        score_fake=_area_weighted_score(fake_logits, gridded_operations),
+    )

--- a/fme/core/step/discriminator.py
+++ b/fme/core/step/discriminator.py
@@ -83,14 +83,19 @@ class StepDiscriminator:
 
     @contextlib.contextmanager
     def gradient_sync_disabled(self):
-        """Context under which forward passes do not sync gradients across
-        ranks on backward.
+        """Context under which forward passes do not arm gradient syncing.
 
         Used for forward passes whose gradients with respect to discriminator
-        parameters will be discarded (the generator's adversarial term), so
-        the single synchronized backward per batch is the discriminator's own
-        loss. ``no_sync`` only exists on DistributedDataParallel, hence the
-        isinstance check; other wrappers have nothing to disable.
+        parameters will be discarded (the generator's adversarial term).
+        ``no_sync`` marks the forwards it wraps, not a graph: a forward under
+        it does not call the DDP reducer's ``prepare_for_backward``, so a
+        later backward through that graph fires no reduction (grads still
+        accumulate locally and must be discarded by the caller). The
+        discriminator's own loss must therefore run its forwards *outside*
+        this context and immediately precede its backward, so that backward
+        is the one the armed reducer services. ``no_sync`` only exists on
+        DistributedDataParallel, hence the isinstance check; other wrappers
+        have nothing to disable.
         """
         torch_module = self._module.torch_module
         if isinstance(torch_module, DistributedDataParallel):
@@ -137,31 +142,6 @@ class StepDiscriminator:
         self._module.load_state(state["module"])
 
 
-@dataclasses.dataclass
-class GanStepLosses:
-    """Adversarial losses and diagnostics for one forward step.
-
-    Parameters:
-        generator_loss: Non-saturating generator term (how strongly the
-            discriminator rejects the generated pair), with gradients flowing
-            into the generator. Unweighted.
-        discriminator_loss: The discriminator's training loss (real + fake
-            sides), with gradients flowing only into the discriminator.
-        discriminator_loss_real: Detached real-side component.
-        discriminator_loss_fake: Detached fake-side component.
-        score_real: Detached mean sigmoid score on real pairs (1 = confidently
-            real; 0.5 at equilibrium).
-        score_fake: Detached mean sigmoid score on generated pairs.
-    """
-
-    generator_loss: torch.Tensor
-    discriminator_loss: torch.Tensor
-    discriminator_loss_real: torch.Tensor
-    discriminator_loss_fake: torch.Tensor
-    score_real: torch.Tensor
-    score_fake: torch.Tensor
-
-
 def _area_weighted_bce(
     logits: torch.Tensor,
     target_value: float,
@@ -183,58 +163,152 @@ def _detached(data: TensorMapping) -> TensorDict:
     return {k: v.detach() for k, v in data.items()}
 
 
-def compute_gan_step_losses(
+def compute_generator_adversarial_loss(
     discriminator: StepDiscriminator,
     gridded_operations: GriddedOperations,
-    real_input: TensorMapping,
-    real_output: TensorMapping,
     fake_input: TensorMapping,
     fake_output: TensorMapping,
-    real_labels: BatchLabels | None = None,
     fake_labels: BatchLabels | None = None,
-) -> GanStepLosses:
+) -> torch.Tensor:
     """
-    Compute non-saturating GAN losses for one forward step.
+    Compute the non-saturating generator adversarial term for one step.
 
-    The generated pair is judged twice: once with gradients flowing into the
-    generator (the generator's adversarial term, computed with gradient sync
-    disabled since its discriminator-parameter gradients are discarded), and
-    once fully detached for the discriminator's own loss. Real and fake sides
-    of the discriminator loss are averaged separately, so differing batch
-    sizes (e.g. ensemble members on the fake side only) stay balanced.
+    Gradients flow through the discriminator into the generator; the
+    discriminator's own parameter gradients from this term are discarded by
+    the caller, so the forward runs under ``gradient_sync_disabled`` (no DDP
+    reduction is armed for the generator's backward).
 
     Args:
-        discriminator: The discriminator to evaluate and train.
+        discriminator: The discriminator judging the pair.
         gridded_operations: Provides the area-weighted spherical mean reducing
             per-pixel binary cross-entropy to a scalar.
-        real_input: Denormalized input-timestep data from the dataset.
-        real_output: Denormalized output-timestep data from the dataset.
         fake_input: Denormalized input the model consumed this step (already
             detached from previous steps when the host detaches between
             steps).
         fake_output: Denormalized model output for this step.
-        real_labels: Labels for the real pairs' batch members.
         fake_labels: Labels for the generated pairs' batch members.
 
     Returns:
-        The step's adversarial losses and detached diagnostics.
+        Unweighted generator adversarial loss (how strongly the discriminator
+        rejects the generated pair).
     """
     with discriminator.gradient_sync_disabled():
         generator_logits = discriminator.forward(
             fake_input, fake_output, labels=fake_labels
         )
-    generator_loss = _area_weighted_bce(generator_logits, 1.0, gridded_operations)
-    fake_logits = discriminator.forward(
-        _detached(fake_input), _detached(fake_output), labels=fake_labels
-    )
-    real_logits = discriminator.forward(real_input, real_output, labels=real_labels)
-    loss_real = _area_weighted_bce(real_logits, 1.0, gridded_operations)
-    loss_fake = _area_weighted_bce(fake_logits, 0.0, gridded_operations)
-    return GanStepLosses(
-        generator_loss=generator_loss,
-        discriminator_loss=loss_real + loss_fake,
-        discriminator_loss_real=loss_real.detach(),
-        discriminator_loss_fake=loss_fake.detach(),
-        score_real=_area_weighted_score(real_logits, gridded_operations),
-        score_fake=_area_weighted_score(fake_logits, gridded_operations),
+    return _area_weighted_bce(generator_logits, 1.0, gridded_operations)
+
+
+@dataclasses.dataclass
+class GanStepPair:
+    """Real and generated (input, output) pairs for one optimized step,
+    cached so the discriminator's own loss can run after the generator's
+    optimizer step (its forwards must immediately precede its backward for
+    DDP gradient reduction to service it; see
+    ``StepDiscriminator.gradient_sync_disabled``).
+
+    The fake side is detached so the discriminator loss cannot backpropagate
+    into the generator.
+    """
+
+    real_input: TensorDict
+    real_output: TensorDict
+    fake_input: TensorDict
+    fake_output: TensorDict
+    real_labels: BatchLabels | None
+    fake_labels: BatchLabels | None
+
+    @classmethod
+    def from_step_data(
+        cls,
+        real_input: TensorMapping,
+        real_output: TensorMapping,
+        fake_input: TensorMapping,
+        fake_output: TensorMapping,
+        real_labels: BatchLabels | None,
+        fake_labels: BatchLabels | None,
+    ) -> "GanStepPair":
+        return cls(
+            real_input=dict(real_input),
+            real_output=dict(real_output),
+            fake_input=_detached(fake_input),
+            fake_output=_detached(fake_output),
+            real_labels=real_labels,
+            fake_labels=fake_labels,
+        )
+
+
+@dataclasses.dataclass
+class DiscriminatorLosses:
+    """The discriminator's training loss and detached diagnostics, aggregated
+    over the batch's optimized steps.
+
+    Parameters:
+        loss: The discriminator's training loss (real + fake sides, summed
+            over steps), with gradients flowing only into the discriminator.
+        loss_real: Detached real-side component, averaged over steps.
+        loss_fake: Detached fake-side component, averaged over steps.
+        score_real: Detached mean sigmoid score on real pairs, averaged over
+            steps (1 = confidently real; 0.5 at equilibrium).
+        score_fake: Detached mean sigmoid score on generated pairs, averaged
+            over steps.
+    """
+
+    loss: torch.Tensor
+    loss_real: torch.Tensor
+    loss_fake: torch.Tensor
+    score_real: torch.Tensor
+    score_fake: torch.Tensor
+
+
+def compute_discriminator_losses(
+    discriminator: StepDiscriminator,
+    gridded_operations: GriddedOperations,
+    pairs: list[GanStepPair],
+) -> DiscriminatorLosses:
+    """
+    Compute the discriminator's training loss over a batch's optimized steps.
+
+    Real and fake sides are averaged separately per step, so differing batch
+    sizes (e.g. ensemble members on the fake side only) stay balanced; steps
+    are summed. All forwards run before the caller's single backward — under
+    DDP they arm the reducer that backward services, so this must be the
+    discriminator's final forward-backward of the batch (see
+    ``StepDiscriminator.gradient_sync_disabled``).
+
+    Args:
+        discriminator: The discriminator to train.
+        gridded_operations: Provides the area-weighted spherical mean reducing
+            per-pixel binary cross-entropy to a scalar.
+        pairs: One real/fake pair per optimized step.
+
+    Returns:
+        The discriminator's loss and detached diagnostics.
+    """
+    if not pairs:
+        raise ValueError("pairs must be non-empty")
+    losses_real = []
+    losses_fake = []
+    scores_real = []
+    scores_fake = []
+    for pair in pairs:
+        fake_logits = discriminator.forward(
+            pair.fake_input, pair.fake_output, labels=pair.fake_labels
+        )
+        real_logits = discriminator.forward(
+            pair.real_input, pair.real_output, labels=pair.real_labels
+        )
+        losses_real.append(_area_weighted_bce(real_logits, 1.0, gridded_operations))
+        losses_fake.append(_area_weighted_bce(fake_logits, 0.0, gridded_operations))
+        scores_real.append(_area_weighted_score(real_logits, gridded_operations))
+        scores_fake.append(_area_weighted_score(fake_logits, gridded_operations))
+    loss_real = torch.stack(losses_real).sum()
+    loss_fake = torch.stack(losses_fake).sum()
+    n_steps = len(pairs)
+    return DiscriminatorLosses(
+        loss=loss_real + loss_fake,
+        loss_real=loss_real.detach() / n_steps,
+        loss_fake=loss_fake.detach() / n_steps,
+        score_real=torch.stack(scores_real).mean(),
+        score_fake=torch.stack(scores_fake).mean(),
     )

--- a/fme/core/step/discriminator.py
+++ b/fme/core/step/discriminator.py
@@ -272,8 +272,9 @@ def _r1_gradient_penalty(
 ) -> torch.Tensor:
     """R1 gradient penalty (Mescheder et al. 2018) on real data.
 
-    Returns the area-weighted mean of ``||∇_x D(x)||²`` over the real
-    inputs — the unweighted penalty; the caller multiplies by ``λ/2``.
+    Returns ``E_x[||∇_x D(x)||²]`` — the area-weighted spatial mean of
+    the squared gradient norm (summed over the channel dimension), averaged
+    over the batch. The caller multiplies by ``λ/2``.
     ``create_graph=True`` so the penalty's own gradients flow into the
     discriminator's optimizer step.
     """
@@ -282,8 +283,10 @@ def _r1_gradient_penalty(
         inputs=real_inputs,
         create_graph=True,
     )
-    grad_sq = grads.square()
-    return gridded_operations.area_weighted_mean(grad_sq).mean()
+    # sum over channels to get per-pixel ||grad||², then area-weighted
+    # spatial mean, then batch mean
+    grad_norm_sq = grads.square().sum(dim=-3, keepdim=True)
+    return gridded_operations.area_weighted_mean(grad_norm_sq).mean()
 
 
 def compute_discriminator_losses(

--- a/fme/core/step/discriminator.py
+++ b/fme/core/step/discriminator.py
@@ -124,15 +124,17 @@ class StepDiscriminator:
             Per-pixel logits of shape [n_batch, 1, n_lat, n_lon]; positive
             means "judged real".
         """
-        input_norm = self._normalizer.normalize(
-            {name: input[name] for name in self._in_names}
-        )
+        tensors: list[torch.Tensor] = []
+        if self._in_names:
+            input_norm = self._normalizer.normalize(
+                {name: input[name] for name in self._in_names}
+            )
+            tensors.append(self._in_packer.pack(input_norm, axis=self.CHANNEL_DIM))
         output_norm = self._normalizer.normalize(
             {name: output[name] for name in self._out_names}
         )
-        input_tensor = self._in_packer.pack(input_norm, axis=self.CHANNEL_DIM)
-        output_tensor = self._out_packer.pack(output_norm, axis=self.CHANNEL_DIM)
-        pair_tensor = torch.cat([input_tensor, output_tensor], dim=self.CHANNEL_DIM)
+        tensors.append(self._out_packer.pack(output_norm, axis=self.CHANNEL_DIM))
+        pair_tensor = torch.cat(tensors, dim=self.CHANNEL_DIM)
         return self._module(pair_tensor, labels=labels)
 
     def get_state(self) -> dict[str, Any]:
@@ -330,13 +332,15 @@ def compute_discriminator_losses(
             pair.fake_input, pair.fake_output, labels=pair.fake_labels
         )
         if use_r1:
-            real_packed = torch.cat(
-                [
-                    torch.stack(list(pair.real_input.values()), dim=-3),
-                    torch.stack(list(pair.real_output.values()), dim=-3),
-                ],
-                dim=-3,
+            pack_parts = []
+            if pair.real_input:
+                pack_parts.append(
+                    torch.stack(list(pair.real_input.values()), dim=-3)
+                )
+            pack_parts.append(
+                torch.stack(list(pair.real_output.values()), dim=-3)
             )
+            real_packed = torch.cat(pack_parts, dim=-3)
             real_packed.requires_grad_(True)
             n_in = len(pair.real_input)
             real_input_r1 = dict(

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -12,6 +12,7 @@ from fme.core.normalizer import StandardNormalizer
 from fme.core.ocean import OceanConfig
 from fme.core.step._multi_call import MultiCall, MultiCallConfig, StepMethod
 from fme.core.step.args import StepArgs
+from fme.core.step.discriminator import StepDiscriminator
 from fme.core.step.output import StepOutput
 from fme.core.step.step import StepABC, StepConfigABC, StepSelector
 from fme.core.typing_ import TensorDict, TensorMapping
@@ -275,6 +276,10 @@ class MultiCallStep(StepABC):
     @property
     def modules(self) -> torch.nn.ModuleList:
         return self._wrapped_step.modules
+
+    @property
+    def discriminator(self) -> StepDiscriminator | None:
+        return self._wrapped_step.discriminator
 
     @property
     def normalizer(self) -> StandardNormalizer:

--- a/fme/core/step/output.py
+++ b/fme/core/step/output.py
@@ -6,7 +6,7 @@ import torch
 from fme.core.corrector.output import CorrectorDiagnostics
 from fme.core.step.step_diagnostics import StepDiagnostics
 from fme.core.stepper_state import StepperState
-from fme.core.typing_ import TensorDict
+from fme.core.typing_ import TensorDict, TensorMapping
 
 
 @dataclasses.dataclass
@@ -19,6 +19,10 @@ class StepOutput:
             None if no state is carried.
         corrector_diagnostics: The corrector's per-variable correction ``delta``
             for this step. Empty when no corrector ran or none modified anything.
+        input: The denormalized input the step consumed, populated by
+            prediction generators for consumers that need the step's
+            conditioning (e.g. adversarial losses). Reflects the generator's
+            between-step detach behavior. None when not populated.
     """
 
     output: TensorDict
@@ -26,6 +30,7 @@ class StepOutput:
     corrector_diagnostics: CorrectorDiagnostics = dataclasses.field(
         default_factory=CorrectorDiagnostics
     )
+    input: TensorMapping | None = None
 
     @classmethod
     def stack_diagnostics(

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -23,6 +23,7 @@ from fme.core.optimization import NullOptimization
 from fme.core.packer import Packer
 from fme.core.registry import CorrectorSelector, ModuleSelector
 from fme.core.step.args import StepArgs
+from fme.core.step.discriminator import StepDiscriminator
 from fme.core.step.global_mean_removal import (
     GlobalMeanRemoval,
     GlobalMeanRemovalConfigUnion,
@@ -78,6 +79,12 @@ class SingleModuleStepConfig(StepConfigABC):
             a random subset of input channels is zeroed during training, with
             the same mask broadcast across the whole batch. Disabled during
             inference (eval mode).
+        discriminator: Optional builder for a discriminator module judging
+            (input, output) timestep pairs for adversarial training. The
+            module receives the normalized input and output variables as
+            channels and emits one per-pixel logit channel. Trained by the
+            training stepper's separate discriminator optimizer, never by the
+            main optimizer.
     """
 
     builder: ModuleSelector
@@ -95,6 +102,7 @@ class SingleModuleStepConfig(StepConfigABC):
     include_channel_mask_inputs: bool = False
     global_mean_removal: GlobalMeanRemovalConfigUnion | None = None
     input_dropout: VariableMaskingConfig | None = None
+    discriminator: ModuleSelector | None = None
 
     def __post_init__(self):
         self.crps_training = None  # unused, kept for backwards compatibility
@@ -337,6 +345,20 @@ class SingleModuleStep(StepABC):
         else:
             self.secondary_decoder = NoSecondaryDecoder()
 
+        if config.discriminator is not None:
+            # Wraps DistributedDataParallel internally, so ranks start from
+            # rank 0's weights without joining init_weights (parameter_init
+            # loads donor generators, which carry no discriminator).
+            self._discriminator: StepDiscriminator | None = StepDiscriminator(
+                builder=config.discriminator,
+                in_names=config.in_names,
+                out_names=config.out_names,
+                normalizer=normalizer,
+                dataset_info=dataset_info,
+            )
+        else:
+            self._discriminator = None
+
         init_weights(self.modules)
         self._img_shape = dataset_info.img_shape
         self._config = config
@@ -392,6 +414,10 @@ class SingleModuleStep(StepABC):
         modules = [self.module.torch_module]
         modules.extend(self.secondary_decoder.torch_modules)
         return nn.ModuleList(modules)
+
+    @property
+    def discriminator(self) -> StepDiscriminator | None:
+        return self._discriminator
 
     def step(
         self,
@@ -474,6 +500,8 @@ class SingleModuleStep(StepABC):
     def train(self, mode: bool = True) -> StepABC:
         super().train(mode)
         self._corrector.train(mode)
+        if self._discriminator is not None:
+            self._discriminator.train(mode)
         return self
 
     def set_epoch(self, epoch: int) -> None:
@@ -491,6 +519,8 @@ class SingleModuleStep(StepABC):
         corrector_state = self._corrector.get_state()
         if len(corrector_state) > 0:
             state["corrector"] = corrector_state
+        if self._discriminator is not None:
+            state["discriminator"] = self._discriminator.get_state()
         return state
 
     def load_state(self, state: dict[str, Any]) -> None:
@@ -508,6 +538,11 @@ class SingleModuleStep(StepABC):
         if "secondary_decoder" in state:
             self.secondary_decoder.load_module_state(state["secondary_decoder"])
         self._corrector.load_state(state.get("corrector", {}))
+        # Absent key is allowed: a checkpoint from a run without a
+        # discriminator can warm-start one, which then keeps its fresh
+        # initialization.
+        if self._discriminator is not None and "discriminator" in state:
+            self._discriminator.load_state(state["discriminator"])
 
 
 def _raise_input_nan_error(input_norm: TensorMapping) -> None:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -282,8 +282,16 @@ class SingleModuleStepConfig(StepConfigABC):
             # loads donor generators, which carry no discriminator).
             discriminator: StepDiscriminator | None = StepDiscriminator(
                 builder=self.discriminator,
-                in_names=self.discriminator_in_names or self.in_names,
-                out_names=self.discriminator_out_names or self.out_names,
+                in_names=(
+                    self.discriminator_in_names
+                    if self.discriminator_in_names is not None
+                    else self.in_names
+                ),
+                out_names=(
+                    self.discriminator_out_names
+                    if self.discriminator_out_names is not None
+                    else self.out_names
+                ),
                 normalizer=normalizer,
                 dataset_info=dataset_info,
             )

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -85,6 +85,12 @@ class SingleModuleStepConfig(StepConfigABC):
             channels and emits one per-pixel logit channel. Trained by the
             training stepper's separate discriminator optimizer, never by the
             main optimizer.
+        discriminator_in_names: When set, the discriminator sees only these
+            input variables instead of all ``in_names``. Every name must
+            appear in ``in_names``.
+        discriminator_out_names: When set, the discriminator sees only these
+            output variables instead of all ``out_names``. Every name must
+            appear in ``out_names``.
     """
 
     builder: ModuleSelector
@@ -103,6 +109,8 @@ class SingleModuleStepConfig(StepConfigABC):
     global_mean_removal: GlobalMeanRemovalConfigUnion | None = None
     input_dropout: VariableMaskingConfig | None = None
     discriminator: ModuleSelector | None = None
+    discriminator_in_names: list[str] | None = None
+    discriminator_out_names: list[str] | None = None
 
     def __post_init__(self):
         self.crps_training = None  # unused, kept for backwards compatibility
@@ -123,6 +131,20 @@ class SingleModuleStepConfig(StepConfigABC):
                 raise ValueError(
                     f"next_step_forcing_name is an output variable: '{name}'"
                 )
+        if self.discriminator_in_names is not None:
+            for name in self.discriminator_in_names:
+                if name not in self.in_names:
+                    raise ValueError(
+                        f"discriminator_in_names entry '{name}' "
+                        f"not in in_names: {self.in_names}"
+                    )
+        if self.discriminator_out_names is not None:
+            for name in self.discriminator_out_names:
+                if name not in self.out_names:
+                    raise ValueError(
+                        f"discriminator_out_names entry '{name}' "
+                        f"not in out_names: {self.out_names}"
+                    )
         if self.secondary_decoder is not None:
             for name in self.secondary_decoder.secondary_diagnostic_names:
                 if name in self.in_names:
@@ -260,8 +282,8 @@ class SingleModuleStepConfig(StepConfigABC):
             # loads donor generators, which carry no discriminator).
             discriminator: StepDiscriminator | None = StepDiscriminator(
                 builder=self.discriminator,
-                in_names=self.in_names,
-                out_names=self.out_names,
+                in_names=self.discriminator_in_names or self.in_names,
+                out_names=self.discriminator_out_names or self.out_names,
                 normalizer=normalizer,
                 dataset_info=dataset_info,
             )

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -254,12 +254,26 @@ class SingleModuleStepConfig(StepConfigABC):
         logging.info("Initializing stepper from provided config")
         corrector = self.corrector.get_corrector(dataset_info)
         normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        if self.discriminator is not None:
+            # Wraps DistributedDataParallel internally, so ranks start from
+            # rank 0's weights without joining init_weights (parameter_init
+            # loads donor generators, which carry no discriminator).
+            discriminator: StepDiscriminator | None = StepDiscriminator(
+                builder=self.discriminator,
+                in_names=self.in_names,
+                out_names=self.out_names,
+                normalizer=normalizer,
+                dataset_info=dataset_info,
+            )
+        else:
+            discriminator = None
         return SingleModuleStep(
             config=self,
             dataset_info=dataset_info,
             corrector=corrector,
             normalizer=normalizer,
             init_weights=init_weights,
+            discriminator=discriminator,
         )
 
     def load(self):
@@ -281,6 +295,7 @@ class SingleModuleStep(StepABC):
         corrector: CorrectorABC,
         normalizer: StandardNormalizer,
         init_weights: Callable[[list[nn.Module]], None],
+        discriminator: StepDiscriminator | None = None,
     ):
         """
         Args:
@@ -290,6 +305,10 @@ class SingleModuleStep(StepABC):
             normalizer: The normalizer to use.
             timestep: Timestep of the model.
             init_weights: Function to initialize the weights of the module.
+            discriminator: Optional discriminator judging (input, output)
+                timestep pairs. Excluded from ``modules`` (and so from
+                ``init_weights``); optimized separately by the training
+                stepper.
         """
         super().__init__()
         if config.global_mean_removal is not None:
@@ -345,19 +364,7 @@ class SingleModuleStep(StepABC):
         else:
             self.secondary_decoder = NoSecondaryDecoder()
 
-        if config.discriminator is not None:
-            # Wraps DistributedDataParallel internally, so ranks start from
-            # rank 0's weights without joining init_weights (parameter_init
-            # loads donor generators, which carry no discriminator).
-            self._discriminator: StepDiscriminator | None = StepDiscriminator(
-                builder=config.discriminator,
-                in_names=config.in_names,
-                out_names=config.out_names,
-                normalizer=normalizer,
-                dataset_info=dataset_info,
-            )
-        else:
-            self._discriminator = None
+        self._discriminator = discriminator
 
         init_weights(self.modules)
         self._img_shape = dataset_info.img_shape

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -12,6 +12,7 @@ from fme.core.normalizer import StandardNormalizer
 from fme.core.ocean import OceanConfig
 from fme.core.registry.registry import Registry
 from fme.core.step.args import StepArgs
+from fme.core.step.discriminator import StepDiscriminator
 from fme.core.step.output import StepOutput
 from fme.core.typing_ import TensorDict, TensorMapping
 
@@ -312,6 +313,16 @@ class StepABC(abc.ABC):
     @abc.abstractmethod
     def modules(self) -> nn.ModuleList:
         pass
+
+    @property
+    def discriminator(self) -> StepDiscriminator | None:
+        """Optional discriminator judging (input, output) timestep pairs.
+
+        Excluded from ``modules`` so it never joins the modules being trained
+        by the main optimizer; trainers that use it optimize it separately.
+        None when the step defines no discriminator.
+        """
+        return None
 
     @property
     @abc.abstractmethod

--- a/fme/core/step/test_discriminator.py
+++ b/fme/core/step/test_discriminator.py
@@ -292,3 +292,60 @@ def test_missing_variable_raises():
     del input["a"]
     with pytest.raises(KeyError):
         discriminator.forward(input, output)
+
+
+def test_empty_in_names_forward():
+    """A discriminator with no input conditioning (empty in_names) should
+    forward successfully, producing logits from only the output fields."""
+    module = _ChannelMeanLogits(weight=1.0)
+    discriminator = StepDiscriminator(
+        builder=ModuleSelector(type="prebuilt", config={"module": module}),
+        in_names=[],
+        out_names=OUT_NAMES,
+        normalizer=_get_normalizer(OUT_NAMES),
+        dataset_info=get_dataset_info(img_shape=IMG_SHAPE),
+    )
+    input, output = _get_pair()
+    logits = discriminator.forward(input, output)
+    assert logits.shape == (3, 1, *IMG_SHAPE)
+
+
+def test_empty_in_names_gan_losses():
+    """The full GAN loss pipeline (generator + discriminator losses) should
+    work with empty in_names, and the area_weighted_bce should not raise a
+    shape mismatch."""
+    module = _ChannelMeanLogits(weight=0.5)
+    discriminator = StepDiscriminator(
+        builder=ModuleSelector(type="prebuilt", config={"module": module}),
+        in_names=[],
+        out_names=OUT_NAMES,
+        normalizer=_get_normalizer(OUT_NAMES),
+        dataset_info=get_dataset_info(img_shape=IMG_SHAPE),
+    )
+    gridded_ops = _get_gridded_operations()
+    _, fake_output = _get_pair()
+    fake_input: dict = {}
+    gen_loss = compute_generator_adversarial_loss(
+        discriminator=discriminator,
+        gridded_operations=gridded_ops,
+        fake_input=fake_input,
+        fake_output=fake_output,
+    )
+    assert gen_loss.shape == ()
+
+    real_input: dict = {}
+    _, real_output = _get_pair()
+    pair = GanStepPair.from_step_data(
+        real_input=real_input,
+        real_output=real_output,
+        fake_input=fake_input,
+        fake_output=fake_output,
+        real_labels=None,
+        fake_labels=None,
+    )
+    losses = compute_discriminator_losses(
+        discriminator=discriminator,
+        gridded_operations=gridded_ops,
+        pairs=[pair],
+    )
+    assert losses.loss.shape == ()

--- a/fme/core/step/test_discriminator.py
+++ b/fme/core/step/test_discriminator.py
@@ -7,7 +7,12 @@ from fme.core.device import get_device
 from fme.core.gridded_ops import LatLonOperations
 from fme.core.normalizer import StandardNormalizer
 from fme.core.registry import ModuleSelector
-from fme.core.step.discriminator import StepDiscriminator, compute_gan_step_losses
+from fme.core.step.discriminator import (
+    GanStepPair,
+    StepDiscriminator,
+    compute_discriminator_losses,
+    compute_generator_adversarial_loss,
+)
 from fme.core.testing.dataset_info import get_dataset_info
 
 IN_NAMES = ["a", "b"]
@@ -100,25 +105,41 @@ def _get_gridded_operations() -> LatLonOperations:
     return LatLonOperations(torch.ones(*IMG_SHAPE))
 
 
-def test_gan_step_losses_at_chance_logits():
+def _get_gan_pair(
+    real_input: dict, real_output: dict, fake_input: dict, fake_output: dict
+) -> GanStepPair:
+    return GanStepPair.from_step_data(
+        real_input=real_input,
+        real_output=real_output,
+        fake_input=fake_input,
+        fake_output=fake_output,
+        real_labels=None,
+        fake_labels=None,
+    )
+
+
+def test_gan_losses_at_chance_logits():
     """A zero-logit discriminator is at equilibrium: both sides score 0.5 and
     every BCE term is ln(2)."""
     discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.0))
     real_input, real_output = _get_pair()
     fake_input, fake_output = _get_pair()
-    losses = compute_gan_step_losses(
+    generator_loss = compute_generator_adversarial_loss(
         discriminator=discriminator,
         gridded_operations=_get_gridded_operations(),
-        real_input=real_input,
-        real_output=real_output,
         fake_input=fake_input,
         fake_output=fake_output,
     )
-    ln2 = torch.tensor(math.log(2.0), device=losses.generator_loss.device)
-    torch.testing.assert_close(losses.generator_loss, ln2)
-    torch.testing.assert_close(losses.discriminator_loss_real, ln2)
-    torch.testing.assert_close(losses.discriminator_loss_fake, ln2)
-    torch.testing.assert_close(losses.discriminator_loss, 2 * ln2)
+    losses = compute_discriminator_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        pairs=[_get_gan_pair(real_input, real_output, fake_input, fake_output)],
+    )
+    ln2 = torch.tensor(math.log(2.0), device=generator_loss.device)
+    torch.testing.assert_close(generator_loss, ln2)
+    torch.testing.assert_close(losses.loss_real, ln2)
+    torch.testing.assert_close(losses.loss_fake, ln2)
+    torch.testing.assert_close(losses.loss, 2 * ln2)
     torch.testing.assert_close(
         losses.score_real, torch.full_like(losses.score_real, 0.5)
     )
@@ -127,23 +148,54 @@ def test_gan_step_losses_at_chance_logits():
     )
 
 
-def test_generator_loss_flows_into_fake_pair_only():
+def test_discriminator_losses_aggregate_over_steps():
+    """The backward loss sums steps; the diagnostics average them."""
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.0))
+    pairs = []
+    for _ in range(3):
+        real_input, real_output = _get_pair()
+        fake_input, fake_output = _get_pair()
+        pairs.append(_get_gan_pair(real_input, real_output, fake_input, fake_output))
+    losses = compute_discriminator_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        pairs=pairs,
+    )
+    ln2 = torch.tensor(math.log(2.0), device=losses.loss.device)
+    torch.testing.assert_close(losses.loss, 6 * ln2)
+    torch.testing.assert_close(losses.loss_real, ln2)
+    torch.testing.assert_close(losses.loss_fake, ln2)
+
+
+def test_discriminator_losses_require_pairs():
+    discriminator = _get_discriminator()
+    with pytest.raises(ValueError, match="non-empty"):
+        compute_discriminator_losses(
+            discriminator=discriminator,
+            gridded_operations=_get_gridded_operations(),
+            pairs=[],
+        )
+
+
+def test_generator_loss_flows_into_fake_pair_and_discriminator():
+    """The generator's adversarial term backpropagates into the generated pair
+    and (as a side effect discarded by the trainer via zero_gradients) into the
+    discriminator's parameters — but never into the real pair."""
     discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
-    real_input, real_output = _get_pair()
     fake_input, fake_output = _get_pair()
     for tensor in list(fake_input.values()) + list(fake_output.values()):
         tensor.requires_grad_(True)
-    losses = compute_gan_step_losses(
+    generator_loss = compute_generator_adversarial_loss(
         discriminator=discriminator,
         gridded_operations=_get_gridded_operations(),
-        real_input=real_input,
-        real_output=real_output,
         fake_input=fake_input,
         fake_output=fake_output,
     )
-    losses.generator_loss.backward()
+    generator_loss.backward()
     assert fake_output["b"].grad is not None
     assert fake_input["a"].grad is not None
+    (weight,) = discriminator.modules[0].parameters()
+    assert weight.grad is not None
 
 
 def test_discriminator_loss_does_not_flow_into_generator():
@@ -152,15 +204,12 @@ def test_discriminator_loss_does_not_flow_into_generator():
     fake_input, fake_output = _get_pair()
     for tensor in list(fake_input.values()) + list(fake_output.values()):
         tensor.requires_grad_(True)
-    losses = compute_gan_step_losses(
+    losses = compute_discriminator_losses(
         discriminator=discriminator,
         gridded_operations=_get_gridded_operations(),
-        real_input=real_input,
-        real_output=real_output,
-        fake_input=fake_input,
-        fake_output=fake_output,
+        pairs=[_get_gan_pair(real_input, real_output, fake_input, fake_output)],
     )
-    losses.discriminator_loss.backward()
+    losses.loss.backward()
     assert all(tensor.grad is None for tensor in fake_input.values())
     assert all(tensor.grad is None for tensor in fake_output.values())
     (weight,) = discriminator.modules[0].parameters()
@@ -171,17 +220,14 @@ def test_detached_diagnostics_carry_no_graph():
     discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
     real_input, real_output = _get_pair()
     fake_input, fake_output = _get_pair()
-    losses = compute_gan_step_losses(
+    losses = compute_discriminator_losses(
         discriminator=discriminator,
         gridded_operations=_get_gridded_operations(),
-        real_input=real_input,
-        real_output=real_output,
-        fake_input=fake_input,
-        fake_output=fake_output,
+        pairs=[_get_gan_pair(real_input, real_output, fake_input, fake_output)],
     )
     for diagnostic in [
-        losses.discriminator_loss_real,
-        losses.discriminator_loss_fake,
+        losses.loss_real,
+        losses.loss_fake,
         losses.score_real,
         losses.score_fake,
     ]:

--- a/fme/core/step/test_discriminator.py
+++ b/fme/core/step/test_discriminator.py
@@ -234,6 +234,49 @@ def test_detached_diagnostics_carry_no_graph():
         assert diagnostic.grad_fn is None
 
 
+def test_r1_penalty_increases_loss_and_penalizes_gradients():
+    """With R1 enabled the total loss exceeds the base real+fake loss, and
+    the penalty itself is positive and differentiable."""
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
+    real_input, real_output = _get_pair()
+    fake_input, fake_output = _get_pair()
+    pair = _get_gan_pair(real_input, real_output, fake_input, fake_output)
+    base = compute_discriminator_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        pairs=[pair],
+    )
+    real_input2, real_output2 = _get_pair()
+    fake_input2, fake_output2 = _get_pair()
+    pair2 = _get_gan_pair(real_input2, real_output2, fake_input2, fake_output2)
+    with_r1 = compute_discriminator_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        pairs=[pair2],
+        r1_penalty_coefficient=10.0,
+    )
+    assert with_r1.r1_penalty > 0
+    assert with_r1.loss > base.loss_real + base.loss_fake
+    with_r1.loss.backward()
+    (weight,) = discriminator.modules[0].parameters()
+    assert weight.grad is not None
+
+
+def test_r1_penalty_zero_when_disabled():
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
+    real_input, real_output = _get_pair()
+    fake_input, fake_output = _get_pair()
+    losses = compute_discriminator_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        pairs=[_get_gan_pair(real_input, real_output, fake_input, fake_output)],
+        r1_penalty_coefficient=0.0,
+    )
+    torch.testing.assert_close(
+        losses.r1_penalty, torch.tensor(0.0, device=losses.r1_penalty.device)
+    )
+
+
 def test_train_mode_toggles():
     discriminator = _get_discriminator()
     assert discriminator.training

--- a/fme/core/step/test_discriminator.py
+++ b/fme/core/step/test_discriminator.py
@@ -1,0 +1,205 @@
+import math
+
+import pytest
+import torch
+
+from fme.core.device import get_device
+from fme.core.gridded_ops import LatLonOperations
+from fme.core.normalizer import StandardNormalizer
+from fme.core.registry import ModuleSelector
+from fme.core.step.discriminator import StepDiscriminator, compute_gan_step_losses
+from fme.core.testing.dataset_info import get_dataset_info
+
+IN_NAMES = ["a", "b"]
+OUT_NAMES = ["b", "c"]
+IMG_SHAPE = (5, 5)
+
+
+class _ChannelMeanLogits(torch.nn.Module):
+    """Per-pixel logit head with a parameter so optimizers can build."""
+
+    def __init__(self, weight: float = 0.0):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.full((1,), weight))
+
+    def forward(self, x):
+        return x.mean(dim=-3, keepdim=True) * self.weight
+
+
+def _get_normalizer(names: list[str], mean: float = 0.0) -> StandardNormalizer:
+    return StandardNormalizer(
+        means={name: torch.tensor(mean) for name in names},
+        stds={name: torch.tensor(1.0) for name in names},
+    )
+
+
+def _get_discriminator(
+    module: torch.nn.Module | None = None, mean: float = 0.0
+) -> StepDiscriminator:
+    if module is None:
+        module = _ChannelMeanLogits()
+    return StepDiscriminator(
+        builder=ModuleSelector(type="prebuilt", config={"module": module}),
+        in_names=IN_NAMES,
+        out_names=OUT_NAMES,
+        normalizer=_get_normalizer(sorted(set(IN_NAMES + OUT_NAMES)), mean=mean),
+        dataset_info=get_dataset_info(img_shape=IMG_SHAPE),
+    )
+
+
+def _get_pair(n_batch: int = 3) -> tuple[dict, dict]:
+    device = get_device()
+    input = {name: torch.randn(n_batch, *IMG_SHAPE, device=device) for name in IN_NAMES}
+    output = {
+        name: torch.randn(n_batch, *IMG_SHAPE, device=device) for name in OUT_NAMES
+    }
+    return input, output
+
+
+def test_forward_returns_per_pixel_logits():
+    discriminator = _get_discriminator()
+    input, output = _get_pair(n_batch=3)
+    logits = discriminator.forward(input, output)
+    assert logits.shape == (3, 1, *IMG_SHAPE)
+
+
+def test_forward_ignores_extra_variables():
+    """Callers may pass supersets (e.g. the model's full output dict)."""
+    discriminator = _get_discriminator()
+    input, output = _get_pair()
+    extra = torch.randn_like(input["a"])
+    logits = discriminator.forward(
+        {**input, "extra": extra}, {**output, "extra": extra}
+    )
+    torch.testing.assert_close(logits, discriminator.forward(input, output))
+
+
+def test_forward_normalizes_inputs():
+    """A pair at the climatological mean packs to all-zero channels."""
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=1.0), mean=2.0)
+    device = get_device()
+    input = {name: torch.full((2, *IMG_SHAPE), 2.0, device=device) for name in IN_NAMES}
+    output = {
+        name: torch.full((2, *IMG_SHAPE), 2.0, device=device) for name in OUT_NAMES
+    }
+    logits = discriminator.forward(input, output)
+    torch.testing.assert_close(logits, torch.zeros_like(logits))
+
+
+def test_state_round_trip():
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.7))
+    other = _get_discriminator(module=_ChannelMeanLogits(weight=0.1))
+    other.load_state(discriminator.get_state())
+    input, output = _get_pair()
+    torch.testing.assert_close(
+        other.forward(input, output), discriminator.forward(input, output)
+    )
+
+
+def _get_gridded_operations() -> LatLonOperations:
+    return LatLonOperations(torch.ones(*IMG_SHAPE))
+
+
+def test_gan_step_losses_at_chance_logits():
+    """A zero-logit discriminator is at equilibrium: both sides score 0.5 and
+    every BCE term is ln(2)."""
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.0))
+    real_input, real_output = _get_pair()
+    fake_input, fake_output = _get_pair()
+    losses = compute_gan_step_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        real_input=real_input,
+        real_output=real_output,
+        fake_input=fake_input,
+        fake_output=fake_output,
+    )
+    ln2 = torch.tensor(math.log(2.0), device=losses.generator_loss.device)
+    torch.testing.assert_close(losses.generator_loss, ln2)
+    torch.testing.assert_close(losses.discriminator_loss_real, ln2)
+    torch.testing.assert_close(losses.discriminator_loss_fake, ln2)
+    torch.testing.assert_close(losses.discriminator_loss, 2 * ln2)
+    torch.testing.assert_close(
+        losses.score_real, torch.full_like(losses.score_real, 0.5)
+    )
+    torch.testing.assert_close(
+        losses.score_fake, torch.full_like(losses.score_fake, 0.5)
+    )
+
+
+def test_generator_loss_flows_into_fake_pair_only():
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
+    real_input, real_output = _get_pair()
+    fake_input, fake_output = _get_pair()
+    for tensor in list(fake_input.values()) + list(fake_output.values()):
+        tensor.requires_grad_(True)
+    losses = compute_gan_step_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        real_input=real_input,
+        real_output=real_output,
+        fake_input=fake_input,
+        fake_output=fake_output,
+    )
+    losses.generator_loss.backward()
+    assert fake_output["b"].grad is not None
+    assert fake_input["a"].grad is not None
+
+
+def test_discriminator_loss_does_not_flow_into_generator():
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
+    real_input, real_output = _get_pair()
+    fake_input, fake_output = _get_pair()
+    for tensor in list(fake_input.values()) + list(fake_output.values()):
+        tensor.requires_grad_(True)
+    losses = compute_gan_step_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        real_input=real_input,
+        real_output=real_output,
+        fake_input=fake_input,
+        fake_output=fake_output,
+    )
+    losses.discriminator_loss.backward()
+    assert all(tensor.grad is None for tensor in fake_input.values())
+    assert all(tensor.grad is None for tensor in fake_output.values())
+    (weight,) = discriminator.modules[0].parameters()
+    assert weight.grad is not None
+
+
+def test_detached_diagnostics_carry_no_graph():
+    discriminator = _get_discriminator(module=_ChannelMeanLogits(weight=0.5))
+    real_input, real_output = _get_pair()
+    fake_input, fake_output = _get_pair()
+    losses = compute_gan_step_losses(
+        discriminator=discriminator,
+        gridded_operations=_get_gridded_operations(),
+        real_input=real_input,
+        real_output=real_output,
+        fake_input=fake_input,
+        fake_output=fake_output,
+    )
+    for diagnostic in [
+        losses.discriminator_loss_real,
+        losses.discriminator_loss_fake,
+        losses.score_real,
+        losses.score_fake,
+    ]:
+        assert diagnostic.grad_fn is None
+
+
+def test_train_mode_toggles():
+    discriminator = _get_discriminator()
+    assert discriminator.training
+    discriminator.train(False)
+    assert not discriminator.training
+    discriminator.train()
+    assert discriminator.training
+
+
+def test_missing_variable_raises():
+    discriminator = _get_discriminator()
+    input, output = _get_pair()
+    del input["a"]
+    with pytest.raises(KeyError):
+        discriminator.forward(input, output)

--- a/fme/core/step/test_multi_call.py
+++ b/fme/core/step/test_multi_call.py
@@ -286,3 +286,30 @@ def test_loss_normalizer_uses_extra_stats_names(include_multi_call_in_loss: bool
             "b_doubled_co2",
             "b_halved_co2",
         }
+
+
+def test_multi_call_step_forwards_discriminator():
+    """A discriminator defined by the wrapped step must stay visible through
+    the wrapper, or the training stepper would silently ignore it (and its
+    weight-0 configuration guard would be bypassed)."""
+    config = MultiCallStepConfig(
+        wrapped_step=StepSelector(
+            type="mock",
+            config={"in_names": ["CO2", "a", "b"], "out_names": ["b", "c"]},
+        ),
+        config=MultiCallConfig(
+            forcing_name="CO2",
+            forcing_multipliers={"_doubled_co2": 2},
+            output_names=["c"],
+        ),
+    )
+    step = config.get_step(DatasetInfo(), lambda x: None)
+    assert step.discriminator is None
+    sentinel = unittest.mock.Mock()
+    with unittest.mock.patch.object(
+        type(step._wrapped_step),
+        "discriminator",
+        new_callable=unittest.mock.PropertyMock,
+        return_value=sentinel,
+    ):
+        assert step.discriminator is sentinel

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -2216,3 +2216,47 @@ def test_multi_call_step_forwards_train_eval():
     wrapped_step.train.reset_mock()
     step.train()
     wrapped_step.train.assert_called_once_with(True)
+
+
+def test_discriminator_in_names_rejects_unknown():
+    names = ["a", "b", "c"]
+    with pytest.raises(ValueError, match="discriminator_in_names entry 'z'"):
+        SingleModuleStepConfig(
+            builder=ModuleSelector(type="MLP", config={}),
+            in_names=names,
+            out_names=names,
+            normalization=trivial_network_and_loss_normalization(names),
+            discriminator_in_names=["a", "z"],
+        )
+
+
+def test_discriminator_out_names_rejects_unknown():
+    names = ["a", "b", "c"]
+    with pytest.raises(ValueError, match="discriminator_out_names entry 'z'"):
+        SingleModuleStepConfig(
+            builder=ModuleSelector(type="MLP", config={}),
+            in_names=names,
+            out_names=names,
+            normalization=trivial_network_and_loss_normalization(names),
+            discriminator_out_names=["a", "z"],
+        )
+
+
+def test_discriminator_subset_names_accepted():
+    names = ["a", "b", "c"]
+    config = SingleModuleStepConfig(
+        builder=ModuleSelector(type="MLP", config={}),
+        in_names=names,
+        out_names=names,
+        normalization=trivial_network_and_loss_normalization(names),
+        discriminator=ModuleSelector(type="MLP", config={}),
+        discriminator_in_names=["a"],
+        discriminator_out_names=["b", "c"],
+    )
+    step = config.get_step(
+        dataset_info=get_dataset_info(img_shape=DEFAULT_IMG_SHAPE),
+        init_weights=lambda modules: None,
+    )
+    assert step.discriminator is not None
+    assert step.discriminator.in_names == ["a"]
+    assert step.discriminator.out_names == ["b", "c"]


### PR DESCRIPTION
Adds adversarial training to the stepper: a discriminator judges whether an (input, output) timestep pair comes from the training data or from the model, the generator is trained to fool it alongside its base loss, and the discriminator trains against real dataset transitions. Motivation: proper scoring rules (CRPS/energy score) reward calibrated marginals but not sharp spatial texture; an adversarial term directly penalizes distinguishable texture (first target: small-scale precipitation spectral power in the 1deg daily stochastic recipe). Draft while the gating experiment runs.

Changes:
- `fme.core.step.discriminator.StepDiscriminator`: Step-API-level discriminator -- normalizes and packs (input, output) variable dicts, emits per-pixel logits (`n_out_channels=1`); DDP-wrapped internally.
- `fme.core.step.discriminator`: non-saturating BCE terms (area-weighted spherical mean). `compute_generator_adversarial_loss` gives the per-step generator term on the generated pair; `compute_discriminator_losses` gives the discriminator's loss on real-vs-detached-fake pairs over all optimized steps, plus detached score/loss diagnostics.
- DDP contract: the generator's adversarial forwards run under `gradient_sync_disabled` (`no_sync`), so the generator's backward deposits only unsynced discriminator gradients, which are then discarded. The discriminator's own real/fake forwards and backward run **after** the generator's optimizer step: those forwards arm the DDP reducer, and its backward is the one reduced. A `pytest.mark.parallel` test trains on per-rank data and asserts cross-rank parameter equality; it fails if the ordering regresses.
- `fme.core.step.step.StepABC.discriminator` / `fme.core.step.single_module.SingleModuleStepConfig.discriminator`: optional discriminator on the step, excluded from `modules` (so the main optimizer, EMA, parameter_init, `wandb.watch`, the logged parameter count, and gradient-norm logging never touch it); weights ride in step state under a `discriminator` key, tolerated-if-missing so non-GAN donors can warm-start one. `MultiCallStep` forwards the wrapped step's discriminator.
- `fme.core.step.output.StepOutput.input` + `Stepper.predict_generator`: the generator now reports the exact input it consumed each step (reflecting its between-step detach behavior), which conditions the fake pair.
- `fme.ace.stepper.TrainStepperConfig.discriminator_loss_weight` / `.discriminator_optimization`: adversarial term added on every optimized forward step; the discriminator gets its own optimizer (mirrors the run's `optimization:` block by default via `OptimizationConfig.copy_without_schedule` -- type/lr/kwargs/AMP/clipping, never a scheduler; constant LR only). A discriminator with weight 0, weight > 0 without a discriminator, a scheduler or gradient accumulation on the D optimizer, and `n_ic_timesteps != 1` with a discriminator are all rejected at training construction; data_mask with a discriminator is rejected at the first training batch.
- `fme.ace.stepper.TrainStepper`: computes the generator's adversarial loss per optimized step (fake pair = the generator's own conditioning and output, ensemble members folded into batch), then after the generator step zeroes the deposited adversarial gradients and trains the discriminator on the cached pairs (real pair = dataset transition with the same next-step-forcing assembly). Logs `adversarial_loss_step_N`, `discriminator_loss_real/fake`, `discriminator_score_real/fake` -- these surface in wandb only as per-batch training keys (`batch_adversarial_loss_step_0`, `batch_discriminator_...`), cross-rank reduced every `log_train_every_n_batches`; the epoch aggregators do not forward them, so there are no `train/mean/` or `val/mean/` variants. The `loss` metric includes the weighted adversarial term in training mode while eval-mode (NullOptimization) passes exclude it and never update the discriminator. Discriminator forwards run under autocast, matching the generator's mixed-precision treatment (note: AMP + discriminator is untested on GPU). Discriminator optimizer state is checkpointed inside the stepper payload (a `TRAINING_ONLY_STATE_KEYS` entry: kept in `include_optimization=True` checkpoints for preemption resume, dropped from best/inference checkpoints; inference loads ignore it).
- `TrainStepper(training=False)`: eval-only construction path used by the inference evaluator's validation pass -- skips the training-only configuration guards and builds no discriminator optimizer, so GAN checkpoints evaluate cleanly.
- `fme.core.optimization.Optimization.zero_gradients`: discard gradients deposited by another loss's backward.
- `TrainStepperConfig.discriminator_r1_penalty`: R1 gradient penalty (Mescheder et al. 2018) on the real data, computed per optimized step as `coefficient * E[mean_spatial(||grad_x D(x)||^2)]` with `create_graph=True` so the penalty's own gradients flow into the discriminator's optimizer step. The squared gradient norm is summed over input channels (squared L2 norm per pixel), then area-weighted-averaged over the sphere. Penalizes sharp decision boundaries; 0 disables. Logged as `batch_discriminator_r1_penalty`. Added after two runs collapsed from discriminator overshoot -- the discriminator learned to perfectly separate real from generated pairs faster than the generator could adapt, even with TTUR (10x lower D lr) and a quarter-size D.
- `TrainStepperConfig.discriminator_r1_warmup_epochs`: number of epochs at training start during which the R1 penalty coefficient is forced to 0, preventing the penalty -- which can be ~10^6 larger at random initialization than at convergence -- from freezing the discriminator before it has learned useful gradients.

Known semantics worth flagging:
- For steps beyond the first, the real pair is a teacher-forced dataset transition while the fake pair is a free-running rollout transition, so the discriminator can separate them on accumulated rollout drift rather than texture. The gating experiment is 1-step pretraining, where the pairs are exactly matched; multi-step use should revisit this (e.g. restrict the term to step 0).
- Cost: one discriminator forward per optimized step in the generator's graph, plus two forwards and one backward per optimized step for the discriminator's own update. With R1 enabled, the real-side forward uses `create_graph=True` (second-order), adding one extra backward through the discriminator per optimized step.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Design note for review: the discriminator LR intentionally has no schedule in v1 (TrainStepper never sees the epoch/valid-loss signals that drive schedulers); if this feature graduates, the plan is to move the base optimizer onto TrainStepper and plumb those signals through.