### PR TITLE
Add L1 loss type to StepLossConfig

### DIFF
--- a/fme/core/loss.py
+++ b/fme/core/loss.py
@@ -938,7 +938,7 @@ class StepLossConfig:
             weights to apply to their normalized losses
     """
 
-    type: Literal["LpLoss", "MSE", "AreaWeightedMSE", "EnsembleLoss"] = "MSE"
+    type: Literal["LpLoss", "L1", "MSE", "AreaWeightedMSE", "EnsembleLoss"] = "MSE"
     kwargs: Mapping[str, Any] = dataclasses.field(default_factory=lambda: {})
     global_mean_type: Literal["LpLoss"] | None = None
     global_mean_kwargs: Mapping[str, Any] = dataclasses.field(

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -639,12 +639,6 @@ def test_step_loss_forwards_data_mask():
 
 
 def test_step_loss_config_l1_is_reachable_from_config():
-    """``type: L1`` must be admitted by StepLossConfig's Literal.
-
-    ``_L1Loss`` and ``LossConfig``'s ``"L1"`` branch have always worked, but
-    the value was missing from ``StepLossConfig``'s ``Literal``, so dacite
-    rejected it at config parse for every stepper.
-    """
     out_names = ["var_0"]
     normalizer = StandardNormalizer(
         means={name: torch.as_tensor(0.0) for name in out_names},

--- a/fme/core/test_loss.py
+++ b/fme/core/test_loss.py
@@ -1,3 +1,4 @@
+import dacite
 import pytest
 import torch
 
@@ -635,6 +636,37 @@ def test_step_loss_forwards_data_mask():
     # var_0: MSE=1.0 (4 samples). var_1: MSE=4.0 but all masked out → no contribution.
     # Without the mask the total would be mean(1.0, 4.0) = 2.5.
     torch.testing.assert_close(result.total(), torch.tensor(1.0, device=get_device()))
+
+
+def test_step_loss_config_l1_is_reachable_from_config():
+    """``type: L1`` must be admitted by StepLossConfig's Literal.
+
+    ``_L1Loss`` and ``LossConfig``'s ``"L1"`` branch have always worked, but
+    the value was missing from ``StepLossConfig``'s ``Literal``, so dacite
+    rejected it at config parse for every stepper.
+    """
+    out_names = ["var_0"]
+    normalizer = StandardNormalizer(
+        means={name: torch.as_tensor(0.0) for name in out_names},
+        stds={name: torch.as_tensor(1.0) for name in out_names},
+    )
+    gridded_operations: GriddedOperations = LatLonOperations(torch.ones(1, 1))
+    config = dacite.from_dict(
+        data_class=StepLossConfig,
+        data={"type": "L1"},
+        config=dacite.Config(strict=True),
+    )
+    step_loss = config.build(
+        gridded_operations,
+        out_names=out_names,
+        channel_dim=-3,
+        normalizer=normalizer,
+    )
+    x_mapping = {"var_0": torch.full((4, 5, 5), 2.0).to(get_device())}
+    y_mapping = {"var_0": torch.zeros(4, 5, 5).to(get_device())}
+    result = step_loss(x_mapping, y_mapping, step=0)
+    # mean absolute error is 2.0, where MSE would give 4.0
+    torch.testing.assert_close(result.total(), torch.tensor(2.0, device=get_device()))
 
 
 def test_weighted_mapping_loss_with_ensemble_and_data_mask():


### PR DESCRIPTION
`LossConfig` has supported an `"L1"` branch (building `_L1Loss`) since it was introduced, but `StepLossConfig.type` never included `"L1"` in its `Literal`. Because dacite validates against the `Literal` at parse time, any stepper config with `type: L1` was rejected before the loss could be built — the single-module steppers and the coupled per-component ones alike.

This adds `"L1"` to `StepLossConfig.type` so the existing `_L1Loss` path is reachable from user-facing YAML configs. `LpLoss(p=1)` is not a workaround because it normalizes by the per-channel `‖y‖`, making its semantics different from a plain mean-absolute-error loss.

Changes:
- `fme.core.loss.StepLossConfig.type`: Literal widened to include `"L1"`
- `fme.core.test_loss.test_step_loss_config_l1_is_reachable_from_config`: parses an L1 config through dacite (covering the parse path that was broken, not just the branch), builds the loss, and asserts the MAE value (2.0) discriminates from MSE (4.0)

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (no dependency changes)
