### PR TITLE
Time stride on coupled input datasets; 5-daily fractions for the CM4-like-AM4 random-CO2 coupled sea ice ensemble

### DIFF
--- a/pr-plan.md
+++ b/pr-plan.md
@@ -1,0 +1,190 @@
+# Time stride on coupled input datasets; 5-daily fractions for the CM4-like-AM4 random-CO2 coupled sea ice ensemble
+
+`CoupledInputDatasetConfig` gains a `time_stride`, so an input store can be
+subsampled to a coarser cadence before any coupling arithmetic runs. Putting the
+1-degree sea-surface stores in the `ocean` slot at a 5-day stride makes
+`compute_coupled_sea_ice`'s existing ocean-sourced branch emit 6-hourly coupled
+sea ice whose sea ice and ocean fractions vary every 5 days and stay coherent
+with the land fraction. No coupling code changes.
+
+---
+
+## `scripts/data_process/create_coupled_datasets.py` (modified)
+
+```python
+@dataclasses.dataclass
+class CoupledInputDatasetConfig:
+    zarr_path: str
+    time_chunk_size: int
+    extra_fields: ExtraFieldsConfig = dataclasses.field(default_factory=ExtraFieldsConfig)
+    first_timestamp: str | None = None
+    last_timestamp: str | None = None
+    time_stride: str | None = None  # NEW — e.g. "5D": keep one snapshot per stride
+
+    def get_dataset(self) -> xr.Dataset:  # CHANGED — apply the stride after the time slice
+        ...
+
+    def log_info(self, label) -> None:  # CHANGED — log the stride when configured
+        ...
+
+
+def _stride_steps(time: xr.DataArray, time_stride: str) -> int:  # NEW
+    """Number of input timesteps spanning time_stride; raises on a non-uniform
+    axis or a stride that is not a whole multiple of the input cadence."""
+    ...
+```
+
+### Critical detail — where the stride applies and where the windows are anchored
+
+```python
+# get_dataset, in order:
+ds = xr.open_zarr(self.zarr_path, chunks={"time": self.time_chunk_size})
+ds = ds.sel(time=slice(self.first_timestamp, self.last_timestamp))   # unchanged
+if self.time_stride is not None:                                     # NEW
+    ds = ds.isel(time=slice(None, None, _stride_steps(ds.time, self.time_stride)))
+```
+
+- **Composition.** The timestamp slice runs first, so the stride is anchored at
+  the first timestamp *of the selected range* — `first_timestamp` is the window
+  origin when it is set, and the record's first timestamp otherwise.
+- **This config sets no `first_timestamp` on the strided input**, so the anchor
+  is the record's first timestamp. It has to be: the ocean-sourced branch does
+  `fractions.reindex({time: atmos.time}, method="ffill")`, and any atmosphere
+  timestamp earlier than the first selected snapshot would forward-fill from
+  nothing and come out NaN. The window origin the config being replaced used for
+  `window_avg` is later than the record start and cannot be reused here.
+- **Trailing remainder.** The record length need not be a whole multiple of the
+  stride; the last selected snapshot forward-fills through the end of the
+  atmosphere record, so the final interval is shorter than the others rather
+  than truncated.
+- **`isel`, not `resample`.** The sea-surface fields are snapshots, so the
+  subsample selects instants and does not average.
+- **Not `CoupledSeaIceConfig.timedelta`.** That field feeds
+  `_make_serializable_time_coord`, which asserts the reconstructed coordinate
+  matches the *atmosphere* time axis length; a 5-day value there fails the
+  assertion. It stays at the output cadence.
+
+### What runs unchanged
+
+`compute_coupled_sea_ice` reaches its ocean-sourced branch when no `sea_ice`
+dataset is configured, no `window_avg` is configured, and the `ocean` dataset
+carries sea ice fields. The strided sea-surface store satisfies all three, and
+carries `sea_surface_fraction`, `sea_ice_fraction`, and `ocean_sea_ice_fraction`
+under the names `OceanInputFieldsConfig` already defaults to. So
+`_compute_fractions_from_ocean` computes coherent fractions at the strided
+cadence and they are forward-filled onto the atmosphere's 6-hourly index.
+`compute_coupled_ocean` runs only when `coupled_sea_surface` is configured, so
+the `ocean` input alone produces no coupled ocean output.
+
+Under `include_ts` the emitted `surface_temperature` is `_interpolate_sst`'s
+blend, `(1 - ofrac) * ts + ofrac * ts_strided`. It is piecewise constant on the
+stride interval only where `ocean_fraction` is 1, and stays raw 6-hourly over
+land and under full sea ice. That is intended.
+
+## `scripts/data_process/configs/CM4-like-AM4-random-CO2-ensemble-coupled.yaml` (modified)
+
+Rewritten in place; nine ensemble members, one atmosphere / sea-surface store
+pair each.
+
+```yaml
+version: "2026-08-18"                     # CHANGED
+family_name: CM4-like-AM4-random-CO2-coupled
+output_directory: gs://vcm-ml-intermediate  # CHANGED — was /climate-default (Weka)
+
+coupled_datasets:
+  coupled_sea_ice:
+    include_ts: true
+    # window_avg:                         # REMOVED — snapshots, not interval means;
+    #   window_timedelta: 120h            #   a window_avg also routes off the
+    #   first_timestamp: ...              #   ocean-sourced branch entirely
+    #   shift_timestamps_to_avg_interval_midpoint: true
+  output_writer:
+    n_dask_workers: 32                    # unchanged
+
+stats:
+  start_date: "0153-01-01T06:00:00"       # unchanged — same spin-up skip as before
+
+input_datasets:
+  runs:
+    random-CO2-1xCO2-ic_0001:             # × 9: {1,2,4}xCO2 × ic_000{1,2,3}
+      atmosphere:
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0001.zarr  # CHANGED — was 2025-12-02
+        time_chunk_size: 360              # CHANGED — was 500; the store's time shard
+        extra_fields:
+          names_and_prefixes: ["ak_", "bk_"]
+      ocean:                              # NEW — replaces the sea_ice slot
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-1xCO2-ic_0001.zarr
+        time_chunk_size: 365              # the sea-surface store's time shard
+        time_stride: "5D"
+      # sea_ice:                          # REMOVED — the ocean slot is the sea ice source now
+  climate_data_type: "CM4"
+  stats:
+    atmosphere_dir: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2-stats/combined  # CHANGED
+```
+
+- The two store generations named here cover the same time record, so the
+  merged `uncoupled_atmosphere` stats stay comparable to the previous ensemble's.
+- `time_chunk_size` is set to each store's own time shard length rather than the
+  previous uniform value, so a dask chunk is one shard.
+- Outputs land at
+  `gs://vcm-ml-intermediate/2026-08-18-CM4-like-AM4-random-CO2-coupled/<run>-sea_ice.zarr`
+  with per-run stats under the sibling `-stats/` tree and the ensemble-combined
+  stats under its `combined/`.
+
+---
+
+## Tests
+
+## `scripts/data_process/test_create_coupled_datasets.py` (modified)
+
+```python
+def test_time_stride_selects_every_nth_instant():
+    # GOAL: get_dataset on a synthetic uniform-cadence store returns the instants
+    # a whole-multiple stride selects, anchored at the record's first timestamp,
+    # with the trailing remainder left unselected rather than truncating.
+    # PARAMETERIZE: stride ∈ {one input step (no-op), several steps}.
+
+def test_time_stride_composes_with_timestamp_range():
+    # GOAL: with first_timestamp/last_timestamp set, the range is applied first and
+    # the stride anchors on the first in-range instant.
+
+def test_time_stride_none_is_todays_behavior():
+    # GOAL: regression guard — no time_stride returns the same time axis as before.
+
+def test_time_stride_invalid_raises():
+    # GOAL: a clear error, not a silent wrong cadence.
+    # PARAMETERIZE: cause ∈ {non-uniform time axis, stride not a whole multiple of
+    #                        the input cadence, stride shorter than one step}.
+```
+
+## `scripts/data_process/test_coupled_dataset_utils.py` (modified)
+
+```python
+def test_ocean_sourced_strided_fractions_are_piecewise_constant():
+    # GOAL: end-to-end over a strided ocean input — the emitted land/ocean/sea-ice
+    # fractions are constant within each stride interval, change at its boundaries,
+    # partition to 1 at every cell and instant, and the output keeps the atmosphere's
+    # own time axis.
+
+def test_ocean_sourced_strided_include_ts_blend():
+    # GOAL: the emitted surface_temperature is piecewise constant on the stride
+    # interval where ocean_fraction == 1 and equals the raw atmosphere field where
+    # ocean_fraction == 0.
+```
+
+## `scripts/data_process/test_config.py` (unmodified)
+
+`test_valid_create_coupled_datasets_config` already sweeps every `*-coupled.yaml`
+through dacite in strict mode, so the rewritten config's schema is covered as
+soon as it lands.
+
+---
+
+## Open Questions
+
+- `output_directory` moves from `/climate-default` to `gs://vcm-ml-intermediate`,
+  which changes where this shipped config writes for anyone running it against
+  Weka. Objections welcome; the run producing these stores is a GCS run.
+- `time_stride: "5D"` spells the subsample as a physical span, matching
+  `window_timedelta`. An integer count of input timesteps would need no cadence
+  inference — is the timedelta spelling worth the validation it requires?

