### PR TITLE
Add a uniform-temperature ocean heat content correction

### DIFF
--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -453,15 +453,26 @@ def _force_conserve_ocean_heat_content(
     or a mean over a different set of columns, would leave the corrected heat
     content off by the difference between the two integrals.
 
-    Restricting the increment to ``dz > 0`` is a separate concern and does not
-    affect conservation. ``vertical_coordinate.dz`` is zero wherever a layer is
-    invalid (land, or below the sea floor), so an unmasked increment would
-    deposit no heat there either. The mask is there so that invalid cells pass
-    through unchanged rather than being shifted by a physical increment: they
-    hold raw denormalized network output, and when no spatial mask provider is
-    configured nothing overwrites them after the corrector runs.
-    ``scaled_temperature`` rescales invalid cells instead of leaving them
-    alone, which is pre-existing behavior and not something the budget needs.
+    Which cells the increment lands on is a separate concern and does not
+    affect conservation. It lands on every cell ``vertical_coordinate.mask``
+    marks valid. ``dz > 0`` is not the right test for this and is not the same
+    cell set: the mask is more permissive than the bathymetry, so a cell can be
+    marked valid and still have zero thickness. On the 1 degree ocean store
+    that is 4.6% of all valid-marked cells and 60% of the bottom level's. Those
+    cells hold real data, the output masker keeps them and the metrics score
+    them, so restricting the increment to ``dz > 0`` would split a scored level
+    into shifted and unshifted cells along a mask/bathymetry inconsistency in
+    the store rather than along anything physical, leaving the unshifted
+    majority of a deep level tied to neither the budget nor its neighbors.
+    Shifting them costs the budget nothing, because zero thickness means they
+    absorb no heat either way.
+
+    Cells the mask excludes are a different matter and are left alone: they hold
+    fill rather than data, and when no spatial mask provider is configured
+    nothing overwrites them after the corrector runs, so ``+ delta_T`` there
+    would drift away from the fill value where ``* ratio`` keeps a zero fill at
+    zero. ``scaled_temperature`` rescales every cell regardless, which is
+    pre-existing behavior and not something the budget needs.
     """
     if method not in ("scaled_temperature", "uniform_temperature"):
         raise NotImplementedError(
@@ -548,22 +559,26 @@ def _force_conserve_ocean_heat_content(
         temperature_increment = (
             target_ocean_heat_content - global_gen_ocean_heat_content
         ) / heat_capacity_per_area
-        # zero thickness marks a layer the depth integral cannot see; the mask
-        # leaves those cells' raw network output untouched, and costs the budget
-        # nothing because they absorb no heat either way
-        is_valid = (vertical_coordinate.dz > 0.0).to(
+        # every cell the store marks valid is shifted, including the ones the
+        # bathymetry puts at zero thickness -- they hold data and are scored, and
+        # shifting them adds no heat. Cells outside the mask hold fill, so they
+        # are left alone. Not interchangeable with dz > 0; see the docstring.
+        # ``> 0`` rather than ``== 1`` mirrors depth_integral's own mask test.
+        is_masked_valid = (vertical_coordinate.mask > 0.0).to(
             dtype=gen_potential_temperature.dtype
         )
         for k in range(n_levels):
             name = f"thetao_{k}"
-            out[name] = gen.data[name] + temperature_increment * is_valid.select(-1, k)
+            out[name] = gen.data[name] + temperature_increment * is_masked_valid.select(
+                -1, k
+            )
         if "sst" in gen.data:
             # an increment needs no Kelvin offset, unlike the multiplicative
             # path. sst is not in the heat content integral, so shifting it by
             # the same increment as thetao_0 is a consistency choice, not a
-            # budget requirement; the surface layer's validity is the
-            # wet-column indicator depth_integral itself uses.
-            out["sst"] = gen.data["sst"] + temperature_increment * is_valid.select(
-                -1, 0
-            )
+            # budget requirement; the surface level's mask is the wet-column
+            # indicator depth_integral itself uses.
+            out["sst"] = gen.data[
+                "sst"
+            ] + temperature_increment * is_masked_valid.select(-1, 0)
     return out

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -7,6 +7,7 @@ import torch
 
 from fme.core.atmosphere_data import AtmosphereData
 from fme.core.constants import (
+    DENSITY_OF_SEA_WATER_CM4,
     FREEZING_TEMPERATURE_KELVIN,
     LATENT_HEAT_OF_VAPORIZATION,
     SPECIFIC_HEAT_OF_SEA_WATER_CM4,
@@ -95,10 +96,16 @@ class OceanHeatContentBudgetConfig:
     """Configuration for ocean heat content budget correction.
 
     Parameters:
-        method: Method to use for OHC budget correction. The available option is
-            "scaled_temperature", which enforces conservation of heat content
-            by scaling the predicted potential temperature by a vertically and
-            horizontally uniform correction factor.
+        method: Method to use for OHC budget correction. Both options enforce
+            the same column heat content budget and differ only in how the
+            correction is distributed in the vertical:
+
+            - "scaled_temperature": multiply the predicted potential
+              temperature by a vertically and horizontally uniform correction
+              factor, so the heat is deposited in proportion to ``T_k * dz_k``.
+            - "uniform_temperature": add a vertically and horizontally uniform
+              temperature increment, so the heat is deposited in proportion to
+              ``dz_k`` alone.
         constant_unaccounted_heating: Area-weighted global mean
             column-integrated heating in W/m**2 to be added to the energy flux
             into the ocean when conserving the heat content. This can be useful
@@ -107,7 +114,7 @@ class OceanHeatContentBudgetConfig:
 
     """
 
-    method: Literal["scaled_temperature"]
+    method: Literal["scaled_temperature", "uniform_temperature"]
     constant_unaccounted_heating: float = 0.0
 
 
@@ -203,7 +210,7 @@ class OceanHeatContentCorrection:
     area_weighted_mean: AreaWeightedMean
     vertical_coordinate: HasOceanDepthIntegral | None
     timestep_seconds: float
-    method: Literal["scaled_temperature"]
+    method: Literal["scaled_temperature", "uniform_temperature"]
     unaccounted_heating: float
 
     def __call__(
@@ -416,10 +423,38 @@ def _force_conserve_ocean_heat_content(
     area_weighted_mean: AreaWeightedMean,
     vertical_coordinate: HasOceanDepthIntegral,
     timestep_seconds: float,
-    method: Literal["scaled_temperature"] = "scaled_temperature",
+    method: Literal["scaled_temperature", "uniform_temperature"] = "scaled_temperature",
     unaccounted_heating: float = 0.0,
 ) -> TensorDict:
-    if method != "scaled_temperature":
+    """Adjust the generated potential temperature so the global-mean column
+    ocean heat content matches the input value plus the heat the surface and
+    geothermal fluxes deposit over one timestep.
+
+    Both methods conserve the same budget and differ only in the vertical
+    profile of the heat they deposit:
+
+    scaled_temperature
+        Multiply every level by one global ratio, depositing heat in proportion
+        to ``T_k * dz_k``.
+    uniform_temperature
+        Add one global temperature increment to every valid level, depositing
+        heat in proportion to ``dz_k`` alone. The increment is
+        ``(target - global_gen_ohc) / heat_capacity_per_area``, where the
+        denominator is the area-weighted global mean of the column integral of
+        ``rho * cp``.
+
+    The invariant the ``uniform_temperature`` masking relies on is that
+    ``vertical_coordinate.dz`` is zero exactly where a layer is invalid (land,
+    or below the sea floor), which is the same weight
+    ``vertical_coordinate.depth_integral`` applies. So restricting the
+    increment to ``dz > 0`` both keeps it out of invalid cells and leaves the
+    heat it adds equal to ``delta_T`` times the very integral that forms the
+    denominator -- making conservation exact rather than off by the masked
+    fraction. ``scaled_temperature`` needs no such mask because it scales
+    invalid cells rather than shifting them, and invalid cells carry no weight
+    in the integral either way.
+    """
+    if method not in ("scaled_temperature", "uniform_temperature"):
         raise NotImplementedError(
             f"Method {method!r} not implemented for ocean heat content conservation"
         )
@@ -470,17 +505,50 @@ def _force_conserve_ocean_heat_content(
     expected_change_ocean_heat_content = (
         energy_flux_global_mean + unaccounted_heating
     ) * timestep_seconds
-    heat_content_correction_ratio = (
+    target_ocean_heat_content = (
         global_input_ocean_heat_content + expected_change_ocean_heat_content
-    ) / global_gen_ocean_heat_content
-    # apply same temperature correction to all vertical layers
+    )
     out: TensorDict = {}
-    n_levels = gen.sea_water_potential_temperature.shape[-1]
-    for k in range(n_levels):
-        name = f"thetao_{k}"
-        out[name] = gen.data[name] * heat_content_correction_ratio
-    if "sst" in gen.data:
-        out["sst"] = (  # assuming sst in Kelvin
-            gen.data["sst"] - FREEZING_TEMPERATURE_KELVIN
-        ) * heat_content_correction_ratio + FREEZING_TEMPERATURE_KELVIN
+    gen_potential_temperature = gen.sea_water_potential_temperature
+    n_levels = gen_potential_temperature.shape[-1]
+    if method == "scaled_temperature":
+        heat_content_correction_ratio = (
+            target_ocean_heat_content / global_gen_ocean_heat_content
+        )
+        # apply same temperature correction to all vertical layers
+        for k in range(n_levels):
+            name = f"thetao_{k}"
+            out[name] = gen.data[name] * heat_content_correction_ratio
+        if "sst" in gen.data:
+            out["sst"] = (  # assuming sst in Kelvin
+                gen.data["sst"] - FREEZING_TEMPERATURE_KELVIN
+            ) * heat_content_correction_ratio + FREEZING_TEMPERATURE_KELVIN
+    else:
+        heat_capacity_per_area = area_weighted_mean(
+            vertical_coordinate.depth_integral(
+                torch.ones_like(gen_potential_temperature)
+                * SPECIFIC_HEAT_OF_SEA_WATER_CM4
+                * DENSITY_OF_SEA_WATER_CM4
+            ),
+            keepdim=True,
+            name="ocean_heat_content",
+        )
+        temperature_increment = (
+            target_ocean_heat_content - global_gen_ocean_heat_content
+        ) / heat_capacity_per_area
+        # zero thickness marks a layer the depth integral cannot see, so the
+        # increment must not land there; see the docstring.
+        is_valid = (vertical_coordinate.dz > 0.0).to(
+            dtype=gen_potential_temperature.dtype
+        )
+        for k in range(n_levels):
+            name = f"thetao_{k}"
+            out[name] = gen.data[name] + temperature_increment * is_valid.select(-1, k)
+        if "sst" in gen.data:
+            # an increment needs no Kelvin offset, unlike the multiplicative
+            # path; the surface layer's validity is the ocean-column indicator
+            # depth_integral itself uses.
+            out["sst"] = gen.data["sst"] + temperature_increment * is_valid.select(
+                -1, 0
+            )
     return out

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -467,9 +467,20 @@ def _force_conserve_ocean_heat_content(
     Shifting them costs the budget nothing, because zero thickness means they
     absorb no heat either way.
 
+    The test is ``mask > 0`` rather than ``mask == 1`` because ``dz`` is itself
+    ``mask``-weighted, so ``dz_k`` is zero wherever ``mask_k`` is zero and
+    ``dz_k * (mask_k > 0)`` equals ``dz_k`` cell for cell whatever values the
+    mask takes. That identity is exactly what makes the deposited heat equal
+    ``delta_T * heat_capacity_per_area``. ``mask == 1`` would only hold it for
+    a strictly 0/1 mask, which is what ``DepthCoordinate`` documents but not
+    what it enforces -- the mask is read straight out of the store's
+    ``mask_<k>`` variables.
+
     Cells the mask excludes are a different matter and are left alone: they hold
-    fill rather than data, and when no spatial mask provider is configured
-    nothing overwrites them after the corrector runs, so ``+ delta_T`` there
+    fill rather than data, and nothing necessarily overwrites them after the
+    corrector runs -- the output masker skips any variable it has no matching
+    mask for, so e.g. ``sst`` is left as the corrector wrote it on a store with
+    per-level masks but no ``mask_sst`` or ``mask_2d``. There ``+ delta_T``
     would drift away from the fill value where ``* ratio`` keeps a zero fill at
     zero. ``scaled_temperature`` rescales every cell regardless, which is
     pre-existing behavior and not something the budget needs.
@@ -563,7 +574,8 @@ def _force_conserve_ocean_heat_content(
         # bathymetry puts at zero thickness -- they hold data and are scored, and
         # shifting them adds no heat. Cells outside the mask hold fill, so they
         # are left alone. Not interchangeable with dz > 0; see the docstring.
-        # ``> 0`` rather than ``== 1`` mirrors depth_integral's own mask test.
+        # ``> 0`` rather than ``== 1`` because dz is mask-weighted, so this is
+        # the indicator for which dz * indicator == dz; see the docstring.
         is_masked_valid = (vertical_coordinate.mask > 0.0).to(
             dtype=gen_potential_temperature.dtype
         )

--- a/fme/core/corrector/ocean.py
+++ b/fme/core/corrector/ocean.py
@@ -443,16 +443,25 @@ def _force_conserve_ocean_heat_content(
         denominator is the area-weighted global mean of the column integral of
         ``rho * cp``.
 
-    The invariant the ``uniform_temperature`` masking relies on is that
-    ``vertical_coordinate.dz`` is zero exactly where a layer is invalid (land,
-    or below the sea floor), which is the same weight
-    ``vertical_coordinate.depth_integral`` applies. So restricting the
-    increment to ``dz > 0`` both keeps it out of invalid cells and leaves the
-    heat it adds equal to ``delta_T`` times the very integral that forms the
-    denominator -- making conservation exact rather than off by the masked
-    fraction. ``scaled_temperature`` needs no such mask because it scales
-    invalid cells rather than shifting them, and invalid cells carry no weight
-    in the integral either way.
+    ``uniform_temperature`` conserves exactly because its denominator is the
+    same integral that weights the heat it deposits. Adding ``delta_T`` at
+    every level raises the column integral of ``rho * cp * T`` by ``delta_T``
+    times the column integral of ``rho * cp``, and ``heat_capacity_per_area``
+    is the area-weighted mean of exactly that column integral, taken through
+    ``vertical_coordinate.depth_integral`` over the same columns. So the
+    denominator must keep coming from ``depth_integral``: a nominal ``dz`` sum,
+    or a mean over a different set of columns, would leave the corrected heat
+    content off by the difference between the two integrals.
+
+    Restricting the increment to ``dz > 0`` is a separate concern and does not
+    affect conservation. ``vertical_coordinate.dz`` is zero wherever a layer is
+    invalid (land, or below the sea floor), so an unmasked increment would
+    deposit no heat there either. The mask is there so that invalid cells pass
+    through unchanged rather than being shifted by a physical increment: they
+    hold raw denormalized network output, and when no spatial mask provider is
+    configured nothing overwrites them after the corrector runs.
+    ``scaled_temperature`` rescales invalid cells instead of leaving them
+    alone, which is pre-existing behavior and not something the budget needs.
     """
     if method not in ("scaled_temperature", "uniform_temperature"):
         raise NotImplementedError(
@@ -524,6 +533,9 @@ def _force_conserve_ocean_heat_content(
                 gen.data["sst"] - FREEZING_TEMPERATURE_KELVIN
             ) * heat_content_correction_ratio + FREEZING_TEMPERATURE_KELVIN
     else:
+        # this must stay a depth_integral over the same columns as the heat
+        # content itself, or conservation is off by the difference; see the
+        # docstring
         heat_capacity_per_area = area_weighted_mean(
             vertical_coordinate.depth_integral(
                 torch.ones_like(gen_potential_temperature)
@@ -536,8 +548,9 @@ def _force_conserve_ocean_heat_content(
         temperature_increment = (
             target_ocean_heat_content - global_gen_ocean_heat_content
         ) / heat_capacity_per_area
-        # zero thickness marks a layer the depth integral cannot see, so the
-        # increment must not land there; see the docstring.
+        # zero thickness marks a layer the depth integral cannot see; the mask
+        # leaves those cells' raw network output untouched, and costs the budget
+        # nothing because they absorb no heat either way
         is_valid = (vertical_coordinate.dz > 0.0).to(
             dtype=gen_potential_temperature.dtype
         )
@@ -546,8 +559,10 @@ def _force_conserve_ocean_heat_content(
             out[name] = gen.data[name] + temperature_increment * is_valid.select(-1, k)
         if "sst" in gen.data:
             # an increment needs no Kelvin offset, unlike the multiplicative
-            # path; the surface layer's validity is the ocean-column indicator
-            # depth_integral itself uses.
+            # path. sst is not in the heat content integral, so shifting it by
+            # the same increment as thetao_0 is a consistency choice, not a
+            # budget requirement; the surface layer's validity is the
+            # wet-column indicator depth_integral itself uses.
             out["sst"] = gen.data["sst"] + temperature_increment * is_valid.select(
                 -1, 0
             )

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -926,6 +926,36 @@ def test_uniform_temperature_shifts_valid_zero_thickness_cells():
     )
 
 
+def test_uniform_temperature_conserves_under_a_fractional_mask():
+    # Why the valid-cell test is mask > 0 and not mask == 1. dz is itself
+    # mask-weighted, so dz * (mask > 0) == dz cell for cell whatever values the
+    # mask takes, which is the identity conservation rests on. DepthCoordinate
+    # documents a 0/1 mask but does not enforce one -- it is read straight out
+    # of the store's mask_<k> variables -- and under mask == 1 a fractional
+    # cell would carry integral weight while going unshifted, so the budget
+    # would miss.
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    mask = depth_coordinate.mask.clone()
+    # a full-thickness, fully-wet column, so this is not also a dz == 0 cell
+    mask[2, 2, 1] = 0.5
+    fractional = DepthCoordinate(
+        _SEA_FLOOR_IDEPTH, mask, cast(torch.Tensor, depth_coordinate.deptho)
+    )
+    assert (fractional.dz[2, 2, 1] > 0.0) and (mask[2, 2, 1] != 1.0)
+    corrected = _build_ohc_corrector(ops, fractional, "uniform_temperature")(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    target = (
+        _global_mean_ohc(ops, fractional, input_data)
+        + _SEA_FLOOR_NET_FLUX * _SEA_FLOOR_TIMESTEP.total_seconds()
+    )
+    torch.testing.assert_close(
+        _global_mean_ohc(ops, fractional, corrected), target, rtol=1e-6, atol=0.0
+    )
+
+
 @pytest.mark.parametrize("method", ["scaled_temperature", "uniform_temperature"])
 def test_ocean_heat_content_correction_is_differentiable(method):
     # The correction runs inside the training loop and the loss differentiates

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -40,8 +40,8 @@ class _MockDepth:
         return torch.nansum(_MASK * integrand * thickness, dim=-1)
 
     @property
-    def dz(self) -> torch.Tensor:
-        return _MASK * _MOCK_IDEPTH.diff(dim=-1)
+    def mask(self) -> torch.Tensor:
+        return _MASK
 
 
 _VERTICAL_COORD = _MockDepth()
@@ -653,12 +653,21 @@ _SEA_FLOOR_TIMESTEP = datetime.timedelta(seconds=5 * 24 * 3600)
 def _make_sea_floor_fixture(nsamples: int = 2, seed: int = 0):
     """Build a masked multi-level ocean fixture with a non-trivial sea floor.
 
-    Three of the nine columns are special: one is all land, one has only its
-    surface layer in the water, and one has two of its three layers. Every wet
-    column's deepest valid layer is a partial bottom cell (``deptho`` falls
-    inside it), so the effective thickness is neither the nominal layer
-    thickness nor a 0/1 multiple of it, and a correction derived from a
-    hand-rolled nominal ``dz`` sum would not conserve heat.
+    Four of the nine columns are special:
+
+    - (0, 0) is all land.
+    - (0, 1) has only its surface layer in the water.
+    - (1, 1) has two of its three layers.
+    - (2, 0) is marked valid at all three levels but its ``deptho`` puts the
+      bottom one below the sea floor, so that cell has ``mask == 1`` and
+      ``dz == 0``. This is how the 1 degree ocean store actually is -- the mask
+      is uniformly more permissive than the bathymetry -- and it is the case
+      that separates ``mask > 0`` from ``dz > 0``.
+
+    Every other wet column's deepest valid layer is a partial bottom cell
+    (``deptho`` falls inside it), so the effective thickness is neither the
+    nominal layer thickness nor a 0/1 multiple of it, and a correction derived
+    from a hand-rolled nominal ``dz`` sum would not conserve heat.
 
     Returns:
         ``(ops, depth_coordinate, input_data, gen_data, forcing_data)``.
@@ -672,9 +681,13 @@ def _make_sea_floor_fixture(nsamples: int = 2, seed: int = 0):
     levels = torch.arange(nz, device=DEVICE)
     mask = (levels < n_valid_levels.unsqueeze(-1)).to(torch.float32)
     deptho = torch.tensor(
-        [[0.0, 7.0, 45.0], [45.0, 22.0, 45.0], [45.0, 45.0, 52.0]], device=DEVICE
+        [[0.0, 7.0, 45.0], [45.0, 22.0, 45.0], [22.0, 45.0, 52.0]], device=DEVICE
     )
     depth_coordinate = DepthCoordinate(_SEA_FLOOR_IDEPTH, mask, deptho)
+    # (2, 0) level 2: marked valid, zero thickness
+    assert (
+        (depth_coordinate.mask > 0.0) & (depth_coordinate.dz == 0.0)
+    ).any(), "fixture must contain a valid-marked zero-thickness cell"
     masks: TensorDict = {f"mask_{k}": mask[:, :, k] for k in range(nz)}
     masks["mask_2d"] = mask[:, :, 0]
     # non-uniform in latitude only, as the area weights require
@@ -744,6 +757,7 @@ def test_uniform_temperature_conserves_with_an_unmasked_depth_coordinate():
     # increment has to broadcast against that without changing shape.
     nlat, nlon, nz, nsamples = 4, 4, 3, 2
     depth_coordinate = DepthCoordinate(_SEA_FLOOR_IDEPTH, torch.ones(nz, device=DEVICE))
+    assert depth_coordinate.mask.shape == (nz,)
     assert depth_coordinate.dz.shape == (nz,)
     area = (
         torch.tensor([0.5, 1.0, 1.5, 1.0], device=DEVICE)
@@ -787,7 +801,8 @@ def test_uniform_temperature_deposits_heat_proportional_to_thickness():
     )
     nz = _SEA_FLOOR_NZ
     dz = depth_coordinate.dz
-    valid = dz > 0.0
+    # the increment lands on the mask; the heat it deposits goes as dz
+    shifted = depth_coordinate.mask > 0.0
     uniform = _build_ohc_corrector(ops, depth_coordinate, "uniform_temperature")(
         input_data, gen_data, forcing_data, None
     ).corrected
@@ -804,7 +819,7 @@ def test_uniform_temperature_deposits_heat_proportional_to_thickness():
     heat_capacity = SPECIFIC_HEAT_OF_SEA_WATER_CM4 * DENSITY_OF_SEA_WATER_CM4
     for k in range(nz):
         expected = torch.where(
-            valid[..., k], delta_temperature, torch.zeros_like(delta_temperature)
+            shifted[..., k], delta_temperature, torch.zeros_like(delta_temperature)
         ).expand(uniform_increment[k].shape)
         torch.testing.assert_close(uniform_increment[k], expected, rtol=1e-5, atol=1e-8)
         # so the heat added at each level is cp * rho * dz_k * delta_T: the only
@@ -836,29 +851,78 @@ def test_uniform_temperature_deposits_heat_proportional_to_thickness():
     assert not torch.allclose(scaled_increment[1], uniform_increment[1])
 
 
-def test_uniform_temperature_leaves_invalid_cells_unchanged():
-    # Invalid cells hold raw denormalized network output, and with no spatial
+def test_uniform_temperature_leaves_cells_outside_the_mask_unchanged():
+    # Cells the mask excludes hold fill rather than data, and with no spatial
     # mask provider nothing overwrites them after the corrector, so the
-    # increment must not shift them. This is the assertion the dz > 0 mask
-    # exists for; conservation holds with or without it.
+    # increment must not shift them. This is the assertion the mask exists for;
+    # conservation holds with or without it.
     ops, depth_coordinate, input_data, gen_data, forcing_data = (
         _make_sea_floor_fixture()
     )
     corrected = _build_ohc_corrector(ops, depth_coordinate, "uniform_temperature")(
         input_data, gen_data, forcing_data, None
     ).corrected
-    dz = depth_coordinate.dz
+    mask, dz = depth_coordinate.mask, depth_coordinate.dz
+    # this pins mask == 0, which on this fixture (as on the real store) is a
+    # strictly smaller set than dz == 0
+    assert ((mask > 0.0) & (dz == 0.0)).any()
     for k in range(_SEA_FLOOR_NZ):
         name = f"thetao_{k}"
-        invalid = (dz[..., k] == 0.0).expand(gen_data[name].shape)
-        assert invalid.any(), f"fixture has no invalid cell at level {k}"
+        outside = (mask[..., k] == 0.0).expand(gen_data[name].shape)
+        assert outside.any(), f"fixture has no out-of-mask cell at level {k}"
         torch.testing.assert_close(
-            corrected[name][invalid], gen_data[name][invalid], rtol=0.0, atol=0.0
+            corrected[name][outside], gen_data[name][outside], rtol=0.0, atol=0.0
         )
     # the sst on a dry column is likewise untouched
-    dry = (dz[..., 0] == 0.0).expand(gen_data["sst"].shape)
+    dry = (mask[..., 0] == 0.0).expand(gen_data["sst"].shape)
     torch.testing.assert_close(
         corrected["sst"][dry], gen_data["sst"][dry], rtol=0.0, atol=0.0
+    )
+
+
+def test_uniform_temperature_shifts_valid_zero_thickness_cells():
+    # The 1 degree ocean store marks cells valid that its bathymetry puts below
+    # the sea floor: 4.6% of all valid-marked cells, and 60% of the bottom
+    # level's. They hold real data, the output masker keeps them and every
+    # metric scores them, so the increment has to reach them -- otherwise a
+    # scored level splits into shifted and unshifted cells along a
+    # mask/bathymetry inconsistency, and the unshifted ones are tied to
+    # neither the budget nor their neighbors over a long rollout. Shifting
+    # them adds no heat, so the budget still closes exactly.
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    mask, dz = depth_coordinate.mask, depth_coordinate.dz
+    valid_zero_thickness = (mask > 0.0) & (dz == 0.0)
+    assert valid_zero_thickness.any()
+    corrected = _build_ohc_corrector(ops, depth_coordinate, "uniform_temperature")(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    increment = [
+        corrected[f"thetao_{k}"] - gen_data[f"thetao_{k}"] for k in range(_SEA_FLOOR_NZ)
+    ]
+    # the global increment, read off a column where every level has thickness
+    delta_temperature = increment[0][:, 2:3, 2:3]
+    checked = 0
+    for k in range(_SEA_FLOOR_NZ):
+        cells = valid_zero_thickness[..., k].expand(increment[k].shape)
+        if not cells.any():
+            continue
+        checked += 1
+        torch.testing.assert_close(
+            increment[k][cells],
+            delta_temperature.expand(increment[k].shape)[cells],
+            rtol=1e-5,
+            atol=1e-8,
+        )
+    assert checked > 0
+    # and the budget still closes exactly, because those cells absorb no heat
+    target = (
+        _global_mean_ohc(ops, depth_coordinate, input_data)
+        + _SEA_FLOOR_NET_FLUX * _SEA_FLOOR_TIMESTEP.total_seconds()
+    )
+    torch.testing.assert_close(
+        _global_mean_ohc(ops, depth_coordinate, corrected), target, rtol=1e-6, atol=0.0
     )
 
 

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -717,8 +717,10 @@ def _global_mean_ohc(ops, depth_coordinate, data: TensorMapping) -> torch.Tensor
 @pytest.mark.parametrize("unaccounted_heating", [0.0, 0.1])
 def test_uniform_temperature_conserves_ocean_heat_content(unaccounted_heating):
     # The additive correction must hit the same budget the multiplicative one
-    # does. If the increment's denominator and its valid-cell mask came from
-    # different integrals this would be off by the masked fraction.
+    # does. This is what pins the increment's denominator: if it came from
+    # anything other than depth_integral over the same columns as the heat
+    # content (a nominal dz sum, or a mean including the dry columns) the
+    # corrected heat content would miss the target.
     ops, depth_coordinate, input_data, gen_data, forcing_data = (
         _make_sea_floor_fixture()
     )
@@ -793,6 +795,10 @@ def test_uniform_temperature_deposits_heat_proportional_to_thickness():
 
 
 def test_uniform_temperature_leaves_invalid_cells_unchanged():
+    # Invalid cells hold raw denormalized network output, and with no spatial
+    # mask provider nothing overwrites them after the corrector, so the
+    # increment must not shift them. This is the assertion the dz > 0 mask
+    # exists for; conservation holds with or without it.
     ops, depth_coordinate, input_data, gen_data, forcing_data = (
         _make_sea_floor_fixture()
     )

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -737,6 +737,48 @@ def test_uniform_temperature_conserves_ocean_heat_content(unaccounted_heating):
     )
 
 
+def test_uniform_temperature_conserves_with_an_unmasked_depth_coordinate():
+    # A dataset with no mask_0 gets a DepthCoordinate whose mask is 1-D and no
+    # spatial mask provider (see fme.core.dataset.xarray), so dz carries no
+    # horizontal dimensions and the valid-cell mask is a scalar per level. The
+    # increment has to broadcast against that without changing shape.
+    nlat, nlon, nz, nsamples = 4, 4, 3, 2
+    depth_coordinate = DepthCoordinate(_SEA_FLOOR_IDEPTH, torch.ones(nz, device=DEVICE))
+    assert depth_coordinate.dz.shape == (nz,)
+    area = (
+        torch.tensor([0.5, 1.0, 1.5, 1.0], device=DEVICE)
+        .unsqueeze(-1)
+        .expand(nlat, nlon)
+    )
+    ops = LatLonOperations(area)  # NullSpatialMaskProvider
+    shape = (nsamples, nlat, nlon)
+    torch.manual_seed(0)
+
+    def rand(offset: float) -> torch.Tensor:
+        return torch.rand(shape, device=DEVICE) * 4.0 + offset
+
+    input_data = {f"thetao_{k}": rand(1.0) for k in range(nz)}
+    gen_data: TensorDict = {f"thetao_{k}": rand(1.0) for k in range(nz)}
+    gen_data["sst"] = rand(274.15)
+    gen_data["hfds"] = torch.full(shape, 3.0, device=DEVICE)
+    forcing_data = {
+        "hfgeou": torch.full(shape, 1.0, device=DEVICE),
+        "sea_surface_fraction": torch.ones(shape, device=DEVICE),
+    }
+    corrected = _build_ohc_corrector(ops, depth_coordinate, "uniform_temperature")(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    for name in [f"thetao_{k}" for k in range(nz)] + ["sst"]:
+        assert corrected[name].shape == gen_data[name].shape, name
+    target = (
+        _global_mean_ohc(ops, depth_coordinate, input_data)
+        + _SEA_FLOOR_NET_FLUX * _SEA_FLOOR_TIMESTEP.total_seconds()
+    )
+    torch.testing.assert_close(
+        _global_mean_ohc(ops, depth_coordinate, corrected), target, rtol=1e-6, atol=0.0
+    )
+
+
 def test_uniform_temperature_deposits_heat_proportional_to_thickness():
     # The property the whole experiment turns on: uniform_temperature deposits
     # heat in proportion to dz_k, scaled_temperature in proportion to T_k * dz_k.

--- a/fme/core/corrector/test_ocean.py
+++ b/fme/core/corrector/test_ocean.py
@@ -1,14 +1,18 @@
 import dataclasses
 import datetime
+from typing import Any, cast
 
+import dacite
 import pytest
 import torch
 
 from fme import get_device
+from fme.core.constants import DENSITY_OF_SEA_WATER_CM4, SPECIFIC_HEAT_OF_SEA_WATER_CM4
 from fme.core.coordinates import DepthCoordinate
 from fme.core.corrector.ocean import (
     OceanCorrectorConfig,
     OceanHeatContentBudgetConfig,
+    OceanHeatContentCorrection,
     SeaIceFractionConfig,
     SurfaceEnergyFluxCorrectionConfig,
     _compute_ocean_net_surface_energy_flux,
@@ -16,7 +20,7 @@ from fme.core.corrector.ocean import (
 from fme.core.gridded_ops import LatLonOperations
 from fme.core.ocean_data import OceanData
 from fme.core.spatial_mask_provider import SpatialMaskProvider
-from fme.core.typing_ import TensorMapping
+from fme.core.typing_ import TensorDict, TensorMapping
 
 DEVICE = get_device()
 IMG_SHAPE = (5, 5)
@@ -27,11 +31,17 @@ _LAT, _LON = 2, 2
 _MASK[_LAT, _LON, :] = 0.0
 
 
+_MOCK_IDEPTH = torch.tensor([0.0, 5.0, 15.0], device=DEVICE)
+
+
 class _MockDepth:
     def depth_integral(self, integrand: torch.Tensor) -> torch.Tensor:
-        idepth = torch.tensor([0, 5, 15], device=DEVICE)
-        thickness = idepth.diff(dim=-1)
+        thickness = _MOCK_IDEPTH.diff(dim=-1)
         return torch.nansum(_MASK * integrand * thickness, dim=-1)
+
+    @property
+    def dz(self) -> torch.Tensor:
+        return _MASK * _MOCK_IDEPTH.diff(dim=-1)
 
 
 _VERTICAL_COORD = _MockDepth()
@@ -541,7 +551,8 @@ def test_ocean_corrector_empty_delta_when_nothing_modified():
     torch.testing.assert_close(result.corrected["so_0"], gen_data["so_0"])
 
 
-def test_ocean_corrector_is_per_member_under_ensemble_folding():
+@pytest.mark.parametrize("method", ["scaled_temperature", "uniform_temperature"])
+def test_ocean_corrector_is_per_member_under_ensemble_folding(method):
     """Ensemble training folds the ensemble members into the batch dimension, so
     the corrector sees several members at once. Every correction must act
     per-member: one that coupled across the batch dim (e.g. a global mean taken
@@ -558,7 +569,7 @@ def test_ocean_corrector_is_per_member_under_ensemble_folding():
             zero_where_ice_free_names=["sea_ice_thickness"],
         ),
         ocean_heat_content_correction=OceanHeatContentBudgetConfig(
-            method="scaled_temperature",
+            method=method,
             constant_unaccounted_heating=0.1,
         ),
     )
@@ -630,3 +641,234 @@ def test_ocean_corrector_is_per_member_under_ensemble_folding():
     # above is not vacuous
     for name in folded:
         assert not torch.allclose(folded[name][0], folded[name][1])
+
+
+_SEA_FLOOR_NLAT, _SEA_FLOOR_NLON, _SEA_FLOOR_NZ = 3, 3, 3
+_SEA_FLOOR_IDEPTH = torch.tensor([0.0, 10.0, 30.0, 60.0], device=DEVICE)
+# hfds + hfgeou in the fixture, uniform over the wet columns, in W/m**2
+_SEA_FLOOR_NET_FLUX = 4.0
+_SEA_FLOOR_TIMESTEP = datetime.timedelta(seconds=5 * 24 * 3600)
+
+
+def _make_sea_floor_fixture(nsamples: int = 2, seed: int = 0):
+    """Build a masked multi-level ocean fixture with a non-trivial sea floor.
+
+    Three of the nine columns are special: one is all land, one has only its
+    surface layer in the water, and one has two of its three layers. Every wet
+    column's deepest valid layer is a partial bottom cell (``deptho`` falls
+    inside it), so the effective thickness is neither the nominal layer
+    thickness nor a 0/1 multiple of it, and a correction derived from a
+    hand-rolled nominal ``dz`` sum would not conserve heat.
+
+    Returns:
+        ``(ops, depth_coordinate, input_data, gen_data, forcing_data)``.
+    """
+    torch.manual_seed(seed)
+    nlat, nlon, nz = _SEA_FLOOR_NLAT, _SEA_FLOOR_NLON, _SEA_FLOOR_NZ
+    n_valid_levels = torch.full((nlat, nlon), nz, device=DEVICE)
+    n_valid_levels[0, 0] = 0  # all land
+    n_valid_levels[0, 1] = 1  # only the surface layer is in the water
+    n_valid_levels[1, 1] = 2
+    levels = torch.arange(nz, device=DEVICE)
+    mask = (levels < n_valid_levels.unsqueeze(-1)).to(torch.float32)
+    deptho = torch.tensor(
+        [[0.0, 7.0, 45.0], [45.0, 22.0, 45.0], [45.0, 45.0, 52.0]], device=DEVICE
+    )
+    depth_coordinate = DepthCoordinate(_SEA_FLOOR_IDEPTH, mask, deptho)
+    masks: TensorDict = {f"mask_{k}": mask[:, :, k] for k in range(nz)}
+    masks["mask_2d"] = mask[:, :, 0]
+    # non-uniform in latitude only, as the area weights require
+    area = torch.tensor([0.5, 1.0, 1.5], device=DEVICE).unsqueeze(-1).expand(nlat, nlon)
+    ops = LatLonOperations(area, SpatialMaskProvider(masks))
+    shape = (nsamples, nlat, nlon)
+
+    def rand(offset: float) -> torch.Tensor:
+        return torch.rand(shape, device=DEVICE) * 4.0 + offset
+
+    input_data = {f"thetao_{k}": rand(1.0) for k in range(nz)}
+    input_data["sst"] = rand(274.15)
+    gen_data = {f"thetao_{k}": rand(1.0) for k in range(nz)}
+    gen_data["sst"] = rand(274.15)
+    gen_data["hfds"] = torch.full(shape, 3.0, device=DEVICE)
+    forcing_data = {
+        "hfgeou": torch.full(shape, 1.0, device=DEVICE),
+        "sea_surface_fraction": mask[:, :, 0].expand(shape),
+    }
+    return ops, depth_coordinate, input_data, gen_data, forcing_data
+
+
+def _build_ohc_corrector(ops, depth_coordinate, method, unaccounted_heating=0.0):
+    return OceanCorrectorConfig(
+        ocean_heat_content_correction=OceanHeatContentBudgetConfig(
+            method=method,
+            constant_unaccounted_heating=unaccounted_heating,
+        )
+    )._build(ops, depth_coordinate, _SEA_FLOOR_TIMESTEP)
+
+
+def _global_mean_ohc(ops, depth_coordinate, data: TensorMapping) -> torch.Tensor:
+    return ops.area_weighted_mean(
+        OceanData(data, depth_coordinate).ocean_heat_content,
+        keepdim=True,
+        name="ocean_heat_content",
+    )
+
+
+@pytest.mark.parametrize("unaccounted_heating", [0.0, 0.1])
+def test_uniform_temperature_conserves_ocean_heat_content(unaccounted_heating):
+    # The additive correction must hit the same budget the multiplicative one
+    # does. If the increment's denominator and its valid-cell mask came from
+    # different integrals this would be off by the masked fraction.
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    corrector = _build_ohc_corrector(
+        ops, depth_coordinate, "uniform_temperature", unaccounted_heating
+    )
+    corrected = corrector(input_data, gen_data, forcing_data, None).corrected
+    expected_change = (
+        _SEA_FLOOR_NET_FLUX + unaccounted_heating
+    ) * _SEA_FLOOR_TIMESTEP.total_seconds()
+    target = _global_mean_ohc(ops, depth_coordinate, input_data) + expected_change
+    torch.testing.assert_close(
+        _global_mean_ohc(ops, depth_coordinate, corrected), target, rtol=1e-6, atol=0.0
+    )
+
+
+def test_uniform_temperature_deposits_heat_proportional_to_thickness():
+    # The property the whole experiment turns on: uniform_temperature deposits
+    # heat in proportion to dz_k, scaled_temperature in proportion to T_k * dz_k.
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    nz = _SEA_FLOOR_NZ
+    dz = depth_coordinate.dz
+    valid = dz > 0.0
+    uniform = _build_ohc_corrector(ops, depth_coordinate, "uniform_temperature")(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    scaled = _build_ohc_corrector(ops, depth_coordinate, "scaled_temperature")(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+
+    uniform_increment = [
+        uniform[f"thetao_{k}"] - gen_data[f"thetao_{k}"] for k in range(nz)
+    ]
+    # one global increment per sample, read off a column where every level is
+    # valid; the correction is per-sample, so keep the sample dimension
+    delta_temperature = uniform_increment[0][:, 2:3, 2:3]
+    heat_capacity = SPECIFIC_HEAT_OF_SEA_WATER_CM4 * DENSITY_OF_SEA_WATER_CM4
+    for k in range(nz):
+        expected = torch.where(
+            valid[..., k], delta_temperature, torch.zeros_like(delta_temperature)
+        ).expand(uniform_increment[k].shape)
+        torch.testing.assert_close(uniform_increment[k], expected, rtol=1e-5, atol=1e-8)
+        # so the heat added at each level is cp * rho * dz_k * delta_T: the only
+        # k dependence is dz_k
+        heat_added = heat_capacity * dz[..., k] * uniform_increment[k]
+        torch.testing.assert_close(
+            heat_added,
+            heat_capacity * dz[..., k] * delta_temperature.expand(heat_added.shape),
+            rtol=1e-5,
+            atol=1e-8,
+        )
+
+    scaled_increment = [
+        scaled[f"thetao_{k}"] - gen_data[f"thetao_{k}"] for k in range(nz)
+    ]
+    # contrast: the multiplicative increment is (ratio - 1) * T_k, so the heat
+    # added at each level goes as T_k * dz_k
+    ratio_minus_one = (
+        scaled_increment[0][:, 2:3, 2:3] / gen_data["thetao_0"][:, 2:3, 2:3]
+    )
+    for k in range(nz):
+        torch.testing.assert_close(
+            scaled_increment[k],
+            gen_data[f"thetao_{k}"] * ratio_minus_one,
+            rtol=1e-5,
+            atol=1e-8,
+        )
+    # and the two profiles are genuinely different on this fixture
+    assert not torch.allclose(scaled_increment[1], uniform_increment[1])
+
+
+def test_uniform_temperature_leaves_invalid_cells_unchanged():
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    corrected = _build_ohc_corrector(ops, depth_coordinate, "uniform_temperature")(
+        input_data, gen_data, forcing_data, None
+    ).corrected
+    dz = depth_coordinate.dz
+    for k in range(_SEA_FLOOR_NZ):
+        name = f"thetao_{k}"
+        invalid = (dz[..., k] == 0.0).expand(gen_data[name].shape)
+        assert invalid.any(), f"fixture has no invalid cell at level {k}"
+        torch.testing.assert_close(
+            corrected[name][invalid], gen_data[name][invalid], rtol=0.0, atol=0.0
+        )
+    # the sst on a dry column is likewise untouched
+    dry = (dz[..., 0] == 0.0).expand(gen_data["sst"].shape)
+    torch.testing.assert_close(
+        corrected["sst"][dry], gen_data["sst"][dry], rtol=0.0, atol=0.0
+    )
+
+
+@pytest.mark.parametrize("method", ["scaled_temperature", "uniform_temperature"])
+def test_ocean_heat_content_correction_is_differentiable(method):
+    # The correction runs inside the training loop and the loss differentiates
+    # through it, so the corrected output must stay on the autograd graph.
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    network_output = {
+        name: value.clone().requires_grad_(True) for name, value in gen_data.items()
+    }
+    corrected = _build_ohc_corrector(ops, depth_coordinate, method)(
+        input_data, network_output, forcing_data, None
+    ).corrected
+    loss = corrected["sst"].sum()
+    for k in range(_SEA_FLOOR_NZ):
+        loss = loss + corrected[f"thetao_{k}"].sum()
+    loss.backward()
+    # the temperature levels and the surface heat flux the budget reads all
+    # carry gradient
+    for name in [f"thetao_{k}" for k in range(_SEA_FLOOR_NZ)] + ["hfds"]:
+        grad = network_output[name].grad
+        assert grad is not None, f"no gradient reached {name}"
+        assert torch.isfinite(grad).all(), f"non-finite gradient at {name}"
+        assert (grad != 0.0).any(), f"gradient at {name} is identically zero"
+
+
+def test_ocean_heat_content_method_round_trips_through_from_state():
+    config = OceanCorrectorConfig.from_state(
+        {
+            "ocean_heat_content_correction": {
+                "method": "uniform_temperature",
+                "constant_unaccounted_heating": 0.25,
+            }
+        }
+    )
+    assert config.ocean_heat_content_correction == OceanHeatContentBudgetConfig(
+        method="uniform_temperature", constant_unaccounted_heating=0.25
+    )
+
+
+def test_ocean_heat_content_unknown_method_raises():
+    with pytest.raises(dacite.DaciteError):
+        OceanCorrectorConfig.from_state(
+            {"ocean_heat_content_correction": {"method": "not_a_method"}}
+        )
+    # a method that got past config validation still fails loudly at the write
+    ops, depth_coordinate, input_data, gen_data, forcing_data = (
+        _make_sea_floor_fixture()
+    )
+    correction = OceanHeatContentCorrection(
+        area_weighted_mean=ops.area_weighted_mean,
+        vertical_coordinate=depth_coordinate,
+        timestep_seconds=_SEA_FLOOR_TIMESTEP.total_seconds(),
+        method=cast(Any, "not_a_method"),
+        unaccounted_heating=0.0,
+    )
+    with pytest.raises(NotImplementedError):
+        correction(input_data, gen_data, forcing_data, None)

--- a/fme/core/ocean_data.py
+++ b/fme/core/ocean_data.py
@@ -37,6 +37,16 @@ class HasOceanDepthIntegral(Protocol):
         integrand: torch.Tensor,
     ) -> torch.Tensor: ...
 
+    @property
+    def dz(self) -> torch.Tensor:
+        """Layer thickness in meters, the weight ``depth_integral`` applies.
+
+        The last dimension is the vertical. Thickness is zero wherever a layer
+        is invalid (below the sea floor or on land), so ``dz > 0`` is exactly
+        the set of cells a depth integral can see.
+        """
+        ...
+
 
 class HasCellAreaInMetersSquared(Protocol):
     """Protocol for objects that can provide cell areas in square meters."""

--- a/fme/core/ocean_data.py
+++ b/fme/core/ocean_data.py
@@ -38,12 +38,17 @@ class HasOceanDepthIntegral(Protocol):
     ) -> torch.Tensor: ...
 
     @property
-    def dz(self) -> torch.Tensor:
-        """Layer thickness in meters, the weight ``depth_integral`` applies.
+    def mask(self) -> torch.Tensor:
+        """Per-level validity: 1 where a layer holds data, 0 elsewhere.
 
-        The last dimension is the vertical. Thickness is zero wherever a layer
-        is invalid (below the sea floor or on land), so ``dz > 0`` is exactly
-        the set of cells a depth integral can see.
+        The last dimension is the vertical; any leading dimensions are
+        horizontal and broadcast against the integrand.
+
+        This is the store's own record of which cells hold data, and it is more
+        permissive than the bathymetry: a cell can be marked valid and still
+        have zero layer thickness, in which case it holds real data but carries
+        no weight in ``depth_integral``. So ``mask > 0`` and ``dz > 0`` are
+        different cell sets and are not interchangeable.
         """
         ...
 


### PR DESCRIPTION
<!-- This description becomes the squash-and-merge commit message: keep it self-contained and describe the final state from main. Put PR-process notes (stacking/rebase, review responses, commit-by-commit narratives) in a PR comment, not here. -->
The ocean heat content corrector currently has one method, `scaled_temperature`, which conserves the column heat content budget by multiplying every potential-temperature level by a single global ratio. That deposits the correction in proportion to `T_k * dz_k`, and it has a structural problem for training: the corrected field is invariant under a global rescaling of the network's temperature output, so the amplitude the network predicts is unconstrained by any loss computed after the corrector. Measured on the deployed 1° ocean runs, the correction is 0.2x to 8x the size of the field itself and differs by 2x between seeds, so the amplitude is an unpinned gauge.

This adds a second method, `uniform_temperature`, which conserves the same budget by adding a single global temperature increment to every level, depositing the correction in proportion to `dz_k` alone. The additive form has no such rescaling invariance, so a post-corrector loss does constrain the predicted amplitude. It also changes which levels absorb the correction, which is the property a follow-up training experiment tests.

`scaled_temperature` is bit-for-bit unchanged and remains what every existing config gets, including the legacy `ocean_heat_content_correction: true` migration.

The increment is `(global_input_ohc + expected_change_ohc - global_gen_ohc) / heat_capacity_per_area`, where the denominator is the area-weighted global mean of the column integral of `rho * cp` taken through the vertical coordinate's own `depth_integral`. Conservation is exact to floating-point tolerance because that denominator is the same integral that weights the heat the increment deposits: partial bottom cells and the per-level valid mask enter it exactly as they enter the heat content integral itself. A denominator built any other way, such as a nominal `dz` sum or a mean over a different set of columns, would leave the corrected heat content off by the difference between the two integrals.

Separately from conservation, the increment is applied where the vertical coordinate's `mask` marks a layer valid. This is deliberately not `dz > 0`: the mask is uniformly more permissive than the bathymetry, so a cell can be marked valid and still have zero layer thickness — on the 1° ocean store, 4.6% of all valid-marked cells and 60% of the bottom level's. Those cells hold real data, the output masker keeps them and every metric scores them, so keying the increment to thickness would split a scored level into shifted and unshifted cells along a mask/bathymetry inconsistency in the store rather than along anything physical. Shifting them costs the budget nothing, because zero thickness means they absorb no heat either way. Cells the mask excludes are left alone: they hold fill rather than data, and nothing necessarily overwrites them after the corrector runs, so an additive increment there would drift away from the fill value where a multiplicative one keeps a zero fill at zero. The increment stays on the autograd graph, since the correction runs inside the training loop and the loss differentiates through it.

Changes:
- `fme.core.corrector.ocean.OceanHeatContentBudgetConfig.method` and `OceanHeatContentCorrection.method` accept `"uniform_temperature"` alongside `"scaled_temperature"`
- `fme.core.corrector.ocean._force_conserve_ocean_heat_content` gains the additive branch, sharing the existing global-mean/flux/geothermal plumbing and `expected_change_ocean_heat_content` with the multiplicative one; its docstring states which invariant conservation rests on and which one the valid-cell mask serves
- `fme.core.ocean_data.HasOceanDepthIntegral` requires `mask`, the per-level validity flags, which `DepthCoordinate` already provided

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (no dependency changes)