### PR TITLE
Add example for uploading a dataset to a HF bucket via the `hf` CLI

### DIFF
--- a/scripts/upload_to_hugging_face/Dockerfile
+++ b/scripts/upload_to_hugging_face/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+# Install git and curl since they are required for running with gantry.
+RUN apt-get update && apt-get install -y --no-install-recommends git curl
+
+# Install the Hugging Face CLI and ensure it is in the search path.
+RUN curl -LsSf https://hf.co/cli/install.sh | bash
+ENV PATH="/root/.local/bin:$PATH"
+
+# Set environment variables for performant uploads per Paul Laskowski.
+ENV HF_XET_HIGH_PERFORMANCE=1
+ENV HF_XET_SHARD_CACHE_SIZE_LIMIT=40GiB
+
+ENTRYPOINT ["/bin/bash"]

--- a/scripts/upload_to_hugging_face/Dockerfile
+++ b/scripts/upload_to_hugging_face/Dockerfile
@@ -12,6 +12,9 @@ ENV PATH="/root/.local/bin:$PATH"
 # uploads; HF_XET_SHARD_CACHE_SIZE_LIMIT=40GiB is larger than the default 16GB,
 # which also facilitates performance. See documentation here for more details:
 # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+
+# Running without both results in roughly 10x slower peak upload throughput for
+# the same store on ai2/phobos.
 ENV HF_XET_HIGH_PERFORMANCE=1
 ENV HF_XET_SHARD_CACHE_SIZE_LIMIT=40GiB
 

--- a/scripts/upload_to_hugging_face/Dockerfile
+++ b/scripts/upload_to_hugging_face/Dockerfile
@@ -7,7 +7,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends git curl
 RUN curl -LsSf https://hf.co/cli/install.sh | bash
 ENV PATH="/root/.local/bin:$PATH"
 
-# Set environment variables for performant uploads per Paul Laskowski.
+# Set environment variables for performant uploads based on recommendation from
+# Paul Laskowski. HF_XET_HIGH_PERFORMANCE=1 enables optimal parallelization of
+# uploads; HF_XET_SHARD_CACHE_SIZE_LIMIT=40GiB is larger than the default 16GB,
+# which also facilitates performance. See documentation here for more details:
+# https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
 ENV HF_XET_HIGH_PERFORMANCE=1
 ENV HF_XET_SHARD_CACHE_SIZE_LIMIT=40GiB
 

--- a/scripts/upload_to_hugging_face/Makefile
+++ b/scripts/upload_to_hugging_face/Makefile
@@ -1,0 +1,14 @@
+DOCKER_IMAGE := spencerc/hf-cli-gantry
+DOCKER_PLATFORM := linux/amd64
+BEAKER_WORKSPACE := ai2/ace
+BEAKER_IMAGE_NAME := hf-cli-gantry
+
+.PHONY: build_image push_image
+
+build_image:
+	docker build --platform $(DOCKER_PLATFORM) -t $(DOCKER_IMAGE) .
+
+push_image: build_image
+	beaker image create $(DOCKER_IMAGE) \
+		--name $(BEAKER_IMAGE_NAME) \
+		--workspace $(BEAKER_WORKSPACE)

--- a/scripts/upload_to_hugging_face/example.sh
+++ b/scripts/upload_to_hugging_face/example.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd $REPO_ROOT
+
+N_GPUS=0
+BEAKER_IMAGE=spencerc/hf-cli-gantry
+JOB_NAME=hf-sync-example
+
+STORE=abrupt4xCO2-ic_0001.zarr
+SOURCE=/climate-default/2025-02-07-vertically-resolved-1deg-c96-shield-som-abrupt-4xCO2-ensemble-fme-dataset/${STORE}
+DESTINATION=hf://buckets/allenai/ai2cm-scratch/abrupt-4xCO2-ensemble/${STORE}
+
+gantry run \
+    --name "${JOB_NAME}" \
+    --description 'Sync dataset on WEKA with a Hugging Face bucket' \
+    --beaker-image "${BEAKER_IMAGE}" \
+    --workspace ai2/ace \
+    --priority high \
+    --cluster ai2/phobos \
+    --env-secret HF_TOKEN=hugging-face-token \
+    --gpus "${N_GPUS}" \
+    --shared-memory 64GiB \
+    --min-runtime 8h \
+    --no-python \
+    --allow-dirty \
+    --weka climate-default:/climate-default \
+    -- hf sync "${SOURCE}" "${DESTINATION}"

--- a/scripts/upload_to_hugging_face/example.sh
+++ b/scripts/upload_to_hugging_face/example.sh
@@ -5,7 +5,6 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd $REPO_ROOT
 
-N_GPUS=0
 BEAKER_IMAGE=spencerc/hf-cli-gantry
 JOB_NAME=hf-sync-example
 
@@ -21,7 +20,7 @@ gantry run \
     --priority high \
     --cluster ai2/phobos \
     --env-secret HF_TOKEN=hugging-face-token \
-    --gpus "${N_GPUS}" \
+    --gpus 0 \
     --shared-memory 64GiB \
     --min-runtime 8h \
     --no-python \


### PR DESCRIPTION
This PR provides an example lightweight Beaker image and gantry submission script for uploading a zarr store on WEKA to a Hugging Face bucket.  This approach uses the `hf` command line interface, which is documented [here](https://huggingface.co/docs/huggingface_hub/en/guides/cli).  The scratch bucket this job writes to can be viewed [here](https://huggingface.co/buckets/allenai/ai2cm-scratch) and  [this is a link](https://beaker.org/orgs/ai2/workspaces/ace/work/01M215MYFH3RTKPZ73DDWVD8VM?taskId=01M215MYFQFZ707RN9141TGW6R&jobId=01M215MYK7VQWY0NSFMHER3TT1) to the successful Beaker job.

Changes:
- Adds a `scripts/upload_to_hugging_face` directory with a `Makefile`, `Dockerfile`, and `example.sh` script.
