### PR TITLE
Plot Nino3.4 power spectrum as power per octave against period

### DIFF
--- a/fme/ace/aggregator/inference/enso/dynamic_index.py
+++ b/fme/ace/aggregator/inference/enso/dynamic_index.py
@@ -15,14 +15,19 @@ from fme.core.distributed import Distributed
 from fme.core.gridded_ops import LatLonOperations
 from fme.core.typing_ import TensorDict
 
-from ...plotting import clamp_date_axis, plot_mean_and_samples
+from ...plotting import (
+    clamp_date_axis,
+    format_period_axis,
+    plot_mean_and_samples,
+    plot_power_spectrum_by_period,
+)
 from ..build_context import MetricBuildContext, MetricNotSupportedError
 from ..data import InferenceBatchData, MetricBuildResult
 from ..utils import (
     SAMPLE_DIM,
     TIME_DIM,
     LatLonRegion,
-    _calculate_sample_average_power_spectrum,
+    _calculate_power_spectrum_by_sample,
     _compute_sample_mean_std,
     anomalies_from_monthly_climo,
     compute_psd_band_power,
@@ -31,6 +36,15 @@ from ..utils import (
 )
 
 SEA_SURFACE_TEMPERATURE_NAMES = ["sst", "surface_temperature", "TS"]
+MAX_PLOTTED_PERIOD_YEARS = 16.0
+
+
+def _max_plotted_period(freqs_per_year: np.ndarray) -> float:
+    """The longest period to show, capped at the period ENSO spectra are cut at."""
+    resolved = freqs_per_year[freqs_per_year > 0.0]
+    if resolved.size == 0:
+        return MAX_PLOTTED_PERIOD_YEARS
+    return min(MAX_PLOTTED_PERIOD_YEARS, float(1.0 / resolved.min()))
 
 
 class RegionalIndexAggregator:
@@ -188,15 +202,17 @@ class RegionalIndexAggregator:
                 sst_name in indices
                 and indices[sst_name].dropna("time").sizes["time"] > 1
             ):
-                freq, power_spectrum = _calculate_sample_average_power_spectrum(
+                freq, power_by_sample = _calculate_power_spectrum_by_sample(
                     indices[sst_name]
                 )
+                power_spectrum = power_by_sample.mean(axis=SAMPLE_DIM)
                 fig, ax = plt.subplots(1, 1)
-                ax.plot(freq, power_spectrum, label="predicted ensemble mean")
+                plot_power_spectrum_by_period(
+                    ax, freq, power_by_sample, "predicted ensemble mean"
+                )
                 ax.set_title("Power Spectrum of Nino3.4 Index")
-                ax.set_xlabel("Frequency [cycles/year]")
-                ax.set_ylabel("Power [K**2]")
-                ax.set(yscale="log")
+                ax.set_ylabel("Power [K$^2$/octave]")
+                format_period_axis(ax, max_period_years=_max_plotted_period(freq))
                 ax.legend()
                 fig.tight_layout()
                 logs[f"{sst_name}_nino34_index_power_spectrum"] = fig
@@ -288,26 +304,35 @@ class PairedRegionalIndexAggregator:
                 sst_name in prediction_indices
                 and prediction_indices[sst_name].notnull().any().item()
             ):
