### PR TITLE
Add CM4 ocean 1-daily data processing

### DIFF
--- a/scripts/data_process/Makefile
+++ b/scripts/data_process/Makefile
@@ -346,6 +346,14 @@ cm4_piControl_ocean_stats:
 cm4_1pctCO2_ocean_stats:
 	./compute_stats.sh --config configs/CM4-1pctCO2-ocean-$(RESOLUTION)-140yr.yaml
 
+.PHONY: cm4_piControl_ocean_1daily_stats
+cm4_piControl_ocean_1daily_stats:
+	./compute_stats.sh --config configs/CM4-piControl-ocean-$(RESOLUTION)-1daily-200yr.yaml
+
+.PHONY: cm4_1pctCO2_ocean_1daily_stats
+cm4_1pctCO2_ocean_1daily_stats:
+	./compute_stats.sh --config configs/CM4-1pctCO2-ocean-$(RESOLUTION)-1daily-140yr.yaml
+
 .PHONY: create_coupled_datasets_env
 create_coupled_datasets_env:
 	conda create -y -n create_coupled_datasets python=3.11 pip
@@ -359,6 +367,14 @@ cm4_piControl_coupled:
 .PHONY: cm4_1pctCO2_coupled
 cm4_1pctCO2_coupled:
 	conda run --no-capture-output -n create_coupled_datasets python ./create_coupled_datasets.py --yaml configs/CM4-1pctCO2-coupled-$(RESOLUTION)-140yr.yaml
+
+.PHONY: cm4_piControl_coupled_1daily
+cm4_piControl_coupled_1daily:
+	conda run --no-capture-output -n create_coupled_datasets python ./create_coupled_datasets.py --yaml configs/CM4-piControl-coupled-$(RESOLUTION)-1daily-200yr.yaml
+
+.PHONY: cm4_1pctCO2_coupled_1daily
+cm4_1pctCO2_coupled_1daily:
+	conda run --no-capture-output -n create_coupled_datasets python ./create_coupled_datasets.py --yaml configs/CM4-1pctCO2-coupled-$(RESOLUTION)-1daily-140yr.yaml
 
 .PHONY: e3smv3_piControl_100yr_coupled
 e3smv3_piControl_100yr_coupled:

--- a/scripts/data_process/configs/CM4-1pctCO2-coupled-1deg-1daily-140yr.yaml
+++ b/scripts/data_process/configs/CM4-1pctCO2-coupled-1deg-1daily-140yr.yaml
@@ -1,0 +1,57 @@
+# make cm4_1pctCO2_coupled_1daily RESOLUTION=1deg
+version: "2026-09-09"
+family_name: cm4-1pctCO2-1deg-coupled-1daily
+output_directory: gs://vcm-ml-intermediate
+
+coupled_datasets:
+  coupled_ts:
+    how: interpolate_sst
+  coupled_sea_surface:
+    precomputed_sea_ice_mask:
+      zarr_path: gs://vcm-ml-intermediate/2026-09-09-cm4-piControl-1deg-coupled-1daily-ocean.zarr
+    ocean_extra_masked_names: ["HI", "sea_ice_volume", "UI", "VI", "sfdsi"]
+    ocean_extra_fill_values:
+      UI: 0.0
+      VI: 0.0
+    surface_flux_window_avg:
+      window_timedelta: 24h
+      # The ocean store labels its 1-day intervals at the interval end, so the
+      # flux windows are right-labeled at those same instants (no midpoint
+      # shift): each window (t - 24h, t] ends at an ocean timestep t.
+      first_timestamp: "0001-01-02T00:00:00"
+      last_timestamp: "0141-01-01T00:00:00"
+      subset_names:
+        - DLWRFsfc
+        - DSWRFsfc
+        - ULWRFsfc
+        - USWRFsfc
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - eastward_surface_wind_stress
+        - northward_surface_wind_stress
+        - total_frozen_precipitation_rate
+  coupled_sea_ice:
+    # No window_avg and no sea_ice input dataset: the sea ice fraction is
+    # sourced from the ocean store's native 1-daily fields and forward-filled
+    # onto the atmosphere's 6-hourly time index.
+    include_ts: true
+    use_atmosphere_sea_ice_fraction_fallback: false
+  output_writer:
+    n_dask_workers: 32
+
+input_datasets:
+  climate_data_type: "CM4"
+  atmosphere:
+    zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-1pctCO2-atmosphere-land-1deg-8layer-140yr.zarr
+    time_chunk_size: 360
+    extra_fields:
+      names_and_prefixes: ["ak_", "bk_"]
+  ocean:
+    zarr_path: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-1deg-ocean-1daily.zarr
+    time_chunk_size: 365
+    extra_fields:
+      names_and_prefixes: ["idepth_", "mask_", "deptho"]
+  stats:
+    atmosphere_dir: gs://vcm-ml-intermediate/2026-06-19-CM4-1pctCO2-atmosphere-land-1deg-8layer-140yr-stats/combined
+    ocean_dir: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-1deg-ocean-1daily-stats/2026-09-02-cm4-1pctCO2-1deg-ocean-1daily

