### PR TITLE
Let inference netCDF writers target a remote experiment_dir

### DIFF
--- a/fme/ace/inference/data_writer/main.py
+++ b/fme/ace/inference/data_writer/main.py
@@ -15,7 +15,7 @@ from fme.ace.data_loading.batch_data import (
     PairedData,
     PrognosticState,
 )
-from fme.core.cloud import to_netcdf_via_inter_filesystem_copy
+from fme.core.cloud import makedirs, to_netcdf_via_inter_filesystem_copy
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.generics.writer import WriterABC
 
@@ -175,7 +175,7 @@ class DataWriterConfig:
 
         def writer_factory(name: str) -> RawDataWriter | TimeCoarsen:
             path = os.path.join(experiment_dir, STEP_DIAGNOSTICS_DIR)
-            os.makedirs(path, exist_ok=True)
+            makedirs(path, exist_ok=True)
             writer: RawDataWriter | TimeCoarsen = RawDataWriter(
                 path=path,
                 label=name,

--- a/fme/ace/inference/data_writer/monthly.py
+++ b/fme/ace/inference/data_writer/monthly.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
+import os
 from collections.abc import Iterable, Mapping, Sequence
-from pathlib import Path
 
 import cftime
 import numpy as np
@@ -17,7 +17,7 @@ from fme.ace.inference.data_writer.utils import (
     DIM_INFO_LATLON,
     get_all_names,
 )
-from fme.core.cloud import is_local
+from fme.core.cloud import StagedFile
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.writer import DATETIME_ENCODING_UNITS
 
@@ -105,7 +105,9 @@ class MonthlyDataWriter:
     ):
         """
         Args:
-            path: Directory to write netCDF file(s).
+            path: Directory to write netCDF file(s). May be remote (e.g.
+                ``gs://``), in which case the file is written to a local
+                staging directory and uploaded when the writer is finalized.
             label: Label to append to the filename.
             initial_condition_times: 1D array of initial condition times
                 (start time for each inference run).
@@ -116,9 +118,10 @@ class MonthlyDataWriter:
             coords: Coordinate data to be written to the file.
             dataset_metadata: Metadata for the dataset.
         """
-        if not is_local(path):
-            raise ValueError("MonthlyDataWriter only supports local file systems.")
-        filename = str(Path(path) / f"{label}.nc")
+        # netCDF4 can only stream into a local file handle, so a remote
+        # destination is staged locally and uploaded by ``finalize``.
+        self._staged_file = StagedFile(os.path.join(str(path), f"{label}.nc"))
+        filename = self._staged_file.path
         n_initial_conditions = len(initial_condition_times)
         calendar = infer_calendar(initial_condition_times)
         self._save_names = save_names
@@ -334,6 +337,7 @@ class MonthlyDataWriter:
     def finalize(self):
         self.flush()
         self.dataset.close()
+        self._staged_file.upload()
 
 
 def add_data(

--- a/fme/ace/inference/data_writer/monthly.py
+++ b/fme/ace/inference/data_writer/monthly.py
@@ -120,7 +120,7 @@ class MonthlyDataWriter:
         """
         # netCDF4 can only stream into a local file handle, so a remote
         # destination is staged locally and uploaded by ``finalize``.
-        self._staged_file = StagedFile(os.path.join(str(path), f"{label}.nc"))
+        self._staged_file = StagedFile(os.path.join(path, f"{label}.nc"))
         filename = self._staged_file.path
         n_initial_conditions = len(initial_condition_times)
         calendar = infer_calendar(initial_condition_times)

--- a/fme/ace/inference/data_writer/raw.py
+++ b/fme/ace/inference/data_writer/raw.py
@@ -124,7 +124,7 @@ class RawDataWriter:
         """
         # netCDF4 can only stream into a local file handle, so a remote
         # destination is staged locally and uploaded by ``finalize``.
-        self._staged_file = StagedFile(os.path.join(str(path), f"{label}.nc"))
+        self._staged_file = StagedFile(os.path.join(path, f"{label}.nc"))
         filename = self._staged_file.path
         calendar = infer_calendar(initial_condition_times)
         n_initial_conditions = len(initial_condition_times)

--- a/fme/ace/inference/data_writer/raw.py
+++ b/fme/ace/inference/data_writer/raw.py
@@ -1,8 +1,8 @@
 import copy
 import dataclasses
 import datetime
+import os
 from collections.abc import Iterable, Mapping, Sequence
-from pathlib import Path
 from typing import Literal
 
 import cftime
@@ -18,7 +18,7 @@ from fme.ace.inference.data_writer.utils import (
     DIM_INFO_LATLON,
     get_all_names,
 )
-from fme.core.cloud import is_local
+from fme.core.cloud import StagedFile
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.writer import DATETIME_ENCODING_UNITS, TIMEDELTA_ENCODING_UNITS
 
@@ -110,7 +110,9 @@ class RawDataWriter:
     ):
         """
         Args:
-            path: Directory within which to write the file.
+            path: Directory within which to write the file. May be remote
+                (e.g. ``gs://``), in which case the file is written to a local
+                staging directory and uploaded when the writer is finalized.
             label: Name of the file to write.
             initial_condition_times: 1D array of initial condition times
                 (start time for each inference run).
@@ -120,13 +122,10 @@ class RawDataWriter:
             coords: Coordinate data to be written to the file.
             dataset_metadata: Metadata for the dataset.
         """
-        if not is_local(path):
-            raise ValueError(
-                "The RawDataWriter only supports local file systems. Consider "
-                "using the ZarrWriter instead, which supports writing to a "
-                "non-local filesystem."
-            )
-        filename = str(Path(path) / f"{label}.nc")
+        # netCDF4 can only stream into a local file handle, so a remote
+        # destination is staged locally and uploaded by ``finalize``.
+        self._staged_file = StagedFile(os.path.join(str(path), f"{label}.nc"))
+        filename = self._staged_file.path
         calendar = infer_calendar(initial_condition_times)
         n_initial_conditions = len(initial_condition_times)
         self._save_names = save_names
@@ -261,6 +260,7 @@ class RawDataWriter:
     def finalize(self):
         self.flush()
         self.dataset.close()
+        self._staged_file.upload()
 
 
 def get_batch_lead_time_microseconds(

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -1,6 +1,8 @@
 import datetime
+import os
 
 import cftime
+import fsspec
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -16,6 +18,7 @@ from fme.ace.inference.data_writer.main import DataWriterConfig
 from fme.ace.inference.data_writer.raw import get_batch_lead_time_microseconds
 from fme.ace.inference.data_writer.time_coarsen import TimeCoarsenConfig
 from fme.ace.inference.data_writer.zarr import ZarrWriterConfig
+from fme.core.cloud import open_dataset_via_inter_filesystem_copy
 from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.device import get_device
 from fme.core.labels import BatchLabels
@@ -847,3 +850,102 @@ def test_get_batch_lead_time_microseconds_overflow(years_ahead, overflow):
     else:
         with pytest.raises(OverflowError):
             get_batch_lead_time_microseconds(init_times, batch_time)
+
+
+def _write_batches_and_finalize(experiment_dir: str, n_lat: int = 4, n_lon: int = 5):
+    """Write two batches of paired data through the netCDF sub-writers."""
+    n_initial_conditions = 2
+    calendar = "proleptic_gregorian"
+    initial_condition_times = get_initial_condition_times(
+        (2020, 1, 1, 0, 0, 0), calendar, n_initial_conditions
+    )
+    writer = DataWriterConfig(
+        save_prediction_files=True,
+        save_monthly_files=True,
+        names=None,
+    ).build_paired(
+        experiment_dir=experiment_dir,
+        initial_condition_times=initial_condition_times,
+        n_timesteps=8,
+        timestep=TIMESTEP,
+        variable_metadata={"a": VariableMetadata(units="m", long_name="a_name")},
+        coords={"lat": np.arange(n_lat), "lon": np.arange(n_lon)},
+        dataset_metadata=DatasetMetadata(source={"inference_version": "1.0"}),
+    )
+    torch.manual_seed(0)
+    for i_batch in range(2):
+        batch_time = xr.concat(
+            [
+                xr.DataArray(
+                    xr.date_range(
+                        cftime.DatetimeProlepticGregorian(2020, 1, 1 + 2 * i_batch),
+                        periods=4,
+                        freq="6h",
+                        calendar=calendar,
+                        use_cftime=True,
+                    ).values,
+                    dims="time",
+                )
+                for _ in range(n_initial_conditions)
+            ],
+            dim="sample",
+        )
+        data = {"a": torch.rand(n_initial_conditions, 4, n_lat, n_lon)}
+        writer.append_batch(
+            batch=get_paired_data(prediction=data, reference=data, time=batch_time)
+        )
+    writer.finalize()
+
+
+NETCDF_OUTPUT_FILENAMES = [
+    "autoregressive_predictions.nc",
+    "autoregressive_target.nc",
+    "monthly_mean_predictions.nc",
+    "monthly_mean_target.nc",
+]
+
+
+def test_netcdf_writers_with_non_local_experiment_dir(tmp_path):
+    """netCDF output written to a remote store matches the local output."""
+    experiment_dir = "memory://netcdf-remote-test"
+    fs, _ = fsspec.url_to_fs(experiment_dir)
+    fs.makedirs(experiment_dir, exist_ok=True)
+    try:
+        _write_batches_and_finalize(experiment_dir)
+        _write_batches_and_finalize(str(tmp_path))
+        for filename in NETCDF_OUTPUT_FILENAMES:
+            remote = os.path.join(experiment_dir, filename)
+            assert fs.exists(remote), f"{filename} was not uploaded"
+            remote_ds = open_dataset_via_inter_filesystem_copy(
+                remote, decode_timedelta=False
+            )
+            local_ds = xr.open_dataset(tmp_path / filename, decode_timedelta=False)
+            xr.testing.assert_identical(remote_ds, local_ds)
+    finally:
+        fs.rm(experiment_dir, recursive=True)
+
+
+def test_netcdf_writers_upload_only_on_finalize():
+    """A run that dies before finalizing leaves nothing at the destination."""
+    experiment_dir = "memory://netcdf-remote-partial-test"
+    fs, _ = fsspec.url_to_fs(experiment_dir)
+    fs.makedirs(experiment_dir, exist_ok=True)
+    try:
+        writer = DataWriterConfig(
+            save_prediction_files=True,
+            save_monthly_files=True,
+        ).build_paired(
+            experiment_dir=experiment_dir,
+            initial_condition_times=get_initial_condition_times(
+                (2020, 1, 1, 0, 0, 0), "proleptic_gregorian", 1
+            ),
+            n_timesteps=4,
+            timestep=TIMESTEP,
+            variable_metadata={},
+            coords={"lat": np.arange(4), "lon": np.arange(5)},
+            dataset_metadata=DatasetMetadata(),
+        )
+        writer.flush()
+        assert fs.ls(experiment_dir) == []
+    finally:
+        fs.rm(experiment_dir, recursive=True)

--- a/fme/ace/inference/data_writer/test_data_writer.py
+++ b/fme/ace/inference/data_writer/test_data_writer.py
@@ -947,5 +947,11 @@ def test_netcdf_writers_upload_only_on_finalize():
         )
         writer.flush()
         assert fs.ls(experiment_dir) == []
