### PR TITLE
Reinstate per-variable selection for corrector-loss features

### DIFF
--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -107,6 +107,7 @@ from fme.core.corrector.ice import IceCorrectorConfig
 from fme.core.corrector.loss_config import (
     CorrectorLossConfig,
     CorrectorRegularizationConfig,
+    PreCorrectorOptimizationConfig,
 )
 from fme.core.corrector.ocean import OceanCorrectorConfig
 from fme.core.dataset.concat import ConcatDatasetConfig

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -898,7 +898,8 @@ class Stepper:
     def build_corrector_loss(
         self, corrector_loss: CorrectorLossConfig | None
     ) -> CorrectorLoss | None:
-        """Build the corrector-delta half of the training loss, if configured.
+        """Validate and build the corrector-delta half of the training loss,
+        if configured.
 
         Args:
             corrector_loss: Optional. With the null default, this method builds
@@ -910,6 +911,7 @@ class Stepper:
         if corrector_loss is None:
             return None
         return corrector_loss.build(
+            self.loss_names,
             normalizer=self._step_obj.get_loss_normalizer(),
             channel_dim=self.CHANNEL_DIM,
         )

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -65,6 +65,7 @@ from fme.core.coordinates import (
 from fme.core.corrector.loss_config import (
     CorrectorLossConfig,
     CorrectorRegularizationConfig,
+    PreCorrectorOptimizationConfig,
 )
 from fme.core.corrector.output import CorrectorOutput
 from fme.core.corrector.registry import (
@@ -3253,17 +3254,20 @@ def _corrector_loss_stepper(
     disabled_epochs: int = 0,
     dataset_info: DatasetInfo | None = None,
     input_masking: StaticSpatialMaskingConfig | None = None,
+    names: list[str] | None = None,
 ) -> Stepper:
-    """Build an ["a"] -> ["a"] stepper, optionally installing a correction."""
+    """Build a ``names`` -> ``names`` stepper, optionally installing a
+    correction. ``names`` defaults to ``["a"]``."""
+    names = ["a"] if names is None else names
     config = StepperConfig(
         step=StepSelector(
             type="single_module",
             config=dataclasses.asdict(
                 SingleModuleStepConfig(
                     builder=ModuleSelector(type="prebuilt", config={"module": module}),
-                    in_names=["a"],
-                    out_names=["a"],
-                    normalization=trivial_network_and_loss_normalization(["a"]),
+                    in_names=list(names),
+                    out_names=list(names),
+                    normalization=trivial_network_and_loss_normalization(names),
                 )
             ),
         ),
@@ -3299,7 +3303,11 @@ def test_train_on_batch_pre_corrector_equivalence():
             _AddOne(), ConstantOffsetCorrection("a", offset)
         ),
         loss=StepLossConfig(type="MSE"),
-        corrector_loss=CorrectorLossConfig(precorrector_optimization=True),
+        corrector_loss=CorrectorLossConfig(
+            precorrector_optimization=PreCorrectorOptimizationConfig(
+                names_and_prefixes=["a"]
+            )
+        ),
     )
     baseline_out = baseline.train_on_batch(data, optimization=NullOptimization())
     corrected_out = corrected.train_on_batch(data, optimization=NullOptimization())
@@ -3318,7 +3326,9 @@ def test_gradient_flows_through_correction_when_configured():
         names=["a"], n_samples=2, n_timesteps=2, epoch=0
     ).to_device()
     corrector_loss = CorrectorLossConfig(
-        regularization=CorrectorRegularizationConfig(norm="L2")
+        regularization=CorrectorRegularizationConfig(
+            names_and_prefixes=["a"], norm="L2"
+        )
     )
     grads = {}
     for label, config in (("baseline", None), ("regularized", corrector_loss)):
@@ -3350,7 +3360,9 @@ def test_corrector_penalty_gradient_accumulation():
         stepper=_corrector_loss_stepper(_ScaleModule(), _ScaleCorrection("a", 2.0)),
         loss=StepLossConfig(type="MSE"),
         corrector_loss=CorrectorLossConfig(
-            regularization=CorrectorRegularizationConfig(norm="L2")
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=["a"], norm="L2"
+            )
         ),
     )
     optimization = OptimizationConfig(use_gradient_accumulation=True).build(
@@ -3392,8 +3404,12 @@ def test_masked_output_with_corrector_loss_finite():
         stepper=stepper,
         loss=StepLossConfig(type="MSE"),
         corrector_loss=CorrectorLossConfig(
-            precorrector_optimization=True,
-            regularization=CorrectorRegularizationConfig(norm="L2"),
+            precorrector_optimization=PreCorrectorOptimizationConfig(
+                names_and_prefixes=["a"]
+            ),
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=["a"], norm="L2"
+            ),
         ),
     )
     data = BatchData.new_for_testing(
@@ -3428,7 +3444,9 @@ def test_epoch_scheduled_corrector():
 
     train_stepper = make(
         CorrectorLossConfig(
-            regularization=CorrectorRegularizationConfig(norm="L2", weight=weight)
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=["a"], norm="L2", weight=weight
+            )
         )
     )
     baseline = make(None)
@@ -3449,7 +3467,7 @@ def test_epoch_scheduled_corrector():
     )
 
     # the corrector is always applied in eval mode, so the validation pass of
-    # the still-disabled epoch applies the penalty
+    # the still-disabled epoch resolves the selection and applies the penalty
     for stepper in (train_stepper, baseline):
         stepper.set_eval()
     eval_pass = train_stepper.train_on_batch(data, optimization=NullOptimization())
@@ -3491,7 +3509,9 @@ def test_penalty_rides_the_existing_metrics():
 
     with_reg = make(
         CorrectorLossConfig(
-            regularization=CorrectorRegularizationConfig(norm="L2", weight=weight)
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=["a"], norm="L2", weight=weight
+            )
         )
     )
     baseline = make(None)
@@ -3533,8 +3553,12 @@ def test_both_features_together():
         ),
         loss=StepLossConfig(type="MSE"),
         corrector_loss=CorrectorLossConfig(
-            precorrector_optimization=True,
-            regularization=CorrectorRegularizationConfig(norm="L2", weight=weight),
+            precorrector_optimization=PreCorrectorOptimizationConfig(
+                names_and_prefixes=["a"]
+            ),
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=["a"], norm="L2", weight=weight
+            ),
         ),
     )
     no_corrector = _init_train_stepper(
@@ -3555,3 +3579,31 @@ def test_both_features_together():
     # the returned predictions stay fully corrected
     ic = data.data["a"][:, 0]
     torch.testing.assert_close(both_out.gen_data["a"][:, 0, 1], ic + 1.0 + offset)
+
+
+@pytest.mark.parametrize("selected,trains", [("b", False), ("a", True)])
+def test_corrector_loss_errors_at_the_first_active_step(selected, trains):
+    # the build-time check covers the loss names, so a name the loss covers but
+    # the installed correction does not touch survives it and raises on the
+    # first step whose delta is non-empty.
+    torch.manual_seed(0)
+    data = BatchData.new_for_testing(
+        names=["a", "b"], n_samples=2, n_timesteps=2, epoch=0
+    ).to_device()
+    train_stepper = _init_train_stepper(
+        stepper=_corrector_loss_stepper(
+            _AddOne(), ConstantOffsetCorrection("a", 2.0), names=["a", "b"]
+        ),
+        loss=StepLossConfig(type="MSE"),
+        corrector_loss=CorrectorLossConfig(
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=[selected], norm="L2"
+            )
+        ),
+    )
+    if trains:
+        output = train_stepper.train_on_batch(data, optimization=NullOptimization())
+        assert torch.isfinite(output.metrics["loss"])
+    else:
+        with pytest.raises(ValueError, match="match none of the correction deltas"):
+            train_stepper.train_on_batch(data, optimization=NullOptimization())

--- a/fme/core/corrector/loss_config.py
+++ b/fme/core/corrector/loss_config.py
@@ -1,5 +1,5 @@
 import dataclasses
-import logging
+from collections.abc import Collection
 from typing import Literal
 
 from fme.core.loss import (
@@ -8,22 +8,52 @@ from fme.core.loss import (
     WeightedMappingLoss,
     _L1Loss,
     _MSELoss,
+    require_matched_entries,
 )
+from fme.core.name_and_prefix_matcher import NameAndPrefixSelection
 from fme.core.normalizer import StandardNormalizer
+
+_LOSS_NAMES_SUBJECT = "variables the loss covers"
+
+
+@dataclasses.dataclass
+class PreCorrectorOptimizationConfig:
+    """Selects corrector-modified variables whose main-loss prediction is the
+    pre-corrector network output ``prediction - delta``.
+
+    Selection is pure opt-in; this feature may be enabled together with
+    corrector regularization.
+
+    Parameters:
+        names_and_prefixes: ``NameAndPrefixMatcher`` entries selecting the
+            corrector-modified variables to optimize pre-corrector.
+    """
+
+    names_and_prefixes: list[str]
+
+    def __post_init__(self):
+        if not self.names_and_prefixes:
+            raise ValueError(
+                "precorrector_optimization requires names_and_prefixes: "
+                "configuring the feature while selecting nothing is a "
+                "contradiction, not a no-op."
+            )
 
 
 @dataclasses.dataclass
 class CorrectorRegularizationConfig:
-    """A penalty pushing every correction delta toward zero in
+    """A penalty pushing selected correction deltas toward zero in
     loss-normalized space.
 
     The penalty is not subject to the main loss's per-step sqrt decay
     (``sqrt_loss_step_decay_constant``); only ``weight`` scales it. Nor does it
-    take the main loss's per-variable ``weights``: every channel enters
+    take the main loss's per-variable ``weights``: every selected channel enters
     the mean with weight 1.0. This feature may be enabled together with
     pre-corrector optimization.
 
     Parameters:
+        names_and_prefixes: ``NameAndPrefixMatcher`` entries selecting the
+            corrector-modified variables whose deltas are penalized.
         norm: Which norm of the normalized deltas is penalized. ``"L1"`` is the
             mean absolute delta. ``"L2"`` is the mean squared delta, the
             squared L2 norm: the square root is not taken, which keeps the
@@ -31,10 +61,17 @@ class CorrectorRegularizationConfig:
         weight: The positive weight applied to the penalty in the total loss.
     """
 
+    names_and_prefixes: list[str]
     norm: Literal["L1", "L2"]
     weight: float = 1.0
 
     def __post_init__(self):
+        if not self.names_and_prefixes:
+            raise ValueError(
+                "regularization requires names_and_prefixes: configuring "
+                "the feature while selecting nothing is a contradiction, "
+                "not a no-op."
+            )
         if self.weight <= 0:
             raise ValueError(
                 f"regularization weight must be positive, got {self.weight}"
@@ -45,8 +82,7 @@ class CorrectorRegularizationConfig:
         normalizer: StandardNormalizer,
         channel_dim: int,
     ) -> CorrectorRegularizer:
-        """Build the penalty. Its channels are whatever delta keys each step's
-        corrector produces.
+        """Build the penalty, deferring its channels to the first delta.
 
         Args:
             normalizer: The loss normalizer, used to normalize the deltas.
@@ -63,6 +99,7 @@ class CorrectorRegularizationConfig:
             )
 
         return CorrectorRegularizer(
+            selection=NameAndPrefixSelection(tuple(self.names_and_prefixes)),
             build_loss=build_loss,
             weight=self.weight,
         )
@@ -72,20 +109,17 @@ class CorrectorRegularizationConfig:
 class CorrectorLossConfig:
     """Training-only consumption of correction deltas by the step loss.
 
-    Both features act on every delta the corrector produces at each step;
-    neither selects names.
-
     Parameters:
-        precorrector_optimization: Optimize the corrector-modified variables
-            against their pre-corrector network outputs.
-        regularization: Penalize every correction delta toward zero.
+        precorrector_optimization: Optimize selected corrector-modified
+            variables against their pre-corrector network outputs.
+        regularization: Penalize selected correction deltas toward zero.
     """
 
-    precorrector_optimization: bool = False
+    precorrector_optimization: PreCorrectorOptimizationConfig | None = None
     regularization: CorrectorRegularizationConfig | None = None
 
     def __post_init__(self):
-        if not self.precorrector_optimization and self.regularization is None:
+        if self.precorrector_optimization is None and self.regularization is None:
             raise ValueError(
                 "corrector_loss requires at least one of "
                 "precorrector_optimization or regularization: configuring "
@@ -95,25 +129,47 @@ class CorrectorLossConfig:
 
     def build(
         self,
+        loss_names: Collection[str],
         normalizer: StandardNormalizer,
         channel_dim: int,
     ) -> CorrectorLoss:
-        """Build the corrector loss, logging each enabled feature.
+        """Check the configured entries against the names the loss covers, then
+        build.
+
+        ``loss_names`` is exactly the set the loss can pack and the loss
+        normalizer covers, so an entry matching nothing in it can never be
+        penalized under any corrector. What it cannot catch -- that the
+        corrector modifies a name, and that the step does not then drop that
+        name from the delta -- is why the entries are checked again, against
+        the corrector's actual delta keys, the first time the corrector loss
+        runs on a non-empty delta.
 
         Args:
+            loss_names: The names the step loss covers.
             normalizer: The loss normalizer, used to normalize the deltas.
             channel_dim: The channel dimension of the loss inputs.
         """
-        if self.precorrector_optimization:
-            logging.info("corrector_loss: optimizing pre-corrector outputs")
+        precorrector_selection = None
+        if self.precorrector_optimization is not None:
+            precorrector_selection = NameAndPrefixSelection(
+                tuple(self.precorrector_optimization.names_and_prefixes)
+            )
+            require_matched_entries(
+                precorrector_selection,
+                loss_names,
+                "precorrector_optimization",
+                _LOSS_NAMES_SUBJECT,
+            )
         regularizer = None
         if self.regularization is not None:
-            logging.info(
-                "corrector_loss: penalizing correction deltas with norm "
-                f"{self.regularization.norm} and weight {self.regularization.weight}"
+            require_matched_entries(
+                NameAndPrefixSelection(tuple(self.regularization.names_and_prefixes)),
+                loss_names,
+                "regularization",
+                _LOSS_NAMES_SUBJECT,
             )
             regularizer = self.regularization.build(normalizer, channel_dim)
         return CorrectorLoss(
-            precorrector_optimization=self.precorrector_optimization,
+            precorrector_selection=precorrector_selection,
             regularizer=regularizer,
         )

--- a/fme/core/corrector/test_loss_config.py
+++ b/fme/core/corrector/test_loss_config.py
@@ -1,11 +1,13 @@
 from collections.abc import Iterable
 
+import dacite
 import pytest
 import torch
 
 from fme.core.corrector.loss_config import (
     CorrectorLossConfig,
     CorrectorRegularizationConfig,
+    PreCorrectorOptimizationConfig,
 )
 from fme.core.device import get_device
 from fme.core.loss import CorrectorLoss
@@ -17,6 +19,7 @@ _SHAPE = (2, 2, 2)  # (batch, lat, lon)
 _NAMES = ["a", "b_0", "b_1"]
 _MEANS = {"a": 1.0, "b_0": -2.0, "b_1": 0.5}
 _STDS = {"a": 2.0, "b_0": 0.5, "b_1": 4.0}
+_LOSS_NAMES = list(_NAMES)
 
 
 def _fixed(offset: float, scale: float) -> torch.Tensor:
@@ -40,33 +43,88 @@ def _normalizer(names: Iterable[str] = _NAMES) -> StandardNormalizer:
     )
 
 
-def _build(config: CorrectorLossConfig) -> CorrectorLoss:
+def _build(
+    config: CorrectorLossConfig,
+    loss_names: Iterable[str] = _LOSS_NAMES,
+) -> CorrectorLoss:
     return config.build(
+        list(loss_names),
         normalizer=_normalizer(),
         channel_dim=-3,
     )
 
 
+def _resolved(config: CorrectorLossConfig) -> CorrectorLoss:
+    """A built corrector loss whose names are resolved against ``_delta_dict``."""
+    corrector_loss = _build(config)
+    corrector_loss.resolve_names(_delta_dict().keys())
+    return corrector_loss
+
+
 def test_config_post_init_errors():
-    # both features off; weight <= 0 — each raises in __post_init__.
+    # both features None; a present feature selecting nothing; weight <= 0 —
+    # each raises in __post_init__.
     with pytest.raises(ValueError, match="at least one"):
         CorrectorLossConfig()
+    with pytest.raises(ValueError, match="names_and_prefixes"):
+        PreCorrectorOptimizationConfig(names_and_prefixes=[])
+    with pytest.raises(ValueError, match="names_and_prefixes"):
+        CorrectorRegularizationConfig(names_and_prefixes=[], norm="L2")
     for weight in (0.0, -1.0):
         with pytest.raises(ValueError, match="weight"):
-            CorrectorRegularizationConfig(norm="L2", weight=weight)
+            CorrectorRegularizationConfig(
+                names_and_prefixes=["a"], norm="L2", weight=weight
+            )
 
 
-def test_penalty_covers_every_delta():
-    # the penalty needs no name configuration: it covers exactly the delta
-    # keys of each call.
+@pytest.mark.parametrize(
+    "feature_config",
+    [PreCorrectorOptimizationConfig, CorrectorRegularizationConfig],
+)
+def test_names_and_prefixes_is_required_by_dacite(feature_config):
+    # the YAML path, not the constructor: omitting the selection is a
+    # missing-value error from dacite, not a config that parses and no-ops.
+    with pytest.raises(dacite.exceptions.MissingValueError):
+        dacite.from_dict(feature_config, {}, config=dacite.Config(strict=True))
+
+
+@pytest.mark.parametrize("entry", ["missing_var", "missing_"])
+@pytest.mark.parametrize("feature", ["precorrector_optimization", "regularization"])
+def test_build_errors_on_entry_matching_no_loss_name(entry, feature):
+    # an entry matching nothing the loss covers raises at build.
+    # PARAMETERIZE: entry in {exact name, trailing-underscore prefix}.
+    if feature == "precorrector_optimization":
+        config = CorrectorLossConfig(
+            precorrector_optimization=PreCorrectorOptimizationConfig(
+                names_and_prefixes=[entry]
+            )
+        )
+    else:
+        config = CorrectorLossConfig(
+            regularization=CorrectorRegularizationConfig(
+                names_and_prefixes=[entry], norm="L2"
+            )
+        )
+    with pytest.raises(ValueError, match="match none of the variables the loss"):
+        _build(config)
+
+
+def test_build_defers_regularizer_channels():
+    # a config whose entries all match loss_names builds, and the regularizer
+    # reports no names until the corrector loss has seen a delta.
     config = CorrectorLossConfig(
-        regularization=CorrectorRegularizationConfig(norm="L2", weight=2.0)
+        regularization=CorrectorRegularizationConfig(
+            names_and_prefixes=["b_"], norm="L2", weight=2.0
+        )
     )
     corrector_loss = _build(config)
     assert corrector_loss.penalty_weight == 2.0
+    with pytest.raises(RuntimeError, match="channels were resolved"):
+        corrector_loss.penalty(_delta_dict())
+    corrector_loss.resolve_names(_delta_dict().keys())
     penalty = corrector_loss.penalty(_delta_dict())
     assert penalty is not None
-    assert list(penalty.get_channel_losses()) == ["a", "b_0", "b_1"]
+    assert list(penalty.get_channel_losses()) == ["b_0", "b_1"]
 
 
 @pytest.mark.parametrize(
@@ -80,9 +138,11 @@ def test_penalty_matches_the_configured_norm(norm, reduce):
     # the penalty is the mean of the normalized delta under the configured
     # norm; "L2" is the mean square, not its root.
     config = CorrectorLossConfig(
-        regularization=CorrectorRegularizationConfig(norm=norm)
+        regularization=CorrectorRegularizationConfig(
+            names_and_prefixes=["a"], norm=norm
+        )
     )
-    penalty = _build(config).penalty(_delta_dict())
+    penalty = _resolved(config).penalty(_delta_dict())
     assert penalty is not None
     normalized = _delta_dict()["a"] / _STDS["a"]
     torch.testing.assert_close(

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
-from collections.abc import Callable, Mapping
+import logging
+from collections.abc import Callable, Collection, Mapping
 from typing import Any, Literal
 
 import torch
@@ -10,6 +11,7 @@ import torch.nn.functional as F
 from fme.core.device import get_device
 from fme.core.ensemble import get_crps, get_energy_score
 from fme.core.gridded_ops import GriddedOperations
+from fme.core.name_and_prefix_matcher import NameAndPrefixSelection
 from fme.core.normalizer import StandardNormalizer
 from fme.core.packer import Packer
 from fme.core.typing_ import TensorDict, TensorMapping
@@ -977,38 +979,94 @@ class StepLossConfig:
         )
 
 
-class CorrectorRegularizer(torch.nn.Module):
-    """A penalty pushing every correction delta toward zero.
+def require_matched_entries(
+    selection: NameAndPrefixSelection,
+    names: Collection[str],
+    feature: str,
+    subject: str,
+) -> list[str]:
+    """The names the selection matches, sorted; raises if any entry matches none.
 
-    Holds the two things the penalty is: a factory for the loss over the
-    deltas, and the weight it enters the step total with. The penalty's
-    channels are each call's delta keys; no names are fixed up front, because
-    which names the corrector produces is only observable in its deltas.
+    The one validation primitive of corrector-loss name selection, used both at
+    build against the names the loss covers and at runtime against the
+    corrector's actual delta keys.
+
+    Args:
+        selection: The configured entries.
+        names: The names to match against.
+        feature: The config field the entries came from, for the error text.
+        subject: A plural noun phrase for what ``names`` are, for the error
+            text (e.g. "variables the loss covers").
+    """
+    unmatched = selection.unmatched_entries(names)
+    if unmatched:
+        raise ValueError(
+            f"{feature} selects entries that match none of the {subject}: "
+            + "; ".join(f"{entry!r} matches none" for entry in unmatched)
+            + f". The {subject} are {sorted(names)}."
+        )
+    return selection.matched(names)
+
+
+class CorrectorRegularizer(torch.nn.Module):
+    """A penalty pushing selected correction deltas toward zero.
+
+    Holds the three things the penalty is: the selection of deltas it is taken
+    over, a factory for the loss over them, and the weight it enters the step
+    total with. The names and the loss are fixed by :meth:`resolve`, because
+    which names the selection covers is not knowable until the corrector's
+    first non-empty delta arrives.
     """
 
     def __init__(
         self,
+        selection: NameAndPrefixSelection,
         build_loss: Callable[[list[str]], WeightedMappingLoss],
         weight: float,
     ):
         """
         Args:
+            selection: The configured selection of correction deltas.
             build_loss: Builds the loss applied to the normalized deltas
                 against zeros, over the names it is given.
             weight: The weight applied to the penalty in the step total.
         """
         super().__init__()
+        self._selection = selection
         self._build_loss = build_loss
+        self._loss: WeightedMappingLoss | None = None
+        self._names: list[str] = []
         self._weight = weight
 
     @property
     def weight(self) -> float:
         return self._weight
 
+    @property
+    def names(self) -> list[str]:
+        """The names the penalty is taken over, empty before :meth:`resolve`."""
+        return list(self._names)
+
+    def resolve(self, delta_names: Collection[str]) -> None:
+        """Fix the penalty's channels to the selection's matches among
+        ``delta_names`` and build the loss over them.
+
+        The loss is built over the matched delta keys rather than over the
+        matched loss names, so the penalty is not taken over levels the
+        corrector never touched.
+        """
+        self._names = require_matched_entries(
+            self._selection,
+            delta_names,
+            "regularization",
+            "correction deltas the corrector produced",
+        )
+        self._loss = self._build_loss(self._names)
+
     def forward(
         self, deltas: TensorMapping, data_mask: TensorMapping | None = None
     ) -> LossOutput:
-        """Penalty over the deltas, per channel.
+        """Penalty over the selected deltas, per channel.
 
         The deltas are compared against zeros in loss-normalized space, so with
         an affine normalizer the means cancel and this penalizes ``delta/std``.
@@ -1023,10 +1081,17 @@ class CorrectorRegularizer(torch.nn.Module):
         normalizer the NaN is filled before that mask is taken, and no point
         is zeroed at all.
         """
-        names = sorted(deltas)
+        if self._loss is None:
+            raise RuntimeError(
+                "the penalty was taken before its channels were resolved; "
+                "CorrectorLoss.resolve_names must run first."
+            )
+        selected: TensorDict = {}
         targets: TensorDict = {}
-        for name in names:
+        for name in self._names:
+            _require_delta(deltas, name, "regularization")
             delta = deltas[name]
+            selected[name] = delta
             # NaN target where the delta is NaN-filled; see the docstring for
             # what the downstream loss does with it.
             targets[name] = torch.where(
@@ -1034,33 +1099,34 @@ class CorrectorRegularizer(torch.nn.Module):
                 torch.full_like(delta, torch.nan),
                 torch.zeros_like(delta),
             )
-        return self._build_loss(names)(dict(deltas), targets, data_mask)
+        return self._loss(selected, targets, data_mask)
 
 
 class CorrectorLoss(torch.nn.Module):
     """Loss for corrector optimization.
 
     Owns both features that consume the correction deltas of a ``StepOutput``:
-    pre-corrector optimization and corrector regularization. Each acts on
-    every delta of the step it is given.
+    pre-corrector optimization and corrector regularization.
     """
 
     def __init__(
         self,
-        precorrector_optimization: bool,
+        precorrector_selection: NameAndPrefixSelection | None,
         regularizer: CorrectorRegularizer | None,
     ):
         """
         Args:
-            precorrector_optimization: Whether the main-loss prediction of
-                every corrector-modified variable is the pre-corrector
-                network output.
-            regularizer: The penalty over the correction deltas, or None when
+            precorrector_selection: Selection of the variables whose main-loss
+                prediction is the pre-corrector network output, or None when
+                the feature is off.
+            regularizer: The penalty over the selected deltas, or None when
                 the feature is off.
         """
         super().__init__()
-        self._precorrector_optimization = precorrector_optimization
+        self._precorrector_selection = precorrector_selection
+        self._precorrector_names: list[str] | None = None
         self._regularizer = regularizer
+        self._resolved = False
 
     @property
     def penalty_weight(self) -> float:
@@ -1069,16 +1135,57 @@ class CorrectorLoss(torch.nn.Module):
             return 1.0
         return self._regularizer.weight
 
+    def resolve_names(self, delta_names: Collection[str]) -> None:
+        """Validate both features' entries against the corrector's delta keys
+        and fix the names each acts on. A no-op after the first call.
+
+        Called on the first step whose deltas are non-empty, which is the first
+        point at which the keys the corrector really produces are observable.
+        Empty-delta steps -- every train-mode step of an
+        ``EpochScheduledCorrector``'s disabled epochs -- do not consume it: the
+        corrector is always applied in eval mode, so the end-of-epoch
+        validation pass resolves at the latest.
+        """
+        if self._resolved:
+            return
+        subject = "correction deltas the corrector produced"
+        if self._precorrector_selection is not None:
+            self._precorrector_names = require_matched_entries(
+                self._precorrector_selection,
+                delta_names,
+                "precorrector_optimization",
+                subject,
+            )
+        if self._regularizer is not None:
+            self._regularizer.resolve(delta_names)
+        self._resolved = True
+        if self._precorrector_names is not None:
+            logging.info(
+                "corrector_loss: optimizing pre-corrector outputs for "
+                f"{self._precorrector_names}"
+            )
+        if self._regularizer is not None:
+            logging.info(
+                f"corrector_loss: penalizing deltas for {self._regularizer.names} "
+                f"with weight {self._regularizer.weight}"
+            )
+
     def pre_corrector_outputs(
         self, predict_dict: TensorMapping, deltas: TensorMapping
     ) -> TensorDict:
-        """``predict_dict[k] - deltas[k]`` for every delta key, else
-        ``predict_dict[k]``.
+        """``predict_dict[k] - deltas[k]`` for the selected names, else
+        ``predict_dict[k]``; raises when a selected name is missing.
         """
         net_output = dict(predict_dict)
-        if not self._precorrector_optimization:
+        if self._precorrector_selection is None or len(deltas) == 0:
             return net_output
-        for name in deltas:
+        if self._precorrector_names is None:
+            raise RuntimeError(
+                "the pre-corrector outputs were taken before their names were "
+                "resolved; CorrectorLoss.resolve_names must run first."
+            )
+        for name in self._precorrector_names:
+            _require_delta(deltas, name, "precorrector_optimization")
             net_output[name] = predict_dict[name] - deltas[name]
         return net_output
 
@@ -1091,6 +1198,15 @@ class CorrectorLoss(torch.nn.Module):
         if self._regularizer is None or len(deltas) == 0:
             return None
         return self._regularizer(deltas, data_mask)
+
+
+def _require_delta(deltas: TensorMapping, name: str, feature: str) -> None:
+    if name not in deltas:
+        raise ValueError(
+            f"{feature} selects {name!r}, but the corrector produced no delta "
+            f"for it; it produced deltas for {sorted(deltas)}. An active "
+            "corrector must produce deltas for every selected name."
+        )
 
 
 @dataclasses.dataclass
@@ -1162,6 +1278,7 @@ class StepOutputLoss(torch.nn.Module):
             return StepOutputLossOutput(
                 main=self.step_loss(predict_dict, target_dict, step, data_mask)
             )
+        self.corrector_loss.resolve_names(deltas.keys())
         # Pre-corrector outputs first, so StepLoss never sees a delta.
         net_output = self.corrector_loss.pre_corrector_outputs(predict_dict, deltas)
         main = self.step_loss(net_output, target_dict, step, data_mask)

--- a/fme/core/name_and_prefix_matcher.py
+++ b/fme/core/name_and_prefix_matcher.py
@@ -1,4 +1,6 @@
+import dataclasses
 import re
+from collections.abc import Iterable
 
 
 class NameAndPrefixMatcher:
@@ -34,3 +36,39 @@ class NameAndPrefixMatcher:
         if self._regex is None:
             return False
         return bool(re.match(self._regex, name))
+
+
+@dataclasses.dataclass(frozen=True)
+class NameAndPrefixSelection:
+    """A name-and-prefix selection that keeps its entries reportable.
+
+    ``NameAndPrefixMatcher`` has no per-entry reporting; keeping the entry
+    tuple alongside the matcher enables per-entry validation
+    (``unmatched_entries``) without adding state to the matcher itself.
+
+    Parameters:
+        entries: Names and prefixes following the ``NameAndPrefixMatcher``
+            matching convention.
+    """
+
+    entries: tuple[str, ...]
+
+    @property
+    def matcher(self) -> NameAndPrefixMatcher:
+        """A matcher over all of the selection's entries."""
+        return NameAndPrefixMatcher(list(self.entries))
+
+    def matched(self, names: Iterable[str]) -> list[str]:
+        """Names (sorted) that match any entry."""
+        matcher = self.matcher
+        return sorted(name for name in names if matcher.match(name))
+
+    def unmatched_entries(self, names: Iterable[str]) -> list[str]:
+        """Entries that match none of ``names``."""
+        names = list(names)
+        matchers = [(entry, NameAndPrefixMatcher([entry])) for entry in self.entries]
+        return [
+            entry
+            for entry, matcher in matchers
+            if not any(matcher.match(name) for name in names)
+        ]

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -27,6 +27,7 @@ from fme.core.loss import (
     WeightedMappingLoss,
     _construct_weight_tensor,
 )
+from fme.core.name_and_prefix_matcher import NameAndPrefixSelection
 from fme.core.normalizer import StandardNormalizer
 from fme.core.packer import Packer
 
@@ -1061,7 +1062,9 @@ def _corrector_step_loss() -> StepLoss:
     )
 
 
-def _corrector_regularizer(weight: float = 1.0) -> CorrectorRegularizer:
+def _corrector_regularizer(
+    entries: list[str], weight: float = 1.0
+) -> CorrectorRegularizer:
     def build_loss(names: list[str]) -> WeightedMappingLoss:
         return WeightedMappingLoss(
             loss=LossConfig(type="MSE").build(gridded_operations=None),
@@ -1072,21 +1075,37 @@ def _corrector_regularizer(weight: float = 1.0) -> CorrectorRegularizer:
         )
 
     return CorrectorRegularizer(
+        selection=NameAndPrefixSelection(tuple(entries)),
         build_loss=build_loss,
         weight=weight,
     )
 
 
 def _corrector_loss(
-    precorrector: bool = False,
-    regularize: bool = False,
+    precorrector_names: list[str] | None = None,
+    regularizer_names: list[str] | None = None,
     penalty_weight: float = 1.0,
 ) -> CorrectorLoss:
-    """A corrector loss with the given features on."""
+    """A corrector loss selecting the given entries, with names unresolved."""
     return CorrectorLoss(
-        precorrector_optimization=precorrector,
-        regularizer=(_corrector_regularizer(penalty_weight) if regularize else None),
+        precorrector_selection=(
+            None
+            if precorrector_names is None
+            else NameAndPrefixSelection(tuple(precorrector_names))
+        ),
+        regularizer=(
+            None
+            if regularizer_names is None
+            else _corrector_regularizer(regularizer_names, penalty_weight)
+        ),
     )
+
+
+def _resolved_corrector_loss(**kwargs) -> CorrectorLoss:
+    """As ``_corrector_loss``, resolved against the keys of ``_delta_dict``."""
+    corrector_loss = _corrector_loss(**kwargs)
+    corrector_loss.resolve_names(_delta_dict().keys())
+    return corrector_loss
 
 
 def _expected_penalty(deltas, names) -> torch.Tensor:
@@ -1114,16 +1133,15 @@ def test_step_output_loss_without_corrector_loss_unchanged():
         torch.testing.assert_close(actual[name].loss, expected[name].loss)
 
 
-def test_pre_corrector_outputs_swap_every_delta():
-    # the main loss sees output − delta for every delta key; keys without a
-    # delta use the network output as-is; targets untouched.
-    predict, target = _predict_dict(), _target_dict()
-    deltas = {name: value for name, value in _delta_dict().items() if name != "b_1"}
-    corrector_loss = _corrector_loss(precorrector=True)
+def test_pre_corrector_outputs_selected_only():
+    # the main loss sees output − delta for the configured names only;
+    # other keys use the network output as-is; targets untouched.
+    predict, target, deltas = _predict_dict(), _target_dict(), _delta_dict()
+    corrector_loss = _resolved_corrector_loss(precorrector_names=["a"])
     net_output = corrector_loss.pre_corrector_outputs(predict, deltas)
-    for name in ("a", "b_0"):
-        torch.testing.assert_close(net_output[name], predict[name] - deltas[name])
-    torch.testing.assert_close(net_output["b_1"], predict["b_1"])
+    torch.testing.assert_close(net_output["a"], predict["a"] - deltas["a"])
+    for name in ("b_0", "b_1"):
+        torch.testing.assert_close(net_output[name], predict[name])
     result = StepOutputLoss(_corrector_step_loss(), corrector_loss)(
         predict, target, 0, deltas=deltas
     )
@@ -1139,7 +1157,9 @@ def test_penalty_analytic_value():
     # penalty equals the hand-computed mean of (delta/std)^2 — normalizer
     # means cancel against the zeros target.
     deltas = _delta_dict()
-    penalty = _corrector_loss(regularize=True).penalty(deltas)
+    penalty = _resolved_corrector_loss(regularizer_names=_CORRECTOR_NAMES).penalty(
+        deltas
+    )
     assert penalty is not None
     torch.testing.assert_close(
         penalty.total(), _expected_penalty(deltas, _CORRECTOR_NAMES)
@@ -1157,7 +1177,7 @@ def test_penalty_ignores_main_loss_weights():
         out_names=list(_CORRECTOR_NAMES),
         normalizer=_corrector_normalizer(),
     )
-    corrector_loss = _corrector_loss(regularize=True)
+    corrector_loss = _corrector_loss(regularizer_names=list(_CORRECTOR_NAMES))
     result = StepOutputLoss(weighted_step_loss, corrector_loss)(
         _predict_dict(), _target_dict(), 0, deltas=deltas
     )
@@ -1173,7 +1193,7 @@ def test_penalty_escapes_the_step_decay():
     # it, so it is constant across steps while the main loss shrinks.
     deltas = _delta_dict()
     predict, target = _predict_dict(), _target_dict()
-    corrector_loss = _corrector_loss(regularize=True)
+    corrector_loss = _corrector_loss(regularizer_names=list(_CORRECTOR_NAMES))
 
     def _at_step(step: int):
         decaying_step_loss = StepLossConfig(
@@ -1204,7 +1224,9 @@ def test_penalty_masked_points_dilute():
     masked[0] = torch.nan
     masked.requires_grad_(True)
     deltas["a"] = masked
-    penalty = _corrector_loss(regularize=True).penalty(deltas)
+    penalty = _resolved_corrector_loss(regularizer_names=_CORRECTOR_NAMES).penalty(
+        deltas
+    )
     assert penalty is not None
     total = penalty.total()
     assert torch.isfinite(total)
@@ -1221,7 +1243,9 @@ def test_total_and_channel_decomposition():
     # anywhere per channel.
     predict, target, deltas = _predict_dict(), _target_dict(), _delta_dict()
     corrector_loss = _corrector_loss(
-        precorrector=True, regularize=True, penalty_weight=3.0
+        precorrector_names=["a"],
+        regularizer_names=["b_0", "b_1"],
+        penalty_weight=3.0,
     )
     result = StepOutputLoss(_corrector_step_loss(), corrector_loss)(
         predict, target, 0, deltas=deltas
@@ -1240,12 +1264,12 @@ def test_total_and_channel_decomposition():
 
 
 def test_penalty_uses_the_data_mask():
-    # with a data_mask hiding one sample of a delta variable, that
+    # with a data_mask hiding one sample of a selected variable, that
     # sample contributes to neither half of total().
     predict, target, deltas = _predict_dict(), _target_dict(), _delta_dict()
     keep = torch.ones(_CORRECTOR_SHAPE[0], dtype=torch.bool, device=get_device())
     keep[0] = False
-    corrector_loss = _corrector_loss(regularize=True)
+    corrector_loss = _corrector_loss(regularizer_names=["a"])
     result = StepOutputLoss(_corrector_step_loss(), corrector_loss)(
         predict, target, 0, data_mask={"a": keep}, deltas=deltas
     )
@@ -1265,12 +1289,29 @@ def test_penalty_uses_the_data_mask():
     )
 
 
+@pytest.mark.parametrize("feature", ["precorrector_optimization", "regularization"])
+def test_shrinking_delta_keys_raise(feature):
+    # a resolved name absent from a later step's deltas raises through
+    # _require_delta rather than silently dropping out of the loss.
+    predict, target = _predict_dict(), _target_dict()
+    if feature == "precorrector_optimization":
+        corrector_loss = _resolved_corrector_loss(precorrector_names=["a"])
+    else:
+        corrector_loss = _resolved_corrector_loss(regularizer_names=["a"])
+    loss = StepOutputLoss(_corrector_step_loss(), corrector_loss)
+    shrunk = {k: v for k, v in _delta_dict().items() if k != "a"}
+    with pytest.raises(ValueError, match="produced no delta"):
+        loss(predict, target, 0, deltas=shrunk)
+
+
 @pytest.mark.parametrize("deltas", [None, {}])
 def test_empty_deltas_inert(deltas):
     # empty deltas ⇒ no pre-corrector swap, no penalty; result matches
     # the unconfigured case.
     predict, target = _predict_dict(), _target_dict()
-    corrector_loss = _corrector_loss(precorrector=True, regularize=True)
+    corrector_loss = _corrector_loss(
+        precorrector_names=["a"], regularizer_names=["b_0", "b_1"]
+    )
     result = StepOutputLoss(_corrector_step_loss(), corrector_loss)(
         predict, target, 0, deltas=deltas
     )
@@ -1279,15 +1320,60 @@ def test_empty_deltas_inert(deltas):
     torch.testing.assert_close(result.total(), unconfigured.total())
 
 
-def test_regularizer_channels_come_from_each_calls_deltas():
-    # the penalty covers exactly the delta keys of each call — not every name
-    # the loss covers, and with no set of names fixed across calls.
-    regularizer = _corrector_regularizer()
+@pytest.mark.parametrize("entry", ["missing_var", "missing_"])
+@pytest.mark.parametrize("feature", ["precorrector_optimization", "regularization"])
+def test_resolve_names_errors_on_unmatched_delta_key(feature, entry):
+    # the first non-empty-delta call raises, naming the feature, the unmatched
+    # entries and the delta keys the corrector produced.
+    predict, target, deltas = _predict_dict(), _target_dict(), _delta_dict()
+    if feature == "precorrector_optimization":
+        corrector_loss = _corrector_loss(precorrector_names=[entry])
+    else:
+        corrector_loss = _corrector_loss(regularizer_names=[entry])
+    loss = StepOutputLoss(_corrector_step_loss(), corrector_loss)
+    with pytest.raises(ValueError) as excinfo:
+        loss(predict, target, 0, deltas=deltas)
+    message = str(excinfo.value)
+    assert feature in message
+    assert repr(entry) in message
+    assert str(sorted(deltas)) in message
+
+
+def test_resolve_names_runs_once():
+    # after a first successful non-empty-delta call, a later call whose deltas
+    # would not satisfy the entries neither re-resolves nor raises; the penalty
+    # channels stay the ones first resolved.
+    predict, target, deltas = _predict_dict(), _target_dict(), _delta_dict()
+    corrector_loss = _corrector_loss(regularizer_names=["b_"])
+    loss = StepOutputLoss(_corrector_step_loss(), corrector_loss)
+    loss(predict, target, 0, deltas=deltas)
+    corrector_loss.resolve_names({"a"})
+    result = loss(predict, target, 0, deltas=deltas)
+    assert result.corrector_penalty is not None
+    assert list(result.corrector_penalty.get_channel_losses()) == ["b_0", "b_1"]
+
+
+def test_empty_deltas_do_not_consume_the_check():
+    # repeated empty-delta calls are inert, and an unmatched entry still raises
+    # on the first non-empty call afterwards.
+    predict, target = _predict_dict(), _target_dict()
+    corrector_loss = _corrector_loss(regularizer_names=["missing_var"])
+    loss = StepOutputLoss(_corrector_step_loss(), corrector_loss)
+    for _ in range(3):
+        result = loss(predict, target, 0, deltas={})
+        assert result.corrector_penalty is None
+    with pytest.raises(ValueError, match="match none of the correction deltas"):
+        loss(predict, target, 0, deltas=_delta_dict())
+
+
+def test_regularizer_channels_come_from_the_deltas():
+    # a prefix entry resolves to exactly the matching delta keys, not to every
+    # name the loss covers that it would match.
     deltas = {name: value for name, value in _delta_dict().items() if name != "b_1"}
-    result = regularizer(deltas)
-    assert list(result.get_channel_losses()) == ["a", "b_0"]
-    torch.testing.assert_close(result.total(), _expected_penalty(deltas, ["a", "b_0"]))
-    other = {"b_1": _delta_dict()["b_1"]}
-    result = regularizer(other)
-    assert list(result.get_channel_losses()) == ["b_1"]
-    torch.testing.assert_close(result.total(), _expected_penalty(other, ["b_1"]))
+    regularizer = _corrector_regularizer(["b_"])
+    assert regularizer.names == []
+    regularizer.resolve(deltas.keys())
+    assert regularizer.names == ["b_0"]
+    torch.testing.assert_close(
+        regularizer(deltas).total(), _expected_penalty(deltas, ["b_0"])
+    )


### PR DESCRIPTION
Reinstates per-variable name selection for the corrector-loss features by reverting #1453, so the selection design from #1426 can be reviewed and iterated on its own after #1426 merges without it. The revert commit is recorded with @jpdunc23's authorship, since it restores his implementation.

Changes:
- `fme.core.corrector.loss_config`: restores `PreCorrectorOptimizationConfig` and `CorrectorRegularizationConfig.names_and_prefixes`; `CorrectorLossConfig.build` again takes `loss_names` and checks the configured entries against the names the loss covers at build
- `fme.core.loss`: restores `require_matched_entries`, `CorrectorLoss.resolve_names` (runtime validation against the corrector's delta keys on the first non-empty delta, logging the resolved names), fixed penalty channels via `CorrectorRegularizer.resolve`, and the shrinking-delta-keys errors
- `fme.core.name_and_prefix_matcher`: restores `NameAndPrefixSelection`
- Restores the tests of that machinery

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Do not merge before #1453 has merged into #1426 and #1426 has merged; GitHub retargets this PR as those branches are deleted.
