### PR TITLE
Carry every 6-hourly ERA5 variable into the daily coarsened stores

### DIFF
--- a/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
@@ -1,3 +1,15 @@
+# ERA5 1deg 8-layer dataset: 6-hourly stats plus the daily (factor-4 time
+# coarsened) store and its stats. Run from this directory with
+#   ./compute_dataset.sh --time-coarsen --stats --config configs/era5-1deg-8layer-1940-2025.yaml
+# (never --dataset: the 6-hourly store is produced by scripts/era5). Each step
+# skips outputs that already exist, so the 6-hourly stats and their beaker
+# dataset are not recomputed; give the daily store, its stats directory and its
+# beaker dataset new dated names whenever the daily variable set changes.
+#
+# The daily store carries every variable of the 6-hourly store: instantaneous
+# fields are 00Z snapshots (snapshot_names), 6h-mean fluxes are averaged to
+# daily means (window_names), and time-invariant fields are copied
+# (constant_prefixes). Variables in none of the lists are silently dropped.
 runs:
   2026-08-13-era5-1deg-8layer-1940-2025: ""  # no real data source, config only for computing stats
 data_output_directory: gs://vcm-ml-intermediate
@@ -18,31 +30,53 @@ time_coarsen:
     longitude: 360
   factor: 4
   data_output_directory: gs://vcm-ml-intermediate
-  stats_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-1deg-8layer-daily-stats-1990-2019
+  stats_output_directory: gs://vcm-ml-intermediate/2026-09-08-era5-1deg-8layer-daily-stats-1990-2019
+  beaker_dataset: 2026-09-08-era5-1deg-8layer-daily-stats-1990-2019
   output_names:
-    2026-08-13-era5-1deg-8layer-1940-2025: 2026-08-13-era5-1deg-8layer-daily-1940-2025
+    2026-08-13-era5-1deg-8layer-1940-2025: 2026-09-08-era5-1deg-8layer-daily-1940-2025
   snapshot_names:
     - DPT2m
     - PRESsfc
+    - PRMSL
     - Q10
+    - Q100
+    - Q1000
     - Q200
+    - Q250
     - Q2m
+    - Q50
     - Q500
+    - Q700
     - Q850
     - TMP10
+    - TMP100
+    - TMP1000
     - TMP200
+    - TMP250
     - TMP2m
+    - TMP50
     - TMP500
+    - TMP700
     - TMP850
     - UGRD10
+    - UGRD100
+    - UGRD1000
     - UGRD10m
     - UGRD200
+    - UGRD250
+    - UGRD50
     - UGRD500
+    - UGRD700
     - UGRD850
     - VGRD10
+    - VGRD100
+    - VGRD1000
     - VGRD10m
     - VGRD200
+    - VGRD250
+    - VGRD50
     - VGRD500
+    - VGRD700
     - VGRD850
     - air_temperature_0
     - air_temperature_1
@@ -61,13 +95,16 @@ time_coarsen:
     - eastward_wind_6
     - eastward_wind_7
     - h10
+    - h100
     - h1000
     - h200
     - h250
     - h300
+    - h50
     - h500
     - h700
     - h850
+    - merged_sea_surface_and_skin_temperature
     - northward_wind_0
     - northward_wind_1
     - northward_wind_2
@@ -78,10 +115,16 @@ time_coarsen:
     - northward_wind_7
     - ocean_fraction
     - sea_ice_fraction
+    - sea_surface_temperature
+    - significant_height_of_combined_wind_waves_and_swell
     - soil_moisture_0
     - soil_moisture_1
     - soil_moisture_2
     - soil_moisture_3
+    - soil_temperature_0
+    - soil_temperature_1
+    - soil_temperature_2
+    - soil_temperature_3
     - specific_total_water_0
     - specific_total_water_1
     - specific_total_water_2
@@ -90,8 +133,13 @@ time_coarsen:
     - specific_total_water_5
     - specific_total_water_6
     - specific_total_water_7
+    - surface_snow_amount
+    - surface_snow_area_fraction
+    - surface_snow_thickness
     - surface_temperature
   window_names:
+    - DCLWRFsfc
+    - DCSWRFsfc
     - DLWRFsfc
     - DPT2m_mean
     - DSWRFsfc
@@ -102,6 +150,10 @@ time_coarsen:
     - Q2m_mean
     - SHTFLsfc
     - TMP2m_mean
+    - UCLWRFsfc
+    - UCLWRFtoa
+    - UCSWRFsfc
+    - UCSWRFtoa
     - UGRD10m_mean
     - ULWRFsfc
     - ULWRFtoa
@@ -109,7 +161,10 @@ time_coarsen:
     - USWRFtoa
     - VGRD10m_mean
     - WIND10m_mean
+    - eastward_surface_stress
     - global_mean_co2
+    - northward_surface_stress
+    - runoff_flux
     - surface_temperature_mean
     - tendency_of_total_water_path_due_to_advection
     - total_frozen_precipitation_rate
@@ -117,8 +172,16 @@ time_coarsen:
     - HGTsfc
     - ak_
     - bk_
+    - coarse_soil_type_fraction
+    - fine_soil_type_fraction
     - land_fraction
     - latitude
     - longitude
+    - medium_fine_soil_type_fraction
+    - medium_soil_type_fraction
+    - organic_soil_type_fraction
+    - tropical_organic_soil_type_fraction
+    - undefined_soil_type_fraction
+    - very_fine_soil_type_fraction
   input_time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
     start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
@@ -1,10 +1,16 @@
 # ERA5 1deg 8-layer dataset: 6-hourly stats plus the daily (factor-4 time
 # coarsened) store and its stats. Run from this directory with
 #   ./compute_dataset.sh --time-coarsen --stats --config configs/era5-1deg-8layer-1940-2025.yaml
-# (never --dataset: the 6-hourly store is produced by scripts/era5). Each step
-# skips outputs that already exist, so the 6-hourly stats and their beaker
-# dataset are not recomputed; give the daily store, its stats directory and its
-# beaker dataset new dated names whenever the daily variable set changes.
+# (never --dataset: the 6-hourly store is produced by scripts/era5). The stats,
+# combine-stats and beaker-upload steps skip outputs that already exist, so the
+# 6-hourly stats and their beaker dataset are not recomputed. The time-coarsen
+# step does not skip (its check is a local-path test that is always false on
+# gs:// paths) and rewrites its output, so give the daily store, its stats
+# directory and its beaker dataset new dated names whenever the daily variable
+# set changes; the rename is what protects the previous daily store.
+# Beaker datasets are created by the argo pod's account (andrep), so training
+# configs reference andrep/<beaker_dataset>. The daily store is written as a
+# bare <output_name>.zarr at the bucket root (data_path is its parent).
 #
 # The daily store carries every variable of the 6-hourly store: instantaneous
 # fields are 00Z snapshots (snapshot_names), 6h-mean fluxes are averaged to

--- a/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml
@@ -1,21 +1,8 @@
-# ERA5 1deg 8-layer dataset: 6-hourly stats plus the daily (factor-4 time
-# coarsened) store and its stats. Run from this directory with
+# 6-hourly ERA5 stats plus the daily (factor-4 coarsened) store and its stats:
 #   ./compute_dataset.sh --time-coarsen --stats --config configs/era5-1deg-8layer-1940-2025.yaml
-# (never --dataset: the 6-hourly store is produced by scripts/era5). The stats,
-# combine-stats and beaker-upload steps skip outputs that already exist, so the
-# 6-hourly stats and their beaker dataset are not recomputed. The time-coarsen
-# step does not skip (its check is a local-path test that is always false on
-# gs:// paths) and rewrites its output, so give the daily store, its stats
-# directory and its beaker dataset new dated names whenever the daily variable
-# set changes; the rename is what protects the previous daily store.
-# Beaker datasets are created by the argo pod's account (andrep), so training
-# configs reference andrep/<beaker_dataset>. The daily store is written as a
-# bare <output_name>.zarr at the bucket root (data_path is its parent).
-#
-# The daily store carries every variable of the 6-hourly store: instantaneous
-# fields are 00Z snapshots (snapshot_names), 6h-mean fluxes are averaged to
-# daily means (window_names), and time-invariant fields are copied
-# (constant_prefixes). Variables in none of the lists are silently dropped.
+# The 6-hourly store comes from scripts/era5, so never pass --dataset. Existing
+# stats are skipped but the coarsened store is rewritten, so rename the daily
+# outputs when changing the variable lists. Variables in no list are dropped.
 runs:
   2026-08-13-era5-1deg-8layer-1940-2025: ""  # no real data source, config only for computing stats
 data_output_directory: gs://vcm-ml-intermediate

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -1,3 +1,15 @@
+# ERA5 4deg 8-layer dataset: 6-hourly stats plus the daily (factor-4 time
+# coarsened) store and its stats. Run from this directory with
+#   ./compute_dataset.sh --time-coarsen --stats --config configs/era5-4deg-8layer-1940-2025.yaml
+# (never --dataset: the 6-hourly store is produced by scripts/era5). Each step
+# skips outputs that already exist, so the 6-hourly stats and their beaker
+# dataset are not recomputed; give the daily store, its stats directory and its
+# beaker dataset new dated names whenever the daily variable set changes.
+#
+# The daily store carries every variable of the 6-hourly store: instantaneous
+# fields are 00Z snapshots (snapshot_names), 6h-mean fluxes are averaged to
+# daily means (window_names), and time-invariant fields are copied
+# (constant_prefixes). Variables in none of the lists are silently dropped.
 runs:
   2026-08-13-era5-4deg-8layer-1940-2025: ""  # no real data source, config only for computing stats
 data_output_directory: gs://vcm-ml-intermediate
