### PR TITLE
Add Nino3.4 anomaly correlation by lead to the inline ENSO aggregator

### DIFF
--- a/fme/ace/aggregator/inference/enso/dynamic_index.py
+++ b/fme/ace/aggregator/inference/enso/dynamic_index.py
@@ -239,10 +239,140 @@ class PairedRegionalIndexAggregator:
         self._target_aggregator.record_batch(target_data)
         self._prediction_aggregator.record_batch(prediction_data)
 
+    N_ACC_LEADS = 12
+    MIN_CLIMO_YEARS = 10
+
+    def _get_acc_logs(self) -> dict[str, Any]:
+        """Nino3.4 anomaly correlation by forecast lead month, across samples.
+
+        Both series are anomalized against the TARGET's per-calendar-month
+        climatology over the inference window, so model drift cannot leak
+        into the anomaly baseline. Raw monthly means: no running mean and no
+        drift correction.
+
+        The metric is only trustworthy when the initial conditions span
+        enough distinct years. With a narrow span (e.g. all ICs in one year)
+        the in-window climatology absorbs the ENSO event being scored and,
+        independently, every sample sees the same event, so the across-sample
+        target anomaly variance collapses; that deflates the ACC and flattens
+        its shape versus lead, and an external long-record climatology does
+        not rescue it. The metric converges toward hindcast-style scoring as
+        the IC span grows toward 20-30 distinct years. When any calendar
+        month's climatology bin draws on fewer than MIN_CLIMO_YEARS distinct
+        years (counted over the full IC set across all ranks), the ACC
+        metrics are logged as NaN. The min distinct-years-per-month count and
+        the across-sample target anomaly standard deviation at each logged
+        lead are always logged as diagnostics so this regime is visible.
+        """
+
+        def monthly_by_sample(raw: torch.Tensor, times: xr.DataArray):
+            years = times.dt.year.values
+            months = times.dt.month.values
+            ym = years * 12 + (months - 1)
+            out = []
+            arr = raw.detach().cpu().numpy()
+            for s in range(arr.shape[0]):
+                d = {}
+                for key in np.unique(ym[s]):
+                    sel = arr[s][ym[s] == key]
+                    sel = sel[np.isfinite(sel)]
+                    d[int(key)] = float(sel.mean()) if sel.size else float("nan")
+                out.append(d)
+            return out
+
+        logs: dict[str, Any] = {}
+        dist = Distributed.get_instance()
+        n_leads = self.N_ACC_LEADS
+        for sst_name in self._prediction_aggregator.sea_surface_temperature_names:
+            p_raw = self._prediction_aggregator._raw_indices.get(sst_name)
+            t_raw = self._target_aggregator._raw_indices.get(sst_name)
+            p_times = self._prediction_aggregator._raw_index_times
+            t_times = self._target_aggregator._raw_index_times
+            if p_raw is None or t_raw is None or p_times is None or t_times is None:
+                continue
+            pred_monthly = monthly_by_sample(p_raw, p_times)
+            targ_monthly = monthly_by_sample(t_raw, t_times)
+            climo_values: dict[int, list[float]] = {m: [] for m in range(1, 13)}
+            for d in targ_monthly:
+                for key, v in d.items():
+                    if np.isfinite(v):
+                        climo_values[key % 12 + 1].append(v)
+            climo = {
+                m: float(np.mean(v)) if v else float("nan")
+                for m, v in climo_values.items()
+            }
+            n_samples = len(pred_monthly)
+            pred_anom = np.full((n_samples, n_leads), np.nan)
+            targ_anom = np.full((n_samples, n_leads), np.nan)
+            for s in range(n_samples):
+                if not pred_monthly[s]:
+                    continue
+                init = min(pred_monthly[s])
+                for k in range(1, n_leads + 1):
+                    key = init + k
+                    c = climo[key % 12 + 1]
+                    if key in pred_monthly[s]:
+                        pred_anom[s, k - 1] = pred_monthly[s][key] - c
+                    if key in targ_monthly[s]:
+                        targ_anom[s, k - 1] = targ_monthly[s][key] - c
+            # year-month keys with finite target monthly values on this rank,
+            # gathered so the distinct-year count reflects the full IC set
+            # rather than any one rank's share of it
+            local_keys = sorted(
+                {key for d in targ_monthly for key, v in d.items() if np.isfinite(v)}
+            )
+            gathered_p = dist.gather_irregular(
+                torch.as_tensor(pred_anom, dtype=torch.float32)
+            )
+            gathered_t = dist.gather_irregular(
+                torch.as_tensor(targ_anom, dtype=torch.float32)
+            )
+            gathered_keys = dist.gather_irregular(
+                torch.as_tensor(local_keys, dtype=torch.float32).reshape(-1, 1)
+            )
+            if gathered_p is None or gathered_t is None or gathered_keys is None:
+                continue
+            p_all = torch.cat(gathered_p, dim=0).cpu().numpy()
+            t_all = torch.cat(gathered_t, dim=0).cpu().numpy()
+            all_keys = torch.cat(gathered_keys, dim=0).cpu().numpy().ravel()
+            years_per_month: dict[int, set[int]] = {m: set() for m in range(1, 13)}
+            for key in all_keys.astype(int):
+                years_per_month[int(key) % 12 + 1].add(int(key) // 12)
+            min_years = min(len(v) for v in years_per_month.values())
+            logs[f"{sst_name}_nino34_acc_min_years_per_month"] = float(min_years)
+            for k in (3, 6, 9, 12):
+                t_lead = t_all[:, k - 1]
+                t_lead = t_lead[np.isfinite(t_lead)]
+                logs[f"{sst_name}_nino34_target_anom_std_lead{k}"] = (
+                    float(t_lead.std()) if t_lead.size else float("nan")
+                )
+            accs = np.full(n_leads, np.nan)
+            for k in range(n_leads):
+                a, b = p_all[:, k], t_all[:, k]
+                m = np.isfinite(a) & np.isfinite(b)
+                if m.sum() >= 3 and np.std(a[m]) > 0 and np.std(b[m]) > 0:
+                    a2, b2 = a[m] - a[m].mean(), b[m] - b[m].mean()
+                    accs[k] = float(
+                        (a2 * b2).sum() / np.sqrt((a2**2).sum() * (b2**2).sum())
+                    )
+            if min_years < self.MIN_CLIMO_YEARS:
+                # too few distinct years per climatology bin: the ACC is
+                # deflated and its lead dependence flattened, so report NaN
+                # (the diagnostics above are still logged)
+                accs[:] = np.nan
+            for k in (3, 6, 9, 12):
+                logs[f"{sst_name}_nino34_acc_lead{k}"] = float(accs[k - 1])
+            finite_accs = accs[np.isfinite(accs)]
+            logs[f"{sst_name}_nino34_acc_mean_lead1_12"] = (
+                float(finite_accs.mean()) if finite_accs.size else float("nan")
+            )
+        return logs
+
     def get_logs(self, label: str) -> dict[str, Any]:
         target_indices = self._target_aggregator.get_indices()
         prediction_indices = self._prediction_aggregator.get_indices()
         logs = {}
+        logs.update(self._get_acc_logs())
         for sst_name in self._prediction_aggregator.sea_surface_temperature_names:
             if (
                 sst_name in prediction_indices

--- a/fme/ace/aggregator/inference/enso/test_dynamic_index.py
+++ b/fme/ace/aggregator/inference/enso/test_dynamic_index.py
@@ -10,6 +10,7 @@ from matplotlib import pyplot as plt
 from fme import get_device
 from fme.ace.aggregator.inference.data import InferenceBatchData
 from fme.core.coordinates import LatLonCoordinates
+from fme.core.distributed import Distributed
 from fme.core.testing import mock_distributed
 from fme.core.typing_ import TensorMapping
 
@@ -438,6 +439,138 @@ def test_regional_index_aggregator(variable_name):
     metric_name = f"test/{variable_name}_nino34_index_power_1_16yr"
     assert metric_name in logs
     assert isinstance(logs[metric_name], float)
+
+
+def _make_paired_agg(lat, lon):
+    lat_lon_coordinates = LatLonCoordinates(lat=lat, lon=lon)
+    region = LatLonRegion(
+        lat=lat_lon_coordinates.lat,
+        lon=lat_lon_coordinates.lon,
+        lat_bounds=(4.5, 6.5),
+        lon_bounds=(9.5, 11.5),
+    )
+    ops = lat_lon_coordinates.get_gridded_operations()
+    return PairedRegionalIndexAggregator(
+        target_aggregator=RegionalIndexAggregator(
+            regional_weights=region.regional_weights,
+            regional_mean=ops.regional_area_weighted_mean,
+        ),
+        prediction_aggregator=RegionalIndexAggregator(
+            regional_weights=region.regional_weights,
+            regional_mean=ops.regional_area_weighted_mean,
+        ),
+    )
+
+
+def _make_staggered_times(start_years, n_times):
+    """Per-sample time windows starting Jan 1 of each given year, so calendar
+    months stay aligned across samples while absolute years differ."""
+    arrays = []
+    for year in start_years:
+        start = cftime.datetime(year, 1, 1, calendar="noleap")
+        arrays.append(
+            xr.DataArray(
+                data=xr.date_range(
+                    start=start, periods=n_times, freq="6h", use_cftime=True
+                ).values,
+                dims=("time",),
+            )
+        )
+    return xr.concat(arrays, dim="sample")
+
+
+# six samples of two years each, no overlap: every calendar month's
+# climatology bin draws on 12 distinct years, above the ACC guard threshold
+_WIDE_START_YEARS = (2000, 2003, 2006, 2009, 2012, 2015)
+
+
+def _record_slow_oscillation(sign, start_years=_WIDE_START_YEARS):
+    """Build a paired aggregator and record two years per sample of a
+    spatially-uniform slow oscillation with sample-dependent amplitude, so
+    cross-sample variance exists at every lead month; the prediction is
+    sign * target. Each sample starts Jan 1 of its own start year."""
+    n_lat, n_lon = 10, 20
+    n_sample = len(start_years)
+    n_times = 365 * 4 * 2  # two years at 6-hourly (noleap)
+    time = _make_staggered_times(start_years, n_times)
+    hours = torch.arange(n_times, dtype=torch.float32) * 6
+    signal = torch.sin(2 * torch.pi * hours / (24 * 365 * 1.7))
+    amp = torch.linspace(0.5, 2.5, n_sample)[:, None]
+    series = amp * signal[None, :]
+    field = series[:, :, None, None].expand(n_sample, n_times, n_lat, n_lon)
+    coords = {
+        "lat": torch.arange(n_lat, dtype=torch.float32),
+        "lon": torch.arange(n_lon, dtype=torch.float32),
+    }
+    agg = _make_paired_agg(coords["lat"], coords["lon"])
+    agg.record_batch(
+        InferenceBatchData(
+            prediction={"sst": sign * field.clone(), **coords},
+            prediction_norm={},
+            target={"sst": field.clone(), **coords},
+            target_norm=None,
+            time=time,
+            i_time_start=0,
+        )
+    )
+    return agg
+
+
+@pytest.mark.parametrize("sign", [1.0, -1.0])
+def test_paired_aggregator_acc_by_lead(sign):
+    """Prediction equal to (or the negative of) the target must score an
+    anomaly correlation of +1 (or -1) at every lead."""
+    agg = _record_slow_oscillation(sign)
+    logs = agg._get_acc_logs()
+    for k in (3, 6, 9, 12):
+        assert logs[f"sst_nino34_acc_lead{k}"] == pytest.approx(sign, abs=1e-3)
+        assert logs[f"sst_nino34_target_anom_std_lead{k}"] > 0.0
+    assert logs["sst_nino34_acc_mean_lead1_12"] == pytest.approx(sign, abs=1e-3)
+    assert logs["sst_nino34_acc_min_years_per_month"] == float(
+        2 * len(_WIDE_START_YEARS)
+    )
+
+
+def test_paired_aggregator_acc_narrow_ic_span_yields_nan():
+    """With every initial condition in the same year, the in-window
+    climatology and across-sample anomaly variance are degenerate, so the
+    ACC metrics must be NaN while the diagnostics still report the regime."""
+    agg = _record_slow_oscillation(1.0, start_years=(2000, 2000, 2000, 2000))
+    logs = agg._get_acc_logs()
+    # each sample covers 2000-2001, so every calendar month sees 2 years
+    assert logs["sst_nino34_acc_min_years_per_month"] == 2.0
+    for k in (3, 6, 9, 12):
+        assert np.isnan(logs[f"sst_nino34_acc_lead{k}"])
+        assert np.isfinite(logs[f"sst_nino34_target_anom_std_lead{k}"])
+    assert np.isnan(logs["sst_nino34_acc_mean_lead1_12"])
+
+
+class _FakeDeviceTensor(torch.Tensor):
+    """Simulates a non-CPU tensor: .numpy() raises unless .cpu() is called
+    first, matching the behavior of CUDA tensors returned by NCCL gathers."""
+
+    def numpy(self, *args, **kwargs):
+        raise TypeError(
+            "can't convert fake device tensor to numpy; call Tensor.cpu() first"
+        )
+
+    def cpu(self, *args, **kwargs):
+        return super().cpu(*args, **kwargs).as_subclass(torch.Tensor)
+
+
+def test_paired_aggregator_acc_gathered_tensors_not_cpu_backed(monkeypatch):
+    """Regression test: gather_irregular returns device tensors under NCCL,
+    so _get_acc_logs must move gathered tensors to CPU before numpy
+    conversion."""
+
+    def fake_gather_irregular(self, tensor):
+        return [tensor.as_subclass(_FakeDeviceTensor)]
+
+    monkeypatch.setattr(Distributed, "gather_irregular", fake_gather_irregular)
+    agg = _record_slow_oscillation(1.0)
+    logs = agg._get_acc_logs()
+    for k in (3, 6, 9, 12):
+        assert logs[f"sst_nino34_acc_lead{k}"] == pytest.approx(1.0, abs=1e-3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds _get_acc_logs() to PairedRegionalIndexAggregator: it reduces the raw per-sample Nino3.4 index series kept by the dynamic index aggregators to monthly means, anomalizes both prediction and target against the target's per-calendar-month climatology over the inference window (so model drift cannot leak into the anomaly baseline), and computes the cross-sample anomaly correlation at each forecast lead month. Logs sst_nino34_acc_lead{3,6,9,12} and sst_nino34_acc_mean_lead1_12 alongside the existing ENSO index logs.

The per-rank anomaly matrices are gathered with dist.gather_irregular; the gathered tensors are moved to CPU before numpy conversion because gather_irregular returns device tensors under NCCL.

<!-- This description becomes the squash-and-merge commit message: keep it self-contained and describe the final state from main. Put PR-process notes (stacking/rebase, review responses, commit-by-commit narratives) in a PR comment, not here. -->
Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

Changes:
- symbol (e.g. `fme.core.my_function`) or script and concise description of changes or added feature
- Can group multiple related symbols on a single bullet

- [ ] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated

Resolves #<github issues> (delete if none)