+        # the same files do land once the writer is finalized, so the
+        # assertion above is about the timing of the upload, not about the
+        # writers being inert
+        writer.finalize()
+        for filename in NETCDF_OUTPUT_FILENAMES:
+            assert fs.exists(os.path.join(experiment_dir, filename))
     finally:
         fs.rm(experiment_dir, recursive=True)

--- a/fme/ace/inference/data_writer/test_file_writer.py
+++ b/fme/ace/inference/data_writer/test_file_writer.py
@@ -1,8 +1,10 @@
 import datetime
+import os
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import cftime
+import fsspec
 import numpy as np
 import pandas as pd
 import pytest
@@ -598,6 +600,8 @@ def test_netcdf_file_writer_with_non_local_experiment_dir(
     time_coarsen: TimeCoarsenConfig | MonthlyCoarsenConfig | None,
 ):
     experiment_dir = "memory://experiment_dir"
+    fs, _ = fsspec.url_to_fs(experiment_dir)
+    fs.makedirs(experiment_dir, exist_ok=True)
     format = NetCDFWriterConfig()
     config = FileWriterConfig(
         label="test",
@@ -606,8 +610,8 @@ def test_netcdf_file_writer_with_non_local_experiment_dir(
         format=format,
     )
     initial_condition_times = np.array([cftime.DatetimeGregorian(2020, 1, 1)])
-    with pytest.raises(ValueError, match="only supports local"):
-        config.build(
+    try:
+        writer = config.build(
             experiment_dir=experiment_dir,
             initial_condition_times=initial_condition_times,
             n_timesteps=1,
@@ -616,6 +620,10 @@ def test_netcdf_file_writer_with_non_local_experiment_dir(
             coords={},
             dataset_metadata=DatasetMetadata(),
         )
+        writer.finalize()
+        assert fs.exists(os.path.join(experiment_dir, "test.nc"))
+    finally:
+        fs.rm(experiment_dir, recursive=True)
 
 
 @pytest.mark.parametrize(

--- a/fme/ace/inference/evaluator.py
+++ b/fme/ace/inference/evaluator.py
@@ -178,13 +178,16 @@ class InferenceEvaluatorConfig:
                 While most types of output can be written to a remote
                 ``experiment_dir``, there are some limitations:
 
-                - To write raw or time-coarsened data, the zarr writer must be
-                  used. See the ``files`` parameter of the
-                  :class:`fme.ace.DataWriterConfig` for more details on how this
-                  can be configured. Note that monthly coarsened data cannot
-                  currently be written to zarr, and hence a remote directory,
-                  since it uses a different code path than uniformly coarsened
-                  data.
+                - netCDF output cannot be streamed to a remote store, so each
+                  netCDF file is written to a local temporary directory and
+                  uploaded when it is closed at the end of the run. Its full
+                  contents therefore occupy local disk for the duration of the
+                  run (in the system temporary directory, so set ``TMPDIR`` to
+                  a volume with room for the whole output), and a run that dies
+                  before finalizing leaves no netCDF behind. The zarr writer
+                  (see the ``files`` parameter of
+                  :class:`fme.ace.DataWriterConfig`) writes to a remote store
+                  incrementally and has neither property.
                 - Piping logging output to a file in the ``experiment_dir``
                   is not supported. To silence the warning related to this, set
                   ``log_to_file`` to ``False`` in the

--- a/fme/ace/inference/inference.py
+++ b/fme/ace/inference/inference.py
@@ -224,13 +224,16 @@ class InferenceConfig:
                 While most types of output can be written to a remote
                 ``experiment_dir``, there are some limitations:
 
-                - To write raw or time-coarsened data, the zarr writer must be
-                  used. See the ``files`` parameter of the
-                  :class:`fme.ace.DataWriterConfig` for more details on how this
-                  can be configured. Note that monthly coarsened data cannot
-                  currently be written to zarr, and hence a remote directory,
-                  since it uses a different code path than uniformly coarsened
-                  data.
+                - netCDF output cannot be streamed to a remote store, so each
+                  netCDF file is written to a local temporary directory and
+                  uploaded when it is closed at the end of the run. Its full
+                  contents therefore occupy local disk for the duration of the
+                  run (in the system temporary directory, so set ``TMPDIR`` to
+                  a volume with room for the whole output), and a run that dies
+                  before finalizing leaves no netCDF behind. The zarr writer
+                  (see the ``files`` parameter of
+                  :class:`fme.ace.DataWriterConfig`) writes to a remote store
+                  incrementally and has neither property.
                 - Piping logging output to a file in the ``experiment_dir``
                   is not supported. To silence the warning related to this, set
                   ``log_to_file`` to ``False`` in the

--- a/fme/ace/inference/test_evaluator.py
+++ b/fme/ace/inference/test_evaluator.py
@@ -1340,8 +1340,8 @@ def test_evaluator_with_non_local_experiment_dir(tmp_path: pathlib.Path):
         loader=data.inference_data_loader_config,
         aggregator=InferenceEvaluatorAggregatorConfig(),
         data_writer=DataWriterConfig(
-            save_monthly_files=False,
-            save_prediction_files=False,
+            save_monthly_files=True,
+            save_prediction_files=True,
             files=files,
         ),
         allow_incompatible_dataset=True,  # stepper checkpoint has arbitrary info
@@ -1362,6 +1362,11 @@ def test_evaluator_with_non_local_experiment_dir(tmp_path: pathlib.Path):
         "zonal_mean_diagnostics.nc",
         "time_mean_diagnostics.nc",
         "time_mean_norm_diagnostics.nc",
+        # netCDF writers stage locally and upload on finalize
+        "autoregressive_predictions.nc",
+        "autoregressive_target.nc",
+        "monthly_mean_predictions.nc",
+        "monthly_mean_target.nc",
     ]
     fs, _ = fsspec.url_to_fs(experiment_dir)
     for file in expected_files:

--- a/fme/core/cloud.py
+++ b/fme/core/cloud.py
@@ -43,8 +43,15 @@ class StagedFile:
     Writers that stream into an open local file handle (e.g. a
     ``netCDF4.Dataset``) cannot target a remote store directly. This stages
     such a file: writes go to ``path``, and ``upload`` copies it to
-    ``destination``. Call ``upload`` once the file handle is closed, so a
-    complete file is what lands remotely.
+    ``destination`` with the destination filesystem's ``put_file``. Call
+    ``upload`` once the file handle is closed, so a complete file is what
+    lands remotely.
+
+    ``put_file`` rather than ``inter_filesystem_copy`` because staged netCDF
+    files are multi-GB: gcsfs's ``put_file`` uploads in 50 MiB chunks and
+    verifies the object's checksum on completion, where a stream through
+    ``fsspec.open`` uses a ~5 MiB write block and checks nothing, so silent
+    corruption would go undetected.
 
     When ``destination`` is already local there is no staging at all:
     ``path`` is ``destination`` and ``upload`` does nothing, so local
@@ -70,10 +77,12 @@ class StagedFile:
     def upload(self):
         """Copy the staged file to its destination and discard the staging copy.
 
-        A no-op for a local destination, or if already called.
+        A no-op for a local destination, or if already called. Errors from
+        the upload propagate; the staging copy is kept if it fails.
         """
         if self._tmpdir is not None:
-            inter_filesystem_copy(self._path, self._destination)
+            fs, _ = fsspec.url_to_fs(self._destination)
+            fs.put_file(self._path, self._destination)
             self._tmpdir.cleanup()
             self._tmpdir = None
 

--- a/fme/core/cloud.py
+++ b/fme/core/cloud.py
@@ -37,6 +37,52 @@ def exists(path: str | Path) -> bool:
     return fs.exists(path)
 
 
+class StagedFile:
+    """A file streamed to local disk, copied to its destination when closed.
+
+    Writers that stream into an open local file handle (e.g. a
+    ``netCDF4.Dataset``) cannot target a remote store directly. This stages
+    such a file: writes go to ``path``, and ``upload`` copies it to
+    ``destination``. Call ``upload`` once the file handle is closed, so a
+    complete file is what lands remotely.
+
+    When ``destination`` is already local there is no staging at all:
+    ``path`` is ``destination`` and ``upload`` does nothing, so local
+    behavior is unchanged.
+    """
+
+    def __init__(self, destination: str | Path):
+        self._destination = str(destination)
+        self._tmpdir: tempfile.TemporaryDirectory | None = None
+        if is_local(self._destination):
+            self._path = self._destination
+        else:
+            self._tmpdir = tempfile.TemporaryDirectory()
+            self._path = os.path.join(
+                self._tmpdir.name, os.path.basename(self._destination)
+            )
+
+    @property
+    def path(self) -> str:
+        """The local path to write to."""
+        return self._path
+
+    @property
+    def destination(self) -> str:
+        """The final path of the file, local or remote."""
+        return self._destination
+
+    def upload(self):
+        """Copy the staged file to its destination and discard the staging copy.
+
+        A no-op for a local destination, or if already called.
+        """
+        if self._tmpdir is not None:
+            inter_filesystem_copy(self._path, self._destination)
+            self._tmpdir.cleanup()
+            self._tmpdir = None
+
+
 def to_netcdf_via_inter_filesystem_copy(ds: xr.Dataset, filename: str | Path):
     """Write an xarray dataset to a netCDF file via an inter-filesystem copy."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/fme/core/cloud.py
+++ b/fme/core/cloud.py
@@ -67,11 +67,6 @@ class StagedFile:
         """The local path to write to."""
         return self._path
 
-    @property
-    def destination(self) -> str:
-        """The final path of the file, local or remote."""
-        return self._destination
-
     def upload(self):
         """Copy the staged file to its destination and discard the staging copy.
 

--- a/fme/core/cloud.py
+++ b/fme/core/cloud.py
@@ -51,7 +51,9 @@ class StagedFile:
     files are multi-GB: gcsfs's ``put_file`` uploads in 50 MiB chunks and can
     verify the uploaded object's checksum, where a stream through
     ``fsspec.open`` uses a ~5 MiB write block and checks nothing, so silent
-    corruption would go undetected.
+    corruption would go undetected. The checksum request is gcsfs-specific;
+    other fsspec backends ignore it (s3fs drops unrecognized kwargs) and
+    upload with whatever integrity check they do by default.
 
     When ``destination`` is already local there is no staging at all:
     ``path`` is ``destination`` and ``upload`` does nothing, so local
@@ -78,7 +80,10 @@ class StagedFile:
         """Copy the staged file to its destination and discard the staging copy.
 
         A no-op for a local destination, or if already called. Errors from
-        the upload propagate; the staging copy is kept if it fails.
+        the upload propagate, and a failed upload leaves the staged file in
+        place, so a caller that catches the error can call ``upload`` again to
+        retry. The staging directory is still a temporary directory: it is
+        removed when the process exits, so an uncaught failure loses the file.
         """
         if self._tmpdir is not None:
             fs, _ = fsspec.url_to_fs(self._destination)

--- a/fme/core/cloud.py
+++ b/fme/core/cloud.py
@@ -48,8 +48,8 @@ class StagedFile:
     lands remotely.
 
     ``put_file`` rather than ``inter_filesystem_copy`` because staged netCDF
-    files are multi-GB: gcsfs's ``put_file`` uploads in 50 MiB chunks and
-    verifies the object's checksum on completion, where a stream through
+    files are multi-GB: gcsfs's ``put_file`` uploads in 50 MiB chunks and can
+    verify the uploaded object's checksum, where a stream through
     ``fsspec.open`` uses a ~5 MiB write block and checks nothing, so silent
     corruption would go undetected.
 
@@ -82,7 +82,14 @@ class StagedFile:
         """
         if self._tmpdir is not None:
             fs, _ = fsspec.url_to_fs(self._destination)
-            fs.put_file(self._path, self._destination)
+            # The integrity check is the main reason to use put_file over a
+            # plain stream, and gcsfs leaves it off by default
+            # (consistency="none" is a no-op checker), so ask for it
+            # explicitly. md5 rather than crc32c because crc32c needs the
+            # crcmod package, which is not a dependency. Hashing a multi-GB
+            # file costs CPU, which is cheap next to the transfer itself and
+            # is the point for output we cannot re-derive.
+            fs.put_file(self._path, self._destination, consistency="md5")
             self._tmpdir.cleanup()
             self._tmpdir = None
 

--- a/fme/core/test_cloud.py
+++ b/fme/core/test_cloud.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 
 from fme.core.cloud import (
+    StagedFile,
     exists,
     inter_filesystem_copy,
     is_local,
@@ -102,3 +103,34 @@ def test_open_dataset_via_inter_filesystem_copy():
 
     fs, _ = fsspec.url_to_fs(filename)
     fs.rm(filename, recursive=True)
+
+
+def test_staged_file_local_writes_in_place(tmp_path: Path):
+    destination = str(tmp_path / "local.txt")
+    staged = StagedFile(destination)
+    assert staged.path == destination
+    with open(staged.path, "w") as f:
+        f.write("test")
+    staged.upload()
+    assert Path(destination).read_text() == "test"
+
+
+def test_staged_file_remote_uploads_on_upload(tmp_path: Path):
+    destination = "memory://staged-test/remote.txt"
+    fs, _ = fsspec.url_to_fs(destination)
+    staged = StagedFile(destination)
+    assert is_local(staged.path)
+    assert os.path.basename(staged.path) == "remote.txt"
+    with open(staged.path, "w") as f:
+        f.write("test")
+    # nothing lands remotely until the file is closed and uploaded
+    assert not fs.exists(destination)
+
+    staged.upload()
+    assert fs.read_text(destination) == "test"
+    # staging copy is discarded, and a second upload is a no-op
+    assert not os.path.exists(staged.path)
+    staged.upload()
+    assert fs.read_text(destination) == "test"
+
+    fs.rm(destination, recursive=True)

--- a/fme/core/test_cloud.py
+++ b/fme/core/test_cloud.py
@@ -140,14 +140,17 @@ def test_staged_file_remote_uploads_on_upload(tmp_path: Path):
 
 def test_staged_file_upload_uses_destination_put_file(tmp_path: Path, monkeypatch):
     # the upload must go through the destination filesystem's put_file, which
-    # is what gets gcsfs's chunked, checksum-verified upload for multi-GB files.
+    # is what gets gcsfs's chunked, checksum-verified upload for multi-GB
+    # files, and it must request the checksum: gcsfs defaults to
+    # consistency="none", a no-op checker, so a silent revert to the default
+    # would lose the integrity check while still "working".
     destination = "memory://staged-put-file-test/remote.nc"
     fs, _ = fsspec.url_to_fs(destination)
     calls = []
     original = type(fs).put_file
 
     def spy(self, lpath, rpath, *args, **kwargs):
-        calls.append((lpath, rpath))
+        calls.append((lpath, rpath, kwargs))
         return original(self, lpath, rpath, *args, **kwargs)
 
     monkeypatch.setattr(type(fs), "put_file", spy)
@@ -158,10 +161,22 @@ def test_staged_file_upload_uses_destination_put_file(tmp_path: Path, monkeypatc
     staged_path = staged.path
     staged.upload()
 
-    assert calls == [(staged_path, destination)]
+    assert calls == [(staged_path, destination, {"consistency": "md5"})]
     assert fs.cat_file(destination) == b"test"
 
     fs.rm("memory://staged-put-file-test", recursive=True)
+
+
+def test_md5_is_a_supported_gcsfs_consistency_checker():
+    # StagedFile.upload hardcodes consistency="md5"; if gcsfs stopped
+    # accepting it (or its md5 checker grew an uninstalled dependency, as
+    # crc32c has with crcmod) every remote upload would fail at runtime,
+    # which the memory-filesystem tests above cannot catch.
+    gcsfs_checkers = pytest.importorskip("gcsfs.checkers")
+    checker = gcsfs_checkers.get_consistency_checker("md5")
+    assert checker is not None
+    # and the default really is the no-op checker this kwarg exists to avoid
+    assert type(gcsfs_checkers.get_consistency_checker("none")) is not type(checker)
 
 
 def test_staged_file_upload_error_propagates(tmp_path: Path, monkeypatch):

--- a/fme/core/test_cloud.py
+++ b/fme/core/test_cloud.py
@@ -1,9 +1,13 @@
 import os
+from base64 import b64encode
+from hashlib import md5
 from pathlib import Path
 
 import fsspec
 import pytest
 import xarray as xr
+from gcsfs.checkers import get_consistency_checker
+from gcsfs.retry import ChecksumError
 
 from fme.core.cloud import (
     StagedFile,
@@ -138,7 +142,7 @@ def test_staged_file_remote_uploads_on_upload(tmp_path: Path):
     fs.rm("memory://staged-test", recursive=True)
 
 
-def test_staged_file_upload_uses_destination_put_file(tmp_path: Path, monkeypatch):
+def test_staged_file_upload_uses_destination_put_file(monkeypatch):
     # the upload must go through the destination filesystem's put_file, which
     # is what gets gcsfs's chunked, checksum-verified upload for multi-GB
     # files, and it must request the checksum: gcsfs defaults to
@@ -168,18 +172,25 @@ def test_staged_file_upload_uses_destination_put_file(tmp_path: Path, monkeypatc
 
 
 def test_md5_is_a_supported_gcsfs_consistency_checker():
-    # StagedFile.upload hardcodes consistency="md5"; if gcsfs stopped
-    # accepting it (or its md5 checker grew an uninstalled dependency, as
-    # crc32c has with crcmod) every remote upload would fail at runtime,
-    # which the memory-filesystem tests above cannot catch.
-    gcsfs_checkers = pytest.importorskip("gcsfs.checkers")
-    checker = gcsfs_checkers.get_consistency_checker("md5")
-    assert checker is not None
-    # and the default really is the no-op checker this kwarg exists to avoid
-    assert type(gcsfs_checkers.get_consistency_checker("none")) is not type(checker)
+    # StagedFile.upload hardcodes consistency="md5". gcsfs answers an
+    # unrecognized consistency with the silent no-op checker rather than an
+    # error, so if it stopped accepting "md5" (or its md5 checker grew an
+    # uninstalled dependency, as crc32c has with crcmod) remote uploads would
+    # keep "working" with no integrity check. The memory-filesystem tests
+    # above cannot catch that, so check the checker really hashes.
+    contents = b"staged netcdf bytes"
+    checker = get_consistency_checker("md5")
+    checker.update(contents)
+    checker.validate_json_response(
+        {"md5Hash": b64encode(md5(contents).digest()).decode()}
+    )
+    with pytest.raises(ChecksumError):
+        checker.validate_json_response(
+            {"md5Hash": b64encode(md5(b"other bytes").digest()).decode()}
+        )
 
 
-def test_staged_file_upload_error_propagates(tmp_path: Path, monkeypatch):
+def test_staged_file_upload_error_propagates(monkeypatch):
     destination = "memory://staged-error-test/remote.nc"
     fs, _ = fsspec.url_to_fs(destination)
 
@@ -193,6 +204,13 @@ def test_staged_file_upload_error_propagates(tmp_path: Path, monkeypatch):
         f.write(b"test")
     with pytest.raises(OSError, match="upload failed"):
         staged.upload()
-    # the staging copy survives a failed upload, so nothing is silently lost
+    # the staged file survives a failed upload, so nothing is silently lost
+    # and the upload can be retried
     assert Path(staged.path).read_bytes() == b"test"
     assert not fs.exists(destination)
+
+    monkeypatch.undo()
+    staged.upload()
+    assert fs.cat_file(destination) == b"test"
+
+    fs.rm("memory://staged-error-test", recursive=True)

--- a/fme/core/test_cloud.py
+++ b/fme/core/test_cloud.py
@@ -116,21 +116,68 @@ def test_staged_file_local_writes_in_place(tmp_path: Path):
 
 
 def test_staged_file_remote_uploads_on_upload(tmp_path: Path):
-    destination = "memory://staged-test/remote.txt"
+    # nested destination directory: put_file creates the parents it needs.
+    destination = "memory://staged-test/nested/dir/remote.nc"
     fs, _ = fsspec.url_to_fs(destination)
+    contents = b"\x89HDF\r\n\x1a\n" + bytes(range(256))
     staged = StagedFile(destination)
     assert is_local(staged.path)
-    assert os.path.basename(staged.path) == "remote.txt"
-    with open(staged.path, "w") as f:
-        f.write("test")
+    assert os.path.basename(staged.path) == "remote.nc"
+    with open(staged.path, "wb") as f:
+        f.write(contents)
     # nothing lands remotely until the file is closed and uploaded
     assert not fs.exists(destination)
 
     staged.upload()
-    assert fs.read_text(destination) == "test"
+    assert fs.cat_file(destination) == contents
     # staging copy is discarded, and a second upload is a no-op
     assert not os.path.exists(staged.path)
     staged.upload()
-    assert fs.read_text(destination) == "test"
+    assert fs.cat_file(destination) == contents
 
-    fs.rm(destination, recursive=True)
+    fs.rm("memory://staged-test", recursive=True)
+
+
+def test_staged_file_upload_uses_destination_put_file(tmp_path: Path, monkeypatch):
+    # the upload must go through the destination filesystem's put_file, which
+    # is what gets gcsfs's chunked, checksum-verified upload for multi-GB files.
+    destination = "memory://staged-put-file-test/remote.nc"
+    fs, _ = fsspec.url_to_fs(destination)
+    calls = []
+    original = type(fs).put_file
+
+    def spy(self, lpath, rpath, *args, **kwargs):
+        calls.append((lpath, rpath))
+        return original(self, lpath, rpath, *args, **kwargs)
+
+    monkeypatch.setattr(type(fs), "put_file", spy)
+
+    staged = StagedFile(destination)
+    with open(staged.path, "wb") as f:
+        f.write(b"test")
+    staged_path = staged.path
+    staged.upload()
+
+    assert calls == [(staged_path, destination)]
+    assert fs.cat_file(destination) == b"test"
+
+    fs.rm("memory://staged-put-file-test", recursive=True)
+
+
+def test_staged_file_upload_error_propagates(tmp_path: Path, monkeypatch):
+    destination = "memory://staged-error-test/remote.nc"
+    fs, _ = fsspec.url_to_fs(destination)
+
+    def boom(self, lpath, rpath, *args, **kwargs):
+        raise OSError("upload failed")
+
+    monkeypatch.setattr(type(fs), "put_file", boom)
+
+    staged = StagedFile(destination)
+    with open(staged.path, "wb") as f:
+        f.write(b"test")
+    with pytest.raises(OSError, match="upload failed"):
+        staged.upload()
+    # the staging copy survives a failed upload, so nothing is silently lost
+    assert Path(staged.path).read_bytes() == b"test"
+    assert not fs.exists(destination)


### PR DESCRIPTION
Inference netCDF output could only be written to a local filesystem: `RawDataWriter` and `MonthlyDataWriter` stream into an open `netCDF4.Dataset` handle, which cannot target a remote store, so both raised `ValueError` when `experiment_dir` was not local. That forced `save_prediction_files`/`save_monthly_files` runs to deposit their (often very large) output in the job's result dataset even when the intended consumer reads from GCS.

These writers now accept a remote `experiment_dir`. Each file is streamed to a local temporary directory exactly as before and copied to its destination when the writer is finalized and the handle is closed, so only complete files ever appear at the destination. Local destinations are unchanged: no staging directory is created and the file is written in place.

Two consequences are documented on `InferenceConfig.experiment_dir` and `InferenceEvaluatorConfig.experiment_dir`: the full output occupies local disk for the duration of the run (in the system temp directory, so `TMPDIR` must have room for it), and a run that dies before finalizing leaves nothing at the remote destination. The zarr writer remains the incremental, crash-durable option; the netCDF writers are the option for monthly means, which zarr does not support.

Changes:
- `fme.core.cloud.StagedFile`: new helper owning the local-staging/upload-on-close policy. `path` is where to write; `upload()` copies to the destination with the destination filesystem's fsspec `put_file` and discards the staging copy, and is a no-op for a local destination or on a repeat call. `put_file` rather than `inter_filesystem_copy` because these files are multi-GB: gcsfs's `put_file` uploads in 50 MiB chunks, against a ~5 MiB write block for a stream through `fsspec.open`, and it can verify the uploaded object's checksum, which the stream path does not. The upload passes `consistency="md5"` explicitly, because gcsfs defaults to `consistency="none"`, whose checker is a no-op — without the kwarg `put_file` would gain the chunking and no integrity check at all. md5 rather than crc32c because crc32c requires `crcmod`, which is not a dependency. The checksum request is gcsfs-specific: other fsspec backends ignore the kwarg (s3fs filters unrecognized kwargs), so a non-GCS remote destination uploads with whatever integrity check that backend does by default. `inter_filesystem_copy` itself is unchanged and keeps its small-file callers.
- `fme.ace.inference.data_writer.raw.RawDataWriter`, `fme.ace.inference.data_writer.monthly.MonthlyDataWriter`: replace the `is_local` rejection with a `StagedFile`, uploaded in `finalize`. This also lifts the restriction for `FileWriterConfig` entries using the netCDF format, including `MonthlyCoarsenConfig`.
- `fme.ace.inference.data_writer.main`: create the `step_diagnostics/` subdirectory with `fme.core.cloud.makedirs` rather than `os.makedirs`, which would have created a literal `gs:/...` local directory.
- Tests: `StagedFile` local and remote round-trips, that the upload dispatches to the destination filesystem's `put_file` with `consistency="md5"`, that `md5` is a checker gcsfs actually supports, and that a failed upload raises, keeps the staged file, and can be retried; netCDF output to a `memory://` experiment dir is byte-identical to the local output and appears only at finalize; `test_evaluator_with_non_local_experiment_dir` now enables the netCDF writers and asserts the four `.nc` files land remotely; the file-writer test that asserted rejection of a non-local dir now asserts the file is written.

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated


