### PR TITLE
Allow per-channel fill values for static spatial masking

### DIFF
--- a/fme/core/spatial_masking.py
+++ b/fme/core/spatial_masking.py
@@ -50,21 +50,56 @@ class StaticSpatialMaskingConfig:
         mask_value: Value of the mask variable in masked regions. Either 0 or 1.
         fill_value: A float fill value to use inside of masked regions. Can also be
             "mean", in which case the normalizer means are used as channel-specific
-            fill values.
+            fill values. Applies to every masked channel that no
+            ``fill_value_overrides`` entry selects.
         exclude_names_and_prefixes: Names (2D variables) and prefixes (3D variables)
             to exclude when applying the mask.
+        fill_value_overrides: Per-channel fill values overriding ``fill_value``,
+            keyed by name (2D variables) or prefix (3D variables), following the
+            same convention as ``exclude_names_and_prefixes``. Values take the same
+            form as ``fill_value``. A channel selected by an exact name uses that
+            entry; otherwise the longest matching prefix wins; otherwise
+            ``fill_value`` applies. Every key must select at least one channel, so
+            a typo raises at build time rather than silently doing nothing.
+
+            The motivating case is that the right fill differs by channel. A field
+            whose masked cells hold no data (temperature, salinity) has no true
+            value to restore, so the channel mean is a neutral filler. A field
+            whose masked cells are genuinely dry -- the depth-resolved channels
+            below the sea floor -- carries usable information in being marked out
+            of range, which the mean erases.
 
     """
 
     mask_value: int
     fill_value: Literal["mean"] | float = 0.0
     exclude_names_and_prefixes: list[str] | None = None
+    fill_value_overrides: dict[str, Literal["mean"] | float] | None = None
 
     def __post_init__(self):
         if self.mask_value not in [0, 1]:
             raise ValueError(
                 f"mask_value must be either 0 or 1, but got {self.mask_value}"
             )
+        for key, value in (self.fill_value_overrides or {}).items():
+            if value != "mean" and not isinstance(value, int | float):
+                raise ValueError(
+                    "fill_value_overrides values must be a float or 'mean', but "
+                    f"got {value!r} for {key!r}"
+                )
+
+    def _resolve_fill_value(self, name: str) -> Literal["mean"] | float:
+        """The fill value for one channel.
+
+        Exact name wins, then the longest matching prefix, then ``fill_value``.
+        """
+        overrides = self.fill_value_overrides or {}
+        if name in overrides:
+            return overrides[name]
+        prefixes = [k for k in overrides if name.startswith(k)]
+        if prefixes:
+            return overrides[max(prefixes, key=len)]
+        return self.fill_value
 
     def build(self, mask: HasGetSpatialMask, means: TensorMapping | None = None):
         """
@@ -72,23 +107,56 @@ class StaticSpatialMaskingConfig:
 
         """
         exclude = NameAndPrefixMatcher(self.exclude_names_and_prefixes)
-        if isinstance(self.fill_value, float):
+        if not self.fill_value_overrides:
+            # Unchanged from before per-channel overrides existed.
+            if isinstance(self.fill_value, float):
+                return StaticSpatialMasking(
+                    mask_value=self.mask_value,
+                    fill_value=collections.defaultdict(
+                        lambda: torch.as_tensor(self.fill_value)
+                    ),
+                    mask=mask,
+                    exclude=exclude,
+                )
+            if means is None:
+                raise ValueError(
+                    "fill_values mapping required by build unless configured "
+                    "fill_value is a float."
+                )
             return StaticSpatialMasking(
                 mask_value=self.mask_value,
-                fill_value=collections.defaultdict(
-                    lambda: torch.as_tensor(self.fill_value)
-                ),
+                fill_value=means,
                 mask=mask,
                 exclude=exclude,
             )
+        # With overrides the mapping is resolved per channel, so it has to be
+        # built eagerly over the known channel names rather than deferred to a
+        # defaultdict or to `means` itself.
         if means is None:
             raise ValueError(
-                "fill_values mapping required by build unless configured "
-                "fill_value is a float."
+                "fill_values mapping required by build when fill_value_overrides "
+                "is set, to enumerate the channels and to supply any 'mean' fills."
+            )
+        unmatched = [
+            key
+            for key in self.fill_value_overrides
+            if not any(name == key or name.startswith(key) for name in means)
+        ]
+        if unmatched:
+            raise ValueError(
+                "fill_value_overrides keys match no channel: "
+                f"{sorted(unmatched)}. Keys are names or prefixes, as in "
+                "exclude_names_and_prefixes."
+            )
+        fill_mapping = {}
+        for name in means:
+            resolved = self._resolve_fill_value(name)
+            fill_mapping[name] = (
+                means[name] if resolved == "mean" else torch.as_tensor(float(resolved))
             )
         return StaticSpatialMasking(
             mask_value=self.mask_value,
-            fill_value=means,
+            fill_value=fill_mapping,
             mask=mask,
             exclude=exclude,
         )

--- a/fme/core/spatial_masking.py
+++ b/fme/core/spatial_masking.py
@@ -1,5 +1,6 @@
 import collections
 import dataclasses
+from collections.abc import Iterable
 from typing import Literal, Protocol, runtime_checkable
 
 import torch
@@ -55,19 +56,19 @@ class StaticSpatialMaskingConfig:
         exclude_names_and_prefixes: Names (2D variables) and prefixes (3D variables)
             to exclude when applying the mask.
         fill_value_overrides: Per-channel fill values overriding ``fill_value``,
-            keyed by name (2D variables) or prefix (3D variables), following the
-            same convention as ``exclude_names_and_prefixes``. Values take the same
-            form as ``fill_value``. A channel selected by an exact name uses that
-            entry; otherwise the longest matching prefix wins; otherwise
-            ``fill_value`` applies. Every key must select at least one channel, so
-            a typo raises at build time rather than silently doing nothing.
+            keyed by name (2D variables) or prefix (3D variables), selecting
+            channels by the same convention as ``exclude_names_and_prefixes``.
+            Values take the same form as ``fill_value``. Where more than one key
+            selects a channel the longest key wins, so an exact ``name_<level>``
+            beats the ``name_`` prefix, which beats the bare ``name``; a channel
+            no key selects takes ``fill_value``. Every key must select at least
+            one channel, so a key that selects nothing raises at build time
+            rather than silently doing nothing.
 
-            The motivating case is that the right fill differs by channel. A field
-            whose masked cells hold no data (temperature, salinity) has no true
-            value to restore, so the channel mean is a neutral filler. A field
-            whose masked cells are genuinely dry -- the depth-resolved channels
-            below the sea floor -- carries usable information in being marked out
-            of range, which the mean erases.
+            Use this where the right fill differs by channel: the channel mean is
+            a neutral filler where masked cells hold no data, whereas ``0.0``
+            marks them as out of range, which is usable information where the
+            masked cells are genuinely dry.
 
     """
 
@@ -81,25 +82,43 @@ class StaticSpatialMaskingConfig:
             raise ValueError(
                 f"mask_value must be either 0 or 1, but got {self.mask_value}"
             )
-        for key, value in (self.fill_value_overrides or {}).items():
-            if value != "mean" and not isinstance(value, int | float):
-                raise ValueError(
-                    "fill_value_overrides values must be a float or 'mean', but "
-                    f"got {value!r} for {key!r}"
-                )
 
-    def _resolve_fill_value(self, name: str) -> Literal["mean"] | float:
-        """The fill value for one channel.
+    def _resolve_fill_values(
+        self, names: Iterable[str]
+    ) -> dict[str, Literal["mean"] | float]:
+        """The fill value to use for each of ``names``.
 
-        Exact name wins, then the longest matching prefix, then ``fill_value``.
+        Override keys select channels by the same name-or-prefix convention as
+        ``exclude_names_and_prefixes``. Where more than one key selects a
+        channel the longest key wins, so an exact ``name_<level>`` beats the
+        ``name_`` prefix, which beats the bare ``name``. A channel no key
+        selects takes ``fill_value``.
+
+        Raises:
+            ValueError: If an override key selects none of ``names``.
         """
         overrides = self.fill_value_overrides or {}
-        if name in overrides:
-            return overrides[name]
-        prefixes = [k for k in overrides if name.startswith(k)]
-        if prefixes:
-            return overrides[max(prefixes, key=len)]
-        return self.fill_value
+        matchers = {key: NameAndPrefixMatcher([key]) for key in overrides}
+        channels = list(names)
+        unselected = sorted(
+            key
+            for key, matcher in matchers.items()
+            if not any(matcher.match(channel) for channel in channels)
+        )
+        if unselected:
+            raise ValueError(
+                f"fill_value_overrides keys match no channel: {unselected}. "
+                "Keys are names or prefixes, as in exclude_names_and_prefixes."
+            )
+        resolved: dict[str, Literal["mean"] | float] = {}
+        for channel in channels:
+            selecting = [
+                key for key, matcher in matchers.items() if matcher.match(channel)
+            ]
+            resolved[channel] = (
+                overrides[max(selecting, key=len)] if selecting else self.fill_value
+            )
+        return resolved
 
     def build(self, mask: HasGetSpatialMask, means: TensorMapping | None = None):
         """
@@ -108,13 +127,11 @@ class StaticSpatialMaskingConfig:
         """
         exclude = NameAndPrefixMatcher(self.exclude_names_and_prefixes)
         if not self.fill_value_overrides:
-            # Unchanged from before per-channel overrides existed.
-            if isinstance(self.fill_value, float):
+            if self.fill_value != "mean":
+                fill = torch.as_tensor(float(self.fill_value))
                 return StaticSpatialMasking(
                     mask_value=self.mask_value,
-                    fill_value=collections.defaultdict(
-                        lambda: torch.as_tensor(self.fill_value)
-                    ),
+                    fill_value=collections.defaultdict(lambda: fill),
                     mask=mask,
                     exclude=exclude,
                 )
@@ -129,31 +146,17 @@ class StaticSpatialMaskingConfig:
                 mask=mask,
                 exclude=exclude,
             )
-        # With overrides the mapping is resolved per channel, so it has to be
-        # built eagerly over the known channel names rather than deferred to a
-        # defaultdict or to `means` itself.
+        # A per-channel mapping cannot be deferred to a defaultdict or to `means`
+        # itself, so it is resolved eagerly over the channels `means` names.
         if means is None:
             raise ValueError(
                 "fill_values mapping required by build when fill_value_overrides "
                 "is set, to enumerate the channels and to supply any 'mean' fills."
             )
-        unmatched = [
-            key
-            for key in self.fill_value_overrides
-            if not any(name == key or name.startswith(key) for name in means)
-        ]
-        if unmatched:
-            raise ValueError(
-                "fill_value_overrides keys match no channel: "
-                f"{sorted(unmatched)}. Keys are names or prefixes, as in "
-                "exclude_names_and_prefixes."
-            )
-        fill_mapping = {}
-        for name in means:
-            resolved = self._resolve_fill_value(name)
-            fill_mapping[name] = (
-                means[name] if resolved == "mean" else torch.as_tensor(float(resolved))
-            )
+        fill_mapping = {
+            name: means[name] if value == "mean" else torch.as_tensor(float(value))
+            for name, value in self._resolve_fill_values(means).items()
+        }
         return StaticSpatialMasking(
             mask_value=self.mask_value,
             fill_value=fill_mapping,

--- a/fme/core/test_spatial_masking.py
+++ b/fme/core/test_spatial_masking.py
@@ -239,3 +239,113 @@ def test_static_masking_mask_ignored_name():
     assert masked["masked"][1, 1].isnan()
     # no change to "mask_ignored" because _Mask gives it special treatment
     torch.testing.assert_close(masked["mask_ignored"], data["mask_ignored"])
+
+
+def _overrides_setup():
+    """A 2x2 grid with one masked cell, and means far from any fill value."""
+    mask_2d = torch.tensor([[1.0, 0.0], [1.0, 1.0]], device=DEVICE)
+    mask_3d = mask_2d[..., None].expand(2, 2, 2)
+    data = {
+        "sst": torch.full((1, 2, 2), 7.0, device=DEVICE),
+        "thetao_0": torch.full((1, 2, 2), 7.0, device=DEVICE),
+        "thetao_1": torch.full((1, 2, 2), 7.0, device=DEVICE),
+        "deptho": torch.full((1, 2, 2), 7.0, device=DEVICE),
+    }
+    means = {
+        "sst": torch.tensor(100.0, device=DEVICE),
+        "thetao_0": torch.tensor(200.0, device=DEVICE),
+        "thetao_1": torch.tensor(300.0, device=DEVICE),
+        "deptho": torch.tensor(400.0, device=DEVICE),
+    }
+    return _Mask(mask_2d=mask_2d, mask_3d=mask_3d), data, means
+
+
+def test_fill_value_overrides_apply_per_channel():
+    """mean everywhere except the prefixed and named overrides, which take 0.0."""
+    mask, data, means = _overrides_setup()
+    config = StaticSpatialMaskingConfig(
+        mask_value=0,
+        fill_value="mean",
+        fill_value_overrides={"thetao_": 0.0, "deptho": 0.0},
+    )
+    out = config.build(mask=mask, means=means)(data)
+    # the masked cell is [0, 0, 1]
+    assert out["sst"][0, 0, 1].item() == pytest.approx(100.0)  # default "mean"
+    assert out["thetao_0"][0, 0, 1].item() == pytest.approx(0.0)  # prefix override
+    assert out["thetao_1"][0, 0, 1].item() == pytest.approx(0.0)  # prefix override
+    assert out["deptho"][0, 0, 1].item() == pytest.approx(0.0)  # exact-name override
+    # unmasked cells are untouched in every channel
+    for name in data:
+        assert out[name][0, 0, 0].item() == pytest.approx(7.0)
+
+
+def test_fill_value_overrides_exact_name_beats_prefix():
+    mask, data, means = _overrides_setup()
+    config = StaticSpatialMaskingConfig(
+        mask_value=0,
+        fill_value=0.0,
+        fill_value_overrides={"thetao_": 1.0, "thetao_1": "mean"},
+    )
+    out = config.build(mask=mask, means=means)(data)
+    assert out["sst"][0, 0, 1].item() == pytest.approx(0.0)  # default float
+    assert out["thetao_0"][0, 0, 1].item() == pytest.approx(1.0)  # prefix
+    assert out["thetao_1"][0, 0, 1].item() == pytest.approx(300.0)  # exact name wins
+
+
+def test_fill_value_overrides_longest_prefix_wins():
+    mask, data, means = _overrides_setup()
+    config = StaticSpatialMaskingConfig(
+        mask_value=0,
+        fill_value=0.0,
+        fill_value_overrides={"the": 1.0, "thetao_": 2.0},
+    )
+    out = config.build(mask=mask, means=means)(data)
+    assert out["thetao_0"][0, 0, 1].item() == pytest.approx(2.0)
+
+
+def test_fill_value_overrides_unmatched_key_raises():
+    mask, _, means = _overrides_setup()
+    config = StaticSpatialMaskingConfig(
+        mask_value=0,
+        fill_value="mean",
+        fill_value_overrides={"thetoa_": 0.0},  # typo
+    )
+    with pytest.raises(ValueError, match="match no channel"):
+        config.build(mask=mask, means=means)
+
+
+def test_fill_value_overrides_requires_means():
+    mask, _, _ = _overrides_setup()
+    config = StaticSpatialMaskingConfig(
+        mask_value=0,
+        fill_value=0.0,
+        fill_value_overrides={"thetao_": 0.0},
+    )
+    with pytest.raises(ValueError, match="fill_values mapping required"):
+        config.build(mask=mask, means=None)
+
+
+def test_fill_value_overrides_rejects_bad_value():
+    with pytest.raises(ValueError, match="must be a float or 'mean'"):
+        StaticSpatialMaskingConfig(
+            mask_value=0,
+            fill_value="mean",
+            # The guard exists for configs built from YAML by dacite, where the
+            # static type is not enforced; the ignore is what lets the test reach
+            # the runtime check.
+            fill_value_overrides={"thetao_": "zero"},  # type: ignore[dict-item]
+        )
+
+
+def test_no_overrides_is_unchanged():
+    """The default path must be byte-for-byte the old behaviour."""
+    mask, data, means = _overrides_setup()
+    for fill in (0.0, "mean"):
+        base = StaticSpatialMaskingConfig(mask_value=0, fill_value=fill)
+        explicit = StaticSpatialMaskingConfig(
+            mask_value=0, fill_value=fill, fill_value_overrides=None
+        )
+        a = base.build(mask=mask, means=means)(data)
+        b = explicit.build(mask=mask, means=means)(data)
+        for name in data:
+            assert torch.equal(a[name], b[name])

--- a/fme/core/test_spatial_masking.py
+++ b/fme/core/test_spatial_masking.py
@@ -1,5 +1,6 @@
 import re
 
+import dacite
 import pytest
 import torch
 
@@ -242,22 +243,26 @@ def test_static_masking_mask_ignored_name():
 
 
 def _overrides_setup():
-    """A 2x2 grid with one masked cell, and means far from any fill value."""
+    """A 2x2 grid with one masked cell, and means far from any fill value.
+
+    ``so_0`` and ``sos`` share a leading substring but are distinct channels
+    under the name-and-prefix convention, so they pin down which channels an
+    override key selects.
+    """
     mask_2d = torch.tensor([[1.0, 0.0], [1.0, 1.0]], device=DEVICE)
     mask_3d = mask_2d[..., None].expand(2, 2, 2)
-    data = {
-        "sst": torch.full((1, 2, 2), 7.0, device=DEVICE),
-        "thetao_0": torch.full((1, 2, 2), 7.0, device=DEVICE),
-        "thetao_1": torch.full((1, 2, 2), 7.0, device=DEVICE),
-        "deptho": torch.full((1, 2, 2), 7.0, device=DEVICE),
-    }
+    names = ["sst", "sos", "so_0", "thetao_0", "thetao_1", "deptho"]
+    data = {name: torch.full((1, 2, 2), 7.0, device=DEVICE) for name in names}
     means = {
-        "sst": torch.tensor(100.0, device=DEVICE),
-        "thetao_0": torch.tensor(200.0, device=DEVICE),
-        "thetao_1": torch.tensor(300.0, device=DEVICE),
-        "deptho": torch.tensor(400.0, device=DEVICE),
+        name: torch.tensor(100.0 * (i + 1), device=DEVICE)
+        for i, name in enumerate(names)
     }
     return _Mask(mask_2d=mask_2d, mask_3d=mask_3d), data, means
+
+
+# the one masked cell of every channel in _overrides_setup
+_MASKED_CELL = (0, 0, 1)
+_UNMASKED_CELL = (0, 0, 0)
 
 
 def test_fill_value_overrides_apply_per_channel():
@@ -269,14 +274,37 @@ def test_fill_value_overrides_apply_per_channel():
         fill_value_overrides={"thetao_": 0.0, "deptho": 0.0},
     )
     out = config.build(mask=mask, means=means)(data)
-    # the masked cell is [0, 0, 1]
-    assert out["sst"][0, 0, 1].item() == pytest.approx(100.0)  # default "mean"
-    assert out["thetao_0"][0, 0, 1].item() == pytest.approx(0.0)  # prefix override
-    assert out["thetao_1"][0, 0, 1].item() == pytest.approx(0.0)  # prefix override
-    assert out["deptho"][0, 0, 1].item() == pytest.approx(0.0)  # exact-name override
+    expected = {
+        "sst": means["sst"].item(),  # default "mean"
+        "sos": means["sos"].item(),  # default "mean"
+        "so_0": means["so_0"].item(),  # default "mean"
+        "thetao_0": 0.0,  # prefix override
+        "thetao_1": 0.0,  # prefix override
+        "deptho": 0.0,  # exact-name override
+    }
+    for name, value in expected.items():
+        assert out[name][_MASKED_CELL].item() == pytest.approx(value), name
     # unmasked cells are untouched in every channel
     for name in data:
-        assert out[name][0, 0, 0].item() == pytest.approx(7.0)
+        assert out[name][_UNMASKED_CELL].item() == pytest.approx(7.0), name
+
+
+@pytest.mark.parametrize("key", ["so", "so_"])
+def test_fill_value_overrides_key_does_not_select_similar_name(key):
+    """``so``/``so_`` select the so_<level> channels, never the distinct ``sos``.
+
+    Selection follows NameAndPrefixMatcher, not a raw string prefix, so a key
+    cannot silently capture an unrelated channel that happens to start with it.
+    """
+    mask, data, means = _overrides_setup()
+    config = StaticSpatialMaskingConfig(
+        mask_value=0,
+        fill_value="mean",
+        fill_value_overrides={key: 0.0},
+    )
+    out = config.build(mask=mask, means=means)(data)
+    assert out["so_0"][_MASKED_CELL].item() == pytest.approx(0.0)
+    assert out["sos"][_MASKED_CELL].item() == pytest.approx(means["sos"].item())
 
 
 def test_fill_value_overrides_exact_name_beats_prefix():
@@ -287,28 +315,38 @@ def test_fill_value_overrides_exact_name_beats_prefix():
         fill_value_overrides={"thetao_": 1.0, "thetao_1": "mean"},
     )
     out = config.build(mask=mask, means=means)(data)
-    assert out["sst"][0, 0, 1].item() == pytest.approx(0.0)  # default float
-    assert out["thetao_0"][0, 0, 1].item() == pytest.approx(1.0)  # prefix
-    assert out["thetao_1"][0, 0, 1].item() == pytest.approx(300.0)  # exact name wins
+    assert out["sst"][_MASKED_CELL].item() == pytest.approx(0.0)  # default float
+    assert out["thetao_0"][_MASKED_CELL].item() == pytest.approx(1.0)  # prefix
+    assert out["thetao_1"][_MASKED_CELL].item() == pytest.approx(
+        means["thetao_1"].item()
+    )  # exact name wins
 
 
-def test_fill_value_overrides_longest_prefix_wins():
+def test_fill_value_overrides_longest_key_wins():
+    """The bare name selects the same channels as the prefix, so the prefix wins."""
     mask, data, means = _overrides_setup()
     config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value=0.0,
-        fill_value_overrides={"the": 1.0, "thetao_": 2.0},
+        fill_value_overrides={"thetao": 1.0, "thetao_": 2.0},
     )
     out = config.build(mask=mask, means=means)(data)
-    assert out["thetao_0"][0, 0, 1].item() == pytest.approx(2.0)
+    assert out["thetao_0"][_MASKED_CELL].item() == pytest.approx(2.0)
 
 
-def test_fill_value_overrides_unmatched_key_raises():
+@pytest.mark.parametrize(
+    "key",
+    [
+        "thetoa_",  # transposed letters
+        "dept",  # a truncation that is a raw string prefix of "deptho"
+    ],
+)
+def test_fill_value_overrides_unmatched_key_raises(key):
     mask, _, means = _overrides_setup()
     config = StaticSpatialMaskingConfig(
         mask_value=0,
         fill_value="mean",
-        fill_value_overrides={"thetoa_": 0.0},  # typo
+        fill_value_overrides={key: 0.0},
     )
     with pytest.raises(ValueError, match="match no channel"):
         config.build(mask=mask, means=means)
@@ -325,27 +363,36 @@ def test_fill_value_overrides_requires_means():
         config.build(mask=mask, means=None)
 
 
-def test_fill_value_overrides_rejects_bad_value():
-    with pytest.raises(ValueError, match="must be a float or 'mean'"):
-        StaticSpatialMaskingConfig(
-            mask_value=0,
-            fill_value="mean",
-            # The guard exists for configs built from YAML by dacite, where the
-            # static type is not enforced; the ignore is what lets the test reach
-            # the runtime check.
-            fill_value_overrides={"thetao_": "zero"},  # type: ignore[dict-item]
+def test_fill_value_overrides_bad_value_rejected_on_load():
+    """dacite rejects a non-float, non-"mean" value, so build never sees one."""
+    with pytest.raises(dacite.UnionMatchError):
+        dacite.from_dict(
+            data_class=StaticSpatialMaskingConfig,
+            data={
+                "mask_value": 0,
+                "fill_value": "mean",
+                "fill_value_overrides": {"thetao_": "zero"},
+            },
+            config=dacite.Config(strict=True),
         )
 
 
-def test_no_overrides_is_unchanged():
-    """The default path must be byte-for-byte the old behaviour."""
+@pytest.mark.parametrize("fill_value", [0.0, 0, 3.5, "mean"])
+@pytest.mark.parametrize("overrides", [None, {"deptho": 1.0}])
+def test_fill_value_applies_to_channels_no_override_selects(fill_value, overrides):
+    """``fill_value`` fills every channel an override does not select.
+
+    Parametrized over both branches of ``build`` so the two agree, including for
+    an integer ``fill_value``, which YAML yields for an unsuffixed ``0``.
+    """
     mask, data, means = _overrides_setup()
-    for fill in (0.0, "mean"):
-        base = StaticSpatialMaskingConfig(mask_value=0, fill_value=fill)
-        explicit = StaticSpatialMaskingConfig(
-            mask_value=0, fill_value=fill, fill_value_overrides=None
-        )
-        a = base.build(mask=mask, means=means)(data)
-        b = explicit.build(mask=mask, means=means)(data)
-        for name in data:
-            assert torch.equal(a[name], b[name])
+    config = StaticSpatialMaskingConfig(
+        mask_value=0, fill_value=fill_value, fill_value_overrides=overrides
+    )
+    out = config.build(mask=mask, means=means)(data)
+    for name in data:
+        if overrides is not None and name in overrides:
+            continue
+        expected = means[name].item() if fill_value == "mean" else float(fill_value)
+        assert out[name][_MASKED_CELL].item() == pytest.approx(expected), name
+        assert out[name][_UNMASKED_CELL].item() == pytest.approx(7.0), name


### PR DESCRIPTION
Masked-input handling currently applies one fill value to every masked channel: either `0.0` everywhere or the channel mean everywhere. The right choice differs by channel, and a 1° ocean comparison over 130-year and 200-year free-running rollouts showed both directions mattering at once — the channel mean is better for every 2D surface field, while `0.0` is better for the 19-level velocity and temperature profiles by 1.2–1.4×.

There is a plain reason. Where a masked cell holds no data — temperature and salinity below the sea floor — there is no true value to restore, so the channel mean is a neutral filler and `0.0` injects a large out-of-range value near coastlines. Where a masked cell is genuinely dry, being marked out of range is usable information, and nothing else in the inputs states it per level: the land mask is a single 2D field, whereas the wet fraction falls from 0.69 at the surface to 0.07 at the deepest level, with 89% of surface-ocean columns dry by then. The mean erases that distinction; `0.0` hands it to the network per channel.

This adds the configuration needed to express both at once. It does not change the fill any existing config produces.

Changes:
- `fme.core.spatial_masking.StaticSpatialMaskingConfig.fill_value_overrides` — new optional mapping from channel name or prefix to a fill value (`"mean"` or a float), overriding `fill_value` for the channels it selects. Keys select channels through `NameAndPrefixMatcher`, the same relation `exclude_names_and_prefixes` uses, so a bare `name` selects `name` and `name_<level>`, a `name_` prefix selects `name_<level>`, and `name_<level>` selects exactly that channel. Where several keys select one channel the longest key wins, which orders `name_<level>` over `name_` over `name`; a channel no key selects keeps `fill_value`. A key selecting no channel raises at build time, so a typo fails loudly instead of silently doing nothing.
- `StaticSpatialMaskingConfig.build` — resolves the mapping eagerly over the normalizer's channel names when overrides are set, since a per-channel mapping cannot be deferred to a `defaultdict` or to `means` itself. `means` becomes required in that case, both to enumerate channels and to supply any `"mean"` fills.

`StaticSpatialMasking` already keyed its fill values by channel name, so the change is confined to the config layer; the runtime is untouched. `fme/coupled` reaches this config through the same `StepperConfig.input_masking` field, so it picks the option up with no mirror change. Output masking is unaffected: it fills NaN by construction and has no per-channel fill to configure.

Fixed along the way, both in the function this PR modifies:
- An integer `fill_value` no longer silently means the channel mean. dacite accepts an unsuffixed YAML `0` for `Literal["mean"] | float`, and `isinstance(self.fill_value, float)` then routed it to the means branch. Without this, `fill_value: 0` would have meant `0.0` with overrides set and the channel mean without them. No config in the repo passes an integer `fill_value`, so no existing run changes behavior.
- `fill_value_overrides` values are type-checked at load by dacite (`UnionMatchError`) rather than by a hand-rolled `isinstance` in `__post_init__`, which was unreachable from YAML.

With `fill_value_overrides` unset, `build()` takes the same branches it took before. Tests assert the concrete fill each channel receives on both branches, so the default path is pinned to values rather than to itself.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