@@ -10,31 +22,53 @@ stats:
 time_coarsen:
   factor: 4
   data_output_directory: gs://vcm-ml-intermediate
-  stats_output_directory: gs://vcm-ml-intermediate/2026-08-13-era5-4deg-8layer-daily-stats-1990-2019
+  stats_output_directory: gs://vcm-ml-intermediate/2026-09-08-era5-4deg-8layer-daily-stats-1990-2019
+  beaker_dataset: 2026-09-08-era5-4deg-8layer-daily-stats-1990-2019
   output_names:
-    2026-08-13-era5-4deg-8layer-1940-2025: 2026-08-13-era5-4deg-8layer-daily-1940-2025
+    2026-08-13-era5-4deg-8layer-1940-2025: 2026-09-08-era5-4deg-8layer-daily-1940-2025
   snapshot_names:
     - DPT2m
     - PRESsfc
+    - PRMSL
     - Q10
+    - Q100
+    - Q1000
     - Q200
+    - Q250
     - Q2m
+    - Q50
     - Q500
+    - Q700
     - Q850
     - TMP10
+    - TMP100
+    - TMP1000
     - TMP200
+    - TMP250
     - TMP2m
+    - TMP50
     - TMP500
+    - TMP700
     - TMP850
     - UGRD10
+    - UGRD100
+    - UGRD1000
     - UGRD10m
     - UGRD200
+    - UGRD250
+    - UGRD50
     - UGRD500
+    - UGRD700
     - UGRD850
     - VGRD10
+    - VGRD100
+    - VGRD1000
     - VGRD10m
     - VGRD200
+    - VGRD250
+    - VGRD50
     - VGRD500
+    - VGRD700
     - VGRD850
     - air_temperature_0
     - air_temperature_1
@@ -53,13 +87,16 @@ time_coarsen:
     - eastward_wind_6
     - eastward_wind_7
     - h10
+    - h100
     - h1000
     - h200
     - h250
     - h300
+    - h50
     - h500
     - h700
     - h850
+    - merged_sea_surface_and_skin_temperature
     - northward_wind_0
     - northward_wind_1
     - northward_wind_2
@@ -70,10 +107,16 @@ time_coarsen:
     - northward_wind_7
     - ocean_fraction
     - sea_ice_fraction
+    - sea_surface_temperature
+    - significant_height_of_combined_wind_waves_and_swell
     - soil_moisture_0
     - soil_moisture_1
     - soil_moisture_2
     - soil_moisture_3
+    - soil_temperature_0
+    - soil_temperature_1
+    - soil_temperature_2
+    - soil_temperature_3
     - specific_total_water_0
     - specific_total_water_1
     - specific_total_water_2
@@ -82,8 +125,13 @@ time_coarsen:
     - specific_total_water_5
     - specific_total_water_6
     - specific_total_water_7
+    - surface_snow_amount
+    - surface_snow_area_fraction
+    - surface_snow_thickness
     - surface_temperature
   window_names:
+    - DCLWRFsfc
+    - DCSWRFsfc
     - DLWRFsfc
     - DPT2m_mean
     - DSWRFsfc
@@ -94,6 +142,10 @@ time_coarsen:
     - Q2m_mean
     - SHTFLsfc
     - TMP2m_mean
+    - UCLWRFsfc
+    - UCLWRFtoa
+    - UCSWRFsfc
+    - UCSWRFtoa
     - UGRD10m_mean
     - ULWRFsfc
     - ULWRFtoa
@@ -101,7 +153,10 @@ time_coarsen:
     - USWRFtoa
     - VGRD10m_mean
     - WIND10m_mean
+    - eastward_surface_stress
     - global_mean_co2
+    - northward_surface_stress
+    - runoff_flux
     - surface_temperature_mean
     - tendency_of_total_water_path_due_to_advection
     - total_frozen_precipitation_rate
@@ -109,8 +164,16 @@ time_coarsen:
     - HGTsfc
     - ak_
     - bk_
+    - coarse_soil_type_fraction
+    - fine_soil_type_fraction
     - land_fraction
     - latitude
     - longitude
+    - medium_fine_soil_type_fraction
+    - medium_soil_type_fraction
+    - organic_soil_type_fraction
+    - tropical_organic_soil_type_fraction
+    - undefined_soil_type_fraction
+    - very_fine_soil_type_fraction
   input_time_slice:  # ensures coarsened data starts on 1940-01-03T00:00:00
     start: "1940-01-02T06:00:00"

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -1,10 +1,16 @@
 # ERA5 4deg 8-layer dataset: 6-hourly stats plus the daily (factor-4 time
 # coarsened) store and its stats. Run from this directory with
 #   ./compute_dataset.sh --time-coarsen --stats --config configs/era5-4deg-8layer-1940-2025.yaml
-# (never --dataset: the 6-hourly store is produced by scripts/era5). Each step
-# skips outputs that already exist, so the 6-hourly stats and their beaker
-# dataset are not recomputed; give the daily store, its stats directory and its
-# beaker dataset new dated names whenever the daily variable set changes.
+# (never --dataset: the 6-hourly store is produced by scripts/era5). The stats,
+# combine-stats and beaker-upload steps skip outputs that already exist, so the
+# 6-hourly stats and their beaker dataset are not recomputed. The time-coarsen
+# step does not skip (its check is a local-path test that is always false on
+# gs:// paths) and rewrites its output, so give the daily store, its stats
+# directory and its beaker dataset new dated names whenever the daily variable
+# set changes; the rename is what protects the previous daily store.
+# Beaker datasets are created by the argo pod's account (andrep), so training
+# configs reference andrep/<beaker_dataset>. The daily store is written as a
+# bare <output_name>.zarr at the bucket root (data_path is its parent).
 #
 # The daily store carries every variable of the 6-hourly store: instantaneous
 # fields are 00Z snapshots (snapshot_names), 6h-mean fluxes are averaged to
@@ -20,6 +26,8 @@ stats:
   end_date: "2019-12-31"
   data_type: ERA5
 time_coarsen:
+  # No chunking/sharding block: the defaults (time chunk 1, time shard 360)
+  # are what produced the existing 4deg daily store.
   factor: 4
   data_output_directory: gs://vcm-ml-intermediate
   stats_output_directory: gs://vcm-ml-intermediate/2026-09-08-era5-4deg-8layer-daily-stats-1990-2019

--- a/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
+++ b/scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml
@@ -1,21 +1,8 @@
-# ERA5 4deg 8-layer dataset: 6-hourly stats plus the daily (factor-4 time
-# coarsened) store and its stats. Run from this directory with
+# 6-hourly ERA5 stats plus the daily (factor-4 coarsened) store and its stats:
 #   ./compute_dataset.sh --time-coarsen --stats --config configs/era5-4deg-8layer-1940-2025.yaml
-# (never --dataset: the 6-hourly store is produced by scripts/era5). The stats,
-# combine-stats and beaker-upload steps skip outputs that already exist, so the
-# 6-hourly stats and their beaker dataset are not recomputed. The time-coarsen
-# step does not skip (its check is a local-path test that is always false on
-# gs:// paths) and rewrites its output, so give the daily store, its stats
-# directory and its beaker dataset new dated names whenever the daily variable
-# set changes; the rename is what protects the previous daily store.
-# Beaker datasets are created by the argo pod's account (andrep), so training
-# configs reference andrep/<beaker_dataset>. The daily store is written as a
-# bare <output_name>.zarr at the bucket root (data_path is its parent).
-#
-# The daily store carries every variable of the 6-hourly store: instantaneous
-# fields are 00Z snapshots (snapshot_names), 6h-mean fluxes are averaged to
-# daily means (window_names), and time-invariant fields are copied
-# (constant_prefixes). Variables in none of the lists are silently dropped.
+# The 6-hourly store comes from scripts/era5, so never pass --dataset. Existing
+# stats are skipped but the coarsened store is rewritten, so rename the daily
+# outputs when changing the variable lists. Variables in no list are dropped.
 runs:
   2026-08-13-era5-4deg-8layer-1940-2025: ""  # no real data source, config only for computing stats
 data_output_directory: gs://vcm-ml-intermediate
@@ -26,8 +13,14 @@ stats:
   end_date: "2019-12-31"
   data_type: ERA5
 time_coarsen:
-  # No chunking/sharding block: the defaults (time chunk 1, time shard 360)
-  # are what produced the existing 4deg daily store.
+  chunking:
+    time: 1
+    latitude: 45
+    longitude: 90
+  sharding:  # 16x the 1deg time shard, so shard objects are a similar size
+    time: 3600
+    latitude: 45
+    longitude: 90
   factor: 4
   data_output_directory: gs://vcm-ml-intermediate
   stats_output_directory: gs://vcm-ml-intermediate/2026-09-08-era5-4deg-8layer-daily-stats-1990-2019


### PR DESCRIPTION
The daily 1deg and 4deg ERA5 stores are produced by time-coarsening the 6-hourly stores, keeping only the variables the config lists. The lists covered 113 of the 6-hourly store's 163 variables and left out `PRMSL`, `eastward_surface_stress` and `northward_surface_stress`, which the 1deg training recipe outputs. Training configs that need both the `*_mean` channels of the 2026-08-13 daily store and those three outputs have been merging two daily stores (the 2026-08-13 store plus the 2026-07-24 one), doubling the weka reads, and the 4deg paper-recipe replication drops the three outputs entirely. This PR lists every 6-hourly variable in both daily configs so the regenerated daily stores are a superset of every channel a config reads today.

The 50 added variables, grouped by how the coarsen treats them:

- **snapshot (00Z value; instantaneous analysis fields)**: `PRMSL`; `Q`, `TMP`, `UGRD`, `VGRD` at 50, 100, 250, 700 and 1000 hPa; `h50`, `h100`; `soil_temperature_0`–`3`; `surface_snow_amount`, `surface_snow_area_fraction`, `surface_snow_thickness`; `sea_surface_temperature`, `merged_sea_surface_and_skin_temperature`, `significant_height_of_combined_wind_waves_and_swell`.
- **window (daily mean of the four 6h means; all derived from ERA5 accumulated `mean_*` rates)**: `DCLWRFsfc`, `DCSWRFsfc`, `UCLWRFsfc`, `UCLWRFtoa`, `UCSWRFsfc`, `UCSWRFtoa`, `runoff_flux`, `eastward_surface_stress`, `northward_surface_stress`.
- **constant (no time dimension)**: the eight `*_soil_type_fraction` fields.

`PRMSL` is a snapshot despite ERA5 calling its source `mean_sea_level_pressure`: the ingest pipeline opens it on the analysis time slice, never through the hourly-to-6-hourly averaging. The classification matches the 2026-07-24 store's own `snapshot_names`/`window_names` attributes and the unmerged `scripts/era5-daily-land-variables` config on the names they share. Verified against the 2026-08-13 6-hourly stores (1deg and 4deg have the same 163 variables): every listed name exists, the three lists are disjoint, constants have no `time` dimension, and the union covers every variable.

The daily store and its stats directory are renamed to 2026-09-08 and a `time_coarsen.beaker_dataset` is added (main's configs had none, so the 2026-08-13 daily stats are GCS-only). The 6-hourly store and stats keep their 2026-08-13 names: the stats, combine-stats and beaker-upload steps skip existing outputs, and the 6h beaker datasets already exist under `andrep`, the argo pod's account. The time-coarsen step does not skip (`time_coarsen.py` tests `os.path.exists` on a `gs://` path, always false, while `fs_utils.path_exists` sits beside it), so the rename is what protects the live 2026-08-13 daily stores; fixing that check is a one-line follow-up outside this config-only PR. For consumers: the new stats beaker datasets will be `andrep/2026-09-08-era5-{1,4}deg-8layer-daily-stats-1990-2019`, and the new stores are bare `.zarr` directories at the bucket root (`data_path` is the parent), unlike the 2026-07-24 wrapper-directory layout.

The intended run is `./compute_dataset.sh --time-coarsen --stats --config <config>` for each resolution, which has not been submitted yet.

Changes:
- `scripts/data_process/configs/era5-1deg-8layer-1940-2025.yaml`, `scripts/data_process/configs/era5-4deg-8layer-1940-2025.yaml`: add the 50 missing variables to `time_coarsen.snapshot_names` / `window_names` / `constant_prefixes`; rename the daily store and daily stats directory to 2026-09-08; add `time_coarsen.beaker_dataset` so the daily stats are published to beaker; short header comment with the run command and the rename rule.
- `era5-4deg-8layer-1940-2025.yaml`: explicit `chunking` (1, 45, 90) and `sharding` (3600, 45, 90) for the daily store, so 4deg shard objects are the same order of size as the 1deg store's (360-step shards on 180x360).

- [ ] Tests added (config-only change; `scripts/data_process/test_config.py` already parses every config in the directory against the `time_coarsen`, `get_stats`, `combine_stats` and `upload_stats` Config classes, so both files are covered by existing CI)
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated