### PR TITLE
Add NoiseConditionedSamudra with two noise-injection variants

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -54,3 +54,9 @@ The following module builders are available:
    :undoc-members:
    :show-inheritance:
    :noindex:
+
+.. autoclass:: fme.ace.NoiseConditionedSamudraBuilder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :noindex:

--- a/fme/ace/__init__.py
+++ b/fme/ace/__init__.py
@@ -78,7 +78,11 @@ from fme.ace.registry.hpx import (
     UNetEncoderConfig,
 )
 from fme.ace.registry.land_net import LandNetBuilder
-from fme.ace.registry.m2lines import FloeNetBuilder, SamudraBuilder
+from fme.ace.registry.m2lines import (
+    FloeNetBuilder,
+    NoiseConditionedSamudraBuilder,
+    SamudraBuilder,
+)
 from fme.ace.registry.sfno import SFNO_V0_1_0, SphericalFourierNeuralOperatorBuilder
 from fme.ace.registry.stochastic_sfno import NoiseConditionedSFNO
 from fme.ace.stepper import DerivedForcingsConfig, StepperOverrideConfig

--- a/fme/ace/models/ocean/m2lines/layers.py
+++ b/fme/ace/models/ocean/m2lines/layers.py
@@ -5,6 +5,8 @@ import torch
 import torch.nn as nn
 import torch.utils.checkpoint
 
+from fme.core.models.conditional_sfno.layers import Context, ContextConfig
+
 from .activations import CappedGELU
 
 
@@ -62,11 +64,51 @@ class AvgPool(torch.nn.Module):
         return self.avgpool(x)
 
 
+class NoiseConditioning(torch.nn.Module):
+    """Zero-initialized conditional scale and bias driven by a noise field.
+
+    Applied immediately after a non-affine normalization layer, this turns that
+    norm into a conditional one, the same construction ``ConditionalLayerNorm``
+    uses for the SFNO: ``x -> x * (1 + W_scale(noise)) + W_bias(noise)``. Both
+    convolutions are zero-initialized, so an untrained model is exactly
+    deterministic and stochasticity is learned from the ensemble loss.
+
+    The noise field is drawn at the model's input resolution, while a
+    conditioned block may run at a coarser resolution inside the U-Net, so the
+    noise is area-averaged onto the block's grid before projection.
+    """
+
+    def __init__(self, n_channels: int, embed_dim_noise: int):
+        super().__init__()
+        self.W_scale = torch.nn.Conv2d(
+            embed_dim_noise, n_channels, kernel_size=1, bias=False
+        )
+        self.W_bias = torch.nn.Conv2d(
+            embed_dim_noise, n_channels, kernel_size=1, bias=False
+        )
+        torch.nn.init.constant_(self.W_scale.weight, 0.0)
+        torch.nn.init.constant_(self.W_bias.weight, 0.0)
+
+    def forward(self, x: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+        target = (x.shape[-2], x.shape[-1])
+        if (noise.shape[-2], noise.shape[-1]) != target:
+            noise = torch.nn.functional.adaptive_avg_pool2d(noise, target)
+        return x * (1.0 + self.W_scale(noise)) + self.W_bias(noise)
+
+
 class ConvNeXtBlock(torch.nn.Module):
     """
     A convolution block as reported in https://github.com/CognitiveModeling/dlwp-hpx/blob/main/src/dlwp-hpx/dlwp/model/modules/blocks.py.
     This is a modified version of the actual ConvNextblock which
     is used in the HealPix paper.
+
+    When ``context_config`` is given with a non-zero noise embedding, each
+    normalization layer is followed by a ``NoiseConditioning`` scale and bias
+    read off the ``Context`` passed to ``forward``, making the block's norms
+    conditional, so it requires a normalization layer to condition (``norm`` not
+    None). Samudra's default ``instance`` norm is built with ``affine=False``, so
+    it is a pure normalizer and the conditional scale/bias is exactly a
+    conditional instance norm.
     """
 
     def __init__(
@@ -82,6 +124,7 @@ class ConvNeXtBlock(torch.nn.Module):
         norm_kwargs: Mapping[str, Any] | None = None,
         upscale_factor: int = 4,
         checkpoint_strategy: Literal["all", "simple"] | None = None,
+        context_config: ContextConfig | None = None,
     ):
         super().__init__()
         assert kernel_size % 2 != 0, "Cannot use even kernel sizes!"
@@ -96,6 +139,16 @@ class ConvNeXtBlock(torch.nn.Module):
         self.checkpoint_strategy = checkpoint_strategy
         assert n_layers == 1, "Can only use a single layer here!"  # Needs fixing
 
+        if context_config is None:
+            embed_dim_noise = 0
+        else:
+            embed_dim_noise = context_config.embed_dim_noise
+        if embed_dim_noise > 0 and norm is None:
+            raise ValueError(
+                "Noise conditioning requires a normalization layer to condition, "
+                "but norm is None."
+            )
+
         # 1x1 conv to increase/decrease channel depth if necessary
         if in_channels == out_channels:
             self.skip_module = lambda x: x  # Identity-function required in forward pass
@@ -107,84 +160,71 @@ class ConvNeXtBlock(torch.nn.Module):
                 padding="same",
             )
 
-        # Convolution block
-        convblock = []
+        hidden_channels = int(in_channels * upscale_factor)
+
+        # Convolution block. Layer order is unchanged from the unconditioned
+        # block, so checkpoints trained before conditioning existed still load;
+        # the conditioning modules live in a separate ModuleDict which is empty
+        # (and so contributes no state) when conditioning is off.
+        convblock: list[torch.nn.Module] = []
+        norm_indices: list[int] = []
         convblock.append(
             torch.nn.Conv2d(
                 in_channels=in_channels,
-                out_channels=int(in_channels * upscale_factor),
+                out_channels=hidden_channels,
                 kernel_size=kernel_size,
                 dilation=dilation,
             )
         )
-        # Batch Norm
-        if norm == "batch":
-            convblock.append(
-                torch.nn.BatchNorm2d(in_channels * upscale_factor, **self.norm_kwargs)
-            )
-        # Instance Norm
-        elif norm == "instance":
-            convblock.append(
-                torch.nn.InstanceNorm2d(
-                    in_channels * upscale_factor, **self.norm_kwargs
-                )
-            )
-        # Layer Norm
-        elif norm == "layer":
-            convblock.append(
-                torch.nn.LayerNorm(in_channels * upscale_factor, **self.norm_kwargs)
-            )
-        # No Norm
-        elif norm is None:
-            pass
-        else:
-            raise NotImplementedError(f"Normalization {norm} not implemented")
-
+        norm_layers = self._build_norm(norm, hidden_channels)
+        if norm_layers:
+            norm_indices.append(len(convblock))
+        convblock.extend(norm_layers)
         convblock.append(activation())
 
         convblock.append(
             torch.nn.Conv2d(
-                in_channels=int(in_channels * upscale_factor),
-                out_channels=int(in_channels * upscale_factor),
+                in_channels=hidden_channels,
+                out_channels=hidden_channels,
                 kernel_size=kernel_size,
                 dilation=dilation,
             )
         )
-        # Batch Norm
-        if norm == "batch":
-            convblock.append(
-                torch.nn.BatchNorm2d(in_channels * upscale_factor, **self.norm_kwargs)
-            )
-        # Instance Norm
-        elif norm == "instance":
-            convblock.append(
-                torch.nn.InstanceNorm2d(
-                    in_channels * upscale_factor, **self.norm_kwargs
-                )
-            )
-        # Layer Norm
-        elif norm == "layer":
-            convblock.append(
-                torch.nn.LayerNorm(in_channels * upscale_factor, **self.norm_kwargs)
-            )
-        # No Norm
-        elif norm is None:
-            pass
-        else:
-            raise NotImplementedError(f"Normalization {norm} not implemented")
-
+        norm_layers = self._build_norm(norm, hidden_channels)
+        if norm_layers:
+            norm_indices.append(len(convblock))
+        convblock.extend(norm_layers)
         convblock.append(activation())
 
         # Linear postprocessing
         convblock.append(
             torch.nn.Conv2d(
-                in_channels=int(in_channels * upscale_factor),
+                in_channels=hidden_channels,
                 out_channels=out_channels,
                 kernel_size=1,
                 padding="same",
             )
         )
-        self.convblock = torch.nn.Sequential(*convblock)
+        self.convblock = torch.nn.ModuleList(convblock)
+
+        self.noise_conditioning = torch.nn.ModuleDict()
+        if embed_dim_noise > 0:
+            for index in norm_indices:
+                self.noise_conditioning[str(index)] = NoiseConditioning(
+                    hidden_channels, embed_dim_noise
+                )
+
+    def _build_norm(self, norm: str | None, num_features: int) -> list[torch.nn.Module]:
+        assert self.norm_kwargs is not None
+        if norm == "batch":
+            return [torch.nn.BatchNorm2d(num_features, **self.norm_kwargs)]
+        elif norm == "instance":
+            return [torch.nn.InstanceNorm2d(num_features, **self.norm_kwargs)]
+        elif norm == "layer":
+            return [torch.nn.LayerNorm(num_features, **self.norm_kwargs)]
+        elif norm is None:
+            return []
+        raise NotImplementedError(f"Normalization {norm} not implemented")
 
     def _apply_simple_checkpoint(self, layer, x):
         if self.checkpoint_strategy == "simple" and not isinstance(layer, nn.Conv2d):
@@ -193,9 +233,16 @@ class ConvNeXtBlock(torch.nn.Module):
             x = layer(x)
         return x
 
-    def forward(self, x):
+    def forward(self, x, context: Context | None = None):
+        if len(self.noise_conditioning) > 0 and (
+            context is None or context.noise is None
+        ):
+            raise ValueError(
+                "This ConvNeXtBlock is noise-conditioned, so forward requires a "
+                "Context carrying a noise field."
+            )
         skip = self.skip_module(x)
-        for layer in self.convblock:
+        for i, layer in enumerate(self.convblock):
             if isinstance(layer, nn.Conv2d) and layer.kernel_size[0] != 1:
                 x = torch.nn.functional.pad(
                     x, (self.N_pad, self.N_pad, 0, 0), mode=self.pad
@@ -209,4 +256,7 @@ class ConvNeXtBlock(torch.nn.Module):
                 x = x.permute(0, 3, 1, 2).contiguous()
             else:
                 x = self._apply_simple_checkpoint(layer, x)
+            if str(i) in self.noise_conditioning:
+                assert context is not None and context.noise is not None
+                x = self.noise_conditioning[str(i)](x, context.noise)
         return skip + x

--- a/fme/ace/models/ocean/m2lines/samudra.py
+++ b/fme/ace/models/ocean/m2lines/samudra.py
@@ -13,6 +13,9 @@ from fme.ace.models.ocean.m2lines.layers import (
     ZonallyPeriodicBilinearUpsample,
 )
 from fme.ace.models.ocean.m2lines.utils import pairwise
+from fme.core.models.conditional_sfno.layers import Context, ContextConfig
+
+NoiseInjection = Literal["bottleneck", "all_blocks"]
 
 
 class Samudra(torch.nn.Module):
@@ -43,6 +46,16 @@ class Samudra(torch.nn.Module):
         longitude axis in the decoder, removing the lon=0 seam introduced by the
         default (non-periodic) bilinear upsampling. By default False to preserve
         the behavior of checkpoints trained without it.
+    context_config : ContextConfig, optional
+        If given (with a non-zero noise embedding), the ConvNeXt blocks selected
+        by ``noise_injection`` take a conditional scale and bias off the noise
+        field in the ``Context`` passed to ``forward``. Only noise conditioning
+        is supported; scalar, label, and positional embeddings are not.
+    noise_injection : {"bottleneck", "all_blocks"}, optional
+        Which ConvNeXt blocks are noise-conditioned. ``"bottleneck"`` conditions
+        only the block at the coarsest resolution (DLESyM-Ocean's choice, which
+        perturbs large scales); ``"all_blocks"`` conditions every block (the
+        pattern the ACE SFNO uses). Required when ``context_config`` is given.
 
     Example:
     --------
@@ -74,6 +87,8 @@ class Samudra(torch.nn.Module):
         upscale_factor: int = 4,
         checkpoint_strategy: Literal["all", "simple"] | None = None,
         zonally_periodic_upsample: bool = False,
+        context_config: ContextConfig | None = None,
+        noise_injection: NoiseInjection | None = None,
     ):
         super().__init__()
 
@@ -97,6 +112,44 @@ class Samudra(torch.nn.Module):
             else BilinearUpsample
         )
 
+        if context_config is not None:
+            if context_config.embed_dim_noise <= 0:
+                raise ValueError(
+                    "Samudra conditioning is noise-only, so context_config must "
+                    "have embed_dim_noise > 0."
+                )
+            if (
+                context_config.embed_dim_scalar > 0
+                or context_config.embed_dim_labels > 0
+                or context_config.embed_dim_pos > 0
+            ):
+                raise ValueError(
+                    "Samudra only supports noise conditioning; scalar, label, and "
+                    "positional embeddings are not implemented."
+                )
+            if noise_injection is None:
+                raise ValueError("context_config requires noise_injection to be set")
+        elif noise_injection is not None:
+            raise ValueError("noise_injection requires context_config to be set")
+        self.noise_injection = noise_injection
+
+        # Blocks are numbered in construction order: the num_steps encoder
+        # blocks, the bottleneck block, then the num_steps decoder blocks.
+        num_steps = len(self.ch_width)
+        n_blocks = 2 * num_steps + 1
+        if noise_injection == "bottleneck":
+            conditioned_blocks = {num_steps}
+        elif noise_injection == "all_blocks":
+            conditioned_blocks = set(range(n_blocks))
+        else:
+            conditioned_blocks = set()
+        block_contexts = iter(
+            [
+                context_config if i in conditioned_blocks else None
+                for i in range(n_blocks)
+            ]
+        )
+
         ch_width_with_input = (self.input_channels, *self.ch_width)
 
         # going down
@@ -113,6 +166,7 @@ class Samudra(torch.nn.Module):
                     norm_kwargs=self.norm_kwargs,
                     upscale_factor=self.upscale_factor,
                     checkpoint_strategy=self.checkpoint_strategy,
+                    context_config=next(block_contexts),
                 )
             )
             layers.append(AvgPool())
@@ -127,6 +181,7 @@ class Samudra(torch.nn.Module):
                 norm_kwargs=self.norm_kwargs,
                 upscale_factor=self.upscale_factor,
                 checkpoint_strategy=self.checkpoint_strategy,
+                context_config=next(block_contexts),
             )
         )
         layers.append(upsample_cls(in_channels=b, out_channels=b))
@@ -145,6 +200,7 @@ class Samudra(torch.nn.Module):
                     norm_kwargs=self.norm_kwargs,
                     upscale_factor=self.upscale_factor,
                     checkpoint_strategy=self.checkpoint_strategy,
+                    context_config=next(block_contexts),
                 )
             )
             layers.append(upsample_cls(in_channels=b, out_channels=b))
@@ -159,14 +215,19 @@ class Samudra(torch.nn.Module):
                 norm_kwargs=self.norm_kwargs,
                 upscale_factor=self.upscale_factor,
                 checkpoint_strategy=self.checkpoint_strategy,
+                context_config=next(block_contexts),
             )
         )
         layers.append(torch.nn.Conv2d(b, self.output_channels, self.last_kernel_size))
 
+        unconsumed = object()
+        if next(block_contexts, unconsumed) is not unconsumed:
+            raise AssertionError("not every ConvNeXt block consumed a block context")
+
         self.layers = nn.ModuleList(layers)
         self.num_steps = int(len(ch_width_with_input) - 1)
 
-    def forward(self, fts):
+    def forward(self, fts, context: Context | None = None):
         temp: list[torch.Tensor] = []
         count = 0
         for layer in self.layers:
@@ -178,10 +239,18 @@ class Samudra(torch.nn.Module):
                 fts = torch.nn.functional.pad(
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
-            if self.checkpoint_strategy == "all":
-                fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)
+            # only the ConvNeXt blocks are conditionable; the pooling, upsample
+            # and final conv layers take the tensor alone
+            if isinstance(layer, ConvNeXtBlock):
+                layer_args: tuple = (fts, context)
             else:
-                fts = layer(fts)
+                layer_args = (fts,)
+            if self.checkpoint_strategy == "all":
+                fts = torch.utils.checkpoint.checkpoint(
+                    layer, *layer_args, use_reentrant=False
+                )
+            else:
+                fts = layer(*layer_args)
             if count < self.num_steps:
                 if isinstance(layer, ConvNeXtBlock):
                     temp.append(fts)

--- a/fme/ace/models/ocean/m2lines/test_samudra.py
+++ b/fme/ace/models/ocean/m2lines/test_samudra.py
@@ -5,9 +5,12 @@ import torch
 
 from fme.ace.models.ocean.m2lines.layers import (
     BilinearUpsample,
+    ConvNeXtBlock,
+    NoiseConditioning,
     ZonallyPeriodicBilinearUpsample,
 )
 from fme.core.device import get_device
+from fme.core.models.conditional_sfno.layers import Context, ContextConfig
 from fme.core.testing import validate_tensor
 
 DIR = os.path.abspath(os.path.dirname(__file__))
@@ -165,3 +168,200 @@ def test_samudra_output_is_unchanged():
         output,
         os.path.join(DIR, "testdata/test_samudra_output_is_unchanged.pt"),
     )
+
+
+def _samudra(**kwargs):
+    return Samudra(
+        input_channels=4,
+        output_channels=3,
+        ch_width=[8, 12],
+        dilation=[1, 2],
+        n_layers=[1, 1],
+        **kwargs,
+    )
+
+
+def _context(n_noise, n_samples, img_shape):
+    return Context(
+        embedding_scalar=None,
+        embedding_pos=None,
+        labels=None,
+        noise=torch.randn(n_samples, n_noise, *img_shape),
+    )
+
+
+def _noise_context_config(n_noise):
+    return ContextConfig(
+        embed_dim_scalar=0,
+        embed_dim_labels=0,
+        embed_dim_noise=n_noise,
+        embed_dim_pos=0,
+    )
+
+
+def test_unconditioned_convnext_block_state_dict_has_no_conditioning_keys():
+    """Checkpoints predating conditioning must still load, so an unconditioned
+    block's state dict must be byte-for-byte the same set of keys."""
+    block = ConvNeXtBlock(in_channels=4, out_channels=4, upscale_factor=2)
+    keys = set(block.state_dict())
+    assert not any("noise_conditioning" in key for key in keys)
+    assert keys == {
+        "convblock.0.weight",
+        "convblock.0.bias",
+        "convblock.2.cap",
+        "convblock.3.weight",
+        "convblock.3.bias",
+        "convblock.5.cap",
+        "convblock.6.weight",
+        "convblock.6.bias",
+    }
+
+
+def test_convnext_block_conditioning_requires_a_norm():
+    with pytest.raises(ValueError, match="requires a normalization layer"):
+        ConvNeXtBlock(
+            in_channels=4,
+            out_channels=4,
+            norm=None,
+            context_config=_noise_context_config(4),
+        )
+
+
+def test_convnext_block_conditioning_requires_context_at_forward():
+    block = ConvNeXtBlock(
+        in_channels=4, out_channels=4, context_config=_noise_context_config(4)
+    )
+    with pytest.raises(ValueError, match="requires a"):
+        block(torch.randn(2, 4, 8, 16))
+
+
+def test_convnext_block_conditioning_resamples_coarser_noise():
+    """Inside the U-Net a conditioned block runs at coarser resolution than the
+    input-resolution noise field, so the conditioning must resample."""
+    n_noise = 4
+    block = ConvNeXtBlock(
+        in_channels=4, out_channels=4, context_config=_noise_context_config(n_noise)
+    )
+    for module in block.noise_conditioning.values():
+        torch.nn.init.normal_(module.W_scale.weight, std=0.1)
+        torch.nn.init.normal_(module.W_bias.weight, std=0.1)
+    x = torch.randn(2, 4, 4, 8)
+    out = block(x, _context(n_noise, 2, (16, 32)))
+    assert out.shape == x.shape
+
+
+@pytest.mark.parametrize("noise_injection", ["bottleneck", "all_blocks"])
+def test_samudra_noise_injection_conditions_expected_blocks(noise_injection):
+    n_noise = 4
+    model = _samudra(
+        context_config=_noise_context_config(n_noise),
+        noise_injection=noise_injection,
+    )
+    blocks = [layer for layer in model.layers if isinstance(layer, ConvNeXtBlock)]
+    # 2 encoder blocks + bottleneck + 2 decoder blocks
+    assert len(blocks) == 5
+    conditioned = [len(block.noise_conditioning) > 0 for block in blocks]
+    if noise_injection == "bottleneck":
+        assert conditioned == [False, False, True, False, False]
+    else:
+        assert conditioned == [True] * 5
+
+
+@pytest.mark.parametrize("noise_injection", ["bottleneck", "all_blocks"])
+def test_samudra_conditioning_is_zero_init_so_noise_is_inert(noise_injection):
+    """Zero-initialized conditioning weights make training start deterministic:
+    two different noise draws must give bit-identical output, and that output
+    must match the unconditioned model with the same parameters."""
+    torch.manual_seed(0)
+    n_noise = 4
+    img_shape = (16, 32)
+    conditioned = _samudra(
+        context_config=_noise_context_config(n_noise),
+        noise_injection=noise_injection,
+    )
+    x = torch.randn(2, 4, *img_shape)
+    with torch.no_grad():
+        first = conditioned(x, _context(n_noise, 2, img_shape))
+        second = conditioned(x, _context(n_noise, 2, img_shape))
+    torch.testing.assert_close(first, second, rtol=0.0, atol=0.0)
+
+    plain = _samudra()
+    plain.load_state_dict(
+        {
+            key: value
+            for key, value in conditioned.state_dict().items()
+            if "noise_conditioning" not in key
+        }
+    )
+    with torch.no_grad():
+        torch.testing.assert_close(plain(x), first, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("noise_injection", ["bottleneck", "all_blocks"])
+def test_samudra_noise_changes_output_once_conditioning_is_trained(noise_injection):
+    torch.manual_seed(0)
+    n_noise = 4
+    img_shape = (16, 32)
+    model = _samudra(
+        context_config=_noise_context_config(n_noise),
+        noise_injection=noise_injection,
+    )
+    for module in model.modules():
+        if isinstance(module, NoiseConditioning):
+            torch.nn.init.normal_(module.W_scale.weight, std=0.1)
+            torch.nn.init.normal_(module.W_bias.weight, std=0.1)
+    x = torch.randn(2, 4, *img_shape)
+    with torch.no_grad():
+        first = model(x, _context(n_noise, 2, img_shape))
+        second = model(x, _context(n_noise, 2, img_shape))
+    assert first.shape == (2, 3, *img_shape)
+    assert not torch.allclose(first, second)
+
+
+def test_samudra_conditioning_gradients_reach_conditioning_weights():
+    n_noise = 4
+    img_shape = (16, 32)
+    model = _samudra(
+        context_config=_noise_context_config(n_noise), noise_injection="all_blocks"
+    )
+    model(
+        torch.randn(2, 4, *img_shape), _context(n_noise, 2, img_shape)
+    ).sum().backward()
+    for module in model.modules():
+        if isinstance(module, NoiseConditioning):
+            assert module.W_bias.weight.grad is not None
+            assert torch.any(module.W_bias.weight.grad != 0.0)
+
+
+def test_samudra_checkpointing_with_conditioning():
+    n_noise = 4
+    img_shape = (16, 32)
+    model = _samudra(
+        context_config=_noise_context_config(n_noise),
+        noise_injection="all_blocks",
+        checkpoint_strategy="all",
+    )
+    x = torch.randn(2, 4, *img_shape, requires_grad=True)
+    out = model(x, _context(n_noise, 2, img_shape))
+    assert out.shape == (2, 3, *img_shape)
+    out.sum().backward()
+    assert x.grad is not None
+
+
+def test_samudra_rejects_inconsistent_conditioning_config():
+    with pytest.raises(ValueError, match="noise_injection to be set"):
+        _samudra(context_config=_noise_context_config(4))
+    with pytest.raises(ValueError, match="requires context_config"):
+        _samudra(noise_injection="bottleneck")
+    with pytest.raises(ValueError, match="embed_dim_noise > 0"):
+        _samudra(context_config=_noise_context_config(0), noise_injection="bottleneck")
+    with pytest.raises(ValueError, match="only supports noise conditioning"):
+        _samudra(
+            context_config=ContextConfig(
+                embed_dim_scalar=0,
+                embed_dim_labels=0,
+                embed_dim_noise=4,
+                embed_dim_pos=8,
+            ),
+            noise_injection="bottleneck",
+        )

--- a/fme/ace/registry/m2lines.py
+++ b/fme/ace/registry/m2lines.py
@@ -4,9 +4,11 @@ from typing import Any, Literal
 
 from fme.ace.models.graphcast import GRAPHCAST_AVAIL
 from fme.ace.models.graphcast.main import GraphCast
-from fme.ace.models.ocean.m2lines.samudra import Samudra
+from fme.ace.models.ocean.m2lines.samudra import NoiseInjection, Samudra
 from fme.ace.registry.registry import ModuleConfig, ModuleSelector
+from fme.ace.registry.stochastic_sfno import NoiseConditionedModel
 from fme.core.dataset_info import DatasetInfo
+from fme.core.models.conditional_sfno.layers import ContextConfig
 
 
 @ModuleSelector.register("Samudra")
@@ -54,6 +56,81 @@ class SamudraBuilder(ModuleConfig):
             upscale_factor=self.upscale_factor,
             checkpoint_strategy=self.checkpoint_strategy,
             zonally_periodic_upsample=self.zonally_periodic_upsample,
+        )
+
+
+@ModuleSelector.register("NoiseConditionedSamudra")
+@dataclasses.dataclass
+class NoiseConditionedSamudraBuilder(SamudraBuilder):
+    """
+    Configuration for a noise-conditioned M2Lines Samudra architecture.
+
+    A noise field is drawn on every forward call and supplied as conditioning
+    input to the ConvNeXt blocks' normalization layers, so an ensemble of
+    members can be drawn from one input and trained against a proper scoring
+    rule. The conditioning weights are zero-initialized, so an untrained model
+    is exactly deterministic.
+
+    Parameters:
+        noise_embed_dim: Number of noise channels drawn and projected onto each
+            conditioned block's scale and bias. Defaults to 32, DLESyM-Ocean's
+            choice.
+        noise_injection: Which ConvNeXt blocks are conditioned. "bottleneck"
+            conditions only the block at the coarsest resolution (after the
+            encoder's AvgPools), so the noise perturbs large scales;
+            "all_blocks" conditions every block, the pattern the ACE SFNO uses,
+            which also reaches the finest scales.
+    """
+
+    noise_embed_dim: int = 32
+    noise_injection: NoiseInjection = "bottleneck"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.noise_embed_dim <= 0:
+            raise ValueError("noise_embed_dim must be positive")
+        if self.norm is None:
+            raise ValueError(
+                "noise conditioning needs a normalization layer to condition, "
+                "so norm cannot be None"
+            )
+
+    def build(
+        self,
+        n_in_channels: int,
+        n_out_channels: int,
+        dataset_info: DatasetInfo,
+    ):
+        if len(dataset_info.all_labels) > 0:
+            raise ValueError("NoiseConditionedSamudra does not support labels")
+        context_config = ContextConfig(
+            embed_dim_scalar=0,
+            embed_dim_labels=0,
+            embed_dim_noise=self.noise_embed_dim,
+            embed_dim_pos=0,
+        )
+        samudra = Samudra(
+            input_channels=n_in_channels,
+            output_channels=n_out_channels,
+            ch_width=self.ch_width,
+            dilation=self.dilation,
+            n_layers=self.n_layers,
+            pad=self.pad,
+            norm=self.norm,
+            norm_kwargs=self.norm_kwargs,
+            upscale_factor=self.upscale_factor,
+            checkpoint_strategy=self.checkpoint_strategy,
+            zonally_periodic_upsample=self.zonally_periodic_upsample,
+            context_config=context_config,
+            noise_injection=self.noise_injection,
+        )
+        return NoiseConditionedModel(
+            samudra,
+            img_shape=dataset_info.img_shape,
+            embed_dim_noise=self.noise_embed_dim,
+            embed_dim_pos=0,
+            n_labels=0,
+            label_embed_dim=0,
         )
 
 

--- a/fme/ace/registry/test_m2lines.py
+++ b/fme/ace/registry/test_m2lines.py
@@ -1,6 +1,11 @@
 import pytest
+import torch
 
-from fme.ace.registry.m2lines import SamudraBuilder
+from fme.ace.models.ocean.m2lines.layers import ConvNeXtBlock, NoiseConditioning
+from fme.ace.models.ocean.m2lines.samudra import Samudra
+from fme.ace.registry.m2lines import NoiseConditionedSamudraBuilder, SamudraBuilder
+from fme.ace.registry.registry import ModuleSelector
+from fme.ace.registry.stochastic_sfno import NoiseConditionedModel
 from fme.core.dataset_info import DatasetInfo
 
 
@@ -19,3 +24,86 @@ def test_samudra_builder():
         ValueError, match="norm_kwargs should not have normalized_shape"
     ):
         _ = SamudraBuilder(norm_kwargs={"normalized_shape": (3, 3)})
+
+
+@pytest.mark.parametrize("noise_injection", ["bottleneck", "all_blocks"])
+def test_noise_conditioned_samudra_builder(noise_injection):
+    builder = NoiseConditionedSamudraBuilder(
+        ch_width=[8, 12],
+        dilation=[1, 2],
+        n_layers=[1, 1],
+        noise_embed_dim=6,
+        noise_injection=noise_injection,
+    )
+    img_shape = (16, 32)
+    model = builder.build(5, 3, DatasetInfo(img_shape=img_shape))
+    assert isinstance(model, NoiseConditionedModel)
+    assert isinstance(model.conditional_model, Samudra)
+    assert model.embed_dim == 6
+
+    blocks = [
+        layer
+        for layer in model.conditional_model.layers
+        if isinstance(layer, ConvNeXtBlock)
+    ]
+    n_conditioned = sum(len(block.noise_conditioning) > 0 for block in blocks)
+    assert n_conditioned == (1 if noise_injection == "bottleneck" else len(blocks))
+    for block in blocks:
+        for module in block.noise_conditioning.values():
+            assert module.W_scale.in_channels == 6
+
+    # the module is called the way the stepper calls it: input tensor only
+    output = model(torch.randn(2, 5, *img_shape))
+    assert output.shape == (2, 3, *img_shape)
+
+
+def test_noise_conditioned_samudra_is_registered():
+    selector = ModuleSelector(
+        type="NoiseConditionedSamudra",
+        config={"ch_width": [8], "dilation": [1], "n_layers": [1]},
+    )
+    module = selector.build(4, 2, DatasetInfo(img_shape=(16, 32)))
+    output = module(torch.randn(2, 4, 16, 32))
+    assert output.shape == (2, 2, 16, 32)
+    # defaults are captured in the serialized config
+    assert selector.config["noise_embed_dim"] == 32
+    assert selector.config["noise_injection"] == "bottleneck"
+
+
+def test_noise_conditioned_samudra_builder_validation():
+    with pytest.raises(ValueError, match="noise_embed_dim must be positive"):
+        NoiseConditionedSamudraBuilder(noise_embed_dim=0)
+    with pytest.raises(ValueError, match="norm_kwargs should not have num_features"):
+        NoiseConditionedSamudraBuilder(norm_kwargs={"num_features": 10})
+
+
+def test_noise_conditioned_samudra_rejects_labels():
+    builder = NoiseConditionedSamudraBuilder(ch_width=[8], dilation=[1], n_layers=[1])
+    dataset_info = DatasetInfo(img_shape=(16, 32), all_labels={"a", "b"})
+    with pytest.raises(ValueError, match="does not support labels"):
+        builder.build(4, 2, dataset_info)
+
+
+def test_noise_conditioned_samudra_draws_independent_noise_per_sample():
+    """Ensemble training folds the members into the batch dimension, so
+    identical inputs stacked along the batch must come out as distinct members.
+    """
+    torch.manual_seed(0)
+    img_shape = (16, 32)
+    builder = NoiseConditionedSamudraBuilder(
+        ch_width=[8, 12],
+        dilation=[1, 2],
+        n_layers=[1, 1],
+        noise_embed_dim=6,
+        noise_injection="all_blocks",
+    )
+    model = builder.build(4, 2, DatasetInfo(img_shape=img_shape))
+    for module in model.modules():
+        if isinstance(module, NoiseConditioning):
+            torch.nn.init.normal_(module.W_scale.weight, std=0.1)
+            torch.nn.init.normal_(module.W_bias.weight, std=0.1)
+    x = torch.randn(1, 4, *img_shape).expand(3, 4, *img_shape)
+    with torch.no_grad():
+        output = model(x)
+    assert not torch.allclose(output[0], output[1])
+    assert not torch.allclose(output[1], output[2])

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -539,3 +539,94 @@ def test_ocean_corrector_empty_delta_when_nothing_modified():
     assert dict(result.diagnostics.delta) == {}
     assert set(result.modified_names) == set()
     torch.testing.assert_close(result.corrected["so_0"], gen_data["so_0"])
+
+
+def test_ocean_corrector_is_per_member_under_ensemble_folding():
+    """Ensemble training folds the ensemble members into the batch dimension, so
+    the corrector sees several members at once. Every correction must act
+    per-member: one that coupled across the batch dim (e.g. a global mean taken
+    over samples too) would tie the members together and silently collapse the
+    ensemble spread the proper scoring rule is meant to reward.
+    """
+    torch.manual_seed(0)
+    n_members, nlat, nlon, nlevels = 2, 3, 3, 2
+    config = OceanCorrectorConfig(
+        force_positive_names=["so_0", "so_1"],
+        sea_ice_fraction_correction=SeaIceFractionConfig(
+            sea_ice_fraction_name="sea_ice_fraction",
+            land_fraction_name="land_fraction",
+            zero_where_ice_free_names=["sea_ice_thickness"],
+        ),
+        ocean_heat_content_correction=OceanHeatContentBudgetConfig(
+            method="scaled_temperature",
+            constant_unaccounted_heating=0.1,
+        ),
+    )
+    timestep = datetime.timedelta(seconds=5 * 24 * 3600)
+    mask = torch.ones(nlat, nlon, nlevels)
+    mask[0, 0, :] = 0.0
+    masks = {
+        "mask_0": mask[:, :, 0],
+        "mask_1": mask[:, :, 1],
+        "mask_2d": mask[:, :, 0],
+    }
+    # non-uniform in latitude only, as the area weights require
+    area = torch.tensor([0.5, 1.0, 1.5]).unsqueeze(-1).expand(nlat, nlon)
+    ops = LatLonOperations(area, SpatialMaskProvider(masks))
+    depth_coordinate = DepthCoordinate(torch.tensor([2.5, 10.0, 20.0]), mask)
+    corrector = config._build(ops, depth_coordinate, timestep)
+
+    def randoms(shape):
+        return torch.randn(shape)
+
+    input_data = {
+        "thetao_0": randoms((n_members, nlat, nlon)) + 2.0,
+        "thetao_1": randoms((n_members, nlat, nlon)) + 2.0,
+        "sst": randoms((n_members, nlat, nlon)) + 275.0,
+        "land_fraction": torch.zeros(n_members, nlat, nlon),
+    }
+    # members differ in every generated field, as they would under different
+    # noise draws
+    gen_data = {
+        "thetao_0": randoms((n_members, nlat, nlon)) + 2.0,
+        "thetao_1": randoms((n_members, nlat, nlon)) + 2.0,
+        "sst": randoms((n_members, nlat, nlon)) + 275.0,
+        "so_0": randoms((n_members, nlat, nlon)),
+        "so_1": randoms((n_members, nlat, nlon)),
+        # spans the clamp range at both ends so the sea-ice rebalance engages
+        "sea_ice_fraction": randoms((n_members, nlat, nlon)) * 0.8 + 0.5,
+        "sea_ice_thickness": randoms((n_members, nlat, nlon)),
+        "hfds": randoms((n_members, nlat, nlon)),
+    }
+    forcing_data = {
+        "hfgeou": randoms((n_members, nlat, nlon)),
+        "sea_surface_fraction": mask[:, :, 0].expand(n_members, nlat, nlon),
+    }
+
+    folded = corrector(input_data, gen_data, forcing_data, None).corrected
+    assert set(folded) >= {"so_0", "sea_ice_fraction", "thetao_0", "sst"}
+
+    for member in range(n_members):
+
+        def slice_member(data, member=member):
+            return {name: value[member : member + 1] for name, value in data.items()}
+
+        alone = corrector(
+            slice_member(input_data),
+            slice_member(gen_data),
+            slice_member(forcing_data),
+            None,
+        ).corrected
+        for name, value in alone.items():
+            torch.testing.assert_close(
+                folded[name][member : member + 1],
+                value,
+                msg=lambda m, name=name, member=member: (
+                    f"{name} for member {member} depends on the other members: {m}"
+                ),
+            )
+
+    # and the members really are distinct after correction, so the comparison
+    # above is not vacuous
+    for name in folded:
+        assert not torch.allclose(folded[name][0], folded[name][1])


### PR DESCRIPTION
Makes Samudra noise-conditionable so it can be trained with an ensemble proper scoring rule (`EnsembleLoss`), reusing the generic `NoiseConditionedModel` wrapper rather than adding a second noise path.

Motivation: the deterministic `ocean_wide_ohc_clip` Samudra runs are measurably variance-damped over long piControl rollouts, worst near coasts and in western boundary currents. Stochastic training against a proper scoring rule is the candidate fix; this is the module-side prerequisite.

## Changes

**`ConvNeXtBlock` becomes context-aware.** It takes an optional `ContextConfig`; when its noise embedding is non-zero, each normalization layer is followed by a `NoiseConditioning` module that reads the `Context`'s noise field and applies `x -> x * (1 + W_scale(noise)) + W_bias(noise)`, the same construction `ConditionalLayerNorm` uses for the SFNO. Samudra's default `instance` norm is built with `affine=False`, so this is exactly a conditional instance norm. Conditioning therefore requires a norm to condition (`norm=None` is rejected).

The noise field is drawn at the model's input resolution, while a conditioned block may run coarser inside the U-Net, so the conditioning area-averages the noise onto the block's grid.

`convblock` changes from `Sequential` to `ModuleList` so the forward can interleave conditioning. Layer order and state-dict keys are unchanged, and the conditioning modules live in a separate `ModuleDict` that is empty when conditioning is off, so checkpoints trained before this change still load. The duplicated four-branch norm construction is factored into `_build_norm`.

**`Samudra`** takes `context_config` and `noise_injection` and threads the `Context` through to its ConvNeXt blocks (pooling, upsample, and the final conv still take the tensor alone).

**`NoiseConditionedSamudra` registry entry**, with both injection variants:

- `bottleneck` (default): only the block at the coarsest resolution, DLESyM-Ocean's choice with 32-dim noise. After four `AvgPool`s that sits at 1/16 resolution, so the noise perturbs large scales.
- `all_blocks`: every block, the pattern the ACE SFNO uses, which also reaches the finest scales.

Both are wanted rather than one: the measured variance deficit is worst at coastal and western-boundary-current scales, where bottleneck-only conditioning may push at the wrong scales.

**Zero-init.** The conditioning convolutions are zero-initialized, as the SFNO path does, so an untrained model is exactly deterministic and stochasticity is learned from the ensemble loss.

## Tests

- Both variants condition the expected blocks, and at init two different noise draws give bit-identical output that also matches the unconditioned model loaded with the same parameters.
- With the conditioning weights perturbed, noise changes the output, gradients reach the conditioning weights, and `checkpoint_strategy="all"` still works.
- Identical inputs stacked along the batch dimension come out as distinct members, which is what ensemble folding relies on.
- An unconditioned block's state-dict key set is unchanged.
- The ocean corrector (`force_positive`, sea-ice fraction, OHC budget) is verified to act per-member under ensemble batch folding: correcting a folded 2-member batch equals correcting each member alone. A corrector that coupled across the batch dim would silently collapse the spread the scoring rule is meant to reward. Mutation-checked — making the area-weighted mean also reduce over the batch dim fails the test.

Independent of the patch energy score (#1459); the two compose but neither blocks the other.

Sizing note for whoever trains with this: `n_ensemble=2` doubles the effective batch, so the `ocean_wide_ohc_clip` recipe (4 GPUs, 500 GiB shared memory at `n_forward_steps=8`) needs a halved batch or more memory.