-                pred_freq, prediction_power_spectrum = (
-                    _calculate_sample_average_power_spectrum(
-                        prediction_indices[sst_name]
-                    )
+                pred_freq, prediction_power_by_sample = (
+                    _calculate_power_spectrum_by_sample(prediction_indices[sst_name])
                 )
-                target_freq, target_power_spectrum = (
-                    _calculate_sample_average_power_spectrum(target_indices[sst_name])
+                target_freq, target_power_by_sample = (
+                    _calculate_power_spectrum_by_sample(target_indices[sst_name])
                 )
+                prediction_power_spectrum = prediction_power_by_sample.mean(
+                    axis=SAMPLE_DIM
+                )
+                target_power_spectrum = target_power_by_sample.mean(axis=SAMPLE_DIM)
                 fig, ax = plt.subplots(1, 1)
-                ax.plot(
-                    pred_freq,
-                    prediction_power_spectrum,
-                    label="predicted ensemble mean",
+                plot_power_spectrum_by_period(
+                    ax, target_freq, target_power_by_sample, "target", color="black"
                 )
-                ax.plot(
-                    target_freq, target_power_spectrum, label="target", color="orange"
+                plot_power_spectrum_by_period(
+                    ax,
+                    pred_freq,
+                    prediction_power_by_sample,
+                    "predicted ensemble mean",
                 )
                 ax.set_title("Power Spectrum of Nino3.4 Index")
-                ax.set_xlabel("Frequency [cycles/year]")
-                ax.set(yscale="log")
+                ax.set_ylabel("Power [K$^2$/octave]")
+                format_period_axis(
+                    ax,
+                    max_period_years=max(
+                        _max_plotted_period(pred_freq),
+                        _max_plotted_period(target_freq),
+                    ),
+                )
                 ax.legend()
                 fig.tight_layout()
                 logs[f"{sst_name}_nino34_index_power_spectrum"] = fig

--- a/fme/ace/aggregator/inference/enso/test_dynamic_index.py
+++ b/fme/ace/aggregator/inference/enso/test_dynamic_index.py
@@ -15,6 +15,7 @@ from fme.core.typing_ import TensorMapping
 
 from ..utils import (
     LatLonRegion,
+    _calculate_power_spectrum_by_sample,
     _calculate_sample_average_power_spectrum,
     _compute_sample_mean_std,
     anomalies_from_monthly_climo,
@@ -576,6 +577,35 @@ def test__calculate_sample_average_power_spectrum():
         )
     assert freq.shape == power_spectrum.shape
     assert freq.shape == (3,)
+
+
+def test__calculate_power_spectrum_by_sample_keeps_samples():
+    data = [
+        [0.0, 1.0, 2.0, 5.0, 9.0, 10.0, 11.0],
+        [np.nan, np.nan, 3.0, 4.0, 6.0, 7.0, 8.0],
+    ]
+    with pytest.warns(UserWarning, match="Samples have different lengths"):
+        freq, power_by_sample = _calculate_power_spectrum_by_sample(
+            timeseries=xr.DataArray(data, dims=("sample", "time"))
+        )
+    assert power_by_sample.shape == (2, freq.shape[0])
+    average = _calculate_sample_average_power_spectrum(
+        timeseries=xr.DataArray(data, dims=("sample", "time"))
+    )[1]
+    np.testing.assert_allclose(power_by_sample.mean(axis=0), average)
+
+
+@pytest.mark.parametrize("n_times", [240, 241], ids=["even", "odd"])
+def test_power_spectrum_integrates_to_mean_square(n_times):
+    """The spectrum is a density: integrating it over frequency gives the mean
+    square of the timeseries, which is what makes the plotted power per octave
+    comparable between runs of different length."""
+    rng = np.random.default_rng(0)
+    values = rng.normal(size=(3, n_times))
+    data = xr.DataArray(values, dims=("sample", "time"))
+    freq, power_by_sample = _calculate_power_spectrum_by_sample(data)
+    integral = power_by_sample.sum(axis=1) * (freq[1] - freq[0])
+    np.testing.assert_allclose(integral, (values**2).mean(axis=1), rtol=1e-10)
 
 
 def test_compute_psd_band_power():

--- a/fme/ace/aggregator/inference/utils.py
+++ b/fme/ace/aggregator/inference/utils.py
@@ -43,33 +43,47 @@ class LatLonRegion(Region):
         return self._regional_weights
 
 
-def compute_power_spectrum(
+def compute_power_spectrum_by_sample(
     data: xr.DataArray,
     fs=1,
     time_dim: int = TIME_DIM,
     sample_dim: int = SAMPLE_DIM,
 ):
     """
-    Compute the power spectrum of the input data.
+    Compute the power spectral density of each sample of the input data.
+
+    The returned density is one-sided and normalized so that its integral over
+    frequency equals the mean square of the sample, i.e. it has units of the
+    squared data units per cycle per year.
 
     Args:
-        data: A tensor of size n_time_steps containing the data.
+        data: An array of shape (n_samples, n_time_steps) containing the data.
         fs: The sampling frequency, defaults to 1 sample per month.
         time_dim: Time dimension index
         sample_dim: Sample dimension index
+
+    Returns:
+        The frequencies in cycles per year, and the power spectral density with
+        the same shape as the input data along the sample dimension.
     """
-    if len(data.shape) == 2:
-        uhat = np.fft.rfft(data, axis=time_dim)
-        power = np.abs(uhat) ** 2
-        power = power.mean(axis=sample_dim)
-    else:
+    if len(data.shape) != 2:
         raise ValueError(
             "Expected indicies to be of shape (sample, time) when calculating "
             f"power spectrum, got {data.shape}"
         )
-    n_samples = data.shape[time_dim]
-    freqs = np.fft.rfftfreq(n_samples, d=1 / fs)
+    n_times = data.shape[time_dim]
+    freqs = np.fft.rfftfreq(n_times, d=1 / fs)
     freqs_per_year = freqs / fs * 12.0
+    samples_per_year = 12.0 * fs
+    uhat = np.fft.rfft(data, axis=time_dim)
+    power = np.abs(uhat) ** 2 / (n_times * samples_per_year)
+    # the one-sided density must count the power of the negative frequencies,
+    # which are not their own mirror image only at zero and Nyquist frequency
+    doubled = np.ones(freqs.shape)
+    doubled[1:] = 2.0
+    if n_times % 2 == 0:
+        doubled[-1] = 1.0
+    power = power * np.expand_dims(doubled, axis=sample_dim)
     return freqs_per_year, power
 
 
@@ -94,10 +108,10 @@ def _compute_sample_mean_std(
     return std_by_sample.mean().item()
 
 
-def _calculate_sample_average_power_spectrum(
+def _calculate_power_spectrum_by_sample(
     timeseries: xr.DataArray,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Compute power spectrum averaged across samples.
+    """Compute the power spectrum of each sample of a timeseries.
 
     Handles the case where samples have different lengths by truncating to
     the shortest length.
@@ -121,7 +135,18 @@ def _calculate_sample_average_power_spectrum(
             for data_array in data_arrays
         ]
     )
-    return compute_power_spectrum(all_data)
+    return compute_power_spectrum_by_sample(all_data)
+
+
+def _calculate_sample_average_power_spectrum(
+    timeseries: xr.DataArray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute power spectrum averaged across samples.
+
+    See :func:`_calculate_power_spectrum_by_sample`.
+    """
+    freqs_per_year, power = _calculate_power_spectrum_by_sample(timeseries)
+    return freqs_per_year, power.mean(axis=SAMPLE_DIM)
 
 
 def anomalies_from_monthly_climo(

--- a/fme/ace/aggregator/plotting.py
+++ b/fme/ace/aggregator/plotting.py
@@ -5,6 +5,7 @@ import numpy as np
 import xarray as xr
 from matplotlib.colors import Colormap
 from matplotlib.figure import Figure
+from matplotlib.ticker import NullLocator
 
 from fme.core.wandb import Image, WandB
 
@@ -231,3 +232,65 @@ def plot_mean_and_samples(
                 linestyle="-.",
                 marker="x",
             )
+
+
+PERIOD_AXIS_TICKS_YEARS = (0.5, 1.0, 2.0, 4.0, 8.0, 16.0)
+
+
+def plot_power_spectrum_by_period(
+    ax: Any,
+    freqs_per_year: np.ndarray,
+    power_by_sample: np.ndarray,
+    mean_label: str,
+    color: str = "cornflowerblue",
+    plot_samples: bool = True,
+):
+    """Plot a variance-preserving power spectrum against period.
+
+    The power spectral density is converted to power per octave, ``ln(2) * f *
+    psd(f)``, so that area under the curve is proportional to variance on the
+    logarithmic period axis used by :func:`format_period_axis`. Each sample is
+    drawn as a faint line and their mean as a heavy one.
+
+    Args:
+        ax: The axes to plot on.
+        freqs_per_year: Frequencies in cycles per year.
+        power_by_sample: Power spectral density of shape (sample, frequency).
+        mean_label: Legend label for the sample-mean line.
+        color: Color for all lines.
+        plot_samples: Whether to draw the individual samples.
+    """
+    resolved = freqs_per_year > 0.0
+    periods = 1.0 / freqs_per_year[resolved]
+    power_per_octave = (
+        power_by_sample[:, resolved] * freqs_per_year[resolved] * np.log(2.0)
+    )
+    if plot_samples:
+        for sample_power in power_per_octave:
+            ax.plot(periods, sample_power, color=color, alpha=0.35, linewidth=0.75)
+    ax.plot(
+        periods,
+        power_per_octave.mean(axis=0),
+        color=color,
+        label=mean_label,
+        linewidth=2.0,
+    )
+
+
+def format_period_axis(
+    ax: Any,
+    max_period_years: float,
+    min_period_years: float = 0.5,
+):
+    """Format an axes' x axis as a period in years on a base-2 log scale."""
+    max_period_years = max(max_period_years, 2 * min_period_years)
+    ax.set_xscale("log", base=2)
+    ax.set_xlim(min_period_years, max_period_years)
+    ticks = [
+        tick
+        for tick in PERIOD_AXIS_TICKS_YEARS
+        if min_period_years <= tick <= max_period_years
+    ]
+    ax.set_xticks(ticks, labels=[f"{tick:.1f}" for tick in ticks])
+    ax.xaxis.set_minor_locator(NullLocator())
+    ax.set_xlabel("Period [years]")

--- a/fme/ace/aggregator/test_plotting.py
+++ b/fme/ace/aggregator/test_plotting.py
@@ -9,9 +9,11 @@ from .plotting import (
     _stitch_data_panels,
     clamp_date_axis,
     fold_healpix_data,
+    format_period_axis,
     get_cmap_limits,
     plot_imshow,
     plot_paneled_data,
+    plot_power_spectrum_by_period,
 )
 
 
@@ -136,5 +138,49 @@ def test_clamp_date_axis_allows_a_140_year_series_starting_at_year_0001():
         left, right = ax.get_xlim()
         assert left == mdates.date2num(times[0])
         assert right == mdates.date2num(times[-1])
+    finally:
+        plt.close(fig)
+
+
+def test_plot_power_spectrum_by_period_draws_mean_and_samples():
+    """A line per sample plus a heavy sample-mean line, at power per octave."""
+    freqs_per_year = np.array([0.0, 0.25, 0.5, 1.0])
+    power_by_sample = np.array([[10.0, 4.0, 2.0, 1.0], [20.0, 8.0, 6.0, 3.0]])
+
+    fig, ax = plt.subplots(1, 1)
+    try:
+        plot_power_spectrum_by_period(ax, freqs_per_year, power_by_sample, "mean")
+        assert len(ax.lines) == 3  # two samples and their mean
+        mean_line = ax.lines[-1]
+        assert mean_line.get_label() == "mean"
+        # the zero frequency has no finite period and is dropped
+        np.testing.assert_allclose(mean_line.get_xdata(), [4.0, 2.0, 1.0])
+        expected = np.array([6.0, 4.0, 2.0]) * np.array([0.25, 0.5, 1.0]) * np.log(2.0)
+        np.testing.assert_allclose(mean_line.get_ydata(), expected)
+    finally:
+        plt.close(fig)
+
+
+def test_format_period_axis_labels_octaves():
+    fig, ax = plt.subplots(1, 1)
+    try:
+        format_period_axis(ax, max_period_years=16.0)
+        fig.canvas.draw()
+        assert ax.get_xscale() == "log"
+        assert ax.get_xlim() == (0.5, 16.0)
+        labels = [tick.get_text() for tick in ax.get_xticklabels()]
+        assert labels == ["0.5", "1.0", "2.0", "4.0", "8.0", "16.0"]
+    finally:
+        plt.close(fig)
+
+
+def test_format_period_axis_drops_ticks_beyond_a_short_record():
+    fig, ax = plt.subplots(1, 1)
+    try:
+        format_period_axis(ax, max_period_years=3.0)
+        fig.canvas.draw()
+        assert ax.get_xlim() == (0.5, 3.0)
+        labels = [tick.get_text() for tick in ax.get_xticklabels()]
+        assert labels == ["0.5", "1.0", "2.0"]
     finally:
         plt.close(fig)


### PR DESCRIPTION
Plot the Nino3.4 power spectrum in variance-preserving form (power per octave
vs period in years on a log-2 scale) instead of the previous raw power vs
frequency plot. This is the standard visualization for ENSO variability in
climate science: area under the curve is proportional to variance, making it
easy to see where spectral power concentrates (the 2–7 year ENSO band). The
period axis is capped at 16 years, and ticks that fall beyond the longest
period resolvable by a short record are dropped.

Individual ensemble members are drawn as faint lines behind the heavy
sample-mean line, giving a visual sense of spread across samples. In the
paired (prediction vs target) plot the target line is now black and the
prediction blue, matching the convention in published ENSO spectrum figures.

> **Breaking change to logged scalars.**
> The underlying spectrum is now a properly normalized one-sided power spectral
> density (integral over frequency = mean square of the timeseries) instead of
> the unnormalized `|rfft|²` used previously. This changes the **scale** of
> two wandb scalars:
>
> - `<sst>_nino34_index_power_2_5yr`
> - `<sst>_nino34_index_power_1_16yr`
>
> These values are now in K² and are **not comparable** to values logged by
> earlier runs. The `_norm` ratio variants (`…_power_2_5yr_norm`,
> `…_power_1_16yr_norm`) are **unaffected** because the normalization cancels.

Changes:
- `compute_power_spectrum` → `compute_power_spectrum_by_sample` in
  `fme.ace.aggregator.inference.utils`: returns properly normalized one-sided
  power spectral density per sample (integral over frequency equals the mean
  square of the timeseries)
- `_calculate_sample_average_power_spectrum` refactored into
  `_calculate_power_spectrum_by_sample`; the old function kept as a thin
  wrapper for existing callers
- New `plot_power_spectrum_by_period` and `format_period_axis` helpers in
  `fme.ace.aggregator.plotting`
- `RegionalIndexAggregator` and `PairedRegionalIndexAggregator` updated to use
  the new plotting, with the period axis capped at 16 years
  (`MAX_PLOTTED_PERIOD_YEARS`)

## Example in wandb

[wandb](https://wandb.ai/ai2cm/ace-samudra-cm4/runs/pajx5pp9?nw=nwusertroya&panelDisplayName=inference%2Fenso_index%2Fsst_nino34_index_power_spectrum&panelSectionName=inference%2Fenso_index)

<img width="1615" height="703" alt="Screenshot 2026-09-20 at 3 01 04 PM" src="https://github.com/user-attachments/assets/750d57ad-3deb-44f9-a697-0d72818cd318" />


- [x] Tests added