### PR TITLE
Make enso_coefficient cross-process reduction unconditional

### DIFF
--- a/fme/ace/aggregator/inference/enso/enso_coefficient.py
+++ b/fme/ace/aggregator/inference/enso/enso_coefficient.py
@@ -106,6 +106,11 @@ class EnsoCoefficientEvaluatorAggregator:
         n_samples = len(self._sample_index_series)
         self._target_covariances: list[TensorDict] = [{} for _ in range(n_samples)]
         self._gen_covariances: list[TensorDict] = [{} for _ in range(n_samples)]
+        # spatial shape of each variable, tracked on every process regardless of
+        # whether any of its samples overlap the reference index, so that a
+        # process without data can still take part in the cross-process reduction
+        self._target_shapes: dict[str, torch.Size] = {}
+        self._gen_shapes: dict[str, torch.Size] = {}
         self._index_variance: list[torch.Tensor] = [
             torch.tensor(0.0, dtype=torch.float32, device=get_device())
             for _ in range(n_samples)
@@ -133,6 +138,12 @@ class EnsoCoefficientEvaluatorAggregator:
         assert time.sizes["sample"] == len(
             self._sample_index_series
         ), "number of index series must match number of samples"
+        for shapes, batch_data in (
+            (self._target_shapes, target_data),
+            (self._gen_shapes, gen_data),
+        ):
+            for name, tensor in batch_data.items():
+                shapes[name] = tensor.shape[2:]
         for i_sample, sample_index_series in enumerate(self._sample_index_series):
             if sample_index_series is not None:
                 sample_index_series_window = sample_index_series.sel(
@@ -188,59 +199,16 @@ class EnsoCoefficientEvaluatorAggregator:
 
     def _get_coefficients(self) -> tuple[TensorDict | None, TensorDict | None]:
         dist = Distributed.get_instance()
-        target_coefficients = self._compute_coefficients("target")
-        gen_coefficients = self._compute_coefficients("gen")
-        # average coefficients across samples
-        target_coefficients_all, gen_coefficients_all = {}, {}
-        target_names = set(
-            [
-                name
-                for target_coefficient in target_coefficients
-                for name in target_coefficient.keys()
-            ]
+        # Every process must make the same collective calls in the same order,
+        # including processes whose samples do not overlap the reference index.
+        # Whether a process has data is data-dependent, so making participation
+        # conditional on it would hang the processes that do have data.
+        reduced_target_coefficients = reduce_sample_coefficients(
+            dist, self._compute_coefficients("target"), self._target_shapes
         )
-        for name in target_names:
-            target_coefficients_all[name] = (
-                torch.stack(
-                    [
-                        target_coefficient[name]
-                        for target_coefficient in target_coefficients
-                        if name in target_coefficient
-                    ],
-                    dim=0,
-                )
-                .mean(dim=0)
-                .to(device=get_device())
-            )
-        gen_names = set(
-            [
-                name
-                for gen_coefficient in gen_coefficients
-                for name in gen_coefficient.keys()
-            ]
+        reduced_gen_coefficients = reduce_sample_coefficients(
+            dist, self._compute_coefficients("gen"), self._gen_shapes
         )
-        for name in gen_names:
-            gen_coefficients_all[name] = (
-                torch.stack(
-                    [
-                        gen_coefficient[name]
-                        for gen_coefficient in gen_coefficients
-                        if name in gen_coefficient
-                    ],
-                    dim=0,
-                )
-                .mean(dim=0)
-                .to(device=get_device())
-            )
-        # average coefficients across processes
-        if target_coefficients_all:
-            reduced_target_coefficients = reduce_data(dist, target_coefficients_all)
-        else:
-            reduced_target_coefficients = None
-        if gen_coefficients_all:
-            reduced_gen_coefficients = reduce_data(dist, gen_coefficients_all)
-        else:
-            reduced_gen_coefficients = None
         return reduced_target_coefficients, reduced_gen_coefficients
 
     @torch.no_grad()
@@ -437,28 +405,63 @@ def data_index_covariance(
     return (data * index_values_broadcast).sum(dim=index_dim)
 
 
-def reduce_data(dist: Distributed, rank_tensor_dict: TensorDict) -> TensorDict | None:
-    """Reduce tensor dicts across distributed processes by taking the mean.
+def reduce_sample_coefficients(
+    dist: Distributed,
+    sample_coefficients: list[TensorDict],
+    shapes: Mapping[str, torch.Size],
+) -> TensorDict | None:
+    """Average per-sample coefficients over the samples of all processes.
+
+    Samples whose inference period does not overlap the reference index
+    contribute no coefficients, and a process may have no contributing samples
+    at all. Every process still takes part in the collectives below, and the
+    mean is weighted by each process's number of contributing samples so that
+    the processes without data neither deadlock nor bias the result.
 
     Args:
         dist: Distributed instance.
-        rank_tensor_dict: Tensor dict to reduce.
+        sample_coefficients: Coefficients for each sample, empty for samples
+            that do not overlap the reference index.
+        shapes: Spatial shape of each variable, known on every process.
 
     Returns:
-        Reduced tensor dict.
+        Mean coefficients on the root process, or None if this is not the root
+        process or if no sample on any process had coefficients.
     """
-    if dist.is_distributed():
-        # sort for determinism
-        names = sorted(list(rank_tensor_dict.keys()))
-        rank_tensor = torch.stack([rank_tensor_dict[name] for name in names], dim=0)
-        reduced_tensor = dist.reduce_mean(rank_tensor)
-        gathered_tensor_dict = {name: reduced_tensor[i] for i, name in enumerate(names)}
-    else:
-        gathered_tensor_dict = rank_tensor_dict
-    if dist.is_root():
-        return gathered_tensor_dict
-    else:
+    # sort for determinism: every process must stack its variables in the same
+    # order for the collectives below to line up across processes
+    names = sorted(shapes)
+    if not names:
+        # no batches have been recorded, which is true on all processes
         return None
+    device = get_device()
+    summed = torch.stack(
+        [
+            torch.zeros(shapes[name], dtype=torch.float32, device=device)
+            for name in names
+        ],
+        dim=0,
+    )
+    counts = torch.zeros(len(names), dtype=torch.float32, device=device)
+    for coefficients in sample_coefficients:
+        for i, name in enumerate(names):
+            if name in coefficients:
+                summed[i] += coefficients[name]
+                counts[i] += 1
+    if dist.is_distributed():
+        summed = dist.reduce_sum(summed)
+        counts = dist.reduce_sum(counts)
+    if not dist.is_root():
+        return None
+    reduced = {
+        name: summed[i] / counts[i]
+        for i, name in enumerate(names)
+        if counts[i].item() > 0
+    }
+    if not reduced:
+        # no sample on any process overlapped the reference index
+        return None
+    return reduced
 
 
 @dataclasses.dataclass

--- a/fme/ace/aggregator/inference/enso/enso_coefficient.py
+++ b/fme/ace/aggregator/inference/enso/enso_coefficient.py
@@ -109,8 +109,8 @@ class EnsoCoefficientEvaluatorAggregator:
         # spatial shape of each variable, tracked on every process regardless of
         # whether any of its samples overlap the reference index, so that a
         # process without data can still take part in the cross-process reduction
-        self._target_shapes: dict[str, torch.Size] = {}
-        self._gen_shapes: dict[str, torch.Size] = {}
+        self._target_spatial_shapes: dict[str, torch.Size] = {}
+        self._gen_spatial_shapes: dict[str, torch.Size] = {}
         self._index_variance: list[torch.Tensor] = [
             torch.tensor(0.0, dtype=torch.float32, device=get_device())
             for _ in range(n_samples)
@@ -138,12 +138,12 @@ class EnsoCoefficientEvaluatorAggregator:
         assert time.sizes["sample"] == len(
             self._sample_index_series
         ), "number of index series must match number of samples"
-        for shapes, batch_data in (
-            (self._target_shapes, target_data),
-            (self._gen_shapes, gen_data),
+        for spatial_shapes, batch_data in (
+            (self._target_spatial_shapes, target_data),
+            (self._gen_spatial_shapes, gen_data),
         ):
             for name, tensor in batch_data.items():
-                shapes[name] = tensor.shape[2:]
+                spatial_shapes[name] = tensor.shape[2:]
         for i_sample, sample_index_series in enumerate(self._sample_index_series):
             if sample_index_series is not None:
                 sample_index_series_window = sample_index_series.sel(
@@ -199,15 +199,11 @@ class EnsoCoefficientEvaluatorAggregator:
 
     def _get_coefficients(self) -> tuple[TensorDict | None, TensorDict | None]:
         dist = Distributed.get_instance()
-        # Every process must make the same collective calls in the same order,
-        # including processes whose samples do not overlap the reference index.
-        # Whether a process has data is data-dependent, so making participation
-        # conditional on it would hang the processes that do have data.
         reduced_target_coefficients = reduce_sample_coefficients(
-            dist, self._compute_coefficients("target"), self._target_shapes
+            dist, self._compute_coefficients("target"), self._target_spatial_shapes
         )
         reduced_gen_coefficients = reduce_sample_coefficients(
-            dist, self._compute_coefficients("gen"), self._gen_shapes
+            dist, self._compute_coefficients("gen"), self._gen_spatial_shapes
         )
         return reduced_target_coefficients, reduced_gen_coefficients
 
@@ -408,7 +404,7 @@ def data_index_covariance(
 def reduce_sample_coefficients(
     dist: Distributed,
     sample_coefficients: list[TensorDict],
-    shapes: Mapping[str, torch.Size],
+    spatial_shapes: Mapping[str, torch.Size],
 ) -> TensorDict | None:
     """Average per-sample coefficients over the samples of all processes.
 
@@ -422,7 +418,7 @@ def reduce_sample_coefficients(
         dist: Distributed instance.
         sample_coefficients: Coefficients for each sample, empty for samples
             that do not overlap the reference index.
-        shapes: Spatial shape of each variable, known on every process.
+        spatial_shapes: Spatial shape of each variable, known on every process.
 
     Returns:
         Mean coefficients on the root process, or None if this is not the root
@@ -430,14 +426,14 @@ def reduce_sample_coefficients(
     """
     # sort for determinism: every process must stack its variables in the same
     # order for the collectives below to line up across processes
-    names = sorted(shapes)
+    names = sorted(spatial_shapes)
     if not names:
         # no batches have been recorded, which is true on all processes
         return None
     device = get_device()
     summed = torch.stack(
         [
-            torch.zeros(shapes[name], dtype=torch.float32, device=device)
+            torch.zeros(spatial_shapes[name], dtype=torch.float32, device=device)
             for name in names
         ],
         dim=0,

--- a/fme/ace/aggregator/inference/enso/test_enso_coefficient.py
+++ b/fme/ace/aggregator/inference/enso/test_enso_coefficient.py
@@ -344,7 +344,7 @@ def test_reduce_sample_coefficients_weights_by_sample_count():
     processes, so that a process with more of them carries more weight and
     samples without index overlap do not dilute the mean toward zero.
     """
-    shapes = {"a": torch.Size([2, 2]), "b": torch.Size([2, 2])}
+    spatial_shapes = {"a": torch.Size([2, 2]), "b": torch.Size([2, 2])}
     ones = torch.ones([2, 2], device=get_device())
     # this process: two samples overlapping the index, and one that does not
     sample_coefficients = [
@@ -359,7 +359,7 @@ def test_reduce_sample_coefficients_weights_by_sample_count():
     ]
     with _mock_distributed_singleton(_FakeDistributed(contributions)):
         reduced = reduce_sample_coefficients(
-            Distributed.get_instance(), sample_coefficients, shapes
+            Distributed.get_instance(), sample_coefficients, spatial_shapes
         )
     assert reduced is not None
     # (1.0 + 3.0 + 8.0) / 3 samples, not the (2.0 + 8.0) / 2 process-mean
@@ -372,13 +372,13 @@ def test_reduce_sample_coefficients_none_when_no_process_has_samples():
     """When no sample on any process overlaps the reference index, every
     process reports no coefficients rather than a mean of zeros.
     """
-    shapes = {"a": torch.Size([2, 2]), "b": torch.Size([2, 2])}
+    spatial_shapes = {"a": torch.Size([2, 2]), "b": torch.Size([2, 2])}
     contributions = [
         torch.zeros([2, 2, 2], device=get_device()),
         torch.tensor([0.0, 0.0], device=get_device()),
     ]
     with _mock_distributed_singleton(_FakeDistributed(contributions)):
         reduced = reduce_sample_coefficients(
-            Distributed.get_instance(), [{}, {}], shapes
+            Distributed.get_instance(), [{}, {}], spatial_shapes
         )
     assert reduced is None

--- a/fme/ace/aggregator/inference/enso/test_enso_coefficient.py
+++ b/fme/ace/aggregator/inference/enso/test_enso_coefficient.py
@@ -7,10 +7,16 @@ import torch
 import xarray as xr
 
 from fme.ace.aggregator.inference.data import InferenceBatchData
+from fme.core import metrics
 from fme.core.device import get_device
+from fme.core.distributed import Distributed, distributed
 from fme.core.gridded_ops import LatLonOperations
 
-from .enso_coefficient import OVERLAP_THRESHOLD, EnsoCoefficientEvaluatorAggregator
+from .enso_coefficient import (
+    OVERLAP_THRESHOLD,
+    EnsoCoefficientEvaluatorAggregator,
+    reduce_sample_coefficients,
+)
 
 
 @contextmanager
@@ -236,3 +242,143 @@ def test_enso_agg_calendar(calendar):
     enso_agg.record_batch(batch)
     target_coefficients, gen_coefficients = enso_agg._get_coefficients()
     assert (target_coefficients is not None) and (gen_coefficients is not None)
+
+
+@contextmanager
+def _mock_distributed_singleton(backend):
+    """Install a fake backend as the distributed singleton."""
+    original_singleton = distributed.singleton
+    original_entered = Distributed._entered
+    distributed.singleton = backend
+    Distributed._entered = True  # the fake stands in for an entered context
+    try:
+        yield backend
+    finally:
+        distributed.singleton = original_singleton
+        Distributed._entered = original_entered
+
+
+class _FakeDistributed:
+    """Stands in for the distributed singleton of a two-process job.
+
+    Records the collectives this process takes part in, and optionally adds a
+    second process's contribution to each of them, supplied in call order.
+    """
+
+    world_size = 2
+
+    def __init__(self, contributions: list[torch.Tensor] | None = None):
+        self.calls: list[tuple[str, tuple[int, ...]]] = []
+        self._contributions = None if contributions is None else list(contributions)
+
+    def is_distributed(self) -> bool:
+        return True
+
+    def is_root(self) -> bool:
+        return True
+
+    def reduce_sum(self, tensor: torch.Tensor) -> torch.Tensor:
+        self.calls.append(("reduce_sum", tuple(tensor.shape)))
+        if self._contributions is None:
+            return tensor
+        return tensor + self._contributions.pop(0)
+
+    def weighted_mean(self, data, weights, dim, keepdim=False) -> torch.Tensor:
+        # not a collective; used by the area-weighted RMSE in get_logs
+        return metrics.weighted_mean(data, weights, dim=dim, keepdim=keepdim)
+
+
+def _record_collectives(shift: float) -> tuple[list[tuple[str, tuple[int, ...]]], dict]:
+    """Run an aggregator whose samples are shifted by `shift` index durations,
+    and report the collectives it took part in along with its logs.
+    """
+    n_samples, n_times, n_lat, n_lon = 2, 28, 3, 3
+    data_scale = 3
+    area_weights = torch.ones([n_lat, n_lon], device=get_device())
+    enso_index, sample_time, target_data, gen_data = _get_data(
+        data_scale, n_samples, n_times, n_lat, n_lon
+    )
+    index_duration = enso_index.time[-1].item() - enso_index.time[0].item()
+    sample_time = sample_time + datetime.timedelta(
+        seconds=shift * index_duration.total_seconds()
+    )
+    with change_aggregator_enso_index(EnsoCoefficientEvaluatorAggregator, enso_index):
+        enso_agg = EnsoCoefficientEvaluatorAggregator(
+            initial_time=sample_time.isel(time=0),
+            n_forward_timesteps=(n_times - 1),
+            timestep=datetime.timedelta(hours=6),
+            gridded_operations=LatLonOperations(area_weights),
+        )
+    enso_agg.record_batch(
+        InferenceBatchData(
+            prediction=gen_data,
+            prediction_norm={},
+            target=target_data,
+            target_norm=None,
+            time=sample_time,
+            i_time_start=0,
+        )
+    )
+    with _mock_distributed_singleton(_FakeDistributed()) as recorder:
+        logs = enso_agg.get_logs("enso_coefficients")
+    return recorder.calls, logs
+
+
+def test_collectives_do_not_depend_on_index_overlap():
+    """A process whose samples do not overlap the reference index must still
+    take part in the same collectives, in the same order, as one whose samples
+    do. Otherwise the processes with data block in the reduction waiting for
+    processes that never enter it, and the job dies at the collective timeout.
+    """
+    overlapping_calls, overlapping_logs = _record_collectives(shift=0.0)
+    # shifted a full index duration and a half past the reference index
+    inert_calls, inert_logs = _record_collectives(shift=1.5)
+    assert len(overlapping_calls) > 0
+    assert inert_calls == overlapping_calls
+    assert len(overlapping_logs) > 0
+    assert inert_logs == {}
+
+
+def test_reduce_sample_coefficients_weights_by_sample_count():
+    """Coefficients are averaged over contributing samples across all
+    processes, so that a process with more of them carries more weight and
+    samples without index overlap do not dilute the mean toward zero.
+    """
+    shapes = {"a": torch.Size([2, 2]), "b": torch.Size([2, 2])}
+    ones = torch.ones([2, 2], device=get_device())
+    # this process: two samples overlapping the index, and one that does not
+    sample_coefficients = [
+        {"a": ones, "b": -ones},
+        {"a": 3.0 * ones, "b": -3.0 * ones},
+        {},
+    ]
+    # the other process: a single overlapping sample, coefficients 8.0 and -8.0
+    contributions = [
+        torch.stack([8.0 * ones, -8.0 * ones], dim=0),
+        torch.tensor([1.0, 1.0], device=get_device()),
+    ]
+    with _mock_distributed_singleton(_FakeDistributed(contributions)):
+        reduced = reduce_sample_coefficients(
+            Distributed.get_instance(), sample_coefficients, shapes
+        )
+    assert reduced is not None
+    # (1.0 + 3.0 + 8.0) / 3 samples, not the (2.0 + 8.0) / 2 process-mean
+    assert torch.allclose(reduced["a"], torch.full([2, 2], 4.0, device=get_device()))
+    # each variable is averaged independently, not pooled with the others
+    assert torch.allclose(reduced["b"], torch.full([2, 2], -4.0, device=get_device()))
+
+
+def test_reduce_sample_coefficients_none_when_no_process_has_samples():
+    """When no sample on any process overlaps the reference index, every
+    process reports no coefficients rather than a mean of zeros.
+    """
+    shapes = {"a": torch.Size([2, 2]), "b": torch.Size([2, 2])}
+    contributions = [
+        torch.zeros([2, 2, 2], device=get_device()),
+        torch.tensor([0.0, 0.0], device=get_device()),
+    ]
+    with _mock_distributed_singleton(_FakeDistributed(contributions)):
+        reduced = reduce_sample_coefficients(
+            Distributed.get_instance(), [{}, {}], shapes
+        )
+    assert reduced is None


### PR DESCRIPTION
<!-- This description becomes the squash-and-merge commit message: keep it self-contained and describe the final state from main. Put PR-process notes (stacking/rebase, review responses, commit-by-commit narratives) in a PR comment, not here. -->
The ENSO coefficient aggregator conditionally entered cross-process reductions only when a process had samples overlapping the reference index. Whether a process has overlapping data is data-dependent, so when some processes had data and others did not, the processes with data would block in the collective waiting for processes that never entered it, hanging until the collective timeout killed the job.

Every process now takes part in the same collectives unconditionally, weighted by its number of contributing samples, so a process whose samples do not overlap the reference index can neither deadlock nor bias the result.

Changes:
- `EnsoCoefficientEvaluatorAggregator`: track per-variable spatial shapes (`_target_spatial_shapes`, `_gen_spatial_shapes`) on every process so that processes without data know what to reduce
- `EnsoCoefficientEvaluatorAggregator._get_coefficients`: replace conditional reduction with unconditional calls to the new `reduce_sample_coefficients`
- `reduce_sample_coefficients` (replaces `reduce_data`): every process participates in `reduce_sum` over both the coefficient values and the per-variable sample counts, then divides on root to get a properly weighted mean; the `spatial_shapes` parameter tells every process the shape of each variable
- Tests: `test_collectives_do_not_depend_on_index_overlap` verifies overlapping and non-overlapping processes issue the same collective calls; `test_reduce_sample_coefficients_weights_by_sample_count` and `test_reduce_sample_coefficients_none_when_no_process_has_samples` cover the new reduction logic

- [x] Tests added