### PR TITLE
Return frozenset from output_names to fix per-channel loss label shuffle on resume

### DIFF
--- a/fme/ace/aggregator/loss_metrics.py
+++ b/fme/ace/aggregator/loss_metrics.py
@@ -74,7 +74,7 @@ class PerChannelLossAggregator:
     def get_logs(self, label: str) -> dict[str, float]:
         dist = Distributed.get_instance()
         logs: dict[str, float] = {}
-        for var_name, ws in self._weighted_sums.items():
+        for var_name, ws in sorted(self._weighted_sums.items()):
             count = self._counts[var_name]
             mean = ws / count if count > 0 else ws
             logs[f"{label}/mean/loss/{var_name}"] = float(

--- a/fme/ace/aggregator/test_loss_metrics.py
+++ b/fme/ace/aggregator/test_loss_metrics.py
@@ -1,9 +1,13 @@
 import pytest
 import torch
 
-from fme.ace.aggregator.loss_metrics import PerStepLossAggregator
+from fme.ace.aggregator.loss_metrics import (
+    PerChannelLossAggregator,
+    PerStepLossAggregator,
+)
 from fme.core.device import get_device
 from fme.core.distributed import Distributed
+from fme.core.loss import ChannelLossInfo
 
 
 def test_per_step_loss_aggregator_means_over_uneven_key_sets():
@@ -63,3 +67,36 @@ def test_per_step_loss_aggregator_mismatched_ranks(empty_rank):
         count = sum(r + 1 for r in contributors)
         expected[f"val/mean/loss_step_{step}"] = total / count
     assert logs == pytest.approx(expected)
+
+
+def test_per_channel_loss_aggregator_insertion_order_independent():
+    """get_logs must produce identical results regardless of recording order.
+
+    PerChannelLossAggregator.get_logs calls dist.reduce_mean per key.
+    reduce_mean wraps all_reduce, which matches by call position — so if
+    two ranks iterate keys in different orders, the collectives pair wrong
+    variables and produce means over mixed channels. This test verifies
+    that the log keys and values are independent of insertion order.
+    """
+    device = get_device()
+    data_forward = {
+        "z_var": ChannelLossInfo(loss=torch.tensor(1.0, device=device), count=2),
+        "a_var": ChannelLossInfo(loss=torch.tensor(3.0, device=device), count=2),
+        "m_var": ChannelLossInfo(loss=torch.tensor(5.0, device=device), count=2),
+    }
+    data_reverse = {
+        "m_var": ChannelLossInfo(loss=torch.tensor(5.0, device=device), count=2),
+        "a_var": ChannelLossInfo(loss=torch.tensor(3.0, device=device), count=2),
+        "z_var": ChannelLossInfo(loss=torch.tensor(1.0, device=device), count=2),
+    }
+
+    agg_forward = PerChannelLossAggregator()
+    agg_forward.record(data_forward)
+    logs_forward = agg_forward.get_logs("train")
+
+    agg_reverse = PerChannelLossAggregator()
+    agg_reverse.record(data_reverse)
+    logs_reverse = agg_reverse.get_logs("train")
+
+    assert logs_forward == logs_reverse
+    assert list(logs_forward.keys()) == sorted(logs_forward.keys())

--- a/fme/ace/requirements.py
+++ b/fme/ace/requirements.py
@@ -1,5 +1,5 @@
 import dataclasses
-from collections.abc import Sequence
+from collections.abc import Collection
 
 from fme.core.dataset.schedule import IntSchedule
 
@@ -15,7 +15,7 @@ class InitialConditionRequirements:
         n_ensemble: Number of ensemble members per initial state.
     """
 
-    prognostic_names: Sequence[str]
+    prognostic_names: Collection[str]
     labels: list[str] | None = None
     n_ensemble: int = 1
 
@@ -30,7 +30,7 @@ class PrognosticStateDataRequirements:
         n_timesteps: Number of consecutive timesteps that must be stored.
     """
 
-    names: list[str]
+    names: Collection[str]
     n_timesteps: int
 
 

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -230,7 +230,8 @@ class FCN3StepConfig(StepConfigABC):
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
             names=self._normalize_names + extra_names,
-            residual_scaled_names=self.prognostic_names + extra_residual_scaled_names,
+            residual_scaled_names=sorted(self.prognostic_names)
+            + extra_residual_scaled_names,
         )
 
     @classmethod
@@ -241,46 +242,45 @@ class FCN3StepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self):
+    def _normalize_names(self) -> list[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        return list(set(self.in_names).union(self.out_names))
+        return sorted(set(self.in_names) | set(self.out_names))
 
     @property
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         """
         Names of variables required as inputs to `step`,
         either in `input` or `next_step_input_data`.
         """
         if self.ocean is None:
-            return self.in_names
+            return frozenset(self.in_names)
         else:
-            return list(set(self.in_names).union(self.ocean.forcing_names))
+            return frozenset(self.in_names) | frozenset(self.ocean.forcing_names)
 
     def get_next_step_forcing_names(self) -> list[str]:
         """Names of input-only variables which come from the output timestep."""
         return self.next_step_forcing_names
 
     @property
-    def diagnostic_names(self) -> list[str]:
+    def diagnostic_names(self) -> frozenset[str]:
         """Names of variables which are outputs only."""
-        return []  # not currently supported
+        return frozenset()  # not currently supported
 
     @property
-    def output_names(self) -> list[str]:
-        return self.out_names
+    def output_names(self) -> frozenset[str]:
+        return frozenset(self.out_names)
 
     @property
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        result = set(self.input_names).difference(self.output_names)
+        result = self.input_names - self.output_names
         if self.ocean is not None:
-            result = result.union(self.ocean.forcing_names)
-        result = result.union(self.prescribed_prognostic_names)
-        return list(result)
+            result = result | frozenset(self.ocean.forcing_names)
+        return result | frozenset(self.prescribed_prognostic_names)
 
     @property
     def loss_names(self) -> list[str]:
-        return self.output_names
+        return sorted(self.output_names)
 
     def replace_ocean(self, ocean: OceanConfig | None):
         """

--- a/fme/ace/step/fcn3.py
+++ b/fme/ace/step/fcn3.py
@@ -229,7 +229,7 @@ class FCN3StepConfig(StepConfigABC):
         if extra_residual_scaled_names is None:
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
-            names=self._normalize_names + extra_names,
+            names=sorted(self._normalize_names) + extra_names,
             residual_scaled_names=sorted(self.prognostic_names)
             + extra_residual_scaled_names,
         )
@@ -242,9 +242,9 @@ class FCN3StepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self) -> list[str]:
+    def _normalize_names(self) -> frozenset[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        return sorted(set(self.in_names) | set(self.out_names))
+        return frozenset(set(self.in_names).union(self.out_names))
 
     @property
     def input_names(self) -> frozenset[str]:
@@ -255,7 +255,7 @@ class FCN3StepConfig(StepConfigABC):
         if self.ocean is None:
             return frozenset(self.in_names)
         else:
-            return frozenset(self.in_names) | frozenset(self.ocean.forcing_names)
+            return frozenset(set(self.in_names).union(self.ocean.forcing_names))
 
     def get_next_step_forcing_names(self) -> list[str]:
         """Names of input-only variables which come from the output timestep."""
@@ -273,10 +273,11 @@ class FCN3StepConfig(StepConfigABC):
     @property
     def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        result = self.input_names - self.output_names
+        result = set(self.input_names).difference(self.output_names)
         if self.ocean is not None:
-            result = result | frozenset(self.ocean.forcing_names)
-        return result | frozenset(self.prescribed_prognostic_names)
+            result = result.union(self.ocean.forcing_names)
+        result = result.union(self.prescribed_prognostic_names)
+        return frozenset(result)
 
     @property
     def loss_names(self) -> list[str]:
@@ -319,7 +320,9 @@ class FCN3StepConfig(StepConfigABC):
     ) -> "FCN3Step":
         logging.info("Initializing stepper from provided config")
         corrector = self.corrector.get_corrector(dataset_info)
-        normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        normalizer = self.normalization.get_network_normalizer(
+            sorted(self._normalize_names)
+        )
         return FCN3Step(
             config=self,
             dataset_info=dataset_info,

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -684,14 +684,14 @@ class StepperConfig:
         return self.step.loss_names
 
     @property
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         """Names of variables which are required as inputs."""
         return self.step.input_names
 
     @property
-    def all_names(self) -> set[str]:
+    def all_names(self) -> frozenset[str]:
         """Names of all variables."""
-        return set(self.input_names).union(self.output_names)
+        return self.input_names | self.output_names
 
     @property
     def next_step_forcing_names(self) -> list[str]:
@@ -703,12 +703,12 @@ class StepperConfig:
         return self.step.get_next_step_forcing_names()
 
     @property
-    def prognostic_names(self) -> list[str]:
+    def prognostic_names(self) -> frozenset[str]:
         """Names of variables which both inputs and outputs."""
         return self.step.prognostic_names
 
     @property
-    def output_names(self) -> list[str]:
+    def output_names(self) -> frozenset[str]:
         """Names of variables which are outputs only."""
         return self.step.output_names
 
@@ -1015,11 +1015,11 @@ class Stepper:
         return self._parameter_initializer.base_weights
 
     @property
-    def prognostic_names(self) -> list[str]:
+    def prognostic_names(self) -> frozenset[str]:
         return self._step_obj.prognostic_names
 
     @property
-    def out_names(self) -> list[str]:
+    def out_names(self) -> frozenset[str]:
         return self._step_obj.output_names
 
     @property

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -691,7 +691,7 @@ class StepperConfig:
     @property
     def all_names(self) -> frozenset[str]:
         """Names of all variables."""
-        return self.input_names | self.output_names
+        return frozenset(set(self.input_names).union(self.output_names))
 
     @property
     def next_step_forcing_names(self) -> list[str]:

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -1233,12 +1233,11 @@ def test_stepper_config_input_only_and_all_names_are_sets():
     assert isinstance(config.input_only_names, set)
     assert config.input_only_names == {"a", "c"}
 
-    assert isinstance(config.all_names, set)
+    assert isinstance(config.all_names, frozenset)
     assert config.all_names == {"a", "b", "c", "d"}
 
-    # base config values represent ML channel order and must stay list[str]
-    assert isinstance(config.input_names, list)
-    assert isinstance(config.output_names, list)
+    assert isinstance(config.input_names, frozenset)
+    assert isinstance(config.output_names, frozenset)
 
 
 def _init_train_stepper(

--- a/fme/core/dicts.py
+++ b/fme/core/dicts.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from typing import Any
 
 
@@ -41,7 +41,7 @@ def to_nested_dict(d: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def add_names(
-    left: Mapping[str, Any], right: Mapping[str, Any], names: list[str]
+    left: Mapping[str, Any], right: Mapping[str, Any], names: Collection[str]
 ) -> dict[str, Any]:
     """Add the 'names' from left dict to the right dict and return result.
 

--- a/fme/core/distributed/parallel_tests/test_step.py
+++ b/fme/core/distributed/parallel_tests/test_step.py
@@ -13,7 +13,7 @@ import pathlib
 import tempfile
 import unittest
 import unittest.mock
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 
 import numpy as np
 import pytest
@@ -228,7 +228,7 @@ TIMESTEP = datetime.timedelta(hours=6)
 
 
 def get_tensor_dict(
-    names: list[str], img_shape: tuple[int, int], n_samples: int
+    names: Collection[str], img_shape: tuple[int, int], n_samples: int
 ) -> TensorDict:
     data_dict = {}
     device = fme.get_device()

--- a/fme/core/ocean.py
+++ b/fme/core/ocean.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import datetime
+from collections.abc import Collection
 
 import torch
 
@@ -108,8 +109,8 @@ class OceanConfig:
 
     def build(
         self,
-        in_names: list[str],
-        out_names: list[str],
+        in_names: Collection[str],
+        out_names: Collection[str],
         timestep: datetime.timedelta,
     ) -> "Ocean":
         if not (

--- a/fme/core/step/_multi_call.py
+++ b/fme/core/step/_multi_call.py
@@ -1,6 +1,6 @@
 import dataclasses
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 
 from torch import nn
 
@@ -77,7 +77,7 @@ class MultiCallConfig:
             names.append(get_multi_call_name(name, suffix))
         return names
 
-    def validate(self, in_names: list[str], out_names: list[str]):
+    def validate(self, in_names: Collection[str], out_names: Collection[str]):
         if self.forcing_name not in in_names:
             raise ValueError(
                 f"forcing name {self.forcing_name} not in input names. It is required "

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -169,24 +169,24 @@ class MultiCallStepConfig(StepConfigABC):
         return self.config.names
 
     @property
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         return self.wrapped_step.input_names
 
     def get_next_step_forcing_names(self) -> list[str]:
         return self.wrapped_step.get_next_step_forcing_names()
 
     @property
-    def output_names(self) -> list[str]:
-        return self.wrapped_step.output_names + self._multi_call_outputs
+    def output_names(self) -> frozenset[str]:
+        return self.wrapped_step.output_names | frozenset(self._multi_call_outputs)
 
     @property
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         return self.wrapped_step.next_step_input_names
 
     @property
     def loss_names(self) -> list[str]:
         if self.include_multi_call_in_loss:
-            return self.wrapped_step.loss_names + self._multi_call_outputs
+            return sorted(self.output_names)
         else:
             return self.wrapped_step.loss_names
 

--- a/fme/core/step/multi_call.py
+++ b/fme/core/step/multi_call.py
@@ -177,7 +177,9 @@ class MultiCallStepConfig(StepConfigABC):
 
     @property
     def output_names(self) -> frozenset[str]:
-        return self.wrapped_step.output_names | frozenset(self._multi_call_outputs)
+        return frozenset(
+            set(self.wrapped_step.output_names).union(self._multi_call_outputs)
+        )
 
     @property
     def next_step_input_names(self) -> frozenset[str]:

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -107,7 +107,9 @@ class SeparateRadiationStepConfig(StepConfigABC):
     ) -> "SeparateRadiationStep":
         logging.info("Initializing stepper from provided config")
         corrector = self.corrector.get_corrector(dataset_info)
-        normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        normalizer = self.normalization.get_network_normalizer(
+            sorted(self._normalize_names)
+        )
         return SeparateRadiationStep(
             config=self,
             dataset_info=dataset_info,
@@ -128,7 +130,7 @@ class SeparateRadiationStepConfig(StepConfigABC):
         if extra_residual_scaled_names is None:
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
-            names=self._normalize_names + extra_names,
+            names=sorted(self._normalize_names) + extra_names,
             residual_scaled_names=sorted(self.prognostic_names)
             + extra_residual_scaled_names,
         )
@@ -140,7 +142,7 @@ class SeparateRadiationStepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self) -> list[str]:
+    def _normalize_names(self) -> frozenset[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
         all_names: set[str] = set()
         for names in (
@@ -151,12 +153,12 @@ class SeparateRadiationStepConfig(StepConfigABC):
             self.radiation_diagnostic_names,
         ):
             all_names.update(names)
-        return sorted(all_names)
+        return frozenset(all_names)
 
     @property
     def _forcing_names(self) -> list[str]:
         return sorted(
-            set(self.shared_forcing_names) | set(self.radiation_only_forcing_names)
+            set(self.shared_forcing_names).union(self.radiation_only_forcing_names)
         )
 
     def get_next_step_forcing_names(self) -> list[str]:
@@ -174,8 +176,8 @@ class SeparateRadiationStepConfig(StepConfigABC):
 
     @property
     def diagnostic_names(self) -> frozenset[str]:
-        return frozenset(self.main_diagnostic_names) | frozenset(
-            self.radiation_diagnostic_names
+        return frozenset(
+            set(self.main_diagnostic_names).union(self.radiation_diagnostic_names)
         )
 
     @property
@@ -212,7 +214,7 @@ class SeparateRadiationStepConfig(StepConfigABC):
         if self.ocean is None:
             return ml_in_names
         else:
-            return ml_in_names | frozenset(self.ocean.forcing_names)
+            return frozenset(set(ml_in_names).union(self.ocean.forcing_names))
 
     @property
     def output_names(self) -> frozenset[str]:
@@ -225,10 +227,10 @@ class SeparateRadiationStepConfig(StepConfigABC):
     @property
     def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        result = self.input_names - self.output_names
-        if self.ocean is not None:
-            result = result | frozenset(self.ocean.forcing_names)
-        return result
+        input_only_names = set(self.input_names).difference(self.output_names)
+        if self.ocean is None:
+            return frozenset(input_only_names)
+        return frozenset(input_only_names.union(self.ocean.forcing_names))
 
     @property
     def loss_names(self) -> list[str]:

--- a/fme/core/step/radiation.py
+++ b/fme/core/step/radiation.py
@@ -129,7 +129,8 @@ class SeparateRadiationStepConfig(StepConfigABC):
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
             names=self._normalize_names + extra_names,
-            residual_scaled_names=self.prognostic_names + extra_residual_scaled_names,
+            residual_scaled_names=sorted(self.prognostic_names)
+            + extra_residual_scaled_names,
         )
 
     @classmethod
@@ -141,7 +142,7 @@ class SeparateRadiationStepConfig(StepConfigABC):
     @property
     def _normalize_names(self) -> list[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        all_names = set()
+        all_names: set[str] = set()
         for names in (
             self.main_prognostic_names,
             self.shared_forcing_names,
@@ -150,12 +151,12 @@ class SeparateRadiationStepConfig(StepConfigABC):
             self.radiation_diagnostic_names,
         ):
             all_names.update(names)
-        return list(all_names)
+        return sorted(all_names)
 
     @property
     def _forcing_names(self) -> list[str]:
-        return list(
-            set(self.shared_forcing_names).union(self.radiation_only_forcing_names)
+        return sorted(
+            set(self.shared_forcing_names) | set(self.radiation_only_forcing_names)
         )
 
     def get_next_step_forcing_names(self) -> list[str]:
@@ -172,9 +173,9 @@ class SeparateRadiationStepConfig(StepConfigABC):
         return False
 
     @property
-    def diagnostic_names(self) -> list[str]:
-        return list(
-            set(self.main_diagnostic_names).union(self.radiation_diagnostic_names)
+    def diagnostic_names(self) -> frozenset[str]:
+        return frozenset(self.main_diagnostic_names) | frozenset(
+            self.radiation_diagnostic_names
         )
 
     @property
@@ -202,8 +203,8 @@ class SeparateRadiationStepConfig(StepConfigABC):
         return self.main_prognostic_names + self.main_diagnostic_names
 
     @property
-    def input_names(self) -> list[str]:
-        ml_in_names = (
+    def input_names(self) -> frozenset[str]:
+        ml_in_names = frozenset(
             self.main_prognostic_names
             + self.shared_forcing_names
             + self.radiation_only_forcing_names
@@ -211,27 +212,27 @@ class SeparateRadiationStepConfig(StepConfigABC):
         if self.ocean is None:
             return ml_in_names
         else:
-            return list(set(ml_in_names).union(self.ocean.forcing_names))
+            return ml_in_names | frozenset(self.ocean.forcing_names)
 
     @property
-    def output_names(self) -> list[str]:
-        return (
+    def output_names(self) -> frozenset[str]:
+        return frozenset(
             self.main_prognostic_names
             + self.main_diagnostic_names
             + self.radiation_diagnostic_names
         )
 
     @property
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        input_only_names = set(self.input_names).difference(self.output_names)
-        if self.ocean is None:
-            return list(input_only_names)
-        return list(input_only_names.union(self.ocean.forcing_names))
+        result = self.input_names - self.output_names
+        if self.ocean is not None:
+            result = result | frozenset(self.ocean.forcing_names)
+        return result
 
     @property
     def loss_names(self) -> list[str]:
-        return self.output_names
+        return sorted(self.output_names)
 
     def replace_ocean(self, ocean: OceanConfig | None):
         self.ocean = ocean

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -150,7 +150,7 @@ class SecondaryModuleStepConfig(StepConfigABC):
         if extra_residual_scaled_names is None:
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
-            names=self._normalize_names + extra_names,
+            names=sorted(self._normalize_names) + extra_names,
             residual_scaled_names=sorted(self.prognostic_names)
             + extra_residual_scaled_names,
         )
@@ -162,9 +162,9 @@ class SecondaryModuleStepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self) -> list[str]:
+    def _normalize_names(self) -> frozenset[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        return sorted(set(self.in_names) | self.output_names)
+        return frozenset(set(self.in_names).union(self.output_names))
 
     @property
     def input_names(self) -> frozenset[str]:
@@ -175,7 +175,7 @@ class SecondaryModuleStepConfig(StepConfigABC):
         if self.ocean is None:
             return frozenset(self.in_names)
         else:
-            return frozenset(self.in_names) | frozenset(self.ocean.forcing_names)
+            return frozenset(set(self.in_names).union(self.ocean.forcing_names))
 
     def get_next_step_forcing_names(self) -> list[str]:
         """Names of input-only variables which come from the output timestep."""
@@ -184,7 +184,7 @@ class SecondaryModuleStepConfig(StepConfigABC):
     @property
     def diagnostic_names(self) -> frozenset[str]:
         """Names of variables which are outputs only."""
-        return self.output_names - set(self.in_names)
+        return frozenset(set(self.output_names).difference(self.in_names))
 
     @property
     def output_names(self) -> frozenset[str]:
@@ -193,20 +193,20 @@ class SecondaryModuleStepConfig(StepConfigABC):
             if self.secondary_decoder is not None
             else []
         )
-        return (
-            frozenset(self.out_names)
-            | frozenset(secondary_decoder_names)
-            | frozenset(self.secondary_out_names)
-            | frozenset(self.secondary_residual_out_names)
+        return frozenset(
+            set(self.out_names)
+            .union(secondary_decoder_names)
+            .union(self.secondary_out_names)
+            .union(self.secondary_residual_out_names)
         )
 
     @property
     def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        result = self.input_names - self.output_names
+        result = set(self.input_names).difference(self.output_names)
         if self.ocean is not None:
-            result = result | frozenset(self.ocean.forcing_names)
-        return result | frozenset(self.prescribed_prognostic_names)
+            result = result.union(self.ocean.forcing_names)
+        return frozenset(result.union(self.prescribed_prognostic_names))
 
     @property
     def loss_names(self) -> list[str]:
@@ -244,7 +244,9 @@ class SecondaryModuleStepConfig(StepConfigABC):
     ) -> "SecondaryModuleStep":
         logging.info("Initializing stepper from provided config")
         corrector = self.corrector.get_corrector(dataset_info)
-        normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        normalizer = self.normalization.get_network_normalizer(
+            sorted(self._normalize_names)
+        )
         return SecondaryModuleStep(
             config=self,
             dataset_info=dataset_info,

--- a/fme/core/step/secondary_module.py
+++ b/fme/core/step/secondary_module.py
@@ -151,7 +151,8 @@ class SecondaryModuleStepConfig(StepConfigABC):
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
             names=self._normalize_names + extra_names,
-            residual_scaled_names=self.prognostic_names + extra_residual_scaled_names,
+            residual_scaled_names=sorted(self.prognostic_names)
+            + extra_residual_scaled_names,
         )
 
     @classmethod
@@ -161,57 +162,55 @@ class SecondaryModuleStepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self):
+    def _normalize_names(self) -> list[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        return list(set(self.in_names).union(self.output_names))
+        return sorted(set(self.in_names) | self.output_names)
 
     @property
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         """
         Names of variables required as inputs to `step`,
         either in `input` or `next_step_input_data`.
         """
         if self.ocean is None:
-            return self.in_names
+            return frozenset(self.in_names)
         else:
-            return list(set(self.in_names).union(self.ocean.forcing_names))
+            return frozenset(self.in_names) | frozenset(self.ocean.forcing_names)
 
     def get_next_step_forcing_names(self) -> list[str]:
         """Names of input-only variables which come from the output timestep."""
         return self.next_step_forcing_names
 
     @property
-    def diagnostic_names(self) -> list[str]:
+    def diagnostic_names(self) -> frozenset[str]:
         """Names of variables which are outputs only."""
-        return list(set(self.output_names).difference(self.in_names))
+        return self.output_names - set(self.in_names)
 
     @property
-    def output_names(self) -> list[str]:
+    def output_names(self) -> frozenset[str]:
         secondary_decoder_names = (
             self.secondary_decoder.secondary_diagnostic_names
             if self.secondary_decoder is not None
             else []
         )
-        return list(
-            set(self.out_names)
-            .union(secondary_decoder_names)
-            .union(self.secondary_out_names)
-            .union(self.secondary_residual_out_names)
+        return (
+            frozenset(self.out_names)
+            | frozenset(secondary_decoder_names)
+            | frozenset(self.secondary_out_names)
+            | frozenset(self.secondary_residual_out_names)
         )
 
     @property
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        input_only_names = set(self.input_names).difference(self.output_names)
-        result = set(input_only_names)
+        result = self.input_names - self.output_names
         if self.ocean is not None:
-            result = result.union(self.ocean.forcing_names)
-        result = result.union(self.prescribed_prognostic_names)
-        return list(result)
+            result = result | frozenset(self.ocean.forcing_names)
+        return result | frozenset(self.prescribed_prognostic_names)
 
     @property
     def loss_names(self) -> list[str]:
-        return self.output_names
+        return sorted(self.output_names)
 
     def replace_ocean(self, ocean: OceanConfig | None):
         """

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -144,7 +144,8 @@ class SingleModuleStepConfig(StepConfigABC):
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
             names=self._normalize_names + extra_names,
-            residual_scaled_names=self.prognostic_names + extra_residual_scaled_names,
+            residual_scaled_names=sorted(self.prognostic_names)
+            + extra_residual_scaled_names,
         )
 
     @classmethod
@@ -155,52 +156,50 @@ class SingleModuleStepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self):
+    def _normalize_names(self) -> list[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        return list(set(self.in_names).union(self.output_names))
+        return sorted(set(self.in_names) | self.output_names)
 
     @property
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         """
         Names of variables required as inputs to `step`,
         either in `input` or `next_step_input_data`.
         """
         if self.ocean is None:
-            return self.in_names
+            return frozenset(self.in_names)
         else:
-            return list(set(self.in_names).union(self.ocean.forcing_names))
+            return frozenset(self.in_names) | frozenset(self.ocean.forcing_names)
 
     def get_next_step_forcing_names(self) -> list[str]:
         """Names of input-only variables which come from the output timestep."""
         return self.next_step_forcing_names
 
     @property
-    def diagnostic_names(self) -> list[str]:
+    def diagnostic_names(self) -> frozenset[str]:
         """Names of variables which are outputs only."""
-        return list(set(self.output_names).difference(self.in_names))
+        return self.output_names - set(self.in_names)
 
     @property
-    def output_names(self) -> list[str]:
+    def output_names(self) -> frozenset[str]:
         secondary_names = (
             self.secondary_decoder.secondary_diagnostic_names
             if self.secondary_decoder is not None
             else []
         )
-        return list(set(self.out_names).union(secondary_names))
+        return frozenset(self.out_names) | frozenset(secondary_names)
 
     @property
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        input_only_names = set(self.input_names).difference(self.output_names)
-        result = set(input_only_names)
+        result = self.input_names - self.output_names
         if self.ocean is not None:
-            result = result.union(self.ocean.forcing_names)
-        result = result.union(self.prescribed_prognostic_names)
-        return list(result)
+            result = result | frozenset(self.ocean.forcing_names)
+        return result | frozenset(self.prescribed_prognostic_names)
 
     @property
     def loss_names(self) -> list[str]:
-        return self.output_names
+        return sorted(self.output_names)
 
     @property
     def allow_missing_variables(self) -> bool:
@@ -611,7 +610,7 @@ def step_with_adjustments(
     corrector: CorrectorABC | None,
     ocean: Ocean | None,
     residual_prediction: bool,
-    prognostic_names: list[str],
+    prognostic_names: frozenset[str],
     prescribed_prognostic_names: list[str] | None = None,
     global_mean_removal: GlobalMeanRemoval | None = None,
     data_mask: TensorMapping | None = None,

--- a/fme/core/step/single_module.py
+++ b/fme/core/step/single_module.py
@@ -143,7 +143,7 @@ class SingleModuleStepConfig(StepConfigABC):
         if extra_residual_scaled_names is None:
             extra_residual_scaled_names = []
         return self.normalization.get_loss_normalizer(
-            names=self._normalize_names + extra_names,
+            names=sorted(self._normalize_names) + extra_names,
             residual_scaled_names=sorted(self.prognostic_names)
             + extra_residual_scaled_names,
         )
@@ -156,9 +156,9 @@ class SingleModuleStepConfig(StepConfigABC):
         )
 
     @property
-    def _normalize_names(self) -> list[str]:
+    def _normalize_names(self) -> frozenset[str]:
         """Names of variables which require normalization. I.e. inputs/outputs."""
-        return sorted(set(self.in_names) | self.output_names)
+        return frozenset(set(self.in_names).union(self.output_names))
 
     @property
     def input_names(self) -> frozenset[str]:
@@ -169,7 +169,7 @@ class SingleModuleStepConfig(StepConfigABC):
         if self.ocean is None:
             return frozenset(self.in_names)
         else:
-            return frozenset(self.in_names) | frozenset(self.ocean.forcing_names)
+            return frozenset(set(self.in_names).union(self.ocean.forcing_names))
 
     def get_next_step_forcing_names(self) -> list[str]:
         """Names of input-only variables which come from the output timestep."""
@@ -178,7 +178,7 @@ class SingleModuleStepConfig(StepConfigABC):
     @property
     def diagnostic_names(self) -> frozenset[str]:
         """Names of variables which are outputs only."""
-        return self.output_names - set(self.in_names)
+        return frozenset(set(self.output_names).difference(self.in_names))
 
     @property
     def output_names(self) -> frozenset[str]:
@@ -187,15 +187,15 @@ class SingleModuleStepConfig(StepConfigABC):
             if self.secondary_decoder is not None
             else []
         )
-        return frozenset(self.out_names) | frozenset(secondary_names)
+        return frozenset(set(self.out_names).union(secondary_names))
 
     @property
     def next_step_input_names(self) -> frozenset[str]:
         """Names of variables provided in next_step_input_data."""
-        result = self.input_names - self.output_names
+        result = set(self.input_names).difference(self.output_names)
         if self.ocean is not None:
-            result = result | frozenset(self.ocean.forcing_names)
-        return result | frozenset(self.prescribed_prognostic_names)
+            result = result.union(self.ocean.forcing_names)
+        return frozenset(result.union(self.prescribed_prognostic_names))
 
     @property
     def loss_names(self) -> list[str]:
@@ -244,7 +244,9 @@ class SingleModuleStepConfig(StepConfigABC):
     ) -> "SingleModuleStep":
         logging.info("Initializing stepper from provided config")
         corrector = self.corrector.get_corrector(dataset_info)
-        normalizer = self.normalization.get_network_normalizer(self._normalize_names)
+        normalizer = self.normalization.get_network_normalizer(
+            sorted(self._normalize_names)
+        )
         return SingleModuleStep(
             config=self,
             dataset_info=dataset_info,

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -68,7 +68,7 @@ class StepConfigABC(abc.ABC):
     @property
     @final
     def prognostic_names(self) -> frozenset[str]:
-        return self.input_names & self.output_names
+        return frozenset(set(self.input_names).intersection(self.output_names))
 
     @property
     @abc.abstractmethod

--- a/fme/core/step/step.py
+++ b/fme/core/step/step.py
@@ -46,12 +46,12 @@ class StepConfigABC(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         pass
 
     @property
     @abc.abstractmethod
-    def output_names(self) -> list[str]:
+    def output_names(self) -> frozenset[str]:
         """
         Names of variables output by the step.
         """
@@ -59,7 +59,7 @@ class StepConfigABC(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """
         Names of variables required in next_step_input_data for .step.
         """
@@ -67,8 +67,8 @@ class StepConfigABC(abc.ABC):
 
     @property
     @final
-    def prognostic_names(self) -> list[str]:
-        return list(set(self.input_names).intersection(self.output_names))
+    def prognostic_names(self) -> frozenset[str]:
+        return self.input_names & self.output_names
 
     @property
     @abc.abstractmethod
@@ -182,18 +182,18 @@ class StepSelector(StepConfigABC):
         return self._step_config_instance.get_next_step_forcing_names()
 
     @property
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         return self._step_config_instance.input_names
 
     @property
-    def output_names(self) -> list[str]:
+    def output_names(self) -> frozenset[str]:
         """
         Names of variables output by the step.
         """
         return self._step_config_instance.output_names
 
     @property
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """
         Names of variables required in next_step_input_data for .step.
         """
@@ -290,17 +290,17 @@ class StepABC(abc.ABC):
 
     @property
     @final
-    def input_names(self) -> list[str]:
+    def input_names(self) -> frozenset[str]:
         return self.config.input_names
 
     @property
     @final
-    def output_names(self) -> list[str]:
+    def output_names(self) -> frozenset[str]:
         return self.config.output_names
 
     @property
     @final
-    def prognostic_names(self) -> list[str]:
+    def prognostic_names(self) -> frozenset[str]:
         return self.config.prognostic_names
 
     @property
@@ -320,7 +320,7 @@ class StepABC(abc.ABC):
 
     @property
     @final
-    def next_step_input_names(self) -> list[str]:
+    def next_step_input_names(self) -> frozenset[str]:
         """
         Names of variables required in next_step_input_data for .step.
         """

--- a/fme/core/step/test_multi_call.py
+++ b/fme/core/step/test_multi_call.py
@@ -43,11 +43,11 @@ def test_multi_call(include_multi_call_in_loss: bool):
 
     with unittest.mock.patch.object(MockStep, "step", side_effect=_step):
         step = config.get_step(DatasetInfo(), lambda x: None)
-        assert step.output_names == ["b", "c", "c_doubled_co2"]
+        assert step.output_names == {"b", "c", "c_doubled_co2"}
         if include_multi_call_in_loss:
-            assert step.loss_names == ["b", "c", "c_doubled_co2"]
+            assert step.loss_names == sorted({"b", "c", "c_doubled_co2"})
         else:
-            assert step.loss_names == ["b", "c"]
+            assert step.loss_names == sorted({"b", "c"})
 
         input = {
             "a": torch.randn(1, 2, 3, 4),

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -3,7 +3,7 @@ import pathlib
 import tempfile
 import unittest
 import unittest.mock
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 
 import dacite
 import pytest
@@ -523,7 +523,7 @@ HAS_NEXT_STEP_FORCING_NAME_CASES = [
 
 
 def get_tensor_dict(
-    names: list[str], img_shape: tuple[int, int], n_samples: int
+    names: Collection[str], img_shape: tuple[int, int], n_samples: int
 ) -> TensorDict:
     data_dict = {}
     device = fme.get_device()

--- a/fme/core/step/test_step.py
+++ b/fme/core/step/test_step.py
@@ -1132,6 +1132,34 @@ def test_secondary_module_output_names_residual_on_input_only():
     assert "b" in config.output_names
 
 
+def test_loss_names_sorted_regardless_of_input_order():
+    """loss_names must be deterministic (sorted) regardless of out_names order.
+
+    On main, output_names was list(set(...)) whose iteration order depends on
+    PYTHONHASHSEED. loss_names derived from output_names, so the Packer received
+    a different channel ordering in each new process. This test verifies the
+    fix: loss_names is always alphabetically sorted.
+    """
+    names_a = ["z_var", "a_var", "m_var"]
+    names_b = list(reversed(names_a))
+    normalization_a = get_network_and_loss_normalization_config(names=names_a)
+    normalization_b = get_network_and_loss_normalization_config(names=names_b)
+    config_a = SingleModuleStepConfig(
+        builder=ModuleSelector(type="MLP", config={}),
+        in_names=names_a,
+        out_names=names_a,
+        normalization=normalization_a,
+    )
+    config_b = SingleModuleStepConfig(
+        builder=ModuleSelector(type="MLP", config={}),
+        in_names=names_b,
+        out_names=names_b,
+        normalization=normalization_b,
+    )
+    assert config_a.loss_names == config_b.loss_names
+    assert config_a.loss_names == sorted(names_a)
+
+
 @pytest.mark.parallel
 def test_secondary_module_full_field_and_residual():
     """Test secondary_out_names and secondary_residual_out_names together."""

--- a/fme/core/step/test_step_registry.py
+++ b/fme/core/step/test_step_registry.py
@@ -92,20 +92,20 @@ class MockStepConfig(StepConfigABC):
         return []
 
     @property
-    def input_names(self) -> list[str]:
-        return self.in_names
+    def input_names(self) -> frozenset[str]:
+        return frozenset(self.in_names)
 
     @property
-    def output_names(self) -> list[str]:
-        return self.out_names
+    def output_names(self) -> frozenset[str]:
+        return frozenset(self.out_names)
 
     @property
-    def next_step_input_names(self):
+    def next_step_input_names(self) -> frozenset[str]:
         raise NotImplementedError()
 
     @property
     def loss_names(self) -> list[str]:
-        return self.out_names
+        return sorted(self.out_names)
 
     @property
     def n_ic_timesteps(self) -> int:

--- a/fme/coupled/inference/inference.py
+++ b/fme/coupled/inference/inference.py
@@ -3,7 +3,7 @@ import dataclasses
 import datetime
 import logging
 import os
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import Literal
 
 import cftime
@@ -89,8 +89,8 @@ class CoupledInitialConditionConfig:
 
     def get_initial_condition(
         self,
-        ocean_prognostic_names: Sequence[str],
-        atmosphere_prognostic_names: Sequence[str],
+        ocean_prognostic_names: Collection[str],
+        atmosphere_prognostic_names: Collection[str],
         n_ensemble_per_ic: int,
     ) -> CoupledPrognosticState:
         ocean = self.ocean.get_dataset(self.start_indices)

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -501,11 +501,14 @@ class CoupledStepperConfig:
     def all_names(self) -> CoupledNames:
         """All variable names to log (outputs plus input-only forcings)."""
         atmosphere_names = sorted(
-            self.atmosphere.stepper.output_names
-            | set(self._atmosphere_forcing_exogenous_names)
+            set(self.atmosphere.stepper.output_names).union(
+                self._atmosphere_forcing_exogenous_names
+            )
         )
         ocean_names = sorted(
-            self.ocean.stepper.output_names | set(self._ocean_forcing_exogenous_names)
+            set(self.ocean.stepper.output_names).union(
+                self._ocean_forcing_exogenous_names
+            )
         )
         return CoupledNames(ocean=ocean_names, atmosphere=atmosphere_names)
 

--- a/fme/coupled/stepper.py
+++ b/fme/coupled/stepper.py
@@ -500,14 +500,12 @@ class CoupledStepperConfig:
     @property
     def all_names(self) -> CoupledNames:
         """All variable names to log (outputs plus input-only forcings)."""
-        atmosphere_names = list(
-            set(
-                self.atmosphere.stepper.output_names
-                + self._atmosphere_forcing_exogenous_names
-            )
+        atmosphere_names = sorted(
+            self.atmosphere.stepper.output_names
+            | set(self._atmosphere_forcing_exogenous_names)
         )
-        ocean_names = list(
-            set(self.ocean.stepper.output_names + self._ocean_forcing_exogenous_names)
+        ocean_names = sorted(
+            self.ocean.stepper.output_names | set(self._ocean_forcing_exogenous_names)
         )
         return CoupledNames(ocean=ocean_names, atmosphere=atmosphere_names)
 


### PR DESCRIPTION
Per-channel loss values logged to wandb (train/mean/loss/<varname>)
were numerically wrong in every multi-GPU run and additionally
mislabeled across Beaker preemption/resume cycles.

**Multi-GPU (every run):** `PerChannelLossAggregator.get_logs`
iterates `self._weighted_sums` in insertion order, calling
`dist.reduce_mean` (an `all_reduce` collective matched by call
position) per key. Different PYTHONHASHSEED across ranks means rank
0's reduce for `air_temperature_0` paired with rank 1's reduce for
`surface_pressure` — the logged per-channel losses were means over
mixed variables. The sibling `LossAggregator.get_logs` already guards
this (gathers and sorts the key universe before reducing);
`PerChannelLossAggregator` was missing it.

**Preemption (label shuffling):** `output_names` and siblings returned
`list(set(...))`, whose iteration order depends on PYTHONHASHSEED.
Since `loss_names` derived from `output_names`, the loss Packer
received a different channel ordering in each new process, swapping
per-channel labels while leaving the total loss correct.

The fix:
1. `PerChannelLossAggregator.get_logs` now iterates
   `sorted(self._weighted_sums.items())` so every rank issues the same
   collectives.
2. `output_names`, `input_names`, `next_step_input_names`, and
   `prognostic_names` return `frozenset[str]`, making unorderedness
   explicit. `loss_names` returns `sorted(self.output_names)` for the
   Packer. Downstream signatures widened to `Collection[str]` where
   only membership/iteration is needed.

Changes:
- `PerChannelLossAggregator.get_logs` — sorted iteration over `_weighted_sums`
- `StepConfigABC.output_names`, `.input_names`, `.next_step_input_names`, `.prognostic_names` → `frozenset[str]`
- `StepConfigABC.loss_names` → `sorted(self.output_names)` (deterministic across process restarts)
- `SingleModuleStepConfig`, `SecondaryModuleStepConfig`, `FCN3StepConfig`, `SeparateRadiationStepConfig`, `MultiCallStepConfig` — same pattern
- `StepABC`, `StepSelector` passthroughs — updated return types
- `StepperConfig`, `Stepper` (ace stepper) passthroughs — updated return types
- `MultiCallConfig.validate`, `OceanConfig.build`, `add_names`, `InitialConditionRequirements`, `PrognosticStateDataRequirements`, `CoupledInitialConditionConfig.get_initial_condition` — widened to `Collection[str]`
- `step_with_adjustments` `prognostic_names` parameter — `frozenset[str]`

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #579