### PR TITLE
Log the pre-clip gradient norm as grad_norm

### DIFF
--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -1683,6 +1683,9 @@ class TrainStepper(
             optimization.accumulate_loss(regularizer_loss)
         metrics["loss"] = optimization.get_accumulated_loss().detach()
         optimization.step_weights()
+        grad_norm = optimization.last_grad_norm
+        if grad_norm is not None:
+            metrics["grad_norm"] = torch.tensor(grad_norm)
 
         gen_data = process_ensemble_prediction_generator_list(output_list)
 

--- a/fme/ace/stepper/single_module.py
+++ b/fme/ace/stepper/single_module.py
@@ -32,6 +32,7 @@ from fme.core.dataset.data_typing import VariableMetadata
 from fme.core.dataset.schedule import IntSchedule
 from fme.core.dataset.utils import encode_timestep
 from fme.core.dataset_info import DatasetInfo, MissingDatasetInfo
+from fme.core.device import get_device
 from fme.core.generics.inference import PredictFunction
 from fme.core.generics.optimization import OptimizationABC
 from fme.core.generics.train_stepper import TrainOutputABC, TrainStepperABC
@@ -1685,7 +1686,10 @@ class TrainStepper(
         optimization.step_weights()
         grad_norm = optimization.last_grad_norm
         if grad_norm is not None:
-            metrics["grad_norm"] = torch.tensor(grad_norm)
+            # device matters: MetricsAggregator all_reduces every metric at the
+            # end of the epoch, and NCCL has no CPU backend, so a CPU tensor
+            # among the device-resident metrics aborts distributed training.
+            metrics["grad_norm"] = torch.tensor(grad_norm, device=get_device())
 
         gen_data = process_ensemble_prediction_generator_list(output_list)
 

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -594,6 +594,10 @@ def test_train_on_batch_optimize_last_step_only(optimize_last_step_only: bool):
         ),
     )
     optimization = unittest.mock.Mock(wraps=NullOptimization())
+    # `wraps` proxies method calls but not property access, so the protocol's
+    # `last_grad_norm` would otherwise read back as a Mock. Match the wrapped
+    # NullOptimization, which reports no norm because it does no clipping.
+    optimization.last_grad_norm = None
     stepper.train_on_batch(data=data_with_ic, optimization=optimization)
     if optimize_last_step_only:
         assert len(optimization.accumulate_loss.call_args_list) == 1

--- a/fme/ace/stepper/test_single_module.py
+++ b/fme/ace/stepper/test_single_module.py
@@ -816,6 +816,59 @@ def _setup_and_train_on_batch(
     return stepper.train_on_batch(data, optimization=optimization)
 
 
+def test_train_on_batch_metrics_share_one_device():
+    """Every metric must live on the same device.
+
+    MetricsAggregator all_reduces each metric at the end of the epoch and NCCL
+    has no CPU backend, so a single CPU tensor among device-resident metrics
+    aborts distributed training with "No backend type associated with device
+    type cpu" -- which is invisible to a CPU-only or single-process test run.
+    Asserting the metrics share one device is the platform-independent form of
+    that invariant.
+    """
+    in_names = out_names = ["a", "b"]
+    data, _, _ = get_data(in_names, 3, 2)
+    stepped = _setup_and_train_on_batch(
+        data,
+        in_names,
+        out_names,
+        None,
+        OptimizationConfig(max_grad_norm=1.0),
+        {},
+    )
+    assert "grad_norm" in stepped.metrics, sorted(stepped.metrics)
+    devices = {
+        v.device for v in stepped.metrics.values() if isinstance(v, torch.Tensor)
+    }
+    assert len(devices) == 1, f"metrics span multiple devices: {devices}"
+    assert devices == {get_device()}
+
+
+def test_grad_norm_metric_is_placed_on_the_training_device():
+    """The grad_norm metric follows get_device(), not torch's CPU default.
+
+    The assertion above is vacuous on a CPU-only run, where every device is
+    already `cpu`. Redirecting the stepper's `get_device` to the meta device
+    makes the placement observable without a GPU: an unplaced
+    `torch.tensor(grad_norm)` lands on cpu and fails this.
+    """
+    in_names = out_names = ["a", "b"]
+    data, _, _ = get_data(in_names, 3, 2)
+    with patch(
+        "fme.ace.stepper.single_module.get_device",
+        return_value=torch.device("meta"),
+    ):
+        stepped = _setup_and_train_on_batch(
+            data,
+            in_names,
+            out_names,
+            None,
+            OptimizationConfig(max_grad_norm=1.0),
+            {},
+        )
+    assert stepped.metrics["grad_norm"].device == torch.device("meta")
+
+
 @pytest.mark.parametrize("has_epoch", [True, False])
 @pytest.mark.parametrize("uses_scheduling", [True, False])
 def test_train_on_batch_requires_epoch(has_epoch: bool, uses_scheduling: bool):

--- a/fme/core/generics/optimization.py
+++ b/fme/core/generics/optimization.py
@@ -94,6 +94,15 @@ class OptimizationABC(abc.ABC):
         """
         ...
 
+    @property
+    def last_grad_norm(self) -> float | None:
+        """The total gradient norm before clipping at the last ``step_weights``.
+
+        ``None`` when gradient clipping is not configured, since the norm is a
+        by-product of the clipping call and is not otherwise computed.
+        """
+        return None
+
     @abc.abstractmethod
     def get_state(self):
         """

--- a/fme/core/optimization.py
+++ b/fme/core/optimization.py
@@ -191,6 +191,10 @@ class Optimization(OptimizationABC):
                 params, self._max_grad_norm
             ).item()
 
+    @property
+    def last_grad_norm(self) -> float | None:
+        return self._last_grad_norm
+
     def _step_weights(self):
         if self.gscaler is not None:
             self.gscaler.step(self.optimizer)

--- a/fme/core/test_optimization.py
+++ b/fme/core/test_optimization.py
@@ -878,3 +878,26 @@ def test_optimization_config_passes_max_grad_norm():
         nn.ModuleList([model]), max_epochs=1
     )
     assert opt._max_grad_norm == 1.5
+
+
+def test_last_grad_norm_is_exposed_and_none_without_clipping():
+    """The pre-clip norm clip_grad_norm_ already returns is readable as a metric.
+
+    It is logged as `grad_norm`, which is the only view onto how often
+    max_grad_norm binds; without clipping configured there is no norm to report.
+    """
+    module = torch.nn.Linear(3, 3)
+    with_clip = OptimizationConfig(lr=1e-3, max_grad_norm=1.0).build(
+        modules=torch.nn.ModuleList([module]), max_epochs=1
+    )
+    without_clip = OptimizationConfig(lr=1e-3).build(
+        modules=torch.nn.ModuleList([module]), max_epochs=1
+    )
+    for optimization, expect_norm in ((with_clip, True), (without_clip, False)):
+        optimization.accumulate_loss(module(torch.ones(2, 3)).sum())
+        optimization.step_weights()
+        if expect_norm:
+            assert optimization.last_grad_norm is not None
+            assert optimization.last_grad_norm > 0.0
+        else:
+            assert optimization.last_grad_norm is None


### PR DESCRIPTION
`torch.nn.utils.clip_grad_norm_` already returns the total gradient norm before clipping, and `Optimization` stored it in `_last_grad_norm` — but nothing ever read it, so there was no view onto how often `max_grad_norm` actually binds.

- `OptimizationABC.last_grad_norm` is a new property defaulting to `None`, since the norm is a by-product of the clipping call and is not computed when clipping is off. `Optimization` overrides it to return the stored value, so no other implementation needs changing.
- `train_on_batch` logs it as `grad_norm` when present.

Motivated by comparing an L1 training loss against MSE: `|∂MSE| ∝ |error|` while `|∂L1| = 1`, so the two have systematically different raw gradient magnitudes, and gradient clipping is the one channel AdamW's per-parameter normalization does not absorb. Whether the clip binds is therefore needed to interpret the comparison.

Incidental: `test_train_on_batch_optimize_last_step_only` builds its optimization as `Mock(wraps=NullOptimization())`, and `wraps` proxies method calls but not property access — so the new property read back as a `Mock`. The double now sets `last_grad_norm = None` explicitly, matching the wrapped object, rather than the production code type-checking to accommodate a test double.