### PR TITLE
Allow parameter_init to load a checkpoint into a submodule of the destination

### DIFF
--- a/fme/ace/stepper/parameter_init.py
+++ b/fme/ace/stepper/parameter_init.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from fme.core.device import get_device
 from fme.core.training_history import TrainingHistory
-from fme.core.weight_ops import overwrite_weights
+from fme.core.weight_ops import overwrite_weights, prefix_submodule
 from fme.core.wildcard import apply_by_exclude, apply_by_include, wildcard_match
 
 Weights = list[Mapping[str, Any]]
@@ -106,6 +106,19 @@ class ParameterInitializationConfig:
     Parameters:
         weights_path: path to a Stepper checkpoint
             containing weights to load
+        weights_submodule: dotted name of the submodule of the module being
+            initialized that the checkpoint's module corresponds to. Use it
+            when the destination wraps the checkpoint's architecture, so the
+            checkpoint's parameters live one level down: initializing a
+            noise-conditioned module from a deterministic checkpoint of the
+            same network needs ``conditional_model``, since
+            ``NoiseConditionedModel`` holds the wrapped network under that
+            name. Every loaded parameter name is prefixed with it before being
+            matched against the destination, so ``parameters`` exclude and
+            frozen patterns are written against destination names either way.
+            Parameters the destination has and the checkpoint does not (the
+            zero-initialized conditioning layers, for instance) keep their
+            initialized values.
         parameters: list of ParameterClassification objects, each specifying
             whether parameters are excluded from initialization or frozen.
             By default modules are unfrozen and all parameters are included.
@@ -120,6 +133,7 @@ class ParameterInitializationConfig:
     """
 
     weights_path: str | None = None
+    weights_submodule: str | None = None
     parameters: list[ParameterClassification] = dataclasses.field(default_factory=list)
     alpha: float = 0.0
     beta: float = 0.0
@@ -127,6 +141,17 @@ class ParameterInitializationConfig:
     frozen_parameters: FrozenParameterConfig | None = None
 
     def __post_init__(self):
+        if self.weights_submodule is not None:
+            if self.weights_path is None:
+                raise ValueError(
+                    "weights_submodule has no effect without weights_path; "
+                    "it renames the parameters loaded from that checkpoint."
+                )
+            if not self.weights_submodule or self.weights_submodule.endswith("."):
+                raise ValueError(
+                    "weights_submodule must be a dotted submodule name without a "
+                    f"trailing '.', got {self.weights_submodule!r}"
+                )
         if self.exclude_parameters is not None or self.frozen_parameters is not None:
             if len(self.parameters) > 0:
                 raise ValueError(
@@ -154,6 +179,15 @@ class ParameterInitializationConfig:
         return ParameterInitializer(
             config=self, load_weights_and_history=load_weights_and_history
         )
+
+
+def _maybe_prefixed(
+    state_dict: Mapping[str, Any], submodule: str | None
+) -> Mapping[str, Any]:
+    """``prefix_submodule`` when a submodule is configured, else a passthrough."""
+    if submodule is None:
+        return state_dict
+    return prefix_submodule(state_dict, submodule)
 
 
 def null_weights_and_history(*_) -> StepperWeightsAndHistory:
@@ -211,7 +245,7 @@ class ParameterInitializer:
                 modules, self.base_weights, filled_parameters
             ):
                 overwrite_weights(
-                    state_dict,
+                    _maybe_prefixed(state_dict, self.config.weights_submodule),
                     module,
                     exclude_parameters=classification.exclude,
                 )

--- a/fme/ace/stepper/parameter_init.py
+++ b/fme/ace/stepper/parameter_init.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from fme.core.device import get_device
 from fme.core.training_history import TrainingHistory
-from fme.core.weight_ops import overwrite_weights, prefix_submodule
+from fme.core.weight_ops import overwrite_weights, prefix_submodule, require_subset
 from fme.core.wildcard import apply_by_exclude, apply_by_include, wildcard_match
 
 Weights = list[Mapping[str, Any]]
@@ -114,11 +114,13 @@ class ParameterInitializationConfig:
             same network needs ``conditional_model``, since
             ``NoiseConditionedModel`` holds the wrapped network under that
             name. Every loaded parameter name is prefixed with it before being
-            matched against the destination, so ``parameters`` exclude and
-            frozen patterns are written against destination names either way.
-            Parameters the destination has and the checkpoint does not (the
-            zero-initialized conditioning layers, for instance) keep their
-            initialized values.
+            matched against the destination, both when the weights are loaded
+            and when ``alpha``/``beta`` pair them with the current weights, so
+            ``parameters`` exclude and frozen patterns are written against
+            destination names either way. Parameters the destination has and
+            the checkpoint does not (the zero-initialized conditioning layers,
+            for instance) keep their initialized values. Raises at
+            initialization if no weights were loaded to rename.
         parameters: list of ParameterClassification objects, each specifying
             whether parameters are excluded from initialization or frozen.
             By default modules are unfrozen and all parameters are included.
@@ -142,15 +144,16 @@ class ParameterInitializationConfig:
 
     def __post_init__(self):
         if self.weights_submodule is not None:
-            if self.weights_path is None:
+            # Not validated against weights_path here: the coupled stepper
+            # loads component weights from CoupledParameterInitConfig's
+            # checkpoint, which requires weights_path to be None. Whether any
+            # weights were actually loaded is known only to the initializer,
+            # so apply_weights raises there instead.
+            if any(segment == "" for segment in self.weights_submodule.split(".")):
                 raise ValueError(
-                    "weights_submodule has no effect without weights_path; "
-                    "it renames the parameters loaded from that checkpoint."
-                )
-            if not self.weights_submodule or self.weights_submodule.endswith("."):
-                raise ValueError(
-                    "weights_submodule must be a dotted submodule name without a "
-                    f"trailing '.', got {self.weights_submodule!r}"
+                    "weights_submodule must be a dotted submodule name with no "
+                    "empty segments (no leading, trailing or doubled '.'), got "
+                    f"{self.weights_submodule!r}"
                 )
         if self.exclude_parameters is not None or self.frozen_parameters is not None:
             if len(self.parameters) > 0:
@@ -180,14 +183,18 @@ class ParameterInitializationConfig:
             config=self, load_weights_and_history=load_weights_and_history
         )
 
+    @property
+    def has_submodule_prefix(self) -> bool:
+        """Whether loaded weights are renamed onto a submodule."""
+        return self.weights_submodule is not None
 
-def _maybe_prefixed(
-    state_dict: Mapping[str, Any], submodule: str | None
-) -> Mapping[str, Any]:
-    """``prefix_submodule`` when a submodule is configured, else a passthrough."""
-    if submodule is None:
-        return state_dict
-    return prefix_submodule(state_dict, submodule)
+    def apply_submodule_prefix(
+        self, state_dict: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        """Rename loaded weights onto the configured submodule, if any."""
+        if self.weights_submodule is None:
+            return state_dict
+        return prefix_submodule(state_dict, self.weights_submodule)
 
 
 def null_weights_and_history(*_) -> StepperWeightsAndHistory:
@@ -240,15 +247,23 @@ class ParameterInitializer:
             modules: a list of nn.Modules to initialize
         """
         filled_parameters = self._filled_parameters(len(modules))
-        if self.base_weights is not None:
-            for module, state_dict, classification in zip(
-                modules, self.base_weights, filled_parameters
-            ):
-                overwrite_weights(
-                    _maybe_prefixed(state_dict, self.config.weights_submodule),
-                    module,
-                    exclude_parameters=classification.exclude,
+        if self.base_weights is None:
+            if self.config.has_submodule_prefix:
+                raise ValueError(
+                    "weights_submodule is set but no weights were loaded, so it "
+                    "has nothing to rename. Set weights_path, or the coupled "
+                    "CoupledParameterInitConfig.checkpoint_path, to the "
+                    "checkpoint whose parameters it names."
                 )
+            return
+        for module, state_dict, classification in zip(
+            modules, self.base_weights, filled_parameters
+        ):
+            overwrite_weights(
+                self.config.apply_submodule_prefix(state_dict),
+                module,
+                exclude_parameters=classification.exclude,
+            )
 
     def freeze_weights(self, modules: list[nn.Module]):
         """
@@ -290,18 +305,21 @@ class ParameterInitializer:
         if base_weights is not None and (
             self.config.alpha != 0 or self.config.beta != 0
         ):
-            for module, state_dict in zip(modules, base_weights):
-                state_dict = {
-                    name: value.to(device) for name, value in state_dict.items()
+            # Renamed onto the destination's names, exactly as apply_weights
+            # loaded them, so that the L2-SP terms pair each parameter with the
+            # base value it was initialized from and `exclude` patterns match
+            # destination names in both places.
+            base_weights = [
+                {
+                    name: value.to(device)
+                    for name, value in self.config.apply_submodule_prefix(
+                        state_dict
+                    ).items()
                 }
-                from_names = set(state_dict.keys())
-                to_names = set(module.state_dict().keys())
-                if not from_names.issubset(to_names):
-                    missing_parameters = from_names - to_names
-                    raise ValueError(
-                        f"Dest module is missing parameters {missing_parameters}, "
-                        "which is not allowed"
-                    )
+                for state_dict in base_weights
+            ]
+            for module, state_dict in zip(modules, base_weights):
+                require_subset(state_dict, module)
 
             def regularizer():
                 loss = torch.tensor(0.0, device=device)

--- a/fme/ace/stepper/test_parameter_init.py
+++ b/fme/ace/stepper/test_parameter_init.py
@@ -4,6 +4,7 @@ import copy
 import dataclasses
 import datetime
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 import numpy as np
@@ -465,3 +466,162 @@ def test_parameter_init_weights_loaded_once(tmpdir):
     )
     # the weights should not be loaded again
     mock_load_weights_and_history.assert_called_once()
+
+
+def _samudra_stepper_config(noise_embed_dim: int = 0) -> StepperConfig:
+    """A small Samudra stepper, deterministic or noise-conditioned.
+
+    Above zero ``noise_embed_dim`` the builder returns a NoiseConditionedModel
+    wrapping the Samudra, so the network's parameters move under
+    ``conditional_model`` and a further zero-initialized FiLM layer appears in
+    each conditioned block.
+    """
+    builder_config: dict[str, Any] = {
+        "ch_width": [8, 12],
+        "dilation": [1, 2],
+        "n_layers": [1, 1],
+    }
+    if noise_embed_dim > 0:
+        builder_config["noise_embed_dim"] = noise_embed_dim
+        builder_config["conditioned_blocks"] = "all_blocks"
+    return StepperConfig(
+        step=StepSelector(
+            type="single_module",
+            config=dataclasses.asdict(
+                SingleModuleStepConfig(
+                    builder=ModuleSelector(type="Samudra", config=builder_config),
+                    in_names=["x"],
+                    out_names=["x"],
+                    normalization=NetworkAndLossNormalizationConfig(
+                        network=NormalizationConfig(
+                            means={"x": 0.0},
+                            stds={"x": 1.0},
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_weights_submodule_loads_deterministic_checkpoint_into_wrapped_module(
+    tmpdir,
+):
+    """A noise-conditioned module initialized from a deterministic checkpoint
+    must reproduce that checkpoint's predictions exactly.
+
+    This is what makes "pretrain deterministic, then finetune stochastic" a
+    continuation rather than a restart: the conditioning layers are
+    zero-initialized, so the wrapped model at initialization *is* the
+    deterministic model. Asserting the parameter names matched is weaker --
+    it would pass even if the weights landed on the wrong tensors.
+    """
+    dataset_info = get_dataset_info()
+    deterministic = _samudra_stepper_config().get_stepper(dataset_info=dataset_info)
+    torch.save({"stepper": deterministic.get_state()}, str(tmpdir / "weights.ckpt"))
+
+    initializer = ParameterInitializationConfig(
+        weights_path=str(tmpdir / "weights.ckpt"),
+        weights_submodule="conditional_model",
+    ).build(load_weights_and_history)
+    conditioned = _samudra_stepper_config(noise_embed_dim=6).get_stepper(
+        dataset_info=dataset_info,
+        parameter_initializer=initializer,
+    )
+
+    # modules[0] is the DDP/DummyWrapper layer; .module is the network
+    loaded = conditioned.modules[0]
+    source = deterministic.modules[0]
+    loaded_network = loaded.module
+    # the wrapped network carries the checkpoint's weights verbatim. Its own
+    # state dict is a superset, because the conditioning layers live inside the
+    # ConvNeXt blocks and so appear under conditional_model too.
+    loaded_state = loaded_network.conditional_model.state_dict()
+    source_state = source.module.state_dict()
+    assert set(source_state).issubset(loaded_state)
+    for name, value in source_state.items():
+        assert torch.equal(loaded_state[name], value), name
+    # and the extra conditioning parameters are still at their zero init
+    film_scales = [
+        parameter
+        for name, parameter in loaded.named_parameters()
+        if "noise_conditioning" in name and "W_scale" in name
+    ]
+    assert len(film_scales) > 0
+    for parameter in film_scales:
+        assert torch.count_nonzero(parameter) == 0
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 1, 16, 32, device=get_device())
+    with torch.no_grad():
+        assert torch.equal(loaded(x), source(x))
+
+
+def test_weights_submodule_omitted_raises_naming_the_fix(tmpdir):
+    """Without weights_submodule the load fails, and the error says what to set."""
+    dataset_info = get_dataset_info()
+    deterministic = _samudra_stepper_config().get_stepper(dataset_info=dataset_info)
+    torch.save({"stepper": deterministic.get_state()}, str(tmpdir / "weights.ckpt"))
+
+    initializer = ParameterInitializationConfig(
+        weights_path=str(tmpdir / "weights.ckpt"),
+    ).build(load_weights_and_history)
+    with pytest.raises(ValueError, match="conditional_model"):
+        _samudra_stepper_config(noise_embed_dim=6).get_stepper(
+            dataset_info=dataset_info,
+            parameter_initializer=initializer,
+        )
+
+
+def test_weights_submodule_excludes_match_destination_names(tmpdir):
+    """Exclude patterns are written against destination names, prefix included."""
+    dataset_info = get_dataset_info()
+    deterministic = _samudra_stepper_config().get_stepper(dataset_info=dataset_info)
+    torch.save({"stepper": deterministic.get_state()}, str(tmpdir / "weights.ckpt"))
+
+    excluded = "module.conditional_model.layers.0.convblock.0.weight"
+    initializer = ParameterInitializationConfig(
+        weights_path=str(tmpdir / "weights.ckpt"),
+        weights_submodule="conditional_model",
+        parameters=[ParameterClassification(exclude=[excluded])],
+    ).build(load_weights_and_history)
+    conditioned = _samudra_stepper_config(noise_embed_dim=6).get_stepper(
+        dataset_info=dataset_info,
+        parameter_initializer=initializer,
+    )
+
+    loaded_state = conditioned.modules[0].state_dict()
+    source_state = deterministic.modules[0].state_dict()
+    assert not torch.equal(
+        loaded_state[excluded],
+        source_state["module.layers.0.convblock.0.weight"],
+    )
+    kept = "module.conditional_model.layers.0.convblock.0.bias"
+    assert torch.equal(
+        loaded_state[kept], source_state["module.layers.0.convblock.0.bias"]
+    )
+
+
+@pytest.mark.parametrize(
+    "config, message",
+    [
+        pytest.param(
+            {"weights_submodule": "conditional_model"},
+            "no effect without weights_path",
+            id="no_weights_path",
+        ),
+        pytest.param(
+            {"weights_path": "p.ckpt", "weights_submodule": "conditional_model."},
+            "without a trailing",
+            id="trailing_dot",
+        ),
+        pytest.param(
+            {"weights_path": "p.ckpt", "weights_submodule": ""},
+            "without a trailing",
+            id="empty",
+        ),
+    ],
+)
+def test_weights_submodule_config_validation(config, message):
+    with pytest.raises(ValueError, match=message):
+        ParameterInitializationConfig(**config)

--- a/fme/ace/stepper/test_parameter_init.py
+++ b/fme/ace/stepper/test_parameter_init.py
@@ -553,8 +553,14 @@ def test_weights_submodule_loads_deterministic_checkpoint_into_wrapped_module(
 
     torch.manual_seed(0)
     x = torch.randn(2, 1, 16, 32, device=get_device())
+    loaded.eval()
+    source.eval()
     with torch.no_grad():
         assert torch.equal(loaded(x), source(x))
+        # the conditioning is inert, not merely unlucky: the wrapper draws
+        # fresh noise on every call, and the zero-initialized FiLM scales mean
+        # that draw cannot reach the output.
+        assert torch.equal(loaded(x), loaded(x))
 
 
 def test_weights_submodule_omitted_raises_naming_the_fix(tmpdir):
@@ -603,25 +609,55 @@ def test_weights_submodule_excludes_match_destination_names(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "config, message",
-    [
-        pytest.param(
-            {"weights_submodule": "conditional_model"},
-            "no effect without weights_path",
-            id="no_weights_path",
-        ),
-        pytest.param(
-            {"weights_path": "p.ckpt", "weights_submodule": "conditional_model."},
-            "without a trailing",
-            id="trailing_dot",
-        ),
-        pytest.param(
-            {"weights_path": "p.ckpt", "weights_submodule": ""},
-            "without a trailing",
-            id="empty",
-        ),
-    ],
+    "submodule",
+    ["conditional_model.", ".conditional_model", "", "a..b"],
+    ids=["trailing_dot", "leading_dot", "empty", "doubled_dot"],
 )
-def test_weights_submodule_config_validation(config, message):
-    with pytest.raises(ValueError, match=message):
-        ParameterInitializationConfig(**config)
+def test_weights_submodule_rejects_empty_segments(submodule):
+    with pytest.raises(ValueError, match="empty segments"):
+        ParameterInitializationConfig(
+            weights_path="p.ckpt", weights_submodule=submodule
+        )
+
+
+def test_weights_submodule_without_loaded_weights_raises_at_apply():
+    """The precondition is that weights were loaded, not that weights_path was set.
+
+    The coupled stepper loads component weights from
+    CoupledParameterInitConfig.checkpoint_path, which requires the component's
+    weights_path to be None, so this cannot be checked in __post_init__.
+    """
+    config = ParameterInitializationConfig(weights_submodule="conditional_model")
+    initializer = config.build(load_weights_and_history)
+    with pytest.raises(ValueError, match="no weights were loaded"):
+        initializer.apply_weights([torch.nn.Linear(2, 2)])
+
+
+def test_weights_submodule_applies_to_the_l2_sp_regularizer(tmpdir):
+    """alpha/beta pair each parameter with the base value it was initialized from.
+
+    The regularizer looks up base weights by name in the destination module, so
+    it needs the same renaming apply_weights used; without it every name misses
+    and construction fails.
+    """
+    dataset_info = get_dataset_info()
+    deterministic = _samudra_stepper_config().get_stepper(dataset_info=dataset_info)
+    torch.save({"stepper": deterministic.get_state()}, str(tmpdir / "weights.ckpt"))
+
+    initializer = ParameterInitializationConfig(
+        weights_path=str(tmpdir / "weights.ckpt"),
+        weights_submodule="conditional_model",
+        alpha=1.0,
+    ).build(load_weights_and_history)
+    conditioned = _samudra_stepper_config(noise_embed_dim=6).get_stepper(
+        dataset_info=dataset_info,
+        parameter_initializer=initializer,
+    )
+    regularizer = initializer.get_l2_sp_tuning_regularizer(conditioned.modules)
+    # at initialization the weights are exactly the base weights, so the
+    # keep-close-to-base term is zero; it grows once they move.
+    assert torch.equal(regularizer(), torch.zeros((), device=get_device()))
+    with torch.no_grad():
+        for parameter in conditioned.modules[0].parameters():
+            parameter.add_(1.0)
+    assert regularizer() > 0.0

--- a/fme/core/test_weight_ops.py
+++ b/fme/core/test_weight_ops.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 from torch import nn
 
-from fme.core.weight_ops import CopyWeightsConfig, overwrite_weights
+from fme.core.weight_ops import CopyWeightsConfig, overwrite_weights, prefix_submodule
 
 
 class SimpleLinearModule(torch.nn.Module):
@@ -160,3 +160,38 @@ def test_apply_copy_weights_config(
                     param.detach().cpu().numpy(),
                     original_dest_model_state[name].detach().cpu().numpy(),
                 )
+
+
+def test_prefix_submodule_inserts_after_the_wrapper_prefix():
+    """The leading "module." names the DDP/DummyWrapper layer, not a submodule.
+
+    Prefixing in front of it would produce "conditional_model.module.…" and
+    match nothing, so the new name goes inside it.
+    """
+    renamed = prefix_submodule(
+        {"module.layers.0.weight": torch.zeros(1)}, "conditional_model"
+    )
+    assert list(renamed) == ["module.conditional_model.layers.0.weight"]
+
+
+def test_prefix_submodule_without_wrapper_prefix():
+    renamed = prefix_submodule({"layers.0.weight": torch.zeros(1)}, "wrapped")
+    assert list(renamed) == ["wrapped.layers.0.weight"]
+
+
+def test_overwrite_weights_error_names_the_submodule_that_would_fix_it():
+    class Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 2)
+
+    class Wrapper(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conditional_model = Inner()
+
+    from_state = Inner().state_dict()
+    with pytest.raises(ValueError, match="weights_submodule"):
+        overwrite_weights(from_state, Wrapper())
+    with pytest.raises(ValueError, match="conditional_model"):
+        overwrite_weights(from_state, Wrapper())

--- a/fme/core/test_weight_ops.py
+++ b/fme/core/test_weight_ops.py
@@ -179,6 +179,40 @@ def test_prefix_submodule_without_wrapper_prefix():
     assert list(renamed) == ["wrapped.layers.0.weight"]
 
 
+def test_prefix_submodule_accepts_a_dotted_submodule_name():
+    """A submodule more than one level down is named by its dotted path."""
+    renamed = prefix_submodule(
+        {
+            "module.layers.0.weight": torch.zeros(1),
+            "layers.0.bias": torch.zeros(1),
+        },
+        "outer.inner",
+    )
+    assert set(renamed) == {
+        "module.outer.inner.layers.0.weight",
+        "outer.inner.layers.0.bias",
+    }
+
+
+def test_missing_parameters_message_lists_every_candidate_submodule():
+    """Two submodules can satisfy the subset test, so neither is presented as
+    the answer."""
+
+    class Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 2)
+
+    class TwoWayWrapper(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.first = Inner()
+            self.second = Inner()
+
+    with pytest.raises(ValueError, match="'first' or 'second'"):
+        overwrite_weights(Inner().state_dict(), TwoWayWrapper())
+
+
 def test_overwrite_weights_error_names_the_submodule_that_would_fix_it():
     class Inner(torch.nn.Module):
         def __init__(self):

--- a/fme/core/weight_ops.py
+++ b/fme/core/weight_ops.py
@@ -77,6 +77,9 @@ class CopyWeightsConfig:
         return module
 
 
+_WRAPPER_PREFIX = "module."
+
+
 def strip_leading_module(state_dict: Mapping[str, Any]) -> Mapping[str, Any]:
     """
     Remove the leading "module." from the keys of a state dict.
@@ -86,9 +89,34 @@ def strip_leading_module(state_dict: Mapping[str, Any]) -> Mapping[str, Any]:
     "module." to the keys of the state dict.
     """
     return {
-        k[len("module.") :] if k.startswith("module.") else k: v
+        k[len(_WRAPPER_PREFIX) :] if k.startswith(_WRAPPER_PREFIX) else k: v
         for k, v in state_dict.items()
     }
+
+
+def prefix_submodule(
+    state_dict: Mapping[str, Any], submodule: str
+) -> Mapping[str, Any]:
+    """
+    Rename a state dict onto a submodule of the module it will be loaded into.
+
+    Used when the destination module wraps the architecture the state dict came
+    from, so every parameter lives one level deeper: loading a deterministic
+    checkpoint into a ``NoiseConditionedModel`` of the same network needs
+    ``submodule="conditional_model"``.
+
+    The leading "module." that ``strip_leading_module`` describes names the
+    DistributedDataParallel or DummyWrapper layer rather than a submodule of
+    the network, so the new name is inserted after it and not before it.
+    """
+    renamed = {}
+    for name, value in state_dict.items():
+        if name.startswith(_WRAPPER_PREFIX):
+            inner = name[len(_WRAPPER_PREFIX) :]
+            renamed[f"{_WRAPPER_PREFIX}{submodule}.{inner}"] = value
+        else:
+            renamed[f"{submodule}.{name}"] = value
+    return renamed
 
 
 def overwrite_weights(
@@ -117,11 +145,7 @@ def overwrite_weights(
     from_names = set(from_state.keys())
     to_names = set(to_module.state_dict().keys())
     if not from_names.issubset(to_names):
-        missing_parameters = from_names - to_names
-        raise ValueError(
-            f"Dest module is missing parameters {missing_parameters}, "
-            "which is not allowed"
-        )
+        raise ValueError(_missing_parameters_message(from_names, to_names))
     for name in from_names:
         if any(wildcard_match(pattern, name) for pattern in exclude_parameters):
             continue
@@ -130,6 +154,41 @@ def overwrite_weights(
             overwrite_weight_initial_slice(to_module, name, from_param)
         except AttributeError:  # if state is not a parameter
             pass
+
+
+def _missing_parameters_message(from_names: set[str], to_names: set[str]) -> str:
+    """Explain a failed source-is-subset-of-dest check, with a fix if there is one.
+
+    Only called on the failure path, so the extra work costs nothing in the
+    normal case.
+    """
+    missing = from_names - to_names
+    lines = [
+        f"Dest module is missing {len(missing)} of the source's "
+        f"{len(from_names)} parameters, which is not allowed.",
+    ]
+    # Candidate submodules are compared inside the DDP/DummyWrapper layer, since
+    # that leading "module." is not a submodule of the network (see
+    # strip_leading_module) and prefix_submodule inserts after it.
+    inner_from = set(strip_leading_module(dict.fromkeys(from_names)))
+    inner_to = set(strip_leading_module(dict.fromkeys(to_names)))
+    prefixes = {name.split(".", 1)[0] for name in inner_to if "." in name}
+    fixes = sorted(
+        prefix
+        for prefix in prefixes
+        if {f"{prefix}.{name}" for name in inner_from}.issubset(inner_to)
+    )
+    if fixes:
+        lines.append(
+            "The destination appears to wrap the source: prefixing every source "
+            f"name with {' or '.join(repr(f + '.') for f in fixes)} makes them "
+            "match. If the destination wraps the checkpoint's architecture (for "
+            "example a NoiseConditionedModel built from a deterministic "
+            "checkpoint), set ParameterInitializationConfig.weights_submodule to "
+            f"{fixes[0]!r}."
+        )
+    lines.append(f"Missing: {sorted(missing)}")
+    return " ".join(lines)
 
 
 def overwrite_weight_initial_slice(module, name, from_param):

--- a/fme/core/weight_ops.py
+++ b/fme/core/weight_ops.py
@@ -78,6 +78,14 @@ class CopyWeightsConfig:
 
 
 _WRAPPER_PREFIX = "module."
+_MAX_MISSING_SHOWN = 10
+
+
+def _strip_wrapper_prefix(name: str) -> str:
+    """Remove a leading "module." from one parameter name."""
+    if name.startswith(_WRAPPER_PREFIX):
+        return name[len(_WRAPPER_PREFIX) :]
+    return name
 
 
 def strip_leading_module(state_dict: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -88,10 +96,7 @@ def strip_leading_module(state_dict: Mapping[str, Any]) -> Mapping[str, Any]:
     a DistributedDataParallel layer or DummyWrapper layer, which adds a leading
     "module." to the keys of the state dict.
     """
-    return {
-        k[len(_WRAPPER_PREFIX) :] if k.startswith(_WRAPPER_PREFIX) else k: v
-        for k, v in state_dict.items()
-    }
+    return {_strip_wrapper_prefix(k): v for k, v in state_dict.items()}
 
 
 def prefix_submodule(
@@ -119,6 +124,19 @@ def prefix_submodule(
     return renamed
 
 
+def require_subset(from_state: Mapping[str, Any], to_module: torch.nn.Module):
+    """
+    Raise unless every name in from_state is a parameter name of to_module.
+
+    Shared by the two places that load base weights into a module, so both
+    report the same diagnosis of a name mismatch.
+    """
+    from_names = set(from_state.keys())
+    to_names = set(to_module.state_dict().keys())
+    if not from_names.issubset(to_names):
+        raise ValueError(_missing_parameters_message(from_names, to_names))
+
+
 def overwrite_weights(
     from_state: Mapping[str, Any],
     to_module: torch.nn.Module,
@@ -142,11 +160,8 @@ def overwrite_weights(
     """
     if exclude_parameters is None:
         exclude_parameters = []
-    from_names = set(from_state.keys())
-    to_names = set(to_module.state_dict().keys())
-    if not from_names.issubset(to_names):
-        raise ValueError(_missing_parameters_message(from_names, to_names))
-    for name in from_names:
+    require_subset(from_state, to_module)
+    for name in from_state.keys():
         if any(wildcard_match(pattern, name) for pattern in exclude_parameters):
             continue
         from_param = from_state[name]
@@ -162,33 +177,40 @@ def _missing_parameters_message(from_names: set[str], to_names: set[str]) -> str
     Only called on the failure path, so the extra work costs nothing in the
     normal case.
     """
-    missing = from_names - to_names
-    lines = [
+    missing = sorted(from_names - to_names)
+    parts = [
         f"Dest module is missing {len(missing)} of the source's "
         f"{len(from_names)} parameters, which is not allowed.",
     ]
     # Candidate submodules are compared inside the DDP/DummyWrapper layer, since
     # that leading "module." is not a submodule of the network (see
     # strip_leading_module) and prefix_submodule inserts after it.
-    inner_from = set(strip_leading_module(dict.fromkeys(from_names)))
-    inner_to = set(strip_leading_module(dict.fromkeys(to_names)))
+    inner_from = {_strip_wrapper_prefix(name) for name in from_names}
+    inner_to = {_strip_wrapper_prefix(name) for name in to_names}
     prefixes = {name.split(".", 1)[0] for name in inner_to if "." in name}
-    fixes = sorted(
+    candidates = sorted(
         prefix
         for prefix in prefixes
         if {f"{prefix}.{name}" for name in inner_from}.issubset(inner_to)
     )
-    if fixes:
-        lines.append(
-            "The destination appears to wrap the source: prefixing every source "
-            f"name with {' or '.join(repr(f + '.') for f in fixes)} makes them "
-            "match. If the destination wraps the checkpoint's architecture (for "
-            "example a NoiseConditionedModel built from a deterministic "
-            "checkpoint), set ParameterInitializationConfig.weights_submodule to "
-            f"{fixes[0]!r}."
+    if candidates:
+        # The subset test is necessary but not sufficient: more than one
+        # submodule can satisfy it, and satisfying it is not proof that the
+        # architectures correspond. So this suggests, and does not decide.
+        listed = " or ".join(repr(candidate) for candidate in candidates)
+        parts.append(
+            "The destination may wrap the source: prefixing every source name "
+            f"with {listed} would make the names match. If the destination does "
+            "wrap the checkpoint's architecture (for example a "
+            "NoiseConditionedModel built from a deterministic checkpoint), set "
+            f"ParameterInitializationConfig.weights_submodule to {listed}. Check "
+            "that the submodule really is the checkpoint's architecture; a "
+            "matching prefix alone does not establish that."
         )
-    lines.append(f"Missing: {sorted(missing)}")
-    return " ".join(lines)
+    shown = missing[:_MAX_MISSING_SHOWN]
+    elided = len(missing) - len(shown)
+    parts.append(f"Missing: {shown}" + (f" and {elided} more" if elided > 0 else ""))
+    return " ".join(parts)
 
 
 def overwrite_weight_initial_slice(module, name, from_param):


### PR DESCRIPTION
Initializing a noise-conditioned module from a deterministic checkpoint of the same network was not possible: `SamudraBuilder` returns a bare `Samudra` at `noise_embed_dim: 0` and `NoiseConditionedModel(samudra, ...)` above zero, so enabling conditioning both adds the zero-initialized FiLM tensors and re-parents every existing parameter under `conditional_model`. `overwrite_weights` requires the source names to be a subset of the destination's, so the added parameters were fine but the renamed ones made every source name report as missing. That blocks "pretrain deterministic, then finetune stochastic", which is how the coupled Samudra work initializes its stochastic ocean.

`ParameterInitializationConfig.weights_submodule` names the submodule of the module being initialized that the checkpoint's module corresponds to; loaded parameter names are prefixed with it before matching. Because the conditioning layers are zero-initialized, the wrapped model at initialization then reproduces the checkpoint's predictions exactly, which is what makes the second stage a continuation rather than a restart.

The name is inserted after any leading `module.`, since that names the `DistributedDataParallel`/`DummyWrapper` layer rather than a submodule of the network. The renaming is applied on both paths that consume the loaded weights — `apply_weights` and the `alpha`/`beta` L2-SP regularizer, which pairs each parameter with the base value it was initialized from — so `parameters` exclude and frozen patterns are written against destination names throughout.

The precondition for `weights_submodule` is that weights were loaded, not that `weights_path` was set: the coupled stepper loads component weights from `CoupledParameterInitConfig.checkpoint_path`, which requires the component's `weights_path` to be `None`. Only the initializer knows whether anything was loaded, so `apply_weights` raises there rather than `__post_init__` rejecting a valid coupled configuration.

The failure this fixes was previously reported as a list of every missing parameter name with no indication of the cause, so `overwrite_weights` now reports counts and, when prefixing by a submodule would make the names match, names the candidates and the config field to set. It lists every candidate rather than singling out one: the subset test can be satisfied by more than one submodule, and satisfying it is not proof that the architectures correspond, so the message suggests and does not decide. This is also why `weights_submodule` is explicit rather than auto-detected.

Behavior change on an existing path: in `get_l2_sp_tuning_regularizer` the `.to(device)` applied to the base weights was rebound to a local that was then discarded, so the regularizer closure differenced against the originally-loaded tensors. The moved tensors are now the ones the closure uses.

Changes:
- `fme.ace.stepper.parameter_init.ParameterInitializationConfig`: new optional `weights_submodule` field, validated to reject empty dotted segments; applied via `apply_submodule_prefix` in `ParameterInitializer.apply_weights` and `get_l2_sp_tuning_regularizer`
- `fme.core.weight_ops.prefix_submodule`: renames a state dict onto a submodule of its destination, inserting after the wrapper prefix that `strip_leading_module` describes
- `fme.core.weight_ops.require_subset`: the source-is-subset-of-destination check, shared by `overwrite_weights` and the regularizer so both report the same diagnosis; its failure message reports counts and candidate submodules

- [x] Tests added
- [ ] If dependencies changed, "deps only" image rebuilt and "latest_deps_only_image.txt" file updated (no dependency changes)