--- a/scripts/data_process/configs/CM4-like-AM4-random-CO2-ensemble-coupled.yaml
+++ b/scripts/data_process/configs/CM4-like-AM4-random-CO2-ensemble-coupled.yaml
@@ -1,13 +1,9 @@
-version: "2025-12-04"
+version: "2026-08-18"
 family_name: CM4-like-AM4-random-CO2-coupled
-output_directory: /climate-default
+output_directory: gs://vcm-ml-intermediate
 
 coupled_datasets:
   coupled_sea_ice:
-    window_avg:
-      window_timedelta: 120h
-      first_timestamp: "0152-10-06T00:00:00"
-      shift_timestamps_to_avg_interval_midpoint: true
     include_ts: true
   output_writer:
     n_dask_workers: 32
@@ -19,86 +15,94 @@ input_datasets:
   runs:
     random-CO2-1xCO2-ic_0001:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0001.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0001.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-1xCO2-ic_0001.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-1xCO2-ic_0001.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-2xCO2-ic_0001:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-2xCO2-ic_0001.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-2xCO2-ic_0001.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-2xCO2-ic_0001.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-2xCO2-ic_0001.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-4xCO2-ic_0001:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-4xCO2-ic_0001.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-4xCO2-ic_0001.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-4xCO2-ic_0001.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-4xCO2-ic_0001.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-1xCO2-ic_0002:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0002.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0002.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-1xCO2-ic_0002.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-1xCO2-ic_0002.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-2xCO2-ic_0002:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-2xCO2-ic_0002.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-2xCO2-ic_0002.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-2xCO2-ic_0002.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-2xCO2-ic_0002.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-4xCO2-ic_0002:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-4xCO2-ic_0002.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-4xCO2-ic_0002.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-4xCO2-ic_0002.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-4xCO2-ic_0002.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-1xCO2-ic_0003:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0003.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-1xCO2-ic_0003.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-1xCO2-ic_0003.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-1xCO2-ic_0003.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-2xCO2-ic_0003:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-2xCO2-ic_0003.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-2xCO2-ic_0003.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-2xCO2-ic_0003.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-2xCO2-ic_0003.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
     random-CO2-4xCO2-ic_0003:
       atmosphere:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2/random-CO2-4xCO2-ic_0003.zarr
-        time_chunk_size: 500
+        zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2/random-CO2-4xCO2-ic_0003.zarr
+        time_chunk_size: 360
         extra_fields:
           names_and_prefixes: ["ak_", "bk_"]
-      sea_ice:
-        zarr_path: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-ensemble-sea-ice/random-CO2-4xCO2-ic_0003.zarr
-        time_chunk_size: 500
+      ocean:
+        zarr_path: gs://vcm-ml-intermediate/2026-08-17-cm4-like-am4-random-co2-sea-surface-1deg/random-CO2-4xCO2-ic_0003.zarr
+        time_chunk_size: 365
+        time_stride: "5D"
   climate_data_type: "CM4"
   stats:
-    atmosphere_dir: /climate-default/2025-12-02-CM4-like-AM4-random-CO2-stats/combined
-
+    atmosphere_dir: gs://vcm-ml-intermediate/2026-06-19-CM4-like-AM4-random-CO2-stats/combined

--- a/scripts/data_process/create_coupled_datasets.py
+++ b/scripts/data_process/create_coupled_datasets.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 import click
 import dacite
+import numpy as np
+import pandas as pd
 import xarray as xr
 import yaml
 from combine_stats import combine_stats
@@ -229,6 +231,42 @@ def _combine_ensemble_stats(
             )
 
 
+def _stride_steps(time: xr.DataArray, time_stride: str) -> int:
+    """Number of input timesteps spanning time_stride.
+
+    Args:
+        time: Time coordinate of the input dataset, assumed uniform.
+        time_stride: Coarser cadence to subsample to, as a timedelta string.
+
+    Returns:
+        The stride, in input timesteps.
+
+    Raises:
+        ValueError: If the time axis has fewer than two timestamps or is not
+            uniform, or if time_stride is not a whole multiple of the input
+            cadence.
+    """
+    if len(time) < 2:
+        raise ValueError(
+            "Cannot apply a time_stride to a dataset with fewer than two "
+            f"timestamps; got {len(time)}."
+        )
+    deltas = pd.to_timedelta(pd.Series(np.diff(time.values))).unique()
+    if len(deltas) > 1:
+        raise ValueError(
+            "time_stride requires a uniform input time axis, but found "
+            f"timesteps {sorted(str(d) for d in deltas)}."
+        )
+    step = pd.Timedelta(deltas[0])
+    stride = pd.Timedelta(time_stride)
+    if stride < step or stride % step != pd.Timedelta(0):
+        raise ValueError(
+            f"time_stride {time_stride} is not a whole multiple of the input "
+            f"cadence {step}."
+        )
+    return int(stride // step)
+
+
 @dataclasses.dataclass
 class CoupledInputDatasetConfig:
     """Configuration for a single input dataset.
@@ -239,6 +277,16 @@ class CoupledInputDatasetConfig:
         time_chunk_size: Chunk size for the time dimension.
         extra_fields: Optional list of variable names/prefixes
             to copy to the outputs.
+        first_timestamp: Optional first timestamp to select.
+        last_timestamp: Optional last timestamp to select.
+        time_stride: Optional coarser cadence to subsample the store to, as a
+            timedelta (e.g., "5D"). It must be a whole multiple of the store's
+            own uniform cadence. Snapshots are selected, never averaged, and
+            the stride is anchored at the first timestamp of the range
+            first_timestamp/last_timestamp select, so first_timestamp is the
+            window origin when it is set and the record's first timestamp
+            otherwise. A record whose length is not a whole multiple of the
+            stride leaves a trailing remainder unselected.
     """
 
     zarr_path: str
@@ -248,16 +296,24 @@ class CoupledInputDatasetConfig:
     )
     first_timestamp: str | None = None
     last_timestamp: str | None = None
+    time_stride: str | None = None
 
     def get_dataset(self) -> xr.Dataset:
-        """Load the zarr dataset with specified time chunking and range.
+        """Load the zarr dataset with specified time chunking, range, and stride.
 
         Returns:
-            Dataset loaded from zarr with time selection applied.
+            Dataset loaded from zarr with time selection and subsampling applied.
         """
         logging.info(f"Loading dataset from {self.zarr_path}")
         ds = xr.open_zarr(self.zarr_path, chunks={"time": self.time_chunk_size})
         ds = ds.sel(time=slice(self.first_timestamp, self.last_timestamp))
+        if self.time_stride is not None:
+            steps = _stride_steps(ds.time, self.time_stride)
+            logging.info(
+                f"  Subsampling to {self.time_stride} "
+                f"(every {steps} input timesteps)"
+            )
+            ds = ds.isel(time=slice(None, None, steps))
         logging.info(f"  Loaded dataset with {len(ds.time)} timesteps")
         return ds
 
@@ -271,6 +327,8 @@ class CoupledInputDatasetConfig:
                 f"  time_range: {self.first_timestamp or 'start'} to "
                 f"{self.last_timestamp or 'end'}"
             )
+        if self.time_stride is not None:
+            logging.info(f"  time_stride: {self.time_stride}")
         if self.extra_fields.names_and_prefixes:
             logging.info(f"  extra_fields: {self.extra_fields.names_and_prefixes}")
 

--- a/scripts/data_process/test_create_coupled_datasets.py
+++ b/scripts/data_process/test_create_coupled_datasets.py
@@ -12,6 +12,7 @@ from coupled_dataset_utils import (  # noqa: E402
     CoupledSeaIceConfig,
     CoupledSeaSurfaceConfig,
     CoupledSurfaceTemperatureConfig,
+    compute_coupled_sea_ice,
 )
 from create_coupled_datasets import (  # noqa: E402
     CoupledDatasetsConfig,
@@ -109,6 +110,9 @@ def _make_config(tmp_path):
                 window_avg=WindowAvgDatasetConfig(
                     window_timedelta="120h", first_timestamp=FIRST_WINDOW_END
                 ),
+                # this config deliberately window-averages, which routes off the
+                # ocean-sourced path onto the atmosphere's own sea ice fraction
+                use_atmosphere_sea_ice_fraction_fallback=True,
             ),
             coupled_ts=CoupledSurfaceTemperatureConfig(
                 how="threshold", ocean_fraction_threshold=0.9
@@ -197,3 +201,154 @@ def test_write_datasets_and_stats_debug_writes_nothing(tmp_path):
 
     output_dir = tmp_path / "outputs"
     assert list(output_dir.iterdir()) == []
+
+
+STRIDE_STEPS = 20  # "5D" in 6-hourly steps
+N_STRIDE_TIMES = 45  # two whole 5-day strides plus a trailing remainder
+STRIDE_START = "0152-10-01T06:00:00"
+
+
+def _write_zarr(path, times, name="sst"):
+    xr.Dataset({name: _field(times, seed=9)}).to_zarr(str(path))
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "time_stride, expected_steps", [("6h", 1), ("5D", STRIDE_STEPS)]
+)
+def test_time_stride_selects_every_nth_instant(tmp_path, time_stride, expected_steps):
+    times = _times(STRIDE_START, N_STRIDE_TIMES, "6h")
+    path = _write_zarr(tmp_path / "input.zarr", times)
+    ds = CoupledInputDatasetConfig(
+        zarr_path=path, time_chunk_size=10, time_stride=time_stride
+    ).get_dataset()
+    expected = list(times[::expected_steps])
+    assert list(ds.time.values) == expected
+    # the record is not a whole multiple of a 5-day stride, so its last
+    # timestamp is left unselected rather than truncating the range
+    assert (times[-1] in expected) == (expected_steps == 1)
+
+
+def test_time_stride_composes_with_timestamp_range(tmp_path):
+    times = _times(STRIDE_START, N_STRIDE_TIMES, "6h")
+    path = _write_zarr(tmp_path / "input.zarr", times)
+    first, last = times[2], times[-3]
+    ds = CoupledInputDatasetConfig(
+        zarr_path=path,
+        time_chunk_size=10,
+        first_timestamp=str(first),
+        last_timestamp=str(last),
+        time_stride="5D",
+    ).get_dataset()
+    in_range = times[(times >= first) & (times <= last)]
+    assert list(ds.time.values) == list(in_range[::STRIDE_STEPS])
+    assert ds.time.values[0] == first
+
+
+def test_time_stride_none_is_todays_behavior(tmp_path):
+    times = _times(STRIDE_START, N_STRIDE_TIMES, "6h")
+    path = _write_zarr(tmp_path / "input.zarr", times)
+    ds = CoupledInputDatasetConfig(zarr_path=path, time_chunk_size=10).get_dataset()
+    assert list(ds.time.values) == list(times)
+
+
+@pytest.mark.parametrize(
+    "cause, time_stride, match",
+    [
+        ("non-uniform", "5D", "uniform input time axis"),
+        ("uniform", "7h", "whole multiple"),
+        ("uniform", "1h", "whole multiple"),
+        ("single-timestamp", "5D", "fewer than two"),
+    ],
+)
+def test_time_stride_invalid_raises(tmp_path, cause, time_stride, match):
+    times = _times(STRIDE_START, N_STRIDE_TIMES, "6h")
+    if cause == "non-uniform":
+        times = times[[0, 1, 2, 5, 6]]
+    elif cause == "single-timestamp":
+        times = times[:1]
+    path = _write_zarr(tmp_path / "input.zarr", times)
+    config = CoupledInputDatasetConfig(
+        zarr_path=path, time_chunk_size=10, time_stride=time_stride
+    )
+    with pytest.raises(ValueError, match=match):
+        config.get_dataset()
+
+
+def _strided_route_inputs(tmp_path):
+    """A 6-hourly atmosphere store and a 6-hourly sea-surface store whose sea ice
+    concentration varies every step, so a stride is what makes the emitted
+    fractions 5-daily. Column 0 is all land; row 0 is ice-free open ocean."""
+    times = _times(STRIDE_START, N_STRIDE_TIMES, "6h")
+    steps = np.arange(len(times))
+    land = np.zeros((NLAT, NLON))
+    land[:, 0] = 1.0
+    sic = np.broadcast_to(
+        (steps / len(times)).reshape(-1, 1, 1), (len(times), NLAT, NLON)
+    ).copy()
+    sic[:, 0, :] = 0.0
+
+    def _da(data, dims=("time", "lat", "lon")):
+        coords = {"lat": np.linspace(-80, 80, NLAT), "lon": np.linspace(0, 315, NLON)}
+        if "time" in dims:
+            coords["time"] = times
+        return xr.DataArray(data, dims=dims, coords=coords)
+
+    atmos = xr.Dataset(
+        {
+            "land_fraction": _da(land, dims=("lat", "lon")),
+            "sea_ice_fraction": _da(np.zeros_like(sic)),
+            "ocean_fraction": _da(np.ones_like(sic)),
+            "surface_temperature": _da(
+                np.broadcast_to(
+                    (270.0 + steps).reshape(-1, 1, 1), (len(times), NLAT, NLON)
+                ).copy()
+            ),
+        }
+    )
+    ocean = xr.Dataset(
+        {
+            "sea_surface_fraction": _da(1.0 - land, dims=("lat", "lon")),
+            "ocean_sea_ice_fraction": _da(sic),
+            "sst": _da(np.full_like(sic, 275.0)),
+        }
+    )
+    atmos_path = str(tmp_path / "atmos.zarr")
+    ocean_path = str(tmp_path / "sea_surface.zarr")
+    atmos.to_zarr(atmos_path)
+    ocean.to_zarr(ocean_path)
+    return atmos_path, ocean_path, times, steps, sic
+
+
+def test_strided_ocean_input_gives_5daily_coherent_fractions(tmp_path):
+    atmos_path, ocean_path, times, steps, sic = _strided_route_inputs(tmp_path)
+    atmos = CoupledInputDatasetConfig(
+        zarr_path=atmos_path, time_chunk_size=10
+    ).get_dataset()
+    ocean = CoupledInputDatasetConfig(
+        zarr_path=ocean_path, time_chunk_size=10, time_stride="5D"
+    ).get_dataset()
+
+    result = compute_coupled_sea_ice(
+        atmos, CoupledSeaIceConfig(include_ts=True), ocean=ocean
+    )
+
+    # the output keeps the atmosphere's own 6-hourly axis
+    assert list(result.time.values) == list(times)
+    total = (
+        result["land_fraction"] + result["ocean_fraction"] + result["sea_ice_fraction"]
+    )
+    np.testing.assert_allclose(total.values, 1.0)
+
+    # the fractions step on the strided cadence: each output step carries the
+    # concentration of the most recent selected snapshot
+    held = steps - (steps % STRIDE_STEPS)
+    np.testing.assert_allclose(result["ocean_sea_ice_fraction"].values, sic[held, :, :])
+    # ... and land is unaffected by the stride
+    np.testing.assert_allclose(result["sea_ice_fraction"].values[:, :, 0], 0.0)
+
+    # include_ts: piecewise constant on the stride where ocean_fraction is 1,
+    # raw 6-hourly over land
+    ts = result["surface_temperature"].values
+    np.testing.assert_allclose(ts[:, 0, 1], 270.0 + held)
+    np.testing.assert_allclose(ts[:, 0, 0], 270.0 + steps)


### PR DESCRIPTION
The CM4-like-AM4 random-CO2 coupled sea ice ensemble is built from sea-surface snapshots, so it cannot use a window average; instead the sea ice and ocean fractions are subsampled to a 5-day cadence and forward-filled back onto the 6-hourly atmosphere index, staying coherent with the land fraction. This adds the one capability that was missing for that — a time stride on an input store — and rewrites the ensemble config to use it. The coupling arithmetic in `compute_coupled_sea_ice` is reused unchanged: the strided sea-surface store goes in the `ocean` input slot, where the existing ocean-sourced fraction branch already computes coherent fractions at the input's own cadence and forward-fills them.

`pr-plan.md` at the repo root is the API roadmap under review; it is removed from the branch before this PR leaves draft.

Changes:
- `scripts/data_process/create_coupled_datasets.py`: `CoupledInputDatasetConfig.time_stride` subsamples an input store in time, applied after the `first_timestamp`/`last_timestamp` slice
- `scripts/data_process/configs/CM4-like-AM4-random-CO2-ensemble-coupled.yaml`: rewritten at `version: "2026-08-18"` — sea-surface stores in the `ocean` slot at a 5-day stride, no `sea_ice` input, no `window_avg`, `include_ts: true`, GCS output directory, `2026-06-19` atmosphere inputs and stats
- `scripts/data_process/test_create_coupled_datasets.py`, `scripts/data_process/test_coupled_dataset_utils.py`: stride selection, composition with the timestamp range, invalid-stride errors, and end-to-end piecewise-constant strided fractions and `include_ts` blend

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