--- a/scripts/data_process/configs/CM4-1pctCO2-coupled-4deg-1daily-140yr.yaml
+++ b/scripts/data_process/configs/CM4-1pctCO2-coupled-4deg-1daily-140yr.yaml
@@ -1,0 +1,57 @@
+# make cm4_1pctCO2_coupled_1daily RESOLUTION=4deg
+version: "2026-09-09"
+family_name: cm4-1pctCO2-4deg-coupled-1daily
+output_directory: gs://vcm-ml-intermediate
+
+coupled_datasets:
+  coupled_ts:
+    how: interpolate_sst
+  coupled_sea_surface:
+    precomputed_sea_ice_mask:
+      zarr_path: gs://vcm-ml-intermediate/2026-09-09-cm4-piControl-4deg-coupled-1daily-ocean.zarr
+    ocean_extra_masked_names: ["HI", "sea_ice_volume", "UI", "VI", "sfdsi"]
+    ocean_extra_fill_values:
+      UI: 0.0
+      VI: 0.0
+    surface_flux_window_avg:
+      window_timedelta: 24h
+      # The ocean store labels its 1-day intervals at the interval end, so the
+      # flux windows are right-labeled at those same instants (no midpoint
+      # shift): each window (t - 24h, t] ends at an ocean timestep t.
+      first_timestamp: "0001-01-02T00:00:00"
+      last_timestamp: "0141-01-01T00:00:00"
+      subset_names:
+        - DLWRFsfc
+        - DSWRFsfc
+        - ULWRFsfc
+        - USWRFsfc
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - eastward_surface_wind_stress
+        - northward_surface_wind_stress
+        - total_frozen_precipitation_rate
+  coupled_sea_ice:
+    # No window_avg and no sea_ice input dataset: the sea ice fraction is
+    # sourced from the ocean store's native 1-daily fields and forward-filled
+    # onto the atmosphere's 6-hourly time index.
+    include_ts: true
+    use_atmosphere_sea_ice_fraction_fallback: false
+  output_writer:
+    n_dask_workers: 32
+
+input_datasets:
+  climate_data_type: "CM4"
+  atmosphere:
+    zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-1pctCO2-atmosphere-land-4deg-8layer-140yr.zarr
+    time_chunk_size: 360
+    extra_fields:
+      names_and_prefixes: ["ak_", "bk_"]
+  ocean:
+    zarr_path: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-4deg-ocean-1daily.zarr
+    time_chunk_size: 365
+    extra_fields:
+      names_and_prefixes: ["idepth_", "mask_", "deptho"]
+  stats:
+    atmosphere_dir: gs://vcm-ml-intermediate/2026-06-19-CM4-1pctCO2-atmosphere-land-4deg-8layer-140yr-stats/combined
+    ocean_dir: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-4deg-ocean-1daily-stats/2026-09-02-cm4-1pctCO2-4deg-ocean-1daily

--- a/scripts/data_process/configs/CM4-1pctCO2-ocean-1deg-1daily-140yr.yaml
+++ b/scripts/data_process/configs/CM4-1pctCO2-ocean-1deg-1daily-140yr.yaml
@@ -1,0 +1,10 @@
+# make cm4_1pctCO2_ocean_1daily_stats RESOLUTION=1deg
+runs:
+  2026-09-02-cm4-1pctCO2-1deg-ocean-1daily: ""  # store produced by scripts/gfdl_om4 xrbeam Dataflow pipeline
+data_output_directory: gs://vcm-ml-intermediate
+stats:
+  output_directory: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-1deg-ocean-1daily-stats
+  data_type: CM4
+  beaker_dataset: 2026-09-02-cm4-1pctCO2-1deg-ocean-1daily-stats
+  start_date: "0001-01-02"
+  end_date: "0141-01-01"

--- a/scripts/data_process/configs/CM4-1pctCO2-ocean-4deg-1daily-140yr.yaml
+++ b/scripts/data_process/configs/CM4-1pctCO2-ocean-4deg-1daily-140yr.yaml
@@ -1,0 +1,10 @@
+# make cm4_1pctCO2_ocean_1daily_stats RESOLUTION=4deg
+runs:
+  2026-09-02-cm4-1pctCO2-4deg-ocean-1daily: ""  # store produced by scripts/gfdl_om4 xrbeam Dataflow pipeline
+data_output_directory: gs://vcm-ml-intermediate
+stats:
+  output_directory: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-4deg-ocean-1daily-stats
+  data_type: CM4
+  beaker_dataset: 2026-09-02-cm4-1pctCO2-4deg-ocean-1daily-stats
+  start_date: "0001-01-02"
+  end_date: "0141-01-01"

--- a/scripts/data_process/configs/CM4-piControl-coupled-1deg-1daily-200yr.yaml
+++ b/scripts/data_process/configs/CM4-piControl-coupled-1deg-1daily-200yr.yaml
@@ -1,0 +1,56 @@
+# make cm4_piControl_coupled_1daily RESOLUTION=1deg
+version: "2026-09-09"
+family_name: cm4-piControl-1deg-coupled-1daily
+output_directory: gs://vcm-ml-intermediate
+
+coupled_datasets:
+  coupled_ts:
+    how: interpolate_sst
+  coupled_sea_surface:
+    sst_threshold: 291.75
+    ocean_extra_masked_names: ["HI", "sea_ice_volume", "UI", "VI", "sfdsi"]
+    ocean_extra_fill_values:
+      UI: 0.0
+      VI: 0.0
+    surface_flux_window_avg:
+      window_timedelta: 24h
+      # The ocean store labels its 1-day intervals at the interval end, so the
+      # flux windows are right-labeled at those same instants (no midpoint
+      # shift): each window (t - 24h, t] ends at an ocean timestep t.
+      first_timestamp: "0151-01-02T00:00:00"
+      last_timestamp: "0351-01-01T00:00:00"
+      subset_names:
+        - DLWRFsfc
+        - DSWRFsfc
+        - ULWRFsfc
+        - USWRFsfc
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - eastward_surface_wind_stress
+        - northward_surface_wind_stress
+        - total_frozen_precipitation_rate
+  coupled_sea_ice:
+    # No window_avg and no sea_ice input dataset: the sea ice fraction is
+    # sourced from the ocean store's native 1-daily fields and forward-filled
+    # onto the atmosphere's 6-hourly time index.
+    include_ts: true
+    use_atmosphere_sea_ice_fraction_fallback: false
+  output_writer:
+    n_dask_workers: 32
+
+input_datasets:
+  climate_data_type: "CM4"
+  atmosphere:
+    zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-piControl-atmosphere-land-1deg-8layer-200yr.zarr
+    time_chunk_size: 360
+    extra_fields:
+      names_and_prefixes: ["ak_", "bk_"]
+  ocean:
+    zarr_path: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-1deg-ocean-1daily.zarr
+    time_chunk_size: 365
+    extra_fields:
+      names_and_prefixes: ["idepth_", "mask_", "deptho"]
+  stats:
+    atmosphere_dir: gs://vcm-ml-intermediate/2026-06-19-CM4-piControl-atmosphere-land-1deg-8layer-200yr-stats/combined
+    ocean_dir: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-1deg-ocean-1daily-stats/2026-09-02-cm4-piControl-1deg-ocean-1daily

--- a/scripts/data_process/configs/CM4-piControl-coupled-4deg-1daily-200yr.yaml
+++ b/scripts/data_process/configs/CM4-piControl-coupled-4deg-1daily-200yr.yaml
@@ -1,0 +1,56 @@
+# make cm4_piControl_coupled_1daily RESOLUTION=4deg
+version: "2026-09-09"
+family_name: cm4-piControl-4deg-coupled-1daily
+output_directory: gs://vcm-ml-intermediate
+
+coupled_datasets:
+  coupled_ts:
+    how: interpolate_sst
+  coupled_sea_surface:
+    sst_threshold: 291.75
+    ocean_extra_masked_names: ["HI", "sea_ice_volume", "UI", "VI", "sfdsi"]
+    ocean_extra_fill_values:
+      UI: 0.0
+      VI: 0.0
+    surface_flux_window_avg:
+      window_timedelta: 24h
+      # The ocean store labels its 1-day intervals at the interval end, so the
+      # flux windows are right-labeled at those same instants (no midpoint
+      # shift): each window (t - 24h, t] ends at an ocean timestep t.
+      first_timestamp: "0151-01-02T00:00:00"
+      last_timestamp: "0351-01-01T00:00:00"
+      subset_names:
+        - DLWRFsfc
+        - DSWRFsfc
+        - ULWRFsfc
+        - USWRFsfc
+        - LHTFLsfc
+        - SHTFLsfc
+        - PRATEsfc
+        - eastward_surface_wind_stress
+        - northward_surface_wind_stress
+        - total_frozen_precipitation_rate
+  coupled_sea_ice:
+    # No window_avg and no sea_ice input dataset: the sea ice fraction is
+    # sourced from the ocean store's native 1-daily fields and forward-filled
+    # onto the atmosphere's 6-hourly time index.
+    include_ts: true
+    use_atmosphere_sea_ice_fraction_fallback: false
+  output_writer:
+    n_dask_workers: 32
+
+input_datasets:
+  climate_data_type: "CM4"
+  atmosphere:
+    zarr_path: gs://vcm-ml-intermediate/2026-06-19-CM4-piControl-atmosphere-land-4deg-8layer-200yr.zarr
+    time_chunk_size: 360
+    extra_fields:
+      names_and_prefixes: ["ak_", "bk_"]
+  ocean:
+    zarr_path: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-4deg-ocean-1daily.zarr
+    time_chunk_size: 365
+    extra_fields:
+      names_and_prefixes: ["idepth_", "mask_", "deptho"]
+  stats:
+    atmosphere_dir: gs://vcm-ml-intermediate/2026-06-19-CM4-piControl-atmosphere-land-4deg-8layer-200yr-stats/combined
+    ocean_dir: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-4deg-ocean-1daily-stats/2026-09-02-cm4-piControl-4deg-ocean-1daily

--- a/scripts/data_process/configs/CM4-piControl-ocean-1deg-1daily-200yr.yaml
+++ b/scripts/data_process/configs/CM4-piControl-ocean-1deg-1daily-200yr.yaml
@@ -1,0 +1,10 @@
+# make cm4_piControl_ocean_1daily_stats RESOLUTION=1deg
+runs:
+  2026-09-02-cm4-piControl-1deg-ocean-1daily: ""  # store produced by scripts/gfdl_om4 xrbeam Dataflow pipeline
+data_output_directory: gs://vcm-ml-intermediate
+stats:
+  output_directory: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-1deg-ocean-1daily-stats
+  data_type: CM4
+  beaker_dataset: 2026-09-02-cm4-piControl-1deg-ocean-1daily-stats
+  start_date: "0151-01-02"
+  end_date: "0351-01-01"

--- a/scripts/data_process/configs/CM4-piControl-ocean-4deg-1daily-200yr.yaml
+++ b/scripts/data_process/configs/CM4-piControl-ocean-4deg-1daily-200yr.yaml
@@ -1,0 +1,10 @@
+# make cm4_piControl_ocean_1daily_stats RESOLUTION=4deg
+runs:
+  2026-09-02-cm4-piControl-4deg-ocean-1daily: ""  # store produced by scripts/gfdl_om4 xrbeam Dataflow pipeline
+data_output_directory: gs://vcm-ml-intermediate
+stats:
+  output_directory: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-4deg-ocean-1daily-stats
+  data_type: CM4
+  beaker_dataset: 2026-09-02-cm4-piControl-4deg-ocean-1daily-stats
+  start_date: "0151-01-02"
+  end_date: "0351-01-01"

--- a/scripts/gfdl_om4/Makefile
+++ b/scripts/gfdl_om4/Makefile
@@ -90,6 +90,18 @@ smoke_test_1pctco2_1deg:
 smoke_test_1pctco2_4deg:
 	$(MAKE) smoke_test CONFIG=configs/om4-1pctco2-4deg-5daily.yaml
 
+smoke_test_picontrol_1deg_1daily:
+	$(MAKE) smoke_test CONFIG=configs/cm4-piControl-1deg-1daily.yaml
+
+smoke_test_picontrol_4deg_1daily:
+	$(MAKE) smoke_test CONFIG=configs/cm4-piControl-4deg-1daily.yaml
+
+smoke_test_1pctco2_1deg_1daily:
+	$(MAKE) smoke_test CONFIG=configs/cm4-1pctCO2-1deg-1daily.yaml
+
+smoke_test_1pctco2_4deg_1daily:
+	$(MAKE) smoke_test CONFIG=configs/cm4-1pctCO2-4deg-1daily.yaml
+
 # A repeat run against an already-written output store must refuse to
 # initialize into it (runs a smoke test first if its store is absent).
 smoke_test_repeat_fails:
@@ -111,6 +123,18 @@ check_wetmask_equivalence:
 smoke_tests: check_wetmask_equivalence smoke_test_picontrol_1deg \
 	smoke_test_picontrol_4deg smoke_test_1pctco2_1deg \
 	smoke_test_1pctco2_4deg smoke_test_repeat_fails
+
+# The 1-daily configs carry the 5-daily wetmask sources verbatim, so this
+# guards that pinning rather than the 1-daily streams themselves.
+check_wetmask_equivalence_1daily:
+	conda run --no-capture-output -n $(LOCAL_ENVIRONMENT) python -m pipeline.check_wetmask_equivalence \
+		configs/cm4-piControl-1deg-1daily.yaml \
+		configs/cm4-1pctCO2-1deg-1daily.yaml
+
+smoke_tests_1daily: check_wetmask_equivalence_1daily \
+	smoke_test_picontrol_1deg_1daily smoke_test_picontrol_4deg_1daily \
+	smoke_test_1pctco2_1deg_1daily smoke_test_1pctco2_4deg_1daily
+	$(MAKE) smoke_test_repeat_fails CONFIG=configs/cm4-piControl-1deg-1daily.yaml
 
 build_dataflow:
 	docker build --platform=linux/amd64 -t $(IMAGE_NAME) .
@@ -139,11 +163,28 @@ dataflow_1pctco2_1deg:
 dataflow_1pctco2_4deg:
 	$(MAKE) dataflow CONFIG=configs/om4-1pctco2-4deg-5daily.yaml
 
+dataflow_picontrol_1deg_1daily:
+	$(MAKE) dataflow CONFIG=configs/cm4-piControl-1deg-1daily.yaml
+
+dataflow_picontrol_4deg_1daily:
+	$(MAKE) dataflow CONFIG=configs/cm4-piControl-4deg-1daily.yaml
+
+dataflow_1pctco2_1deg_1daily:
+	$(MAKE) dataflow CONFIG=configs/cm4-1pctCO2-1deg-1daily.yaml
+
+dataflow_1pctco2_4deg_1daily:
+	$(MAKE) dataflow CONFIG=configs/cm4-1pctCO2-4deg-1daily.yaml
+
 .PHONY: create_environment generate_weights generate_weights_one_degree \
 	generate_weights_four_degree generate_face_masks \
 	generate_face_masks_picontrol generate_face_masks_1pctco2 smoke_test \
 	smoke_test_picontrol_1deg smoke_test_picontrol_4deg \
 	smoke_test_1pctco2_1deg smoke_test_1pctco2_4deg \
 	smoke_test_repeat_fails check_wetmask_equivalence smoke_tests \
+	smoke_test_picontrol_1deg_1daily smoke_test_picontrol_4deg_1daily \
+	smoke_test_1pctco2_1deg_1daily smoke_test_1pctco2_4deg_1daily \
+	check_wetmask_equivalence_1daily smoke_tests_1daily \
 	build_dataflow push_dataflow enter dataflow dataflow_picontrol_1deg \
-	dataflow_picontrol_4deg dataflow_1pctco2_1deg dataflow_1pctco2_4deg
+	dataflow_picontrol_4deg dataflow_1pctco2_1deg dataflow_1pctco2_4deg \
+	dataflow_picontrol_1deg_1daily dataflow_picontrol_4deg_1daily \
+	dataflow_1pctco2_1deg_1daily dataflow_1pctco2_4deg_1daily

--- a/scripts/gfdl_om4/configs/cm4-1pctCO2-1deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-1pctCO2-1deg-1daily.yaml
@@ -1,0 +1,121 @@
+# 1-daily 1-degree ocean (Samudra) store from the 140-year CM4 1pctCO2
+# simulation.
+target_grid: F90
+weights_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/regridding-weights/om4-tripolar-0.25deg-to-F90
+expected_level_count: 19
+shift_timestamps_to_avg_interval_midpoint: false
+# The daily snapshot store carries one initial-condition instant before the
+# first flux day; the first flux label drops it and leaves every stream on
+# one time coordinate.
+start_time: '0001-01-02'
+output:
+  path: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-1deg-ocean-1daily.zarr
+  time_chunk_size: 1
+  time_shard_size: 365
+# The wetmask is read before any time subset, so it comes from the store
+# whose first instant is a processed snapshot rather than the unverified
+# initial condition.
+wetmask:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily_snap_subset_to_5daily_snap.zarr
+  variable: thetao
+statics:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_static.zarr
+  variables:
+    - deptho
+    - hfgeou
+streams:
+  - name: snapshot_ocean
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily_snap.zarr
+    variables:
+      - thetao
+      - so
+      - uo
+      - vo
+      - tos
+      - zos
+      - SSH
+      - mlotst
+      - rhoinsitu
+    rotated_pairs:
+      - [uo, vo]
+    # These sources carry coastal staggered velocity faces that are valid
+    # with value exactly 0.0 where the vertical remap unmasked land columns;
+    # the artifact flags them so they are not averaged into coastal centers.
+    face_mask_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/face-masks/om4-1pctco2-2026-06-19
+    postprocess:
+      - kelvin_sst
+  # 1-day-mean surface fluxes/forcings, whose end-of-interval time labels
+  # coincide with the snapshot instants (enforced by the time-alignment
+  # assertion).
+  - name: flux
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily.zarr
+    variables:
+      - hfds
+      - hflso
+      - hfsso
+      - rlntds
+      - rsntds
+      - hfsifrazil
+      - hfevapds
+      - hfrainds
+      - hfrunoffds
+      - wfo
+      - prlq
+      - prsn
+      - evs
+      - sfdsi
+      - tauuo
+      - tauvo
+      - ustar
+    rotated_pairs:
+      - [tauuo, tauvo]
+    postprocess:
+      - hfds_total_area
+  # Ice-model true snapshots, subsampled from 6-hourly to the daily
+  # snapshot instants (every 4th step). The ice SSH is the sea surface as
+  # seen by the ice model, distinct from the ocean-store SSH and zos.
+  - name: ice_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ice_6hourly_snap.zarr
+    variables:
+      - sea_ice_fraction
+      - EXT
+      - HI
+      - HS
+      - UI
+      - VI
+      - TS
+      - TSN
+      - SST
+      - SSS
+      - simass
+      - sisnmass
+      - SSH
+    dim_renaming:
+      xT: xh
+      yT: yh
+      xB: xq
+      yB: yq
+    time_subsample_stride: 4
+    rotated_pairs:
+      - [UI, VI]
+    renaming:
+      SSH: SSH_ice
+      sea_ice_fraction: ocean_sea_ice_fraction
+    full_cell_variables:
+      - sea_ice_fraction
+    postprocess:
+      - sea_ice
+  # Ice-model 6-hourly means at the snapshot instants (each mean covers the
+  # 6 hours ending at the instant), treated as snapshot estimates.
+  - name: ice_mean_as_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ice_6hourly.zarr
+    variables:
+      - T1
+      - T2
+      - T3
+      - T4
+      - T_bulkice
+    dim_renaming:
+      xT: xh
+      yT: yh
+    time_subsample_stride: 4

--- a/scripts/gfdl_om4/configs/cm4-1pctCO2-1deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-1pctCO2-1deg-1daily.yaml
@@ -12,9 +12,7 @@ output:
   path: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-1deg-ocean-1daily.zarr
   time_chunk_size: 1
   time_shard_size: 365
-# The wetmask is read before any time subset, so it comes from the store
-# whose first instant is a processed snapshot rather than the unverified
-# initial condition.
+# wetmask from the 5-daily processing
 wetmask:
   store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily_snap_subset_to_5daily_snap.zarr
   variable: thetao

--- a/scripts/gfdl_om4/configs/cm4-1pctCO2-4deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-1pctCO2-4deg-1daily.yaml
@@ -12,9 +12,7 @@ output:
   path: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-4deg-ocean-1daily.zarr
   time_chunk_size: 1
   time_shard_size: 365
-# The wetmask is read before any time subset, so it comes from the store
-# whose first instant is a processed snapshot rather than the unverified
-# initial condition.
+# wetmask from the 5-daily processing
 wetmask:
   store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily_snap_subset_to_5daily_snap.zarr
   variable: thetao

--- a/scripts/gfdl_om4/configs/cm4-1pctCO2-4deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-1pctCO2-4deg-1daily.yaml
@@ -1,0 +1,121 @@
+# 1-daily 4-degree ocean (Samudra) store from the 140-year CM4 1pctCO2
+# simulation.
+target_grid: F22.5
+weights_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/regridding-weights/om4-tripolar-0.25deg-to-F22.5
+expected_level_count: 19
+shift_timestamps_to_avg_interval_midpoint: false
+# The daily snapshot store carries one initial-condition instant before the
+# first flux day; the first flux label drops it and leaves every stream on
+# one time coordinate.
+start_time: '0001-01-02'
+output:
+  path: gs://vcm-ml-intermediate/2026-09-02-cm4-1pctCO2-4deg-ocean-1daily.zarr
+  time_chunk_size: 1
+  time_shard_size: 365
+# The wetmask is read before any time subset, so it comes from the store
+# whose first instant is a processed snapshot rather than the unverified
+# initial condition.
+wetmask:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily_snap_subset_to_5daily_snap.zarr
+  variable: thetao
+statics:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_static.zarr
+  variables:
+    - deptho
+    - hfgeou
+streams:
+  - name: snapshot_ocean
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily_snap.zarr
+    variables:
+      - thetao
+      - so
+      - uo
+      - vo
+      - tos
+      - zos
+      - SSH
+      - mlotst
+      - rhoinsitu
+    rotated_pairs:
+      - [uo, vo]
+    # These sources carry coastal staggered velocity faces that are valid
+    # with value exactly 0.0 where the vertical remap unmasked land columns;
+    # the artifact flags them so they are not averaged into coastal centers.
+    face_mask_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/face-masks/om4-1pctco2-2026-06-19
+    postprocess:
+      - kelvin_sst
+  # 1-day-mean surface fluxes/forcings, whose end-of-interval time labels
+  # coincide with the snapshot instants (enforced by the time-alignment
+  # assertion).
+  - name: flux
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ocean_1daily.zarr
+    variables:
+      - hfds
+      - hflso
+      - hfsso
+      - rlntds
+      - rsntds
+      - hfsifrazil
+      - hfevapds
+      - hfrainds
+      - hfrunoffds
+      - wfo
+      - prlq
+      - prsn
+      - evs
+      - sfdsi
+      - tauuo
+      - tauvo
+      - ustar
+    rotated_pairs:
+      - [tauuo, tauvo]
+    postprocess:
+      - hfds_total_area
+  # Ice-model true snapshots, subsampled from 6-hourly to the daily
+  # snapshot instants (every 4th step). The ice SSH is the sea surface as
+  # seen by the ice model, distinct from the ocean-store SSH and zos.
+  - name: ice_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ice_6hourly_snap.zarr
+    variables:
+      - sea_ice_fraction
+      - EXT
+      - HI
+      - HS
+      - UI
+      - VI
+      - TS
+      - TSN
+      - SST
+      - SSS
+      - simass
+      - sisnmass
+      - SSH
+    dim_renaming:
+      xT: xh
+      yT: yh
+      xB: xq
+      yB: yq
+    time_subsample_stride: 4
+    rotated_pairs:
+      - [UI, VI]
+    renaming:
+      SSH: SSH_ice
+      sea_ice_fraction: ocean_sea_ice_fraction
+    full_cell_variables:
+      - sea_ice_fraction
+    postprocess:
+      - sea_ice
+  # Ice-model 6-hourly means at the snapshot instants (each mean covers the
+  # 6 hours ending at the instant), treated as snapshot estimates.
+  - name: ice_mean_as_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/1pctCO2/ice_6hourly.zarr
+    variables:
+      - T1
+      - T2
+      - T3
+      - T4
+      - T_bulkice
+    dim_renaming:
+      xT: xh
+      yT: yh
+    time_subsample_stride: 4

--- a/scripts/gfdl_om4/configs/cm4-piControl-1deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-piControl-1deg-1daily.yaml
@@ -1,0 +1,121 @@
+# 1-daily 1-degree ocean (Samudra) store from the 200-year CM4 piControl
+# simulation.
+target_grid: F90
+weights_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/regridding-weights/om4-tripolar-0.25deg-to-F90
+expected_level_count: 19
+shift_timestamps_to_avg_interval_midpoint: false
+# The daily snapshot store carries one initial-condition instant before the
+# first flux day; the first flux label drops it and leaves every stream on
+# one time coordinate.
+start_time: '0151-01-02'
+output:
+  path: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-1deg-ocean-1daily.zarr
+  time_chunk_size: 1
+  time_shard_size: 365
+# The wetmask is read before any time subset, so it comes from the store
+# whose first instant is a processed snapshot rather than the unverified
+# initial condition.
+wetmask:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily_snap_subset_to_5daily_snap.zarr
+  variable: thetao
+statics:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_static.zarr
+  variables:
+    - deptho
+    - hfgeou
+streams:
+  - name: snapshot_ocean
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily_snap.zarr
+    variables:
+      - thetao
+      - so
+      - uo
+      - vo
+      - tos
+      - zos
+      - SSH
+      - mlotst
+      - rhoinsitu
+    rotated_pairs:
+      - [uo, vo]
+    # These sources carry coastal staggered velocity faces that are valid
+    # with value exactly 0.0 where the vertical remap unmasked land columns;
+    # the artifact flags them so they are not averaged into coastal centers.
+    face_mask_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/face-masks/om4-picontrol-2026-06-19
+    postprocess:
+      - kelvin_sst
+  # 1-day-mean surface fluxes/forcings, whose end-of-interval time labels
+  # coincide with the snapshot instants (enforced by the time-alignment
+  # assertion).
+  - name: flux
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily.zarr
+    variables:
+      - hfds
+      - hflso
+      - hfsso
+      - rlntds
+      - rsntds
+      - hfsifrazil
+      - hfevapds
+      - hfrainds
+      - hfrunoffds
+      - wfo
+      - prlq
+      - prsn
+      - evs
+      - sfdsi
+      - tauuo
+      - tauvo
+      - ustar
+    rotated_pairs:
+      - [tauuo, tauvo]
+    postprocess:
+      - hfds_total_area
+  # Ice-model true snapshots, subsampled from 6-hourly to the daily
+  # snapshot instants (every 4th step). The ice SSH is the sea surface as
+  # seen by the ice model, distinct from the ocean-store SSH and zos.
+  - name: ice_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ice_6hourly_snap.zarr
+    variables:
+      - sea_ice_fraction
+      - EXT
+      - HI
+      - HS
+      - UI
+      - VI
+      - TS
+      - TSN
+      - SST
+      - SSS
+      - simass
+      - sisnmass
+      - SSH
+    dim_renaming:
+      xT: xh
+      yT: yh
+      xB: xq
+      yB: yq
+    time_subsample_stride: 4
+    rotated_pairs:
+      - [UI, VI]
+    renaming:
+      SSH: SSH_ice
+      sea_ice_fraction: ocean_sea_ice_fraction
+    full_cell_variables:
+      - sea_ice_fraction
+    postprocess:
+      - sea_ice
+  # Ice-model 6-hourly means at the snapshot instants (each mean covers the
+  # 6 hours ending at the instant), treated as snapshot estimates.
+  - name: ice_mean_as_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ice_6hourly.zarr
+    variables:
+      - T1
+      - T2
+      - T3
+      - T4
+      - T_bulkice
+    dim_renaming:
+      xT: xh
+      yT: yh
+    time_subsample_stride: 4

--- a/scripts/gfdl_om4/configs/cm4-piControl-1deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-piControl-1deg-1daily.yaml
@@ -12,9 +12,7 @@ output:
   path: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-1deg-ocean-1daily.zarr
   time_chunk_size: 1
   time_shard_size: 365
-# The wetmask is read before any time subset, so it comes from the store
-# whose first instant is a processed snapshot rather than the unverified
-# initial condition.
+# wetmask from the 5-daily processing
 wetmask:
   store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily_snap_subset_to_5daily_snap.zarr
   variable: thetao

--- a/scripts/gfdl_om4/configs/cm4-piControl-4deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-piControl-4deg-1daily.yaml
@@ -1,0 +1,121 @@
+# 1-daily 4-degree ocean (Samudra) store from the 200-year CM4 piControl
+# simulation.
+target_grid: F22.5
+weights_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/regridding-weights/om4-tripolar-0.25deg-to-F22.5
+expected_level_count: 19
+shift_timestamps_to_avg_interval_midpoint: false
+# The daily snapshot store carries one initial-condition instant before the
+# first flux day; the first flux label drops it and leaves every stream on
+# one time coordinate.
+start_time: '0151-01-02'
+output:
+  path: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-4deg-ocean-1daily.zarr
+  time_chunk_size: 1
+  time_shard_size: 365
+# The wetmask is read before any time subset, so it comes from the store
+# whose first instant is a processed snapshot rather than the unverified
+# initial condition.
+wetmask:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily_snap_subset_to_5daily_snap.zarr
+  variable: thetao
+statics:
+  store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_static.zarr
+  variables:
+    - deptho
+    - hfgeou
+streams:
+  - name: snapshot_ocean
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily_snap.zarr
+    variables:
+      - thetao
+      - so
+      - uo
+      - vo
+      - tos
+      - zos
+      - SSH
+      - mlotst
+      - rhoinsitu
+    rotated_pairs:
+      - [uo, vo]
+    # These sources carry coastal staggered velocity faces that are valid
+    # with value exactly 0.0 where the vertical remap unmasked land columns;
+    # the artifact flags them so they are not averaged into coastal centers.
+    face_mask_url: gs://vcm-ml-intermediate/2026-07-15-gfdl-om4-pipeline-inputs/face-masks/om4-picontrol-2026-06-19
+    postprocess:
+      - kelvin_sst
+  # 1-day-mean surface fluxes/forcings, whose end-of-interval time labels
+  # coincide with the snapshot instants (enforced by the time-alignment
+  # assertion).
+  - name: flux
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily.zarr
+    variables:
+      - hfds
+      - hflso
+      - hfsso
+      - rlntds
+      - rsntds
+      - hfsifrazil
+      - hfevapds
+      - hfrainds
+      - hfrunoffds
+      - wfo
+      - prlq
+      - prsn
+      - evs
+      - sfdsi
+      - tauuo
+      - tauvo
+      - ustar
+    rotated_pairs:
+      - [tauuo, tauvo]
+    postprocess:
+      - hfds_total_area
+  # Ice-model true snapshots, subsampled from 6-hourly to the daily
+  # snapshot instants (every 4th step). The ice SSH is the sea surface as
+  # seen by the ice model, distinct from the ocean-store SSH and zos.
+  - name: ice_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ice_6hourly_snap.zarr
+    variables:
+      - sea_ice_fraction
+      - EXT
+      - HI
+      - HS
+      - UI
+      - VI
+      - TS
+      - TSN
+      - SST
+      - SSS
+      - simass
+      - sisnmass
+      - SSH
+    dim_renaming:
+      xT: xh
+      yT: yh
+      xB: xq
+      yB: yq
+    time_subsample_stride: 4
+    rotated_pairs:
+      - [UI, VI]
+    renaming:
+      SSH: SSH_ice
+      sea_ice_fraction: ocean_sea_ice_fraction
+    full_cell_variables:
+      - sea_ice_fraction
+    postprocess:
+      - sea_ice
+  # Ice-model 6-hourly means at the snapshot instants (each mean covers the
+  # 6 hours ending at the instant), treated as snapshot estimates.
+  - name: ice_mean_as_snapshot
+    store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ice_6hourly.zarr
+    variables:
+      - T1
+      - T2
+      - T3
+      - T4
+      - T_bulkice
+    dim_renaming:
+      xT: xh
+      yT: yh
+    time_subsample_stride: 4

--- a/scripts/gfdl_om4/configs/cm4-piControl-4deg-1daily.yaml
+++ b/scripts/gfdl_om4/configs/cm4-piControl-4deg-1daily.yaml
@@ -12,9 +12,7 @@ output:
   path: gs://vcm-ml-intermediate/2026-09-02-cm4-piControl-4deg-ocean-1daily.zarr
   time_chunk_size: 1
   time_shard_size: 365
-# The wetmask is read before any time subset, so it comes from the store
-# whose first instant is a processed snapshot rather than the unverified
-# initial condition.
+# wetmask from the 5-daily processing
 wetmask:
   store: gs://vcm-ml-raw-flexible-retention/2026-06-19-CM4-ocean-and-sea-ice-piControl-and-1pctCO2/zarrs/piControl/ocean_1daily_snap_subset_to_5daily_snap.zarr
   variable: thetao


### PR DESCRIPTION
The `gfdl_om4` pipeline builds the CM4 piControl and 1pctCO2 ocean and
sea-ice training stores at 5-daily cadence. The same sources carry the daily
cycle, and training on it needs the same output variable set at 1-daily
cadence. These configs produce it: every output variable of the 5-daily
stores is producible from the 1-daily sources, so the output variable set is
unchanged and only the source stores, the ice subsample stride and the time
range differ.

Changes:
- `scripts/gfdl_om4/configs/cm4-{piControl,1pctCO2}-{1deg,4deg}-1daily.yaml`:
  read `ocean_1daily_snap.zarr` and `ocean_1daily.zarr` in place of their
  5-daily subsets, stride the 6-hourly ice streams by 4 rather than 20, and
  set `start_time` to the first daily flux label so the snapshot store's
  leading initial-condition instant is dropped and every stream shares one
  time coordinate. Wetmask source, face-mask artifacts, regridding weights
  and the variable set carry over from the 5-daily configs unchanged.
- `scripts/gfdl_om4/Makefile`: a `smoke_test_*_1daily` and `dataflow_*_1daily`
  target per new config, `check_wetmask_equivalence_1daily` over the 1-daily
  1-degree pair, and a `smoke_tests_1daily` aggregate. The 5-daily
  `smoke_tests` aggregate and `check_wetmask_equivalence` are unchanged.

`make smoke_tests_1daily`'s constituent checks were run individually and are
green: each of the four configs writes 6 timesteps of 182 variables through
the DirectRunner and passes `pipeline.check_output`, and
`check_wetmask_equivalence_1daily` finds the two 1-degree wetmasks identical
at all 19 levels.

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated
