### PR TITLE
Add Beaker example for copying a dataset from WEKA to Hugging Face

### DIFF
--- a/scripts/upload_to_hugging_face/Dockerfile
+++ b/scripts/upload_to_hugging_face/Dockerfile
@@ -1,0 +1,6 @@
+FROM rclone/rclone:v1.74-stable
+
+# Install bash, git, and curl which are all required for running with gantry.
+RUN apk add --no-cache bash git curl
+
+ENTRYPOINT ["/bin/bash"]

--- a/scripts/upload_to_hugging_face/Makefile
+++ b/scripts/upload_to_hugging_face/Makefile
@@ -1,0 +1,14 @@
+DOCKER_IMAGE := spencerc/rclone-gantry
+DOCKER_PLATFORM := linux/amd64
+BEAKER_WORKSPACE := ai2/ace
+BEAKER_IMAGE_NAME := rclone-gantry
+
+.PHONY: build_image push_image
+
+build_image:
+	docker build --platform $(DOCKER_PLATFORM) -t $(DOCKER_IMAGE) .
+
+push_image: build_image
+	beaker image create $(DOCKER_IMAGE) \
+		--name $(BEAKER_IMAGE_NAME) \
+		--workspace $(BEAKER_WORKSPACE)

--- a/scripts/upload_to_hugging_face/example.sh
+++ b/scripts/upload_to_hugging_face/example.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd $REPO_ROOT
+
+N_GPUS=0
+BEAKER_IMAGE=spencerc/rclone-gantry
+JOB_NAME=rclone-copy-example
+
+STORE=abrupt4xCO2-ic_0001.zarr
+SOURCE=/climate-default/2025-02-07-vertically-resolved-1deg-c96-shield-som-abrupt-4xCO2-ensemble-fme-dataset/${STORE}
+DESTINATION=hf:ai2cm-scratch/abrupt-4xCO2-ensemble/${STORE}
+
+gantry run \
+    --name $JOB_NAME \
+    --description 'Copy dataset from WEKA to Hugging Face' \
+    --beaker-image ${BEAKER_IMAGE} \
+    --workspace ai2/ace \
+    --priority high \
+    --cluster ai2/phobos \
+    --dataset-secret hugging-face-credentials:/config/rclone/rclone.conf \
+    --gpus $N_GPUS \
+    --shared-memory 64GiB \
+    --min-runtime 8h \
+    --no-python \
+    --allow-dirty \
+    --weka climate-default:/climate-default \
+    -- rclone copy \
+        --checksum \
+        --transfers 128 \
+        --checkers 128 \
+        --progress \
+        --stats-one-line \
+        ${SOURCE} \
+        ${DESTINATION}


### PR DESCRIPTION
This PR defines a simple Docker image and provides an example script to submit a Beaker job to copy a dataset from WEKA to a Hugging Face object storage bucket. The script could easily be adapted for submitting a collection of transfer jobs to run in parallel.
