### PR TITLE
Add per-channel patch energy score loss

### DIFF
--- a/fme/core/ensemble.py
+++ b/fme/core/ensemble.py
@@ -139,19 +139,34 @@ def get_patch_energy_score(
         E[||X - y||] - 1/2 E[||X - X'||]
 
     The east-west boundary is periodic and the north-south boundary is
-    zero-padded; since generated and target fields receive identical padding,
-    out-of-domain entries contribute zero to every patch distance, so polar
-    patches are effectively truncated to their valid entries.
+    zero-padded. Both fields receive identical padding (implemented as
+    padding of their pointwise squared difference, which is equivalent), so
+    out-of-domain entries contribute zero to every patch distance and polar
+    patches are effectively truncated to their valid entries. Because the
+    score is divided by the fixed factor patch_size regardless of that
+    truncation, rows within halo distance of a pole contribute
+    proportionally less loss than interior rows (roughly by
+    sqrt(n_valid) / patch_size); this mild polar down-weighting is accepted
+    behavior.
 
-    The result is divided by patch_size (the square root of the patch
-    dimensionality) so its magnitude is comparable to CRPS; for
-    patch_size=1 it equals fair CRPS exactly.
+    The division by patch_size (the square root of the patch
+    dimensionality) makes the magnitude comparable to CRPS; at patch_size=1
+    it equals fair CRPS up to the numerical floor below. The squared patch
+    distance is floored at 1e-12 before the square root (a 1e-6 floor on
+    each distance), giving collapsed ensembles a zero subgradient instead
+    of the unbounded gradient of sqrt at zero.
+
+    The horizontal layout is assumed to be [..., n_lat, n_lon] with a
+    periodic last dimension (a lat-lon grid). Other layouts -- e.g. the
+    HEALPix [..., face, ny, nx] -- would be silently mis-padded, as with
+    the finite-difference CRPS loss.
 
     Args:
         gen: The generated ensemble members, of shape
             [n_batch, n_ensemble, ..., n_lat, n_lon].
         target: The target, of shape [n_batch, 1, ..., n_lat, n_lon].
-        patch_size: Odd width of the square patch in grid points.
+        patch_size: Odd width of the square patch in grid points; at most
+            n_lon.
 
     Returns:
         The patch energy score, of shape [n_batch, ..., n_lat, n_lon].
@@ -164,6 +179,11 @@ def get_patch_energy_score(
         )
     if patch_size < 1 or patch_size % 2 == 0:
         raise ValueError(f"patch_size must be a positive odd integer, got {patch_size}")
+    if patch_size > gen.shape[-1]:
+        raise ValueError(
+            f"patch_size ({patch_size}) must not exceed the longitude "
+            f"dimension ({gen.shape[-1]})"
+        )
     n_batch = gen.shape[0]
     # One pad + pool pass over all three difference fields, stacked on batch.
     diffs = torch.cat(

--- a/fme/core/ensemble.py
+++ b/fme/core/ensemble.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 
 
 def get_crps(
@@ -89,3 +90,91 @@ def get_energy_score(
     target_term = torch.abs(gen - target).mean(axis=1)
     internal_term = -0.5 * torch.abs(gen[:, 0, ...] - gen[:, 1, ...])
     return target_term + internal_term
+
+
+def _patch_l2_distance(diff: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """
+    Compute the per-point Euclidean distance between the patches of two
+    fields, given their pointwise difference.
+
+    ||patch(u) - patch(v)||^2 at each point equals the patch_size x patch_size
+    box-sum of (u - v)^2, because patch extraction is linear and the windows
+    of the two fields are aligned; no patch tensor is ever materialized.
+
+    Args:
+        diff: The pointwise difference of two fields, of shape
+            [..., n_lat, n_lon].
+        patch_size: Odd width of the square patch in grid points.
+
+    Returns:
+        The patch distance, of the same shape as diff.
+    """
+    halo = patch_size // 2
+    shape = diff.shape
+    squared = (diff * diff).reshape(-1, 1, shape[-2], shape[-1])
+    squared = F.pad(squared, (halo, halo, 0, 0), mode="circular")
+    squared = F.pad(squared, (0, 0, halo, halo), mode="constant", value=0.0)
+    box_sum = F.avg_pool2d(
+        squared, kernel_size=patch_size, stride=1, divisor_override=1
+    )
+    # sqrt has an unbounded gradient at zero (identical members, constant
+    # patches); clamping gives a zero subgradient there, like abs() in CRPS.
+    return torch.sqrt(box_sum.clamp_min(1e-12)).reshape(shape)
+
+
+def get_patch_energy_score(
+    gen: torch.Tensor,
+    target: torch.Tensor,
+    patch_size: int = 3,
+) -> torch.Tensor:
+    """
+    Compute a per-channel patch energy score.
+
+    Each grid point is scored with the energy score of the
+    patch_size x patch_size patch of a single channel centered on it, using
+    the Euclidean norm over patch values:
+
+    .. math::
+
+        E[||X - y||] - 1/2 E[||X - X'||]
+
+    The east-west boundary is periodic and the north-south boundary is
+    zero-padded; since generated and target fields receive identical padding,
+    out-of-domain entries contribute zero to every patch distance, so polar
+    patches are effectively truncated to their valid entries.
+
+    The result is divided by patch_size (the square root of the patch
+    dimensionality) so its magnitude is comparable to CRPS; for
+    patch_size=1 it equals fair CRPS exactly.
+
+    Args:
+        gen: The generated ensemble members, of shape
+            [n_batch, n_ensemble, ..., n_lat, n_lon].
+        target: The target, of shape [n_batch, 1, ..., n_lat, n_lon].
+        patch_size: Odd width of the square patch in grid points.
+
+    Returns:
+        The patch energy score, of shape [n_batch, ..., n_lat, n_lon].
+    """
+    if gen.shape[1] != 2:
+        raise NotImplementedError(
+            "Patch energy score is written here specifically for 2 ensemble "
+            f"members, got {gen.shape[1]} ensemble members. "
+            "Update this function (and its tests) to support more."
+        )
+    if patch_size < 1 or patch_size % 2 == 0:
+        raise ValueError(f"patch_size must be a positive odd integer, got {patch_size}")
+    n_batch = gen.shape[0]
+    # One pad + pool pass over all three difference fields, stacked on batch.
+    diffs = torch.cat(
+        [
+            gen[:, 0] - target[:, 0],
+            gen[:, 1] - target[:, 0],
+            gen[:, 0] - gen[:, 1],
+        ],
+        dim=0,
+    )
+    distance = _patch_l2_distance(diffs, patch_size)
+    target_term = 0.5 * (distance[:n_batch] + distance[n_batch : 2 * n_batch])
+    internal_term = -0.5 * distance[2 * n_batch :]
+    return (target_term + internal_term) / patch_size

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -660,6 +660,9 @@ class PatchEnergyScoreLoss(torch.nn.Module):
 
     A grid-space alternative to the spectral :class:`EnergyScoreLoss` that
     scores joint local structure per channel instead of per-mode calibration.
+    Assumes a ``[..., n_lat, n_lon]`` layout with periodic longitude (a
+    lat-lon grid); see :func:`fme.core.ensemble.get_patch_energy_score` for
+    the boundary and normalization details.
 
     Returns a pre-weighted ``(B, C, H, W)`` tensor whose mean over trailing
     dims gives the per-``(B, C)`` loss, like :class:`CRPSLoss`.

--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -8,7 +8,7 @@ import torch.linalg
 import torch.nn.functional as F
 
 from fme.core.device import get_device
-from fme.core.ensemble import get_crps, get_energy_score
+from fme.core.ensemble import get_crps, get_energy_score, get_patch_energy_score
 from fme.core.gridded_ops import GriddedOperations
 from fme.core.normalizer import StandardNormalizer
 from fme.core.packer import Packer
@@ -652,6 +652,31 @@ class CRPSLoss(torch.nn.Module):
         return [StandardLoss(get_crps(x, y, alpha=self.alpha))]
 
 
+class PatchEnergyScoreLoss(torch.nn.Module):
+    """
+    Compute the patch energy score: for each channel and grid point, the
+    energy score of the ``patch_size x patch_size`` patch of that channel
+    centered on the point (periodic east-west, zero-padded north-south).
+
+    A grid-space alternative to the spectral :class:`EnergyScoreLoss` that
+    scores joint local structure per channel instead of per-mode calibration.
+
+    Returns a pre-weighted ``(B, C, H, W)`` tensor whose mean over trailing
+    dims gives the per-``(B, C)`` loss, like :class:`CRPSLoss`.
+    """
+
+    def __init__(self, patch_size: int = 3):
+        super().__init__()
+        if patch_size < 1 or patch_size % 2 == 0:
+            raise ValueError(
+                f"patch_size must be a positive odd integer, got {patch_size}"
+            )
+        self.patch_size = patch_size
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> list[LossComponent]:
+        return [StandardLoss(get_patch_energy_score(x, y, patch_size=self.patch_size))]
+
+
 class FiniteDifferenceCRPSLoss(torch.nn.Module):
     """
     Computes the CRPS of the x and y finite differences of the input tensors,
@@ -718,6 +743,8 @@ class EnsembleLoss(torch.nn.Module):
         finite_difference_crps_levels: int = 1,
         almost_fair_crps_alpha: float = 1.0,
         energy_score_whitening: SpectralWhitening | None = None,
+        patch_energy_score_weight: float = 0.0,
+        patch_energy_score_size: int = 3,
     ):
         super().__init__()
         if crps_weight < 0 or energy_score_weight < 0:
@@ -730,10 +757,17 @@ class EnsembleLoss(torch.nn.Module):
                 "finite_difference_crps_weight must be non-negative, "
                 f"got {finite_difference_crps_weight}"
             )
-        if crps_weight + energy_score_weight == 0:
+        if patch_energy_score_weight < 0:
             raise ValueError(
-                "crps_weight and energy_score_weight must sum to a positive value, "
-                f"got {crps_weight} and {energy_score_weight}"
+                "patch_energy_score_weight must be non-negative, "
+                f"got {patch_energy_score_weight}"
+            )
+        if crps_weight + energy_score_weight + patch_energy_score_weight == 0:
+            raise ValueError(
+                "crps_weight, energy_score_weight and patch_energy_score_weight "
+                "must sum to a positive value, "
+                f"got {crps_weight}, {energy_score_weight} "
+                f"and {patch_energy_score_weight}"
             )
         self.crps_loss = CRPSLoss(alpha=almost_fair_crps_alpha)
         if finite_difference_crps_weight > 0:
@@ -749,10 +783,14 @@ class EnsembleLoss(torch.nn.Module):
             sht=sht,
             whitening=energy_score_whitening,
         )
+        self.patch_energy_score_loss = PatchEnergyScoreLoss(
+            patch_size=patch_energy_score_size
+        )
 
         self.crps_weight = crps_weight
         self.diff_crps_weight = finite_difference_crps_weight
         self.energy_score_weight = energy_score_weight
+        self.patch_energy_score_weight = patch_energy_score_weight
 
     def forward(
         self,
@@ -766,6 +804,9 @@ class EnsembleLoss(torch.nn.Module):
         if self.energy_score_weight > 0:
             for c in self.energy_score_loss(gen_norm, target_norm):
                 components.append(type(c)(c.loss * self.energy_score_weight))
+        if self.patch_energy_score_weight > 0:
+            for c in self.patch_energy_score_loss(gen_norm, target_norm):
+                components.append(type(c)(c.loss * self.patch_energy_score_weight))
         if self.diff_crps_loss is not None:
             for c in self.diff_crps_loss(gen_norm, target_norm):
                 components.append(type(c)(c.loss * self.diff_crps_weight))

--- a/fme/core/test_ensemble.py
+++ b/fme/core/test_ensemble.py
@@ -3,7 +3,7 @@ import dataclasses
 import pytest
 import torch
 
-from fme.core.ensemble import get_crps
+from fme.core.ensemble import get_crps, get_patch_energy_score
 
 
 @dataclasses.dataclass
@@ -53,3 +53,107 @@ def test_crps(n_ensemble: int, alpha: float):
     assert crps_values["perfect"] < crps_values["less_variance"]
     assert crps_values["extra_variance"] < crps_values["deterministic"]
     assert crps_values["less_variance"] < crps_values["deterministic"]
+
+
+def _patch_vectors(field: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """Explicitly build the patch vector at each point of ``[..., H, W]``:
+    periodic in the last (lon) dim, zero-padded in the second-to-last (lat)
+    dim. Returns ``[..., H, W, patch_size**2]``."""
+    halo = patch_size // 2
+    n_lat = field.shape[-2]
+    padded = torch.nn.functional.pad(field, (0, 0, halo, halo))
+    entries = []
+    for i in range(patch_size):
+        for dj in range(-halo, halo + 1):
+            rolled = torch.roll(padded, shifts=-dj, dims=-1)
+            entries.append(rolled[..., i : i + n_lat, :])
+    return torch.stack(entries, dim=-1)
+
+
+def _brute_force_patch_energy_score(
+    gen: torch.Tensor, target: torch.Tensor, patch_size: int
+) -> torch.Tensor:
+    px0 = _patch_vectors(gen[:, 0], patch_size)
+    px1 = _patch_vectors(gen[:, 1], patch_size)
+    py = _patch_vectors(target[:, 0], patch_size)
+    d0 = torch.linalg.norm(px0 - py, dim=-1)
+    d1 = torch.linalg.norm(px1 - py, dim=-1)
+    d01 = torch.linalg.norm(px0 - px1, dim=-1)
+    return (0.5 * (d0 + d1) - 0.5 * d01) / patch_size
+
+
+@pytest.mark.parametrize("patch_size", [1, 3, 5])
+def test_patch_energy_score_matches_brute_force(patch_size: int):
+    torch.manual_seed(0)
+    gen = torch.randn(2, 2, 3, 8, 16)
+    target = torch.randn(2, 1, 3, 8, 16)
+    result = get_patch_energy_score(gen, target, patch_size=patch_size)
+    expected = _brute_force_patch_energy_score(gen, target, patch_size)
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_patch_energy_score_is_proper():
+    """Like test_crps: the perfectly-calibrated ensemble scores best."""
+    torch.manual_seed(0)
+    n_batch = 5000
+    nx, ny = 4, 8
+    truth_amount = 0.8
+    random_amount = 0.5
+    x_predictable = torch.rand(n_batch, 1, nx, ny)
+    x = truth_amount * x_predictable + random_amount * torch.rand(n_batch, 1, nx, ny)
+    scores = {}
+    for name, amount in [
+        ("perfect", random_amount),
+        ("extra_variance", random_amount * 1.2),
+        ("less_variance", random_amount * 0.8),
+        ("deterministic", random_amount * 1e-5),
+    ]:
+        x_sample = truth_amount * x_predictable + amount * torch.rand(
+            n_batch, 2, nx, ny
+        )
+        scores[name] = get_patch_energy_score(x_sample, x, patch_size=3).mean()
+    assert scores["perfect"] < scores["extra_variance"]
+    assert scores["perfect"] < scores["less_variance"]
+    assert scores["extra_variance"] < scores["deterministic"]
+    assert scores["less_variance"] < scores["deterministic"]
+
+
+def test_patch_energy_score_periodic_in_lon():
+    torch.manual_seed(0)
+    gen = torch.randn(2, 2, 3, 8, 16)
+    target = torch.randn(2, 1, 3, 8, 16)
+    score = get_patch_energy_score(gen, target, patch_size=3)
+    rolled_score = get_patch_energy_score(
+        torch.roll(gen, shifts=5, dims=-1),
+        torch.roll(target, shifts=5, dims=-1),
+        patch_size=3,
+    )
+    torch.testing.assert_close(rolled_score, torch.roll(score, shifts=5, dims=-1))
+
+
+def test_patch_energy_score_size_one_is_fair_crps():
+    torch.manual_seed(0)
+    gen = torch.randn(2, 2, 3, 8, 16)
+    target = torch.randn(2, 1, 3, 8, 16)
+    patch = get_patch_energy_score(gen, target, patch_size=1)
+    crps = get_crps(gen, target, alpha=1.0)
+    torch.testing.assert_close(patch, crps, rtol=1e-5, atol=1e-5)
+
+
+def test_patch_energy_score_finite_gradient_at_zero_spread():
+    member = torch.randn(2, 1, 3, 8, 16)
+    gen = member.repeat(1, 2, 1, 1, 1).requires_grad_(True)
+    target = member.clone()
+    score = get_patch_energy_score(gen, target, patch_size=3)
+    score.sum().backward()
+    assert gen.grad is not None
+    assert torch.isfinite(gen.grad).all()
+
+
+def test_patch_energy_score_rejects_bad_inputs():
+    gen = torch.randn(2, 3, 3, 8, 16)
+    target = torch.randn(2, 1, 3, 8, 16)
+    with pytest.raises(NotImplementedError):
+        get_patch_energy_score(gen, target)
+    with pytest.raises(ValueError):
+        get_patch_energy_score(torch.randn(2, 2, 3, 8, 16), target, patch_size=2)

--- a/fme/core/test_ensemble.py
+++ b/fme/core/test_ensemble.py
@@ -157,3 +157,5 @@ def test_patch_energy_score_rejects_bad_inputs():
         get_patch_energy_score(gen, target)
     with pytest.raises(ValueError):
         get_patch_energy_score(torch.randn(2, 2, 3, 8, 16), target, patch_size=2)
+    with pytest.raises(ValueError):
+        get_patch_energy_score(torch.randn(2, 2, 3, 8, 16), target, patch_size=17)

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -1007,7 +1007,9 @@ def test_patch_energy_score_loss_in_ensemble_loss():
         kwargs={
             "crps_weight": 0.9,
             "patch_energy_score_weight": 0.1,
-            "patch_energy_score_size": 3,
+            # non-default size: the test must fail if EnsembleLoss drops the
+            # size forward to PatchEnergyScoreLoss
+            "patch_energy_score_size": 5,
         },
     )
     loss = config.build(

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -3,6 +3,7 @@ import torch
 
 from fme.core import metrics
 from fme.core.device import get_device
+from fme.core.ensemble import get_crps, get_patch_energy_score
 from fme.core.gridded_ops import GriddedOperations, LatLonOperations
 from fme.core.loss import (
     AreaWeightedMSELoss,
@@ -1007,8 +1008,9 @@ def test_patch_energy_score_loss_in_ensemble_loss():
         kwargs={
             "crps_weight": 0.9,
             "patch_energy_score_weight": 0.1,
-            # non-default size: the test must fail if EnsembleLoss drops the
-            # size forward to PatchEnergyScoreLoss
+            # non-default size, checked against the reference functions below:
+            # the pinned expected value fails if EnsembleLoss drops the size
+            # forward to PatchEnergyScoreLoss
             "patch_energy_score_size": 5,
         },
     )
@@ -1021,13 +1023,11 @@ def test_patch_energy_score_loss_in_ensemble_loss():
     assert isinstance(components, list)
     assert len(components) == 2
     total = _components_total(components)
-    assert torch.isfinite(total)
-
-    crps_only = LossConfig(type="EnsembleLoss", kwargs={"crps_weight": 0.9}).build(
-        gridded_operations=LatLonOperations(torch.ones(8, 16, device=get_device())),
+    expected = (
+        0.9 * get_crps(gen, target, alpha=1.0).mean()
+        + 0.1 * get_patch_energy_score(gen, target, patch_size=5).mean()
     )
-    crps_total = _components_total(crps_only(gen, target))
-    assert not torch.equal(total, crps_total)
+    torch.testing.assert_close(total, expected)
 
 
 def test_patch_energy_score_only_ensemble_loss_is_allowed():

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -15,6 +15,7 @@ from fme.core.loss import (
     LossConfig,
     LossOutput,
     LpLoss,
+    PatchEnergyScoreLoss,
     SpectralWhitening,
     SpectralWhiteningConfig,
     StandardLoss,
@@ -997,3 +998,52 @@ def test_ensemble_loss_with_whitening_builds_and_runs(whitening):
     out = loss(x, y)
     assert all(isinstance(c, LossComponent) for c in out)
     assert torch.isfinite(_components_total(out))
+
+
+def test_patch_energy_score_loss_in_ensemble_loss():
+    torch.manual_seed(0)
+    config = LossConfig(
+        type="EnsembleLoss",
+        kwargs={
+            "crps_weight": 0.9,
+            "patch_energy_score_weight": 0.1,
+            "patch_energy_score_size": 3,
+        },
+    )
+    loss = config.build(
+        gridded_operations=LatLonOperations(torch.ones(8, 16, device=get_device())),
+    )
+    gen = torch.randn(2, 2, 3, 8, 16, device=get_device())
+    target = torch.randn(2, 1, 3, 8, 16, device=get_device())
+    components = loss(gen, target)
+    assert isinstance(components, list)
+    assert len(components) == 2
+    total = _components_total(components)
+    assert torch.isfinite(total)
+
+    crps_only = LossConfig(type="EnsembleLoss", kwargs={"crps_weight": 0.9}).build(
+        gridded_operations=LatLonOperations(torch.ones(8, 16, device=get_device())),
+    )
+    crps_total = _components_total(crps_only(gen, target))
+    assert not torch.equal(total, crps_total)
+
+
+def test_patch_energy_score_only_ensemble_loss_is_allowed():
+    config = LossConfig(
+        type="EnsembleLoss",
+        kwargs={"crps_weight": 0.0, "patch_energy_score_weight": 1.0},
+    )
+    loss = config.build(
+        gridded_operations=LatLonOperations(torch.ones(8, 16, device=get_device())),
+    )
+    gen = torch.randn(2, 2, 3, 8, 16, device=get_device())
+    target = torch.randn(2, 1, 3, 8, 16, device=get_device())
+    total = _components_total(loss(gen, target))
+    assert torch.isfinite(total)
+
+
+def test_patch_energy_score_loss_rejects_even_patch_size():
+    with pytest.raises(ValueError):
+        PatchEnergyScoreLoss(patch_size=4)
+    with pytest.raises(ValueError):
+        PatchEnergyScoreLoss(patch_size=0)


### PR DESCRIPTION
Adds an optional per-channel **patch energy score** term to `EnsembleLoss`, a grid-space alternative to the spectral energy score: at each grid point and channel, the fair (2-member) energy score of the `patch_size x patch_size` patch centered on that point, with a periodic east–west boundary and a zero-padded north–south boundary. Where the spectral energy score enforces per-mode calibration globally, the patch energy score scores joint local structure, which is expected to bear on small-scale variability.

The kernel never materializes patches: since patch extraction is linear and the windows of the two fields are aligned, `||patch(u) − patch(v)||²` equals the `patch_size x patch_size` box-sum of the pointwise squared difference, so each patch-distance field costs one pad + sum-pool + sqrt, and no `patch_size**2`-times-larger patch tensor is ever materialized (as an `unfold`-based implementation would require). All three m=2 difference fields (two skill terms, one spread term) run through a single pooling call. Zero padding contributes `(0−0)² = 0` to every distance, so polar patches are effectively truncated to their valid entries. The score is divided by `patch_size` to sit on the CRPS scale; at `patch_size=1` it reduces to fair CRPS up to the numerical floor (the squared distance is floored at `1e-12` before the sqrt, so collapsed ensembles get a zero subgradient — like `abs` in CRPS — instead of NaN). Because the normalization is a fixed `1/patch_size` while polar patches are truncated by the zero padding, rows within the patch halo of a pole carry proportionally less loss weight than interior rows; this mild polar down-weighting is documented as accepted behavior. The kernel assumes a lat–lon `[..., n_lat, n_lon]` layout with periodic longitude, like `FiniteDifferenceCRPSLoss`; HEALPix layouts are out of scope.

Changes:
- `fme.core.ensemble.get_patch_energy_score` (and `_patch_l2_distance`): the kernel, mirroring `get_crps`/`get_energy_score` shape conventions; 2 ensemble members only, odd `patch_size` only, `patch_size` at most `n_lon`
- `fme.core.loss.PatchEnergyScoreLoss`: module wrapper returning a pre-weighted `(B, C, H, W)` `StandardLoss`, so per-channel reduction and logging follow the CRPS path
- `fme.core.loss.EnsembleLoss`: new `patch_energy_score_weight` (default 0.0 — off, no behavior change) and `patch_energy_score_size` (default 3) kwargs, reachable from YAML via `loss.kwargs` like the other ensemble-loss terms

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated