### PR TITLE
Add cross-level attention and time-of-year conditioning to the Swin backbone

### DIFF
--- a/fme/ace/registry/hpx.py
+++ b/fme/ace/registry/hpx.py
@@ -41,6 +41,9 @@ class HEALPixUNetBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         """
         Build a HEALPixUNet model.
@@ -49,6 +52,8 @@ class HEALPixUNetBuilder(ModuleConfig):
             n_in_channels: Number of input channels.
             n_out_channels: Number of output channels.
             dataset_info: Information about the dataset.
+            in_names: Ordered names of the input channels. Unused.
+            out_names: Ordered names of the output channels. Unused.
 
         Returns:
             HEALPixUNet model.

--- a/fme/ace/registry/land_net.py
+++ b/fme/ace/registry/land_net.py
@@ -22,6 +22,9 @@ class LandNetBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ):
         if len(dataset_info.all_labels) > 0:
             raise ValueError("LandNet does not support labels")

--- a/fme/ace/registry/local_net.py
+++ b/fme/ace/registry/local_net.py
@@ -75,6 +75,9 @@ class AnkurLocalNetBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         params = AnkurLocalNetConfig(
             embed_dim=self.embed_dim,
@@ -186,6 +189,9 @@ class LocalNetBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         params = LocalNetConfig(
             embed_dim=self.embed_dim,

--- a/fme/ace/registry/m2lines.py
+++ b/fme/ace/registry/m2lines.py
@@ -39,6 +39,9 @@ class SamudraBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ):
         if len(dataset_info.all_labels) > 0:
             raise ValueError("Samudra does not support labels")
@@ -80,6 +83,9 @@ class FloeNetBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ):
         if not GRAPHCAST_AVAIL:
             raise ImportError("GraphCast dependencies (trimesh, rtree) not available.")

--- a/fme/ace/registry/prebuilt.py
+++ b/fme/ace/registry/prebuilt.py
@@ -22,5 +22,8 @@ class PreBuiltBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         return self.module

--- a/fme/ace/registry/sfno.py
+++ b/fme/ace/registry/sfno.py
@@ -46,6 +46,9 @@ class SphericalFourierNeuralOperatorBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ):
         if len(dataset_info.all_labels) > 0:
             raise ValueError(
@@ -95,6 +98,9 @@ class SFNO_V0_1_0(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ):
         img_shape = dataset_info.img_shape
         if len(dataset_info.all_labels) > 0:

--- a/fme/ace/registry/stochastic_sfno.py
+++ b/fme/ace/registry/stochastic_sfno.py
@@ -330,6 +330,9 @@ class NoiseConditionedSFNOBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ):
         n_labels = len(dataset_info.all_labels)
         if self.label_embed_dim > 0:

--- a/fme/ace/registry/stochastic_sfno.py
+++ b/fme/ace/registry/stochastic_sfno.py
@@ -47,6 +47,50 @@ def isotropic_noise(
     return isht(alm)
 
 
+class TimestepEmbedder(torch.nn.Module):
+    """Embeds a scalar into a vector with sinusoidal features and an MLP.
+
+    The DiT/GLIDE timestep embedder, used by ArchesWeather to embed calendar
+    quantities for adaptive normalization. Note that the geometric frequency
+    ladder is not periodic in the input, so a day-of-year fraction has a
+    discontinuity at the year boundary; this matches ArchesWeather.
+
+    Args:
+        hidden_size: Output dimension.
+        frequency_embedding_size: Width of the intermediate sinusoidal
+            features.
+        max_period: Longest period in the frequency ladder.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        frequency_embedding_size: int = 256,
+        max_period: int = 10000,
+    ):
+        super().__init__()
+        self.frequency_embedding_size = frequency_embedding_size
+        self.max_period = max_period
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(frequency_embedding_size, hidden_size),
+            torch.nn.SiLU(),
+            torch.nn.Linear(hidden_size, hidden_size),
+        )
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        half = self.frequency_embedding_size // 2
+        freqs = torch.exp(
+            -math.log(self.max_period)
+            * torch.arange(start=0, end=half, dtype=torch.float32, device=t.device)
+            / half
+        )
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if self.frequency_embedding_size % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], -1)
+        return self.mlp(embedding.to(t.dtype))
+
+
 class NoiseConditionedModel(torch.nn.Module):
     """Wraps a context-based module with noise and optional label conditioning.
 
@@ -69,6 +113,10 @@ class NoiseConditionedModel(torch.nn.Module):
         inverse_sht: Optional inverse spherical harmonic transform callable.
             If provided, isotropic noise is generated via SHT; otherwise
             gaussian noise is used.
+        time_embed_dim: Dimension of the day-of-year embedding. When > 0 the
+            wrapped module is conditioned on the calendar position of the
+            step, and ``time_fraction`` becomes a required forward argument.
+            0 (default) disables calendar conditioning.
     """
 
     def __init__(
@@ -82,6 +130,7 @@ class NoiseConditionedModel(torch.nn.Module):
         inverse_sht: Callable[[torch.Tensor], torch.Tensor] | None = None,
         lmax: int = 0,
         mmax: int = 0,
+        time_embed_dim: int = 0,
     ):
         super().__init__()
         self.conditional_model = conditional_model
@@ -90,6 +139,9 @@ class NoiseConditionedModel(torch.nn.Module):
         self._inverse_sht = inverse_sht
         self._lmax = lmax
         self._mmax = mmax
+        self.time_embedder: TimestepEmbedder | None = (
+            TimestepEmbedder(time_embed_dim) if time_embed_dim > 0 else None
+        )
 
         if label_embed_dim > 0 and n_labels == 0:
             raise ValueError("label_embed_dim > 0 requires n_labels > 0")
@@ -126,9 +178,25 @@ class NoiseConditionedModel(torch.nn.Module):
             self.pos_embed = None
 
     def forward(
-        self, x: torch.Tensor, labels: torch.Tensor | None = None
+        self,
+        x: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        time_fraction: torch.Tensor | None = None,
     ) -> torch.Tensor:
         x = x.reshape(-1, *x.shape[-3:])
+        if self.time_embedder is not None:
+            if time_fraction is None:
+                # Silently skipping would leave the calendar conditioning as a
+                # no-op that is invisible in the loss, so fail immediately.
+                raise ValueError(
+                    "time_fraction is required for a time-conditioned model but "
+                    "was not provided; check that the step type threads it through."
+                )
+            embedding_scalar: torch.Tensor | None = self.time_embedder(
+                time_fraction.to(device=x.device).reshape(-1)
+            )
+        else:
+            embedding_scalar = None
         if self._inverse_sht is not None:
             noise = isotropic_noise(
                 (x.shape[0], self.embed_dim),
@@ -164,7 +232,7 @@ class NoiseConditionedModel(torch.nn.Module):
         return self.conditional_model(
             x,
             Context(
-                embedding_scalar=None,
+                embedding_scalar=embedding_scalar,
                 embedding_pos=embedding_pos,
                 labels=labels,
                 noise=noise,

--- a/fme/ace/registry/swin_transformer.py
+++ b/fme/ace/registry/swin_transformer.py
@@ -214,6 +214,9 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
             tokens by ``n_levels + 1``, so ``embed_dim`` should be reduced to
             keep the cost comparable.
         column_num_heads: Number of attention heads for cross-level attention.
+        time_embed_dim: Dimension of the day-of-year embedding injected through
+            each block's ``ConditionalLayerNorm``. 0 (default) disables
+            calendar conditioning.
     """
 
     embed_dim: int = 96
@@ -231,6 +234,7 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
     use_cpb_scaling: bool = True
     cross_level_attention: bool = False
     column_num_heads: int = 8
+    time_embed_dim: int = 0
 
     def __post_init__(self):
         if isinstance(self.padding_conf, dict):
@@ -249,7 +253,7 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
         label_embed_dim = self.label_embed_dim
         effective_label_dim = label_embed_dim if label_embed_dim > 0 else n_labels
         context_config = ContextConfig(
-            embed_dim_scalar=0,
+            embed_dim_scalar=self.time_embed_dim,
             embed_dim_labels=effective_label_dim,
             embed_dim_noise=self.noise_embed_dim,
             embed_dim_pos=0,
@@ -302,4 +306,5 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
             n_labels=n_labels,
             label_embed_dim=label_embed_dim,
             inverse_sht=None,
+            time_embed_dim=self.time_embed_dim,
         )

--- a/fme/ace/registry/swin_transformer.py
+++ b/fme/ace/registry/swin_transformer.py
@@ -85,6 +85,9 @@ class SwinTransformerBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         n_labels = len(dataset_info.all_labels)
         context_config = ContextConfig(
@@ -183,6 +186,9 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         n_labels = len(dataset_info.all_labels)
         label_embed_dim = self.label_embed_dim

--- a/fme/ace/registry/swin_transformer.py
+++ b/fme/ace/registry/swin_transformer.py
@@ -9,6 +9,7 @@ from fme.core.dataset_info import DatasetInfo, MissingDatasetInfo
 from fme.core.models.conditional_sfno.layers import Context, ContextConfig
 from fme.core.models.swin_transformer import SwinTransformerNet
 from fme.core.models.swin_transformer.boundary_padding import TensorPaddingConfig
+from fme.core.stacker import ColumnLayout, infer_column_layout
 
 
 class _ContextWrappedModule(nn.Module):
@@ -33,6 +34,34 @@ class _ContextWrappedModule(nn.Module):
             noise=None,
         )
         return self.module(x, context)
+
+
+def _resolve_column_layouts(
+    cross_level_attention: bool,
+    in_names: list[str] | None,
+    out_names: list[str] | None,
+) -> tuple[ColumnLayout | None, ColumnLayout | None]:
+    """Infer the vertical layout of the input and output channels.
+
+    Returns ``(None, None)`` when cross-level attention is disabled, leaving
+    the network as a plain 2D model with levels stacked into channels.
+    """
+    if not cross_level_attention:
+        return None, None
+    if in_names is None or out_names is None:
+        raise ValueError(
+            "cross_level_attention requires channel names, which the caller did "
+            "not provide. This step type does not support cross-level attention."
+        )
+    in_layout = infer_column_layout(in_names)
+    out_layout = infer_column_layout(out_names)
+    if in_layout is None or out_layout is None:
+        raise ValueError(
+            "cross_level_attention requires vertically resolved variables "
+            "(names ending in _<level>) among both the input and output "
+            "channels, but found none."
+        )
+    return in_layout, out_layout
 
 
 @ModuleSelector.register("SwinTransformer")
@@ -61,6 +90,14 @@ class SwinTransformerBuilder(ModuleConfig):
             and applies cos-lat scaling to CPB longitude offsets. Set to False
             to use plain log-spaced CPB offsets (Swin V2 style) without a
             latitude requirement.
+        cross_level_attention: When True, vertically resolved variables (names
+            ending in ``_<level>``) are embedded per level rather than stacked
+            into channels, and each block attends along the vertical axis,
+            matching ArchesWeather's ``axis_attn``. Surface fields become one
+            additional token in that axis. This multiplies the number of latent
+            tokens by ``n_levels + 1``, so ``embed_dim`` should be reduced to
+            keep the cost comparable.
+        column_num_heads: Number of attention heads for cross-level attention.
     """
 
     embed_dim: int = 96
@@ -75,6 +112,8 @@ class SwinTransformerBuilder(ModuleConfig):
     cpb_hidden_dim: int = 64
     padding_conf: TensorPaddingConfig | None = None
     use_cpb_scaling: bool = True
+    cross_level_attention: bool = False
+    column_num_heads: int = 8
 
     def __post_init__(self):
         if isinstance(self.padding_conf, dict):
@@ -112,6 +151,9 @@ class SwinTransformerBuilder(ModuleConfig):
             if self.padding_conf is not None
             else None
         )
+        in_layout, out_layout = _resolve_column_layouts(
+            self.cross_level_attention, in_names, out_names
+        )
         net = SwinTransformerNet(
             in_chans=n_in_channels,
             out_chans=n_out_channels,
@@ -128,6 +170,9 @@ class SwinTransformerBuilder(ModuleConfig):
             cpb_hidden_dim=self.cpb_hidden_dim,
             lat_coords=lat_coords,
             padding_conf=padding_conf,
+            in_layout=in_layout,
+            out_layout=out_layout,
+            column_num_heads=self.column_num_heads,
         )
         return _ContextWrappedModule(net)
 
@@ -161,6 +206,14 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
             and applies cos-lat scaling to CPB longitude offsets. Set to False
             to use plain log-spaced CPB offsets (Swin V2 style) without a
             latitude requirement.
+        cross_level_attention: When True, vertically resolved variables (names
+            ending in ``_<level>``) are embedded per level rather than stacked
+            into channels, and each block attends along the vertical axis,
+            matching ArchesWeather's ``axis_attn``. Surface fields become one
+            additional token in that axis. This multiplies the number of latent
+            tokens by ``n_levels + 1``, so ``embed_dim`` should be reduced to
+            keep the cost comparable.
+        column_num_heads: Number of attention heads for cross-level attention.
     """
 
     embed_dim: int = 96
@@ -176,6 +229,8 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
     cpb_hidden_dim: int = 64
     padding_conf: TensorPaddingConfig | None = None
     use_cpb_scaling: bool = True
+    cross_level_attention: bool = False
+    column_num_heads: int = 8
 
     def __post_init__(self):
         if isinstance(self.padding_conf, dict):
@@ -215,6 +270,9 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
             if self.padding_conf is not None
             else None
         )
+        in_layout, out_layout = _resolve_column_layouts(
+            self.cross_level_attention, in_names, out_names
+        )
         net = SwinTransformerNet(
             in_chans=n_in_channels,
             out_chans=n_out_channels,
@@ -232,6 +290,9 @@ class NoiseConditionedSwinTransformerBuilder(ModuleConfig):
             cpb_hidden_dim=self.cpb_hidden_dim,
             lat_coords=lat_coords,
             padding_conf=padding_conf,
+            in_layout=in_layout,
+            out_layout=out_layout,
+            column_num_heads=self.column_num_heads,
         )
         return NoiseConditionedModel(
             net,

--- a/fme/ace/registry/test_swin_transformer.py
+++ b/fme/ace/registry/test_swin_transformer.py
@@ -302,3 +302,61 @@ def test_nc_swin_transformer_no_cpb_scaling_builds_without_lat_coords():
     )
     x = torch.randn(2, n_in, *IMG_SHAPE, device=fme.get_device())
     assert module(x).shape == (2, n_out, *IMG_SHAPE)
+
+
+_COLUMN_IN = ["land_fraction", "DSWRFtoa"] + [
+    f"{prefix}_{level}" for prefix in ["t", "q"] for level in range(4)
+]
+_COLUMN_OUT = [f"{prefix}_{level}" for prefix in ["t", "q"] for level in range(4)] + [
+    "PRATEsfc"
+]
+
+
+def test_cross_level_attention_builds_a_vertical_axis():
+    """The builder must actually give the net a level axis to attend over."""
+    module = _nc_builder(cross_level_attention=True).build(
+        n_in_channels=len(_COLUMN_IN),
+        n_out_channels=len(_COLUMN_OUT),
+        dataset_info=_get_dataset_info(),
+        in_names=_COLUMN_IN,
+        out_names=_COLUMN_OUT,
+    )
+    assert isinstance(module, NoiseConditionedModel)
+    # 4 levels plus the surface token.
+    assert module.conditional_model.n_tokens == 5
+    out = module(torch.randn(2, len(_COLUMN_IN), *IMG_SHAPE, device=fme.get_device()))
+    assert out.shape == (2, len(_COLUMN_OUT), *IMG_SHAPE)
+
+
+def test_without_cross_level_attention_net_stays_flat():
+    module = _nc_builder(cross_level_attention=False).build(
+        n_in_channels=len(_COLUMN_IN),
+        n_out_channels=len(_COLUMN_OUT),
+        dataset_info=_get_dataset_info(),
+        in_names=_COLUMN_IN,
+        out_names=_COLUMN_OUT,
+    )
+    assert isinstance(module, NoiseConditionedModel)
+    assert module.conditional_model.n_tokens == 1
+
+
+def test_cross_level_attention_without_names_raises():
+    """A step type that cannot supply names must fail loudly, not silently."""
+    with pytest.raises(ValueError, match="did not provide"):
+        _nc_builder(cross_level_attention=True).build(
+            n_in_channels=len(_COLUMN_IN),
+            n_out_channels=len(_COLUMN_OUT),
+            dataset_info=_get_dataset_info(),
+        )
+
+
+def test_cross_level_attention_without_levels_raises():
+    flat = ["land_fraction", "DSWRFtoa"]
+    with pytest.raises(ValueError, match="vertically resolved"):
+        _nc_builder(cross_level_attention=True).build(
+            n_in_channels=len(flat),
+            n_out_channels=len(flat),
+            dataset_info=_get_dataset_info(),
+            in_names=flat,
+            out_names=flat,
+        )

--- a/fme/ace/registry/test_swin_transformer.py
+++ b/fme/ace/registry/test_swin_transformer.py
@@ -360,3 +360,26 @@ def test_cross_level_attention_without_levels_raises():
             in_names=flat,
             out_names=flat,
         )
+
+
+def test_time_embed_dim_requires_time_fraction():
+    """Calendar conditioning must be live, and must fail loudly when unfed."""
+    n_in, n_out = 5, 3
+    module = _nc_builder(time_embed_dim=8).build(
+        n_in_channels=n_in, n_out_channels=n_out, dataset_info=_get_dataset_info()
+    )
+    assert isinstance(module, NoiseConditionedModel)
+    assert module.time_embedder is not None
+    x = torch.randn(2, n_in, *IMG_SHAPE, device=fme.get_device())
+    with pytest.raises(ValueError, match="time_fraction is required"):
+        module(x)
+    out = module(x, time_fraction=torch.rand(2, device=fme.get_device()))
+    assert out.shape == (2, n_out, *IMG_SHAPE)
+
+
+def test_no_time_embed_dim_leaves_conditioning_absent():
+    module = _nc_builder().build(
+        n_in_channels=5, n_out_channels=3, dataset_info=_get_dataset_info()
+    )
+    assert isinstance(module, NoiseConditionedModel)
+    assert module.time_embedder is None

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -24,6 +24,7 @@ from fme.ace.stepper.parameter_init import (
     WeightsAndHistoryLoader,
     null_weights_and_history,
 )
+from fme.ace.stepper.time_fraction import compute_time_fraction
 from fme.ace.stepper.time_length_probabilities import TimeLength, TimeLengthSchedule
 from fme.core.coordinates import SerializableVerticalCoordinate, VerticalCoordinate
 from fme.core.corrector.atmosphere import AtmosphereCorrectorConfig
@@ -1115,6 +1116,7 @@ class Stepper:
             forcing_data.labels,
             data_mask=forcing_data.data_mask,
             stepper_state=ic_batch_data.stepper_state,
+            time=forcing_data.time,
         )
 
     @property
@@ -1130,7 +1132,18 @@ class Stepper:
         labels: BatchLabels | None,
         data_mask: TensorMapping | None = None,
         stepper_state: StepperState | None = None,
+        time: xr.DataArray | None = None,
     ) -> Generator[StepOutput, None, None]:
+        if self._step_obj.requires_time_fraction:
+            if time is None:
+                raise ValueError(
+                    "This step conditions on the time of year, but no times "
+                    "were provided to predict_generator."
+                )
+        else:
+            # Deriving the calendar position requires real cftime data, so
+            # skip it entirely unless a module asked for it.
+            time = None
         state = {k: ic_dict[k].squeeze(self.TIME_DIM) for k in ic_dict}
         for step in range(n_forward_steps):
             input_forcing = {
@@ -1146,6 +1159,12 @@ class Stepper:
                 for k in self._step_obj.next_step_input_names
             }
             input_data = {**state, **input_forcing}
+            # Taken at the output timestep, consistent with next-step forcings
+            # such as insolation, so that all seasonal signals in a given
+            # forward pass describe the same interval.
+            time_fraction = (
+                None if time is None else compute_time_fraction(time[:, step + 1])
+            )
 
             def checkpoint(module):
                 return optimizer.checkpoint(module, step=step)
@@ -1158,6 +1177,7 @@ class Stepper:
                         labels=labels,
                         data_mask=data_mask,
                         stepper_state=stepper_state,
+                        time_fraction=time_fraction,
                     ),
                     wrapper=checkpoint,
                 )
@@ -1697,6 +1717,7 @@ class TrainStepper(
             labels=input_ensemble_data.labels,
             data_mask=forcing_ensemble_data.data_mask,
             stepper_state=input_ensemble_data.stepper_state,
+            time=forcing_ensemble_data.time,
         )
         output_list: list[EnsembleTensorDict] = []
         output_iterator = iter(output_generator)

--- a/fme/ace/stepper/test_time_fraction.py
+++ b/fme/ace/stepper/test_time_fraction.py
@@ -1,0 +1,67 @@
+import cftime
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from fme.ace.stepper.time_fraction import compute_time_fraction
+
+
+def _times(dates, calendar="noleap"):
+    ctor = {
+        "noleap": cftime.DatetimeNoLeap,
+        "360_day": cftime.Datetime360Day,
+        "proleptic_gregorian": cftime.DatetimeProlepticGregorian,
+    }[calendar]
+    return xr.DataArray(np.array([ctor(*date) for date in dates]), dims=["sample"])
+
+
+def test_january_first_is_zero():
+    result = compute_time_fraction(_times([(2000, 1, 1)]))
+    torch.testing.assert_close(result, torch.zeros(1), atol=1e-6, rtol=0)
+
+
+def test_fraction_is_in_unit_interval_across_the_year():
+    dates = [(2000, month, 15) for month in range(1, 13)]
+    result = compute_time_fraction(_times(dates))
+    assert torch.all(result >= 0.0)
+    assert torch.all(result < 1.0)
+    # Monotonic within a single year.
+    assert torch.all(result[1:] > result[:-1])
+
+
+def test_midyear_is_about_one_half():
+    """Day 183 of a 365-day calendar is roughly halfway through the year."""
+    result = compute_time_fraction(_times([(2000, 7, 2)]))
+    assert 0.49 < float(result[0]) < 0.51
+
+
+def test_same_day_in_different_years_matches():
+    """The value must depend only on position within the year."""
+    result = compute_time_fraction(_times([(1985, 3, 21), (2011, 3, 21)]))
+    torch.testing.assert_close(result[0], result[1], atol=1e-3, rtol=0)
+
+
+def test_360_day_calendar_uses_its_own_year_length():
+    """Day 180 of a 360-day year is exactly halfway."""
+    result = compute_time_fraction(_times([(2000, 7, 1)], calendar="360_day"))
+    torch.testing.assert_close(result, torch.tensor([0.5]), atol=1e-6, rtol=0)
+
+
+def test_calendars_disagree_on_the_same_date():
+    """A 360-day year and a 365-day year place the same date differently."""
+    noleap = compute_time_fraction(_times([(2000, 7, 1)]))
+    day360 = compute_time_fraction(_times([(2000, 7, 1)], calendar="360_day"))
+    assert abs(float(noleap[0]) - float(day360[0])) > 1e-3
+
+
+def test_non_cftime_input_raises():
+    """Integer times cannot carry calendar information, so fail loudly."""
+    times = xr.DataArray(np.arange(4), dims=["sample"])
+    with pytest.raises(TypeError, match="cftime"):
+        compute_time_fraction(times)
+
+
+def test_batch_shape_is_preserved():
+    dates = [(2000, 1, 1), (2000, 4, 1), (2000, 8, 1), (2000, 12, 1)]
+    assert compute_time_fraction(_times(dates)).shape == (4,)

--- a/fme/ace/stepper/time_fraction.py
+++ b/fme/ace/stepper/time_fraction.py
@@ -1,0 +1,44 @@
+"""Calendar position of a timestep, for time-of-year conditioning."""
+
+import cftime
+import numpy as np
+import torch
+import xarray as xr
+
+from fme.ace.stepper.insolation.cm4 import CFTIME_TYPES, LENGTH_OF_YEAR
+from fme.core.device import get_device
+
+_YEAR_START = (1, 1, 1)
+
+
+def compute_time_fraction(
+    time: xr.DataArray, dtype: torch.dtype = torch.float32
+) -> torch.Tensor:
+    """Position within the calendar year, as a fraction in [0, 1).
+
+    Calendar-aware: the year length is taken from the calendar of the data, so
+    ``noleap`` and ``360_day`` datasets are handled correctly.
+
+    Args:
+        time: Times for a single timestep, of shape [n_batch].
+        dtype: Floating point type of the result.
+
+    Returns:
+        A [n_batch] tensor on the current device.
+    """
+    values = np.asarray(time.values if isinstance(time, xr.DataArray) else time)
+    first = values.ravel()[0]
+    if not isinstance(first, cftime.datetime):
+        raise TypeError(
+            f"Expected cftime datetimes to derive the time of year, got {type(first)}."
+        )
+    calendar = first.calendar
+    if calendar not in CFTIME_TYPES:
+        raise ValueError(
+            f"Unsupported calendar {calendar!r}, expected one of "
+            f"{sorted(CFTIME_TYPES)}."
+        )
+    year_start = CFTIME_TYPES[calendar](*_YEAR_START)
+    fraction = (values - year_start) / LENGTH_OF_YEAR[calendar]
+    fraction = (fraction - np.floor(fraction)).astype(np.float64)
+    return torch.as_tensor(fraction, device=get_device(), dtype=dtype)

--- a/fme/core/models/mlp/mlp.py
+++ b/fme/core/models/mlp/mlp.py
@@ -26,6 +26,9 @@ class MLPConfig(ModuleConfig):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,  # Not needed for MLP
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         """Build the MLP network."""
         return _build_mlp(

--- a/fme/core/models/swin_transformer/swin_layers.py
+++ b/fme/core/models/swin_transformer/swin_layers.py
@@ -212,10 +212,10 @@ class WindowAttention2D(nn.Module):
 class ColumnMixer(nn.Module):
     """Pointwise ``Linear(dim, dim)`` applied at every spatial location.
 
-    The 2D equivalent of ArchesWeather's cross-level attention (``axis_attn``).
-    It has no normalization and no residual of its own; its output is folded
-    into the window-attention output before the gated shortcut (see
-    ``SwinTransformerBlock``).
+    Used when the latent has no vertical axis, in which case there is no
+    column to attend over. It has no normalization and no residual of its
+    own; its output is folded into the window-attention output before the
+    gated shortcut (see ``SwinTransformerBlock``).
     """
 
     def __init__(self, dim: int):
@@ -224,6 +224,70 @@ class ColumnMixer(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fc(x)
+
+
+class CrossLevelAttention(nn.Module):
+    """Multi-head self-attention along the vertical axis of each column.
+
+    ArchesWeather's ``axis_attn``: at every spatial location the ``n_levels``
+    latent levels attend to each other, independently of all other locations.
+    Because window attention uses a vertical window of 1, this is the only
+    path through which levels interact.
+
+    Input and output are ``(B * n_levels, H, W, C)`` — the vertical axis is
+    folded into the leading dimension so that the surrounding 2D machinery
+    (window partitioning, patch merging, ``ConditionalLayerNorm``) is
+    unaffected. This module unfolds it, attends, and folds it back.
+
+    A learned per-level positional embedding is added before attention,
+    matching ArchesWeather's ``AxialPositionalEmbedding``.
+
+    Args:
+        dim: Number of channels.
+        n_levels: Size of the vertical axis (levels plus the surface token).
+        num_heads: Number of attention heads. Must divide ``dim``.
+        qkv_bias: Whether to add a learnable bias to query/key/value.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_levels: int,
+        num_heads: int = 8,
+        qkv_bias: bool = True,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError(
+                f"dim ({dim}) must be divisible by num_heads ({num_heads})"
+            )
+        self.dim = dim
+        self.n_levels = n_levels
+        self.num_heads = num_heads
+        self.scale = (dim // num_heads) ** -0.5
+        self.pos_embed = nn.Parameter(torch.zeros(n_levels, dim))
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        BZ, H, W, C = x.shape
+        Z = self.n_levels
+        B = BZ // Z
+        # (B*Z, H, W, C) -> (B*H*W, Z, C): one sequence per column.
+        x = x.view(B, Z, H * W, C).transpose(1, 2).reshape(B * H * W, Z, C)
+        x = x + self.pos_embed
+        qkv = (
+            self.qkv(x)
+            .reshape(B * H * W, Z, 3, self.num_heads, C // self.num_heads)
+            .permute(2, 0, 3, 1, 4)
+        )
+        q, k, v = qkv[0], qkv[1], qkv[2]
+        attn = (q * self.scale) @ k.transpose(-2, -1)
+        attn = attn.softmax(dim=-1)
+        x = (attn @ v).transpose(1, 2).reshape(B * H * W, Z, C)
+        x = self.proj(x)
+        return x.view(B, H * W, Z, C).transpose(1, 2).reshape(BZ, H, W, C)
 
 
 class ChannelMixer(nn.Module):
@@ -335,6 +399,10 @@ class SwinTransformerBlock(nn.Module):
             ``ConditionalLayerNorm``-based noise conditioning.
         context_config: Required when ``conditioning="cln"``; passed to each
             ``ConditionalLayerNorm``.
+        n_levels: Size of the vertical axis folded into the batch dimension.
+            When greater than 1, cross-level attention replaces the pointwise
+            ``ColumnMixer``, giving levels a genuine attention path.
+        column_num_heads: Number of heads for cross-level attention.
     """
 
     def __init__(
@@ -352,6 +420,8 @@ class SwinTransformerBlock(nn.Module):
         context_config: ContextConfig | None = None,
         cpb_hidden_dim: int = 64,
         lat_coords: torch.Tensor | None = None,
+        n_levels: int = 1,
+        column_num_heads: int = 8,
     ):
         super().__init__()
         self.dim = dim
@@ -380,7 +450,13 @@ class SwinTransformerBlock(nn.Module):
             cpb_hidden_dim=cpb_hidden_dim,
             qkv_bias=qkv_bias,
         )
-        self.column_mixer = ColumnMixer(dim)
+        self.column_mixer: nn.Module = (
+            CrossLevelAttention(
+                dim, n_levels=n_levels, num_heads=column_num_heads, qkv_bias=qkv_bias
+            )
+            if n_levels > 1
+            else ColumnMixer(dim)
+        )
         self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         self.mlp = _build_mlp(mlp_layer, dim, int(dim * mlp_ratio))
 
@@ -564,6 +640,9 @@ class BasicLayer(nn.Module):
         conditioning: ``"adaln"`` (default) or ``"cln"``.
         context_config: Required when ``conditioning="cln"``; forwarded to each
             block's ``ConditionalLayerNorm``.
+        n_levels: Size of the vertical axis folded into the batch dimension;
+            greater than 1 enables cross-level attention in each block.
+        column_num_heads: Number of heads for cross-level attention.
     """
 
     def __init__(
@@ -582,6 +661,8 @@ class BasicLayer(nn.Module):
         context_config: ContextConfig | None = None,
         cpb_hidden_dim: int = 64,
         lat_coords: torch.Tensor | None = None,
+        n_levels: int = 1,
+        column_num_heads: int = 8,
     ):
         super().__init__()
         if len(drop_path) != depth:
@@ -605,6 +686,8 @@ class BasicLayer(nn.Module):
                     context_config=context_config,
                     cpb_hidden_dim=cpb_hidden_dim,
                     lat_coords=lat_coords,
+                    n_levels=n_levels,
+                    column_num_heads=column_num_heads,
                 )
                 for i in range(depth)
             ]

--- a/fme/core/models/swin_transformer/swin_transformer.py
+++ b/fme/core/models/swin_transformer/swin_transformer.py
@@ -33,11 +33,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""A 2D Swin U-Net backbone for ACE.
+"""A Swin U-Net backbone for ACE.
 
-This is a 2D adaptation of ArchesWeather's 3D Swin U-Net to ACE's
-``(B, C, H, W)`` interface, where all vertical levels are stacked into the
-channel dimension.
+An adaptation of ArchesWeather's 3D Swin U-Net to ACE's ``(B, C, H, W)``
+interface. By default all vertical levels are stacked into the channel
+dimension, giving a purely 2D network. When a ``ColumnLayout`` is supplied,
+levels are instead embedded individually and carried as a separate axis
+folded into the batch dimension, so that each block can attend along the
+vertical (see ``CrossLevelAttention``); window attention is unaffected either
+way, matching ArchesWeather's vertical window size of 1.
 """
 
 import dataclasses
@@ -50,6 +54,7 @@ import torch.nn.functional as F
 
 from fme.core.models.conditional_sfno.layers import Context, ContextConfig
 from fme.core.models.swin_transformer.boundary_padding import TensorPadding
+from fme.core.stacker import ColumnLayout
 
 from .swin_layers import BasicLayer, ChannelMixer, PatchExpanding, PatchMerging
 
@@ -79,10 +84,18 @@ class SwinTransformerNet(nn.Module):
             scalar and label conditioning are applied as independent additive
             AdaLN projections; ``None`` (or both 0) disables AdaLN.  In
             ``"cln"`` mode, ``embed_dim_noise`` drives per-block
-            ``ConditionalLayerNorm``; ``embed_dim_scalar`` must be 0.
+            ``ConditionalLayerNorm``, and a non-zero ``embed_dim_scalar``
+            additionally conditions those norms on a scalar embedding.
         mlp_layer: ``"mlp"`` or ``"swiglu"``.
         conditioning: ``"adaln"`` (default) for native per-stage DiT AdaLN, or
             ``"cln"`` for ``ConditionalLayerNorm``-based noise conditioning.
+        in_layout: Vertical layout of the input channels. When given (together
+            with ``out_layout``), levels are embedded individually and each
+            block attends along the vertical axis. When ``None``, levels stay
+            stacked in the channel dimension and the network is purely 2D.
+        out_layout: Vertical layout of the output channels. Must have the same
+            number of levels as ``in_layout``.
+        column_num_heads: Number of heads for cross-level attention.
     """
 
     def __init__(
@@ -103,6 +116,9 @@ class SwinTransformerNet(nn.Module):
         cpb_hidden_dim: int = 64,
         lat_coords: torch.Tensor | None = None,
         padding_conf: dict | None = None,
+        in_layout: ColumnLayout | None = None,
+        out_layout: ColumnLayout | None = None,
+        column_num_heads: int = 8,
     ):
         super().__init__()
         if depth_multiplier < 1:
@@ -113,6 +129,24 @@ class SwinTransformerNet(nn.Module):
         self.use_skip = use_skip
         self.window_size = window_size
         self.conditioning = conditioning
+        self.in_layout = in_layout
+        self.out_layout = out_layout
+        if (in_layout is None) != (out_layout is None):
+            raise ValueError(
+                "in_layout and out_layout must both be provided or both be None"
+            )
+        if in_layout is not None and out_layout is not None:
+            if in_layout.n_levels != out_layout.n_levels:
+                raise ValueError(
+                    "Input and output must have the same number of levels, got "
+                    f"{in_layout.n_levels} and {out_layout.n_levels}"
+                )
+            # The surface fields are projected to a single extra token that
+            # participates in cross-level attention alongside the levels,
+            # matching ArchesWeather's encoder.
+            self.n_tokens = in_layout.n_levels + 1
+        else:
+            self.n_tokens = 1
 
         ws_h, ws_w = window_size
         self.pad_mult = (ws_h * 2, ws_w * 2)
@@ -163,7 +197,27 @@ class SwinTransformerNet(nn.Module):
         else:
             lat_full = lat_half = None
 
-        self.encoder = nn.Conv2d(in_chans, embed_dim, kernel_size=3, padding=1)
+        if in_layout is not None and out_layout is not None:
+            # Separate stems keep vertical identity: every level of the input
+            # column is embedded by the same weights (so the level axis is
+            # meaningful), while surface fields get their own projection and
+            # become one extra token.
+            self.level_encoder: nn.Module = nn.Conv2d(
+                in_layout.n_vars, embed_dim, kernel_size=3, padding=1
+            )
+            self.surface_encoder: nn.Module = nn.Conv2d(
+                len(in_layout.surface_indices), embed_dim, kernel_size=3, padding=1
+            )
+            self.level_decoder: nn.Module = nn.Conv2d(
+                embed_dim, out_layout.n_vars, kernel_size=3, padding=1
+            )
+            self.surface_decoder: nn.Module = nn.Conv2d(
+                embed_dim, len(out_layout.surface_indices), kernel_size=3, padding=1
+            )
+            self.encoder = nn.Identity()
+            self.decoder: nn.Module = nn.Identity()
+        else:
+            self.encoder = nn.Conv2d(in_chans, embed_dim, kernel_size=3, padding=1)
         self.channel_mixer = ChannelMixer(embed_dim)
 
         d = depth_multiplier
@@ -190,6 +244,8 @@ class SwinTransformerNet(nn.Module):
             context_config=context_config,
             cpb_hidden_dim=cpb_hidden_dim,
             lat_coords=lat_full,
+            n_levels=self.n_tokens,
+            column_num_heads=column_num_heads,
         )
         self.downsample = PatchMerging(embed_dim)
         self.layer2 = BasicLayer(
@@ -207,6 +263,8 @@ class SwinTransformerNet(nn.Module):
             context_config=context_config,
             cpb_hidden_dim=cpb_hidden_dim,
             lat_coords=lat_half,
+            n_levels=self.n_tokens,
+            column_num_heads=column_num_heads,
         )
         self.layer3 = BasicLayer(
             2 * embed_dim,
@@ -223,6 +281,8 @@ class SwinTransformerNet(nn.Module):
             context_config=context_config,
             cpb_hidden_dim=cpb_hidden_dim,
             lat_coords=lat_half,
+            n_levels=self.n_tokens,
+            column_num_heads=column_num_heads,
         )
         self.upsample = PatchExpanding(2 * embed_dim)  # -> embed_dim, 2x spatial
 
@@ -242,9 +302,68 @@ class SwinTransformerNet(nn.Module):
             context_config=context_config,
             cpb_hidden_dim=cpb_hidden_dim,
             lat_coords=lat_full,
+            n_levels=self.n_tokens,
+            column_num_heads=column_num_heads,
         )
         self.final_linear = nn.Linear(decoder_dim, embed_dim, bias=False)
-        self.decoder = nn.Conv2d(embed_dim, out_chans, kernel_size=3, padding=1)
+        if in_layout is None:
+            self.decoder = nn.Conv2d(embed_dim, out_chans, kernel_size=3, padding=1)
+
+    def _repeat_over_tokens(self, x: torch.Tensor) -> torch.Tensor:
+        """Repeat a per-sample conditioning tensor across the vertical axis.
+
+        The latent folds the vertical axis into the batch dimension, so
+        conditioning defined per sample must be repeated to match. Uses
+        ``repeat_interleave`` so that the layout is sample-major, matching
+        ``_encode_columns``.
+        """
+        if self.n_tokens == 1:
+            return x
+        return x.repeat_interleave(self.n_tokens, dim=0)
+
+    def _encode_columns(self, x: torch.Tensor) -> torch.Tensor:
+        """Embed ``(B, C, H, W)`` into ``(B * n_tokens, embed_dim, H, W)``.
+
+        Levels are embedded by shared weights so that the vertical axis is
+        meaningful, and the surface fields become one additional token which
+        participates in cross-level attention alongside them.
+        """
+        assert self.in_layout is not None
+        layout = self.in_layout
+        B, _, H, W = x.shape
+        n_vars, n_levels = layout.n_vars, layout.n_levels
+        # (B, n_vars * n_levels, H, W) -> (B * n_levels, n_vars, H, W), so that
+        # each level is embedded independently by the same weights.
+        column = x[:, layout.start : layout.stop]
+        column = column.view(B, n_vars, n_levels, H, W).transpose(1, 2)
+        column = column.reshape(B * n_levels, n_vars, H, W)
+        column = self.level_encoder(column)  # (B * n_levels, embed_dim, H, W)
+        surface = x[:, list(layout.surface_indices)]
+        surface = self.surface_encoder(surface)  # (B, embed_dim, H, W)
+        # Concatenate along the level axis: surface first, matching
+        # ArchesWeather's ``cat([surface.unsqueeze(2), level], dim=2)``.
+        column = column.view(B, n_levels, -1, H, W)
+        tokens = torch.cat([surface.unsqueeze(1), column], dim=1)
+        return tokens.reshape(B * self.n_tokens, -1, H, W)
+
+    def _decode_columns(self, x: torch.Tensor, batch_size: int) -> torch.Tensor:
+        """Inverse of ``_encode_columns``, back to ``(B, out_chans, H, W)``."""
+        assert self.out_layout is not None
+        layout = self.out_layout
+        _, embed_dim, H, W = x.shape
+        n_vars, n_levels = layout.n_vars, layout.n_levels
+        tokens = x.view(batch_size, self.n_tokens, embed_dim, H, W)
+        surface = self.surface_decoder(tokens[:, 0])
+        column = tokens[:, 1:].reshape(batch_size * n_levels, embed_dim, H, W)
+        column = self.level_decoder(column)  # (B * n_levels, n_vars, H, W)
+        # (B * n_levels, n_vars, H, W) -> (B, n_vars * n_levels, H, W), undoing
+        # the level-major transpose applied when encoding.
+        column = column.view(batch_size, n_levels, n_vars, H, W).transpose(1, 2)
+        column = column.reshape(batch_size, n_vars * n_levels, H, W)
+        out = x.new_empty((batch_size, self.out_chans, H, W))
+        out[:, layout.start : layout.stop] = column
+        out[:, list(layout.surface_indices)] = surface
+        return out
 
     def forward(self, x: torch.Tensor, context: Context | None = None) -> torch.Tensor:
         if self.use_padding:
@@ -256,8 +375,12 @@ class SwinTransformerNet(nn.Module):
         if pad_h > 0 or pad_w > 0:
             x = F.pad(x, (0, pad_w, 0, pad_h))
 
-        x = self.encoder(x)  # (B, embed_dim, Hp, Wp)
-        x = x.permute(0, 2, 3, 1)  # (B, Hp, Wp, embed_dim)
+        batch_size = x.shape[0]
+        if self.in_layout is not None:
+            x = self._encode_columns(x)  # (B * n_tokens, embed_dim, Hp, Wp)
+        else:
+            x = self.encoder(x)  # (B, embed_dim, Hp, Wp)
+        x = x.permute(0, 2, 3, 1)  # (B[*Z], Hp, Wp, embed_dim)
         x = self.channel_mixer(x)
 
         # AdaLN conditioning: extract scalar/label embeddings from context.
@@ -273,9 +396,14 @@ class SwinTransformerNet(nn.Module):
             if self.embed_dim_scalar > 0:
                 if context.embedding_scalar is None:
                     raise ValueError("embedding_scalar is required")
-                cond_scalar = context.embedding_scalar
+                cond_scalar = self._repeat_over_tokens(context.embedding_scalar)
             if self.embed_dim_labels > 0:
-                cond_labels = context.labels  # may be None; BasicLayer skips when None
+                # May be None; BasicLayer skips the label path when it is.
+                cond_labels = (
+                    None
+                    if context.labels is None
+                    else self._repeat_over_tokens(context.labels)
+                )
 
         # CLN conditioning: pad and subsample noise to match U-Net resolutions.
         ctx_full: Context | None = context
@@ -290,9 +418,27 @@ class SwinTransformerNet(nn.Module):
                 noise = self.padding_opt.pad(noise)
             if pad_h > 0 or pad_w > 0:
                 noise = F.pad(noise, (0, pad_w, 0, pad_h))
+            # The latent carries the vertical axis in its batch dimension, so
+            # every per-sample conditioning tensor is shared across a sample's
+            # levels.
+            noise = self._repeat_over_tokens(noise)
             noise_half = noise[..., ::2, ::2]
-            ctx_full = dataclasses.replace(context, noise=noise)
-            ctx_half = dataclasses.replace(context, noise=noise_half)
+            scalar = (
+                None
+                if context.embedding_scalar is None
+                else self._repeat_over_tokens(context.embedding_scalar)
+            )
+            labels = (
+                None
+                if context.labels is None
+                else self._repeat_over_tokens(context.labels)
+            )
+            ctx_full = dataclasses.replace(
+                context, noise=noise, embedding_scalar=scalar, labels=labels
+            )
+            ctx_half = dataclasses.replace(
+                context, noise=noise_half, embedding_scalar=scalar, labels=labels
+            )
 
         x = self.layer1(x, cond_scalar, cond_labels, context=ctx_full)
         skip = x
@@ -304,9 +450,12 @@ class SwinTransformerNet(nn.Module):
             x = torch.cat([x, skip], dim=-1)
         x = self.layer4(x, cond_scalar, cond_labels, context=ctx_full)
 
-        x = self.final_linear(x)  # (B, Hp, Wp, embed_dim)
-        x = x.permute(0, 3, 1, 2)  # (B, embed_dim, Hp, Wp)
-        x = self.decoder(x)  # (B, out_chans, Hp, Wp)
+        x = self.final_linear(x)  # (B[*Z], Hp, Wp, embed_dim)
+        x = x.permute(0, 3, 1, 2)  # (B[*Z], embed_dim, Hp, Wp)
+        if self.out_layout is not None:
+            x = self._decode_columns(x, batch_size)  # (B, out_chans, Hp, Wp)
+        else:
+            x = self.decoder(x)  # (B, out_chans, Hp, Wp)
         x = x[..., :H, :W]
         if self.use_padding:
             x = self.padding_opt.unpad(x)

--- a/fme/core/models/swin_transformer/test_cross_level.py
+++ b/fme/core/models/swin_transformer/test_cross_level.py
@@ -1,0 +1,182 @@
+import pytest
+import torch
+
+from fme.core.models.conditional_sfno.layers import Context, ContextConfig
+from fme.core.stacker import infer_column_layout
+
+from .swin_layers import CrossLevelAttention
+from .swin_transformer import SwinTransformerNet
+
+_COLUMN = [f"{p}_{lvl}" for p in ["t", "q"] for lvl in range(4)]
+_NAMES_IN = ["land_fraction", "DSWRFtoa"] + _COLUMN + ["co2"]
+_NAMES_OUT = ["PRESsfc"] + _COLUMN + ["PRATEsfc", "h500"]
+
+
+def _build(**kwargs) -> SwinTransformerNet:
+    defaults = dict(
+        in_chans=len(_NAMES_IN),
+        out_chans=len(_NAMES_OUT),
+        img_shape=(16, 32),
+        embed_dim=16,
+        depth_multiplier=1,
+        num_heads=(2, 2, 2, 2),
+        window_size=(4, 8),
+        in_layout=infer_column_layout(_NAMES_IN),
+        out_layout=infer_column_layout(_NAMES_OUT),
+        column_num_heads=2,
+    )
+    defaults.update(kwargs)
+    return SwinTransformerNet(**defaults)  # type: ignore[arg-type]
+
+
+class _PadToWidth(torch.nn.Module):
+    """Zero-pad the channel axis, preserving leading channel values."""
+
+    def __init__(self, width: int):
+        super().__init__()
+        self.width = width
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        pad = self.width - x.shape[1]
+        return torch.nn.functional.pad(x, (0, 0, 0, 0, 0, pad))
+
+
+class _TakeFirst(torch.nn.Module):
+    """Slice the leading channels, the inverse of ``_PadToWidth``."""
+
+    def __init__(self, width: int):
+        super().__init__()
+        self.width = width
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x[:, : self.width]
+
+
+def test_column_encode_decode_roundtrip_preserves_channel_positions():
+    """Channels must land back in the positions the packer expects."""
+    net = _build()
+    layout_in = net.in_layout
+    layout_out = net.out_layout
+    assert layout_in is not None and layout_out is not None
+    # Transparent stems let us follow a channel through the fold and back.
+    embed_dim = 16
+    net.level_encoder = _PadToWidth(embed_dim)
+    net.surface_encoder = _PadToWidth(embed_dim)
+    net.level_decoder = _TakeFirst(layout_out.n_vars)
+    net.surface_decoder = _TakeFirst(len(layout_out.surface_indices))
+
+    # Mark each input channel with its own index so we can see where it goes.
+    x = torch.arange(len(_NAMES_IN), dtype=torch.float32)
+    x = x.view(1, -1, 1, 1).expand(1, len(_NAMES_IN), 16, 32).contiguous()
+    tokens = net._encode_columns(x)
+    assert tokens.shape[0] == net.n_tokens  # batch of 1
+
+    # Token 0 is the surface projection, tokens 1.. are the levels in order.
+    surface = tokens[0, : len(layout_in.surface_indices), 0, 0]
+    assert surface.tolist() == [float(i) for i in layout_in.surface_indices]
+    for level in range(layout_in.n_levels):
+        expected = [
+            float(layout_in.start + var * layout_in.n_levels + level)
+            for var in range(layout_in.n_vars)
+        ]
+        assert tokens[1 + level, : layout_in.n_vars, 0, 0].tolist() == expected
+
+
+def test_column_decode_places_channels_at_output_indices():
+    net = _build()
+    layout_out = net.out_layout
+    assert layout_out is not None
+    net.level_decoder = _TakeFirst(layout_out.n_vars)
+    net.surface_decoder = _TakeFirst(len(layout_out.surface_indices))
+
+    # Give each token a distinct constant value.
+    tokens = torch.zeros(net.n_tokens, 16, 4, 8)
+    for token in range(net.n_tokens):
+        tokens[token] = float(token)
+    out = net._decode_columns(tokens, batch_size=1)
+
+    assert out.shape == (1, len(_NAMES_OUT), 4, 8)
+    # Surface channels come from token 0.
+    for index in layout_out.surface_indices:
+        assert torch.all(out[0, index] == 0.0)
+    # Level channels come from token 1 + level, regardless of variable.
+    for var in range(layout_out.n_vars):
+        for level in range(layout_out.n_levels):
+            index = layout_out.start + var * layout_out.n_levels + level
+            assert torch.all(out[0, index] == float(1 + level))
+
+
+def test_cross_level_attention_is_spatially_pointwise():
+    """Columns must not exchange information across space."""
+    torch.manual_seed(0)
+    attn = CrossLevelAttention(dim=8, n_levels=5, num_heads=2).eval()
+    x = torch.randn(2 * 5, 4, 6, 8)
+    with torch.no_grad():
+        base = attn(x)
+        perturbed = x.clone()
+        perturbed[:, 2:] += 10.0
+        after = attn(perturbed)
+    assert torch.allclose(base[:, :2], after[:, :2], atol=1e-6)
+
+
+def test_cross_level_attention_mixes_levels():
+    """A change at one level must reach the others in the same column."""
+    torch.manual_seed(0)
+    attn = CrossLevelAttention(dim=8, n_levels=5, num_heads=2).eval()
+    x = torch.randn(5, 2, 2, 8)  # batch of 1, 5 levels
+    with torch.no_grad():
+        base = attn(x)
+        perturbed = x.clone()
+        perturbed[0] += 10.0  # perturb level 0 only
+        after = attn(perturbed)
+    other_levels_changed = (after[1:] - base[1:]).abs().max()
+    assert other_levels_changed > 1e-3
+
+
+def test_layout_must_be_given_for_both_or_neither():
+    with pytest.raises(ValueError, match="both be provided or both be None"):
+        _build(out_layout=None)
+
+
+def test_mismatched_level_counts_raise():
+    with pytest.raises(ValueError, match="same number of levels"):
+        _build(out_layout=infer_column_layout([f"t_{lvl}" for lvl in range(3)]))
+
+
+def test_forward_without_layout_keeps_flat_encoder():
+    """Absent a column layout the network stays a plain 2D model."""
+    net = SwinTransformerNet(
+        in_chans=len(_NAMES_IN),
+        out_chans=len(_NAMES_OUT),
+        img_shape=(16, 32),
+        embed_dim=16,
+        depth_multiplier=1,
+        num_heads=(2, 2, 2, 2),
+        window_size=(4, 8),
+    ).eval()
+    assert net.n_tokens == 1
+    with torch.no_grad():
+        out = net(torch.randn(2, len(_NAMES_IN), 16, 32))
+    assert out.shape == (2, len(_NAMES_OUT), 16, 32)
+
+
+def test_noise_conditioned_forward_shapes():
+    """Per-sample noise must broadcast over the folded vertical axis."""
+    net = _build(
+        conditioning="cln",
+        context_config=ContextConfig(
+            embed_dim_scalar=0,
+            embed_dim_labels=0,
+            embed_dim_noise=4,
+            embed_dim_pos=0,
+        ),
+    ).eval()
+    context = Context(
+        embedding_scalar=None,
+        embedding_pos=None,
+        labels=None,
+        noise=torch.randn(3, 4, 16, 32),
+    )
+    with torch.no_grad():
+        out = net(torch.randn(3, len(_NAMES_IN), 16, 32), context)
+    assert out.shape == (3, len(_NAMES_OUT), 16, 32)

--- a/fme/core/registry/module.py
+++ b/fme/core/registry/module.py
@@ -81,22 +81,45 @@ class Module:
         self._label_encoding = label_encoding
 
     def __call__(
-        self, input: torch.Tensor, labels: BatchLabels | None = None
+        self,
+        input: torch.Tensor,
+        labels: BatchLabels | None = None,
+        time_fraction: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if labels is not None and self._label_encoding is None:
             raise TypeError("Labels are not allowed for unconditional models")
+
+        # Only forward time_fraction when it is set: most modules take
+        # (input) or (input, labels) and would raise a TypeError on an
+        # unexpected keyword argument. Modules that require it raise
+        # themselves when it is absent.
+        extra: dict[str, Any] = {}
+        if time_fraction is not None:
+            extra["time_fraction"] = time_fraction
 
         if self._label_encoding is not None:
             if labels is None:
                 raise TypeError("Labels are required for conditional models")
             encoded_labels = labels.conform_to_encoding(self._label_encoding)
-            return self._module(input, labels=encoded_labels.tensor)
+            return self._module(input, labels=encoded_labels.tensor, **extra)
         else:
-            return self._module(input)
+            return self._module(input, **extra)
 
     @property
     def torch_module(self) -> nn.Module:
         return self._module
+
+    @property
+    def requires_time_fraction(self) -> bool:
+        """Whether the wrapped module conditions on the time of year.
+
+        Searches submodules because the model is wrapped for distributed
+        training before this is queried.
+        """
+        return any(
+            getattr(module, "time_embedder", None) is not None
+            for module in self._module.modules()
+        )
 
     def get_state(self) -> dict[str, Any]:
         if self._label_encoding is not None:

--- a/fme/core/registry/module.py
+++ b/fme/core/registry/module.py
@@ -31,6 +31,9 @@ class ModuleConfig(abc.ABC):
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> nn.Module:
         """
         Build a nn.Module given information about the input and output channels
@@ -41,6 +44,12 @@ class ModuleConfig(abc.ABC):
             n_out_channels: number of output channels
             dataset_info: Information about the dataset, including img_shape,
                 horizontal coordinates, vertical coordinate, etc.
+            in_names: ordered names of the input channels, matching the packing
+                order of the input tensor. Builders which need to know the
+                vertical structure of the input (e.g. to run attention over
+                pressure levels) can infer it from these names. May be None
+                when the caller does not track names.
+            out_names: ordered names of the output channels, as above.
 
         Returns:
             a nn.Module
@@ -176,6 +185,9 @@ class ModuleSelector:
         n_in_channels: int,
         n_out_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
+        out_names: list[str] | None = None,
     ) -> Module:
         """
         Build a nn.Module given information about the input and output channels
@@ -187,6 +199,9 @@ class ModuleSelector:
             dataset_info: Information about the dataset, including img_shape
                 (shape of last two dimensions of data, e.g. latitude and
                 longitude), horizontal coordinates, vertical coordinate, etc.
+            in_names: ordered names of the input channels, matching the packing
+                order of the input tensor.
+            out_names: ordered names of the output channels.
 
         Returns:
             a Module object
@@ -201,6 +216,8 @@ class ModuleSelector:
             n_in_channels=n_in_channels,
             n_out_channels=n_out_channels,
             dataset_info=dataset_info,
+            in_names=in_names,
+            out_names=out_names,
         )
         return Module(module, label_encoding)
 

--- a/fme/core/registry/test_module_registry.py
+++ b/fme/core/registry/test_module_registry.py
@@ -33,7 +33,15 @@ class MockModule(torch.nn.Module):
 class MockModuleBuilder(ModuleConfig):
     param_shapes: list[tuple[int, ...]]
 
-    def build(self, n_in_channels, n_out_channels, dataset_info):
+    def build(
+        self,
+        n_in_channels,
+        n_out_channels,
+        dataset_info,
+        *,
+        in_names=None,
+        out_names=None,
+    ):
         return MockModule(self.param_shapes)
 
     @classmethod
@@ -52,7 +60,15 @@ class MockModuleBuilderWithDefault(ModuleConfig):
     param_shapes: list[tuple[int, ...]]
     pad: str = "reflect"
 
-    def build(self, n_in_channels, n_out_channels, dataset_info):
+    def build(
+        self,
+        n_in_channels,
+        n_out_channels,
+        dataset_info,
+        *,
+        in_names=None,
+        out_names=None,
+    ):
         return MockModule(self.param_shapes)
 
 

--- a/fme/core/stacker.py
+++ b/fme/core/stacker.py
@@ -1,3 +1,4 @@
+import dataclasses
 import re
 from collections.abc import Iterable, Mapping
 
@@ -28,10 +29,115 @@ def unstack(tensor: torch.Tensor, names: list[str], dim: int = -1) -> TensorMapp
     return {name: tensor.squeeze(dim=dim) for name, tensor in zip(names, tensors)}
 
 
+LEVEL_PATTERN = re.compile(r"_(\d+)$")
+
+
+@dataclasses.dataclass(frozen=True)
+class ColumnLayout:
+    """Describes a contiguous block of channels forming a (variable, level) grid.
+
+    Channels named ``<prefix><level>`` (e.g. ``air_temperature_0``) are
+    interpreted as vertically resolved. This layout records where that block
+    sits within an ordered channel list, so a network can reshape those
+    channels into an explicit level axis and operate along it.
+
+    Attributes:
+        start: Index of the first vertically resolved channel.
+        prefixes: Level-resolved variable prefixes, in channel order.
+        n_levels: Number of levels each prefix has.
+        surface_indices: Indices of all channels outside the column block.
+    """
+
+    start: int
+    prefixes: tuple[str, ...]
+    n_levels: int
+    surface_indices: tuple[int, ...]
+
+    @property
+    def n_vars(self) -> int:
+        return len(self.prefixes)
+
+    @property
+    def n_column_channels(self) -> int:
+        return self.n_vars * self.n_levels
+
+    @property
+    def stop(self) -> int:
+        """Index one past the last vertically resolved channel."""
+        return self.start + self.n_column_channels
+
+
+def infer_column_layout(names: Iterable[str]) -> ColumnLayout | None:
+    """Infer the (variable, level) grid from an ordered list of channel names.
+
+    Names ending in ``_<int>`` are treated as levels of a shared prefix. To be
+    usable as a level axis the vertically resolved channels must form a single
+    contiguous, variable-major block in which every prefix has the same levels,
+    numbered ``0..n_levels-1`` in ascending order.
+
+    Args:
+        names: Channel names in packing order.
+
+    Returns:
+        The inferred layout, or None if no name is level-resolved.
+
+    Raises:
+        ValueError: If level-resolved names are present but do not form a
+            well-defined grid. Failing loudly here is deliberate: silently
+            attending over a subset of levels would be invisible at runtime.
+    """
+    names = list(names)
+    # Group level-resolved names by prefix, preserving first-appearance order.
+    levels_by_prefix: dict[str, list[tuple[int, int]]] = {}
+    for index, name in enumerate(names):
+        match = LEVEL_PATTERN.search(name)
+        if match is not None:
+            prefix = name[: match.start() + 1]
+            levels_by_prefix.setdefault(prefix, []).append((int(match.group(1)), index))
+    if not levels_by_prefix:
+        return None
+
+    prefixes = tuple(levels_by_prefix)
+    n_levels = len(levels_by_prefix[prefixes[0]])
+    for prefix, entries in levels_by_prefix.items():
+        if len(entries) != n_levels:
+            raise ValueError(
+                "Vertically resolved variables must all have the same number of "
+                f"levels, but {prefix!r} has {len(entries)} while "
+                f"{prefixes[0]!r} has {n_levels}."
+            )
+        found = sorted(level for level, _ in entries)
+        if found != list(range(n_levels)):
+            raise ValueError(
+                f"Levels of {prefix!r} must be numbered 0..{n_levels - 1} with no "
+                f"gaps or duplicates, got {found}."
+            )
+
+    # Require variable-major, level-ascending, contiguous ordering, since the
+    # network reshapes this block directly rather than gathering by index.
+    expected = [f"{prefix}{level}" for prefix in prefixes for level in range(n_levels)]
+    start = min(index for entries in levels_by_prefix.values() for _, index in entries)
+    stop = start + len(expected)
+    if names[start:stop] != expected:
+        raise ValueError(
+            "Vertically resolved channels must form a single contiguous block "
+            "ordered variable-major with levels ascending. Expected "
+            f"{expected} at positions {start}..{stop - 1}, got {names[start:stop]}."
+        )
+
+    surface_indices = tuple(i for i in range(len(names)) if not start <= i < stop)
+    return ColumnLayout(
+        start=start,
+        prefixes=prefixes,
+        n_levels=n_levels,
+        surface_indices=surface_indices,
+    )
+
+
 class Stacker:
     """Handles extraction and stacking of data tensors for 3D variables."""
 
-    LEVEL_PATTERN = re.compile(r"_(\d+)$")
+    LEVEL_PATTERN = LEVEL_PATTERN
 
     def __init__(
         self,

--- a/fme/core/step/args.py
+++ b/fme/core/step/args.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+import torch
+
 from fme.core.labels import BatchLabels
 from fme.core.stepper_state import StepperState
 from fme.core.typing_ import TensorMapping
@@ -26,6 +28,10 @@ class StepArgs:
             corrector references seeded from the IC). ``None`` if no state
             has been seeded yet. The step returns an updated stepper_state
             alongside its output dict.
+        time_fraction: Position within the calendar year of the output
+            timestep, as a [n_batch] tensor in [0, 1). Used by modules which
+            condition on the time of year. ``None`` when the step is not
+            time-conditioned.
     """
 
     def __init__(
@@ -35,12 +41,14 @@ class StepArgs:
         labels: BatchLabels | None = None,
         data_mask: TensorMapping | None = None,
         stepper_state: StepperState | None = None,
+        time_fraction: torch.Tensor | None = None,
     ):
         self.input = input
         self.next_step_input_data = next_step_input_data
         self.labels = labels
         self.data_mask = data_mask
         self.stepper_state = stepper_state
+        self.time_fraction = time_fraction
 
     def apply_input_process_func(
         self, func: Callable[[TensorMapping], TensorMapping]
@@ -53,4 +61,5 @@ class StepArgs:
             labels=self.labels,
             data_mask=self.data_mask,
             stepper_state=self.stepper_state,
+            time_fraction=self.time_fraction,
         )

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -301,6 +301,10 @@ class MultiCallStep(StepABC):
     def get_regularizer_loss(self) -> torch.Tensor:
         return self._wrapped_step.get_regularizer_loss()
 
+    @property
+    def requires_time_fraction(self) -> bool:
+        return self._wrapped_step.requires_time_fraction
+
     def train(self, mode: bool = True) -> StepABC:
         super().train(mode)
         self._wrapped_step.train(mode)

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -289,12 +289,16 @@ class SeparateRadiationStep(StepABC):
             n_in_channels=len(config.main_in_names),
             n_out_channels=len(config.main_out_names),
             dataset_info=dataset_info,
+            in_names=list(config.main_in_names),
+            out_names=list(config.main_out_names),
         )
         self.module = module.to(get_device())
         radiation_module = config.radiation_builder.build(
             n_in_channels=len(config.radiation_in_names),
             n_out_channels=len(config.radiation_out_names),
             dataset_info=dataset_info,
+            in_names=list(config.radiation_in_names),
+            out_names=list(config.radiation_out_names),
         )
         self.radiation_module = radiation_module.to(get_device())
         self._img_shape = dataset_info.img_shape

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -406,6 +406,18 @@ class SeparateRadiationStep(StepABC):
     def get_regularizer_loss(self) -> torch.Tensor:
         return torch.tensor(0.0)
 
+    @property
+    def requires_time_fraction(self) -> bool:
+        if self.module.requires_time_fraction or (
+            self.radiation_module.requires_time_fraction
+        ):
+            raise NotImplementedError(
+                "SeparateRadiationStep does not pass time_fraction to its "
+                "modules, so time-of-year conditioning is not supported here. "
+                "Use the single_module step type instead."
+            )
+        return False
+
     def train(self, mode: bool = True) -> StepABC:
         super().train(mode)
         self._corrector.train(mode)

--- a/fme/core/step/secondary_decoder.py
+++ b/fme/core/step/secondary_decoder.py
@@ -33,12 +33,15 @@ class SecondaryDecoderConfig:
         self,
         n_in_channels: int,
         dataset_info: DatasetInfo,
+        *,
+        in_names: list[str] | None = None,
     ) -> "SecondaryDecoder":
         return SecondaryDecoder(
             in_dim=n_in_channels,
             out_names=self.secondary_diagnostic_names,
             network=self.network,
             dataset_info=dataset_info,
+            in_names=in_names,
         )
 
 
@@ -58,6 +61,7 @@ class SecondaryDecoder:
         out_names: list[str],
         network: ModuleSelector,
         dataset_info: DatasetInfo,
+        in_names: list[str] | None = None,
     ):
         """
         Args:
@@ -67,12 +71,16 @@ class SecondaryDecoder:
             dataset_info: Information about the dataset, forwarded to the
                 underlying network builder. Some networks (e.g. MLP) ignore
                 this, while others (e.g. SFNO) require horizontal coordinates.
+            in_names: Ordered names of the input channels, which are the main
+                module's output names. Forwarded to the network builder.
         """
         out_dim = len(out_names)
         self._module: Module = network.build(
             n_in_channels=in_dim,
             n_out_channels=out_dim,
             dataset_info=dataset_info,
+            in_names=in_names,
+            out_names=list(out_names),
         )
         self._packer = Packer(out_names)
 

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -439,6 +439,18 @@ class SecondaryModuleStep(StepABC):
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
 
+    @property
+    def requires_time_fraction(self) -> bool:
+        if self.module.requires_time_fraction or (
+            self.secondary_module.requires_time_fraction
+        ):
+            raise NotImplementedError(
+                "SecondaryModuleStep does not pass time_fraction to its "
+                "modules, so time-of-year conditioning is not supported here. "
+                "Use the single_module step type instead."
+            )
+        return False
+
     def train(self, mode: bool = True) -> StepABC:
         super().train(mode)
         self._corrector.train(mode)

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -302,6 +302,8 @@ class SecondaryModuleStep(StepABC):
             n_in_channels=n_in_channels,
             n_out_channels=n_out_channels,
             dataset_info=dataset_info,
+            in_names=list(config.in_names),
+            out_names=list(config.out_names),
         )
         self.module = module.to(get_device())
 
@@ -314,6 +316,8 @@ class SecondaryModuleStep(StepABC):
             n_in_channels=n_in_channels,
             n_out_channels=len(all_secondary_names),
             dataset_info=dataset_info,
+            in_names=list(config.in_names),
+            out_names=list(all_secondary_names),
         )
         self.secondary_module: Module = secondary_module.to(get_device())
         self.secondary_out_packer: Packer = Packer(all_secondary_names)
@@ -323,6 +327,7 @@ class SecondaryModuleStep(StepABC):
                 config.secondary_decoder.build(
                     n_in_channels=n_out_channels,
                     dataset_info=dataset_info,
+                    in_names=list(config.out_names),
                 ).to(get_device())
             )
         else:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -322,6 +322,8 @@ class SingleModuleStep(StepABC):
             n_in_channels=n_in_channels,
             n_out_channels=n_out_channels,
             dataset_info=dataset_info,
+            in_names=packed_in_names,
+            out_names=list(config.out_names),
         )
         self.module = module.to(get_device())
 
@@ -332,6 +334,7 @@ class SingleModuleStep(StepABC):
                 config.secondary_decoder.build(
                     n_in_channels=n_out_channels,
                     dataset_info=dataset_info,
+                    in_names=list(config.out_names),
                 ).to(get_device())
             )
         else:

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -428,6 +428,7 @@ class SingleModuleStep(StepABC):
             output_tensor = self.module.wrap_module(wrapper)(
                 input_tensor,
                 labels=args.labels,
+                time_fraction=args.time_fraction,
             )
             output_dict = self.out_packer.unpack(output_tensor, axis=self.CHANNEL_DIM)
             secondary_output_dict = self.secondary_decoder.wrap_module(wrapper)(
@@ -473,6 +474,10 @@ class SingleModuleStep(StepABC):
 
     def get_regularizer_loss(self):
         return torch.tensor(0.0)
+
+    @property
+    def requires_time_fraction(self) -> bool:
+        return self.module.requires_time_fraction
 
     def train(self, mode: bool = True) -> StepABC:
         super().train(mode)

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -387,6 +387,17 @@ class StepABC(abc.ABC):
         """
         pass
 
+    @property
+    def requires_time_fraction(self) -> bool:
+        """Whether this step needs the calendar position of each timestep.
+
+        Steps which condition a module on the time of year override this so
+        that the stepper computes ``StepArgs.time_fraction``. Deriving it is
+        only possible from real calendar data, so it is not computed unless a
+        step asks for it.
+        """
+        return False
+
     def set_epoch(self, epoch: int) -> None:
         """Called by the stepper at the start of each training epoch.
 

--- a/fme/core/step/test_args.py
+++ b/fme/core/step/test_args.py
@@ -20,12 +20,14 @@ def test_apply_input_process_func_propagates_metadata():
             global_dry_air_mass=torch.ones(n_batch, 1, 1),
         ),
     )
+    time_fraction = torch.rand(n_batch)
     args = StepArgs(
         input=input_data,
         next_step_input_data=next_step,
         labels=labels,
         data_mask=data_mask,
         stepper_state=stepper_state,
+        time_fraction=time_fraction,
     )
 
     def double(tensors):
@@ -44,6 +46,7 @@ def test_apply_input_process_func_propagates_metadata():
     for name in data_mask:
         torch.testing.assert_close(result.data_mask[name], data_mask[name])
     assert result.stepper_state is stepper_state
+    assert result.time_fraction is time_fraction
 
     known_attrs = {
         "input",
@@ -51,6 +54,7 @@ def test_apply_input_process_func_propagates_metadata():
         "labels",
         "data_mask",
         "stepper_state",
+        "time_fraction",
     }
     actual_attrs = {
         name

--- a/fme/core/test_stacker.py
+++ b/fme/core/test_stacker.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from .stacker import Stacker, unstack
+from .stacker import Stacker, infer_column_layout, unstack
 
 _PREFIX_MAP = {"a": ["aa_", "ab_"], "b": ["b_", "bb_"], "c": ["ca", "cb"]}
 
@@ -128,3 +128,56 @@ def test_inferred_stacker(data_names, expected_prefix_map, expected_level_names)
             tensors = [data[name] for name in expected_levels]
             expected_stacked = torch.stack(tensors, dim=-1)
             assert torch.allclose(stacked, expected_stacked)
+
+
+def _column_names(prefixes, n_levels):
+    return [f"{prefix}{level}" for prefix in prefixes for level in range(n_levels)]
+
+
+def test_infer_column_layout_finds_grid():
+    names = (
+        ["land_fraction", "DSWRFtoa"]
+        + _column_names(["air_temperature_", "eastward_wind_"], 8)
+        + ["global_mean_co2"]
+    )
+    layout = infer_column_layout(names)
+    assert layout is not None
+    assert layout.start == 2
+    assert layout.stop == 18
+    assert layout.n_vars == 2
+    assert layout.n_levels == 8
+    assert layout.prefixes == ("air_temperature_", "eastward_wind_")
+    assert layout.surface_indices == (0, 1, 18)
+
+
+def test_infer_column_layout_without_levels_returns_none():
+    assert infer_column_layout(["land_fraction", "PRESsfc"]) is None
+
+
+def test_infer_column_layout_adapts_to_variable_count():
+    """Which variables are vertically resolved is a legitimate config choice."""
+    for n_vars in (1, 3):
+        prefixes = [f"var{i}_" for i in range(n_vars)]
+        layout = infer_column_layout(_column_names(prefixes, 4))
+        assert layout is not None
+        assert layout.n_vars == n_vars
+        assert layout.n_levels == 4
+
+
+@pytest.mark.parametrize(
+    "names, match",
+    [
+        pytest.param(["a_0", "a_1", "b_0"], "same number of", id="ragged_level_counts"),
+        pytest.param(["a_0", "a_2"], "no gaps or duplicates", id="missing_level"),
+        pytest.param(
+            ["a_0", "b_0", "a_1", "b_1"], "contiguous block", id="level_major_order"
+        ),
+        pytest.param(
+            ["a_0", "a_1", "sfc", "b_0", "b_1"], "contiguous block", id="interleaved"
+        ),
+    ],
+)
+def test_infer_column_layout_raises_on_malformed_grid(names, match):
+    """A malformed grid must fail loudly rather than silently attend over less."""
+    with pytest.raises(ValueError, match=match):
+        infer_column_layout(names)


### PR DESCRIPTION
Adopts two design choices from ArchesWeather that the Swin backbone was missing: cross-level attention, and conditioning on the time of year.

The backbone previously stacked all vertical levels into the channel dimension, so levels could only interact through pointwise linear layers. This is the "column concatenation" scheme ArchesWeather argues against; its own design keeps levels as a tensor axis and attends along it. Separately, the data loader's times were discarded before the step was called, so a module had no way to know where in the year it was.

Both are opt-in and off by default, so existing configs are unaffected.

**Enabling `cross_level_attention` multiplies the number of latent tokens by `n_levels + 1`.** `embed_dim` should be reduced accordingly to keep compute comparable — at 8 levels, the token count grows 9x, which roughly matches halving `embed_dim`.

**The day-of-year embedding is discontinuous across the year boundary.** It reuses the sinusoidal timestep embedder ArchesWeather uses, whose geometric frequency ladder is not periodic in its input, so 31 December and 1 January are far apart in embedding space. This is deliberate — it is what ArchesWeather does, and there it outperformed coarser month-based conditioning — but a periodic encoding would be the obvious alternative if this proves to matter.

Changes:
- `fme.core.registry.module.ModuleConfig.build` and `ModuleSelector.build`: accept keyword-only `in_names` / `out_names` so a builder can tell which channels form a vertical column; passed by every step type that constructs a module
- `fme.core.stacker.ColumnLayout` and `infer_column_layout`: derive the (variable, level) grid from ordered channel names, raising when the level-resolved names do not form a rectangular, contiguous block
- `fme.core.models.swin_transformer.swin_layers.CrossLevelAttention`: multi-head attention along the vertical axis of each column, with a learned per-level positional embedding; replaces `ColumnMixer` when a layout is given
- `fme.core.models.swin_transformer.swin_transformer.SwinTransformerNet`: embeds levels per level and surface fields as one additional token in the same axis, folded into the batch dimension so window attention, patch merging and `ConditionalLayerNorm` are untouched
- `fme.ace.stepper.time_fraction.compute_time_fraction`: calendar position as a fraction in [0, 1), using the year length of the data's own calendar
- `fme.core.step.args.StepArgs`: new optional `time_fraction` field, propagated through `apply_input_process_func`; `StepABC.requires_time_fraction` lets a step declare that it needs it, so it is only derived when used
- `fme.ace.registry.stochastic_sfno.TimestepEmbedder` and `NoiseConditionedModel`: embed the calendar position into `Context.embedding_scalar`, raising if the value is missing rather than leaving the conditioning silently dead
- `fme.ace.registry.swin_transformer`: `cross_level_attention`, `column_num_heads` and `time_embed_dim` config options
- `fme.core.step.secondary_module`, `fme.core.step.radiation`: raise `NotImplementedError` when given a time-conditioned module, since they do not pass the value to their modules

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
